### PR TITLE
chore: remove unused exports and dead code

### DIFF
--- a/src/components/PerformanceProfiler.tsx
+++ b/src/components/PerformanceProfiler.tsx
@@ -2,7 +2,7 @@
  * React Profiler component for measuring component performance
  */
 
-import React, { Profiler, useCallback, useState } from 'react';
+import React, { Profiler, useCallback } from 'react';
 import type { ProfilerOnRenderCallback } from 'react';
 import type { ProfilerData } from '../hooks/useProfilerData';
 
@@ -62,67 +62,3 @@ export const PerformanceProfilerComponent: React.FC<PerformanceProfilerProps> = 
 
 
 
-/**
- * Performance debugging component
- */
-export const PerformanceDebugger: React.FC<{ 
-  visible?: boolean;
-  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-}> = ({ 
-  visible = import.meta.env.DEV,
-  position = 'bottom-right'
-}) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  if (!visible) return null;
-
-  const positionStyles = {
-    'top-left': { top: '1rem', left: '1rem' },
-    'top-right': { top: '1rem', right: '1rem' },
-    'bottom-left': { bottom: '1rem', left: '1rem' },
-    'bottom-right': { bottom: '1rem', right: '1rem' }
-  };
-
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        ...positionStyles[position],
-        background: 'rgba(0, 0, 0, 0.8)',
-        color: 'white',
-        padding: '0.5rem',
-        borderRadius: '0.5rem',
-        fontSize: '0.75rem',
-        fontFamily: 'monospace',
-        zIndex: 10000,
-        minWidth: '200px',
-        backdropFilter: 'blur(10px)'
-      }}
-    >
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        style={{
-          background: 'none',
-          border: 'none',
-          color: 'white',
-          cursor: 'pointer',
-          width: '100%',
-          textAlign: 'left'
-        }}
-      >
-        🔍 Performance Monitor {isExpanded ? '▼' : '▶'}
-      </button>
-      
-      {isExpanded && (
-        <div style={{ marginTop: '0.5rem' }}>
-          <div>Memory: {(performance as unknown as { memory?: { usedJSHeapSize: number } }).memory ? 
-            `${(((performance as unknown as { memory: { usedJSHeapSize: number } }).memory.usedJSHeapSize / 1024 / 1024).toFixed(1))}MB` : 
-            'N/A'
-          }</div>
-          <div>Frame Rate: ~{Math.round(1000 / 16.67)}fps target</div>
-          <div>Press Ctrl+Shift+P for Performance Tests</div>
-        </div>
-      )}
-    </div>
-  );
-};

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -96,7 +96,7 @@ import type { VisualizerStyle } from '../types/visualizer';
  * };
  * ```
  */
-export interface AlbumFilters {
+interface AlbumFilters {
   brightness: number;
   contrast: number;
   saturation: number;
@@ -105,92 +105,34 @@ export interface AlbumFilters {
   sepia: number;
 }
 
+
+
 /**
- * Track and Playback State
- * 
- * Contains all state related to track management and playback.
+ * Internal state type definitions
  */
-export interface TrackState {
+interface TrackState {
   tracks: Track[];
   currentIndex: number;
   isLoading: boolean;
   error: string | null;
 }
 
-/**
- * Playlist State
- * 
- * Contains state related to playlist management and UI.
- */
-export interface PlaylistState {
+interface PlaylistState {
   selectedId: string | null;
   isVisible: boolean;
 }
 
-/**
- * Color and Theme State
- * 
- * Contains state related to accent colors and theme customization.
- */
-export interface ColorState {
+interface ColorState {
   current: string;
   overrides: Record<string, string>;
 }
 
-/**
- * Visual Effects State
- * 
- * Contains state related to visual effects and image processing.
- */
-export interface VisualEffectsState {
+interface VisualEffectsState {
   enabled: boolean;
   menuVisible: boolean;
   filters: AlbumFilters;
   perAlbumGlow: Record<string, { intensity: number; rate: number }>;
   savedFilters: AlbumFilters | null;
-}
-
-/**
- * Grouped Player State
- * 
- * Organized state object with logical groupings for better maintainability.
- */
-export interface GroupedPlayerState {
-  track: TrackState;
-  playlist: PlaylistState;
-  color: ColorState;
-  visualEffects: VisualEffectsState;
-}
-
-/**
- * Player Actions
- * 
- * Grouped action functions for state management.
- */
-export interface PlayerActions {
-  track: {
-    setTracks: (tracks: Track[]) => void;
-    setCurrentIndex: (index: number) => void;
-    setLoading: (loading: boolean) => void;
-    setError: (error: string | null) => void;
-  };
-  playlist: {
-    setSelectedId: (id: string | null) => void;
-    setVisible: (visible: boolean) => void;
-  };
-  color: {
-    setCurrent: (color: string) => void;
-    setOverrides: (overrides: Record<string, string>) => void;
-  };
-  visualEffects: {
-    setEnabled: (enabled: boolean) => void;
-    setMenuVisible: (visible: boolean) => void;
-    setFilters: (filters: AlbumFilters) => void;
-    setPerAlbumGlow: (glow: Record<string, { intensity: number; rate: number }>) => void;
-    handleFilterChange: (filterName: string, value: number | boolean) => void;
-    handleResetFilters: () => void;
-    restoreSavedFilters: () => void;
-  };
 }
 
 /**

--- a/src/utils/colorExtractor.ts
+++ b/src/utils/colorExtractor.ts
@@ -400,29 +400,6 @@ export async function extractDominantColor(imageUrl: string): Promise<ExtractedC
   });
 }
 
-export function getLighterVariant(color: string, amount = 0.2): string {
-  let r: number, g: number, b: number;
-  
-  if (color.startsWith('#')) {
-    const hex = color.slice(1);
-    r = parseInt(hex.substr(0, 2), 16);
-    g = parseInt(hex.substr(2, 2), 16);
-    b = parseInt(hex.substr(4, 2), 16);
-  } else if (color.startsWith('rgb')) {
-    const matches = color.match(/\d+/g);
-    if (!matches) return color;
-    [r, g, b] = matches.map(Number);
-  } else {
-    return color;
-  }
-  
-  r = Math.min(255, Math.floor(r + (255 - r) * amount));
-  g = Math.min(255, Math.floor(g + (255 - g) * amount));
-  b = Math.min(255, Math.floor(b + (255 - b) * amount));
-  
-  return `rgb(${r}, ${g}, ${b})`;
-}
-
 export function getTransparentVariant(color: string, opacity = 0.2): string {
   let r: number, g: number, b: number;
   

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,9 +1,3 @@
-export const colorDistance = (color1: [number, number, number], color2: [number, number, number]): number => {
-  const [r1, g1, b1] = color1;
-  const [r2, g2, b2] = color2;
-  return Math.sqrt((r2 - r1) ** 2 + (g2 - g1) ** 2 + (b2 - b1) ** 2);
-};
-
 export const hexToRgb = (hex: string): [number, number, number] => {
   const cleanHex = hex.replace('#', '');
   return [

--- a/src/utils/featureDetection.ts
+++ b/src/utils/featureDetection.ts
@@ -241,20 +241,4 @@ export const createEnhancedEventListeners = (
   };
 };
 
-/**
- * Check if a specific feature is supported
- */
-export const isFeatureSupported = (feature: keyof BrowserFeatures): boolean => {
-  const features = detectBrowserFeatures();
-  return features[feature];
-};
 
-/**
- * Get browser compatibility score (0-100)
- */
-export const getBrowserCompatibilityScore = (): number => {
-  const features = detectBrowserFeatures();
-  const totalFeatures = Object.keys(features).length;
-  const supportedFeatures = Object.values(features).filter(Boolean).length;
-  return Math.round((supportedFeatures / totalFeatures) * 100);
-};

--- a/src/utils/visualEffectsPerformance.ts
+++ b/src/utils/visualEffectsPerformance.ts
@@ -283,31 +283,3 @@ export const useVisualEffectsPerformance = () => {
   };
 };
 
-/**
- * Performance test runner for automated testing
- */
-export const runVisualEffectsPerformanceTests = async (): Promise<VisualEffectsPerformanceMetrics[]> => {
-  const profiler = new VisualEffectsProfiler();
-  const results: VisualEffectsPerformanceMetrics[] = [];
-
-  // Test with different filter counts
-  const filterCounts = [7, 10, 15, 20];
-  
-  for (const filterCount of filterCounts) {
-    console.log(`Running performance test with ${filterCount} filters...`);
-    const metrics = await profiler.runPerformanceTest(filterCount);
-    results.push(metrics);
-    
-    // Add delay between tests
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
-  // Generate summary report
-  console.log('\n=== Visual Effects Performance Test Summary ===');
-  results.forEach((metrics, index) => {
-    console.log(`\nTest ${index + 1} (${filterCounts[index]} filters):`);
-    console.log(profiler.generateVisualEffectsReport(metrics));
-  });
-
-  return results;
-};


### PR DESCRIPTION
- Remove unused colorDistance export from colorUtils.ts (duplicate in imageProcessor.worker.ts)
- Remove unused getLighterVariant export from colorExtractor.ts
- Remove unused isFeatureSupported and getBrowserCompatibilityScore from featureDetection.ts
- Remove unused PerformanceDebugger component from PerformanceProfiler.tsx
- Remove unused runVisualEffectsPerformanceTests from visualEffectsPerformance.ts
- Move internal type definitions in usePlayerState.ts from exported to internal scope
- Remove unused useState import from PerformanceProfiler.tsx