### PR TITLE
fix: handle empty response body in spotifyApiRequest

### DIFF
--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -166,7 +166,11 @@ async function spotifyApiRequest<T>(
     return undefined as T;
   }
 
-  return response.json();
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+  return JSON.parse(text);
 }
 
 async function fetchAllPaginated<TItem, TResult>(


### PR DESCRIPTION
Spotify's PUT/DELETE /v1/me/tracks endpoints return 200 OK with an empty response body. spotifyApiRequest only handled 204 No Content, then unconditionally called response.json() which threw "SyntaxError: Unexpected end of JSON input" on empty bodies.

Read response as text first and only parse if non-empty.

https://claude.ai/code/session_01LQGYs6GQhmYBLXKvbezRCH