### PR TITLE
fix: ensure quick access panels render above album art glow

### DIFF
--- a/src/components/LeftQuickActionsPanel.tsx
+++ b/src/components/LeftQuickActionsPanel.tsx
@@ -19,7 +19,8 @@ const PanelWrapper = styled.div<{ $transitionDuration: number; $transitionEasing
   right: 100%;
   transform: translateY(-50%);
   transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
-  z-index: ${theme.zIndex.popover};
+  z-index: ${theme.zIndex.uiOverlay};
+  isolation: isolate;
 `;
 
 const PanelContainer = styled.div`

--- a/src/components/QuickActionsPanel.tsx
+++ b/src/components/QuickActionsPanel.tsx
@@ -28,7 +28,8 @@ const PanelWrapper = styled.div<{ $transitionDuration: number; $transitionEasing
   left: 100%;
   transform: translateY(-50%);
   transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
-  z-index: ${theme.zIndex.popover};
+  z-index: ${theme.zIndex.uiOverlay};
+  isolation: isolate;
 `;
 
 const PanelContainer = styled.div`

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -185,7 +185,8 @@ export const theme = {
     popover: '1500',
     skipLink: '1600',
     toast: '1700',
-    tooltip: '1800'
+    tooltip: '1800',
+    uiOverlay: '2000'
   },
   
   // Player-specific sizing constraints


### PR DESCRIPTION
## Problem
The glow effect from the album art (created by `box-shadow` on `AlbumArtContainer`) was bleeding onto the quick access panels, even though the panels had a higher z-index (1500) than the album art (10).

## Solution
- Added new z-index tier `uiOverlay: 2000` to theme for UI elements that must be above visual effects
- Updated both QuickActionsPanel and LeftQuickActionsPanel to use `theme.zIndex.uiOverlay` instead of `theme.zIndex.popover`
- Added `isolation: isolate` to panel wrappers to create proper stacking context isolation
- This ensures the panels are definitively above the glow effect

## Changes
- `src/styles/theme.ts`: Added `uiOverlay: '2000'` to zIndex object
- `src/components/QuickActionsPanel.tsx`: Updated z-index and added isolation
- `src/components/LeftQuickActionsPanel.tsx`: Updated z-index and added isolation

## Testing
- Verified panels now render above the album art glow effect
- No linter errors
- Background coverage remains sufficient with existing `overlay.dark` background