### PR TITLE
Update library loading labels to include playlists and albums

### DIFF
--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -239,8 +239,8 @@ export const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
           <LoadingContainer>
             <SpotifyIcon />
             <LoadingText>
-              <LoadingTitle>Loading Playlists</LoadingTitle>
-              <LoadingSubtext>Discovering your music collection</LoadingSubtext>
+              <LoadingTitle>Loading Your Library</LoadingTitle>
+              <LoadingSubtext>Discovering your playlists and albums</LoadingSubtext>
             </LoadingText>
             <ProgressBar />
           </LoadingContainer>

--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -417,7 +417,7 @@ const PlaylistSelection: React.FC<PlaylistSelectionProps> = ({ onPlaylistSelect 
               <Skeleton style={{ height: '60px' }} />
               <Skeleton style={{ height: '60px' }} />
               <Skeleton style={{ height: '60px' }} />
-              <p style={{ textAlign: 'center', color: 'white' }}>Loading your playlists...</p>
+              <p style={{ textAlign: 'center', color: 'white' }}>Loading your library...</p>
             </LoadingState>
           )}
 


### PR DESCRIPTION
## Summary

Updates the loading screen labels to better indicate that the library includes both playlists and albums, not just playlists.

## Changes

- Changed 'Loading Playlists' to 'Loading Your Library' in PlayerStateRenderer
- Updated subtext to 'Discovering your playlists and albums'
- Changed 'Loading your playlists...' to 'Loading your library...' in PlaylistSelection

This makes it clearer to users that the library loading process includes both playlists and albums.