### PR TITLE
feat: Add accent color glow effect for album art contrast

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -71,17 +71,37 @@ const AlbumArtContainer = styled.div.withConfig({
   margin: 0 auto;
   overflow: hidden;
   background: transparent;
-  /* Enhanced shadow for better contrast against backgrounds */
-  /* Reduced downward shadow spread to prevent overlap with track info */
-  box-shadow: 
-    0 8px 24px rgba(0, 0, 0, 0.85),
-    0 4px 12px rgba(0, 0, 0, 0.75),
-    0 2px 6px rgba(0, 0, 0, 0.65),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  /* Subtle border for definition */
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  /* Accent color glow for floating effect */
+  ${({ accentColor }) => {
+    if (accentColor) {
+      const [r, g, b] = hexToRgb(accentColor);
+      return `
+        box-shadow: 
+          /* White edge for definition */
+          0 0 0 2px rgba(255, 255, 255, 0.4),
+          /* Accent color inner glow */
+          0 0 16px rgba(${r}, ${g}, ${b}, 0.6),
+          0 0 32px rgba(${r}, ${g}, ${b}, 0.45),
+          /* Accent color wide glow - subtle */
+          0 0 48px rgba(${r}, ${g}, ${b}, 0.18),
+          0 0 72px rgba(${r}, ${g}, ${b}, 0.1),
+          /* Depth shadow */
+          0 8px 24px rgba(0, 0, 0, 0.5);
+      `;
+    }
+    return `
+      box-shadow: 
+        0 0 0 2px rgba(255, 255, 255, 0.5),
+        0 0 16px rgba(255, 255, 255, 0.4),
+        0 0 32px rgba(255, 255, 255, 0.3),
+        0 0 48px rgba(255, 255, 255, 0.2),
+        0 0 64px rgba(255, 255, 255, 0.1),
+        0 8px 24px rgba(0, 0, 0, 0.5);
+    `;
+  }}
+  border: none;
   z-index: ${theme.zIndex.docked};
-  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+  transition: box-shadow 0.5s ease;
   
 `;
 

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -287,7 +287,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
 
   // Controls visibility state (default: hidden)
   const [controlsVisible, setControlsVisible] = useState(true);
-  
+
   // Help modal state
   const [showHelp, setShowHelp] = useState(false);
 


### PR DESCRIPTION
## Summary
This PR adds a dynamic accent color glow effect around the album art to improve visual separation from the background, creating a floating card effect.

## Changes
- Added accent color-based glow effect using extracted colors from album art
- Multiple glow layers (16px, 32px, 48px, 72px) create depth and separation
- White edge outline (2px) provides clear definition
- Smooth color transitions (0.5s) when tracks change
- Fallback to white glow when no accent color is available

## Problem Solved
Previously, the album art could blend into dark backgrounds (visualizers, accent color backgrounds), making it difficult to distinguish the player from the background. This glow effect creates clear visual separation while maintaining a cohesive theme by using the album's dominant color.

## Testing
- Tested with various album art colors (vibrant, dark, light)
- Verified glow transitions smoothly between tracks
- Confirmed fallback behavior when accent color is unavailable