### PR TITLE
feat: add keyboard shortcut for toggling controls visibility

### DIFF
--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -115,6 +115,7 @@ const shortcuts = [
   { key: 'G', description: 'Toggle glow effect' },
   { key: 'V', description: 'Toggle background visualizations' },
   { key: 'O', description: 'Open visual effects menu' },
+  { key: 'H', description: 'Toggle controls visibility' },
   { key: 'Esc', description: 'Close menus' },
   { key: '/', description: 'Show this help' },
 ];

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -338,7 +338,8 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
     onToggleGlow: handlers.onGlowToggle,
     onMute: handlers.onMuteToggle,
     onToggleLike: handlers.onToggleLike,
-    onToggleHelp: toggleHelp
+    onToggleHelp: toggleHelp,
+    onToggleControls: toggleControls
   });
 
   return (

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,7 @@
   * - ArrowDown: Volume down (placeholder)
   * - D: Toggle debug mode
   * - L: Like/Unlike track
+  * - H: Toggle controls visibility
   */
 
 import { useEffect } from 'react';
@@ -50,6 +51,7 @@ export interface KeyboardShortcutHandlers {
   onVolumeUp?: () => void;
   onVolumeDown?: () => void;
   onToggleLike?: () => void;
+  onToggleControls?: () => void;
 }
 
 interface UseKeyboardShortcutsOptions {
@@ -84,6 +86,7 @@ export const useKeyboardShortcuts = (
     onVolumeUp,
     onVolumeDown,
     onToggleLike,
+    onToggleControls,
   } = handlers;
 
   useEffect(() => {
@@ -179,6 +182,14 @@ export const useKeyboardShortcuts = (
           }
           break;
 
+        case 'KeyH':
+          // H toggles controls visibility
+          if (!event.ctrlKey && !event.metaKey) {
+            event.preventDefault();
+            onToggleControls?.();
+          }
+          break;
+
         case 'ArrowUp':
           // Prevent default only if we have a handler
           if (onVolumeUp) {
@@ -223,6 +234,7 @@ export const useKeyboardShortcuts = (
     onVolumeUp,
     onVolumeDown,
     onToggleLike,
+    onToggleControls,
     options.enableDebugMode,
   ]);
 };


### PR DESCRIPTION
- Introduced a new keyboard shortcut 'H' to toggle the visibility of controls.
- Updated the KeyboardShortcutsHelp component to include the new shortcut.
- Enhanced the useKeyboardShortcuts hook to handle the 'H' key event and trigger the corresponding handler.