### PR TITLE
refactor: extract shared components and eliminate code duplication

### DIFF
--- a/src/components/ColorPickerPopover.tsx
+++ b/src/components/ColorPickerPopover.tsx
@@ -1,67 +1,12 @@
 import { useState, useEffect, useRef, useLayoutEffect, memo } from 'react';
 import { createPortal } from 'react-dom';
-import styled from 'styled-components';
 import EyedropperOverlay from './EyedropperOverlay';
 import { extractTopVibrantColors } from '../utils/colorExtractor';
 import type { ExtractedColor } from '../utils/colorExtractor';
 import type { Track } from '../services/spotify';
 import { theme } from '../styles/theme';
-import { getContrastColor } from '../utils/colorUtils';
-
-const ControlButton = styled.button.withConfig({
-  shouldForwardProp: (prop) => !['isActive', 'accentColor', '$isMobile', '$isTablet'].includes(prop),
-}) <{ isActive?: boolean; accentColor: string; $isMobile?: boolean; $isTablet?: boolean }>`
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  padding: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return theme.spacing.xs;
-    if ($isTablet) return theme.spacing.sm;
-    return theme.spacing.sm;
-  }};
-  border-radius: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return theme.borderRadius.sm;
-    if ($isTablet) return theme.borderRadius.md;
-    return theme.borderRadius.md;
-  }};
-
-  svg {
-    width: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return '1.25rem';
-    if ($isTablet) return '1.375rem';
-    return '1.5rem';
-  }};
-    height: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return '1.25rem';
-    if ($isTablet) return '1.375rem';
-    return '1.5rem';
-  }};
-    fill: currentColor;
-  }
-
-  ${({ isActive, accentColor }: { isActive?: boolean; accentColor: string }) => isActive ? `
-    background: ${accentColor};
-    color: ${getContrastColor(accentColor)};
-
-    &:hover {
-      background: ${accentColor}DD;
-      color: ${getContrastColor(accentColor)};
-      transform: translateY(-1px);
-    }
-  ` : `
-    background: ${accentColor}33;
-    color: ${theme.colors.white};
-
-    &:hover {
-      background: ${accentColor}4D;
-      color: ${theme.colors.white};
-      transform: translateY(-1px);
-    }
-  `}
-`;
+import { ControlButton } from './controls/styled';
+import { ColorPickerIcon } from './icons/QuickActionIcons';
 
 interface ColorPickerPopoverProps {
   accentColor: string;
@@ -194,11 +139,7 @@ export const ColorPickerPopover = memo<ColorPickerPopoverProps>(({
         $isMobile={$isMobile}
         $isTablet={$isTablet}
       >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3Z" />
-          <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
-          <path d="M14.5 17.5 4.5 15" />
-        </svg>
+        <ColorPickerIcon />
       </ControlButton>
 
       {/* Popover menu rendered in portal */}
@@ -281,8 +222,7 @@ export const ColorPickerPopover = memo<ColorPickerPopoverProps>(({
               </button>
               {/* Always show eyedropper button if album art is available */}
               {currentTrack?.image && (
-                <ControlButton
-                  accentColor={accentColor}
+                <button
                   onClick={() => setShowEyedropper(true)}
                   title="Pick color from album art"
                   aria-label="Pick color from album art"
@@ -297,14 +237,12 @@ export const ColorPickerPopover = memo<ColorPickerPopoverProps>(({
                     justifyContent: 'center',
                     transition: 'box-shadow 0.2s, border 0.2s',
                     color: '#fff',
+                    background: 'transparent',
+                    padding: 0,
                   }}
                 >
-                  <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3Z" />
-                    <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
-                    <path d="M14.5 17.5 4.5 15" />
-                  </svg>
-                </ControlButton>
+                  <ColorPickerIcon />
+                </button>
               )}
             </div>
           )}

--- a/src/components/LeftQuickActionsPanel.tsx
+++ b/src/components/LeftQuickActionsPanel.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import { usePlayerSizing } from '@/hooks/usePlayerSizing';
 import { ControlButton } from './controls/styled';
+import { GlowIcon, BackgroundVisualizerIcon } from './icons/QuickActionIcons';
 
 interface LeftQuickActionsPanelProps {
   accentColor: string;
@@ -39,14 +39,14 @@ const PanelContainer = styled.div`
   backdrop-filter: blur(${theme.drawer.backdropBlur});
 `;
 
-export const LeftQuickActionsPanel: React.FC<LeftQuickActionsPanelProps> = ({
+export const LeftQuickActionsPanel = ({
   accentColor,
   glowEnabled,
   onGlowToggle,
   onBackgroundVisualizerToggle,
   backgroundVisualizerEnabled,
   isVisible = true
-}) => {
+}: LeftQuickActionsPanelProps) => {
   const { isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
 
   if (!isVisible) return null;
@@ -62,9 +62,7 @@ export const LeftQuickActionsPanel: React.FC<LeftQuickActionsPanelProps> = ({
           onClick={onGlowToggle}
           title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
         >
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M21 12H22M18.5 5.5L19.5 4.5M12 3V2M5.5 5.5L4.5 4.5M3 12H2M10 22H14M17 12C17 9.23858 14.7614 7 12 7C9.23858 7 7 9.23858 7 12C7 14.0503 8.2341 15.8124 10 16.584V19H14V16.584C15.7659 15.8124 17 14.0503 17 12Z" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
-          </svg>
+          <GlowIcon />
         </ControlButton>
 
         {onBackgroundVisualizerToggle && (
@@ -76,10 +74,7 @@ export const LeftQuickActionsPanel: React.FC<LeftQuickActionsPanelProps> = ({
             onClick={onBackgroundVisualizerToggle}
             title={`Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`}
           >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M13.4303 15.0014H4.40034C2.58034 15.0014 1.42034 13.0514 2.30034 11.4514L4.63034 7.21141L6.81034 3.24141C7.72034 1.59141 10.1003 1.59141 11.0103 3.24141L13.2003 7.21141L14.2503 9.12141L15.5303 11.4514C16.4103 13.0514 15.2503 15.0014 13.4303 15.0014Z" fill="currentColor" />
-              <path d="M22.6507 15.999C22.6507 19.589 19.7407 22.499 16.1507 22.499C13.1007 22.499 10.5507 20.409 9.84075 17.569C9.77075 17.269 10.0007 16.999 10.3107 16.999H14.0807C15.4707 16.999 16.7307 16.279 17.4407 15.089C18.1407 13.889 18.1707 12.449 17.4907 11.229L16.9907 10.309C16.8007 9.96898 17.0707 9.55898 17.4507 9.62898C20.4107 10.229 22.6507 12.849 22.6507 15.999Z" fill="currentColor" />
-            </svg>
+            <BackgroundVisualizerIcon />
           </ControlButton>
         )}
       </PanelContainer>

--- a/src/components/MobileQuickActionsDrawer.tsx
+++ b/src/components/MobileQuickActionsDrawer.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
-import { usePlayerSizing } from '@/hooks/usePlayerSizing';
 import { ControlButton } from './controls/styled';
 import ColorPickerPopover from './ColorPickerPopover';
 import { useCustomAccentColors } from '@/hooks/useCustomAccentColors';
 import type { Track } from '@/services/spotify';
+import {
+  GlowIcon,
+  BackgroundVisualizerIcon,
+  PlaylistIcon,
+  VisualEffectsIcon,
+  BackToLibraryIcon,
+  ChevronDownIcon,
+} from './icons/QuickActionIcons';
+import { DebugSection, DebugLabel } from './styled/DebugComponents';
 
 interface MobileQuickActionsDrawerProps {
   accentColor: string;
@@ -21,6 +28,8 @@ interface MobileQuickActionsDrawerProps {
   debugModeEnabled?: boolean;
   isExpanded: boolean;
   onToggleExpand: () => void;
+  transitionDuration: number;
+  transitionEasing: string;
 }
 
 /* Sub drawer: sits below the controls panel, slides out from underneath it */
@@ -81,33 +90,13 @@ const DrawerContent = styled.div<{ $isExpanded: boolean; $transitionDuration: nu
   border-width: ${({ $isExpanded }) => ($isExpanded ? '1px' : '0')};
   border-top-width: 0;
 
-  transition:
-    max-height ${({ $transitionDuration, $transitionEasing }) => `${$transitionDuration}ms ${$transitionEasing}`},
-    opacity ${({ $transitionDuration, $transitionEasing }) => `${$transitionDuration}ms ${$transitionEasing}`},
-    padding ${({ $transitionDuration, $transitionEasing }) => `${$transitionDuration}ms ${$transitionEasing}`},
-    border-width ${({ $transitionDuration, $transitionEasing }) => `${$transitionDuration}ms ${$transitionEasing}`};
+  transition: ${({ $transitionDuration, $transitionEasing }) => {
+    const timing = `${$transitionDuration}ms ${$transitionEasing}`;
+    return `max-height ${timing}, opacity ${timing}, padding ${timing}, border-width ${timing}`;
+  }};
 `;
 
-const DebugSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.spacing.xs};
-  padding: ${theme.spacing.xs};
-  margin-top: ${theme.spacing.xs};
-  border-top: 1px dashed rgba(255, 255, 255, 0.2);
-  width: 100%;
-`;
-
-const DebugLabel = styled.div`
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.6);
-  text-align: center;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-`;
-
-export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> = ({
+export const MobileQuickActionsDrawer = ({
   accentColor,
   currentTrack,
   glowEnabled,
@@ -121,8 +110,11 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
   debugModeEnabled = false,
   isExpanded,
   onToggleExpand,
-}) => {
-  const { isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
+  transitionDuration,
+  transitionEasing,
+}: MobileQuickActionsDrawerProps) => {
+  const isMobile = true;
+  const isTablet = false;
 
   const { customAccentColorOverrides, handleCustomAccentColor, handleAccentColorChange } = useCustomAccentColors({
     currentTrackId: currentTrack?.id,
@@ -137,9 +129,7 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
         title={isExpanded ? 'Collapse quick actions' : 'Expand quick actions'}
         aria-expanded={isExpanded}
       >
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M7 10l5 5 5-5H7z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
+        <ChevronDownIcon />
       </DrawerHandle>
 
       <DrawerContent
@@ -147,7 +137,6 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
         $transitionDuration={transitionDuration}
         $transitionEasing={transitionEasing}
       >
-        {/* Glow toggle - from LeftQuickActionsPanel */}
         <ControlButton
           $isMobile={isMobile}
           $isTablet={isTablet}
@@ -156,12 +145,9 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
           onClick={onGlowToggle}
           title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
         >
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M21 12H22M18.5 5.5L19.5 4.5M12 3V2M5.5 5.5L4.5 4.5M3 12H2M10 22H14M17 12C17 9.23858 14.7614 7 12 7C9.23858 7 7 9.23858 7 12C7 14.0503 8.2341 15.8124 10 16.584V19H14V16.584C15.7659 15.8124 17 14.0503 17 12Z" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
-          </svg>
+          <GlowIcon />
         </ControlButton>
 
-        {/* Background visualizer toggle - from LeftQuickActionsPanel */}
         {onBackgroundVisualizerToggle && (
           <ControlButton
             $isMobile={isMobile}
@@ -171,14 +157,10 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
             onClick={onBackgroundVisualizerToggle}
             title={`Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`}
           >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M13.4303 15.0014H4.40034C2.58034 15.0014 1.42034 13.0514 2.30034 11.4514L4.63034 7.21141L6.81034 3.24141C7.72034 1.59141 10.1003 1.59141 11.0103 3.24141L13.2003 7.21141L14.2503 9.12141L15.5303 11.4514C16.4103 13.0514 15.2503 15.0014 13.4303 15.0014Z" fill="currentColor" />
-              <path d="M22.6507 15.999C22.6507 19.589 19.7407 22.499 16.1507 22.499C13.1007 22.499 10.5507 20.409 9.84075 17.569C9.77075 17.269 10.0007 16.999 10.3107 16.999H14.0807C15.4707 16.999 16.7307 16.279 17.4407 15.089C18.1407 13.889 18.1707 12.449 17.4907 11.229L16.9907 10.309C16.8007 9.96898 17.0707 9.55898 17.4507 9.62898C20.4107 10.229 22.6507 12.849 22.6507 15.999Z" fill="currentColor" />
-            </svg>
+            <BackgroundVisualizerIcon />
           </ControlButton>
         )}
 
-        {/* Playlist - from QuickActionsPanel */}
         <ControlButton
           $isMobile={isMobile}
           $isTablet={isTablet}
@@ -186,30 +168,18 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
           onClick={onShowPlaylist}
           title="Show Playlist"
         >
-          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" fill="currentColor" />
-          </svg>
+          <PlaylistIcon />
         </ControlButton>
 
-        {/* Visual effects - from QuickActionsPanel */}
         <ControlButton
           $isMobile={isMobile}
           $isTablet={isTablet}
           accentColor={accentColor}
-          isActive={false}
           onClick={onShowVisualEffects}
           title="Visual effects"
           data-testid="quick-visual-effects-button"
         >
-          <svg viewBox="0 0 24 24" style={{ display: 'block' }} width="1.5rem" height="1.5rem" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              fill="currentColor"
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 00.12-.64l-2-3.46a.5.5 0 00-.6-.22l-2.49 1a7.03 7.03 0 00-1.7-.98l-.38-2.65A.488.488 0 0014 2h-4a.488.488 0 00-.5.42l-.38 2.65c-.63.25-1.21.57-1.77.98l-2.49-1a.5.5 0 00-.6.22l-2 3.46a.5.5 0 00.12.64l2.11 1.65c-.05.32-.08.65-.08.99s.03.67.08.99l-2.11 1.65a.5.5 0 00-.12.64l2 3.46c.14.24.44.33.7.22l2.49-1c.54.41 1.13.74 1.77.98l.38 2.65c.05.28.27.42.5.42h4c.23 0 .45-.14.5-.42l.38-2.65c.63-.25 1.22-.57 1.77-.98l2.49 1c.26.11.56.02.7-.22l2-3.46a.5.5 0 00-.12-.64l-2.11-1.65zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"
-            />
-            <circle cx="12" cy="12" r="2" fill="#fff" />
-          </svg>
+          <VisualEffectsIcon />
         </ControlButton>
 
         <ColorPickerPopover
@@ -230,12 +200,7 @@ export const MobileQuickActionsDrawer: React.FC<MobileQuickActionsDrawerProps> =
             onClick={onBackToLibrary}
             title="Back to Library"
           >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="14" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-            </svg>
+            <BackToLibraryIcon />
           </ControlButton>
         )}
 

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -106,56 +106,9 @@ const ContentWrapper = styled.div.withConfig({
             padding ${props => props.transitionDuration}ms ${props => props.transitionEasing},
             max-width ${props => props.transitionDuration}ms ${props => props.transitionEasing},
             max-height ${props => props.transitionDuration}ms ${props => props.transitionEasing};
-  
-  /* Enable container queries */
+
   container-type: inline-size;
   container-name: player;
-  
-  /* Container query responsive adjustments */
-  @container player (max-width: ${theme.breakpoints.sm}) {
-    width: 100%;
-    height: auto;
-    max-width: 100vw;
-    max-height: 100dvh;
-  }
-
-  @container player (min-width: ${theme.breakpoints.sm}) and (max-width: ${theme.breakpoints.md}) {
-    width: 100%;
-    height: auto;
-    max-width: 100vw;
-    max-height: 100dvh;
-  }
-
-  @container player (min-width: ${theme.breakpoints.md}) and (max-width: ${theme.breakpoints.lg}) {
-    width: 100%;
-    height: auto;
-    max-width: 100vw;
-    max-height: 100dvh;
-  }
-
-  /* Fallback for browsers without container query support */
-  @supports not (container-type: inline-size) {
-    @media (max-width: ${theme.breakpoints.sm}) {
-      width: 100%;
-      height: auto;
-      max-width: 100vw;
-      max-height: 100vh;
-    }
-
-    @media (min-width: ${theme.breakpoints.sm}) and (max-width: ${theme.breakpoints.md}) {
-      width: 100%;
-      height: auto;
-      max-width: 100vw;
-      max-height: 100vh;
-    }
-
-    @media (min-width: ${theme.breakpoints.md}) and (max-width: ${theme.breakpoints.lg}) {
-      width: 100%;
-      height: auto;
-      max-width: 100vw;
-      max-height: 100vh;
-    }
-  }
 `;
 
 const LoadingCard = styled.div.withConfig({
@@ -281,26 +234,18 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
     sepia: 0
   };
 
-  // Controls visibility state (default: hidden)
   const [controlsVisible, setControlsVisible] = useState(true);
-
-  // Mobile quick actions drawer state (slides out from bottom of controls)
   const [mobileDrawerExpanded, setMobileDrawerExpanded] = useState(false);
-
-  // Help modal state
   const [showHelp, setShowHelp] = useState(false);
 
-  // Toggle controls visibility
   const toggleControls = useCallback(() => {
     setControlsVisible(prev => !prev);
   }, []);
 
-  // Toggle mobile quick actions drawer
   const toggleMobileDrawer = useCallback(() => {
     setMobileDrawerExpanded(prev => !prev);
   }, []);
 
-  // Toggle help modal
   const toggleHelp = useCallback(() => {
     setShowHelp(prev => !prev);
   }, []);
@@ -371,7 +316,6 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
           paddingTop: isMobile ? '0.25rem' : '1rem'
         }}>
           <ClickableAlbumArtContainer onClick={toggleControls}>
-            {/* Left-side quick actions panel - desktop/tablet only; on mobile, consolidated into bottom drawer */}
             {!isMobile && (
               <LeftQuickActionsPanel
                 accentColor={ui.accentColor}
@@ -392,18 +336,13 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
               albumFilters={effects.enabled ? effects.filters : defaultFilters}
             />
 
-            {/* Right-side quick actions panel - desktop/tablet only; on mobile, consolidated into bottom drawer */}
             {!isMobile && (
               <QuickActionsPanel
                 accentColor={ui.accentColor}
                 currentTrack={track.current}
-                glowEnabled={effects.enabled}
                 onShowPlaylist={handlers.onShowPlaylist}
                 onShowVisualEffects={handlers.onShowVisualEffects}
-                onGlowToggle={handlers.onGlowToggle}
                 onAccentColorChange={handlers.onAccentColorChange}
-                onBackgroundVisualizerToggle={handlers.onBackgroundVisualizerToggle}
-                backgroundVisualizerEnabled={handlers.backgroundVisualizerEnabled}
                 onBackToLibrary={handlers.onBackToLibrary}
                 debugModeEnabled={handlers.debugModeEnabled}
                 isVisible={controlsVisible}
@@ -456,7 +395,6 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
             </CardContent>
           </AnimatedControlsContainer>
 
-          {/* Mobile: sub drawer slides out from underneath the controls panel (sibling, not embedded) */}
           {isMobile && controlsVisible && (
             <MobileQuickActionsDrawer
               accentColor={ui.accentColor}
@@ -472,6 +410,8 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
               debugModeEnabled={handlers.debugModeEnabled}
               isExpanded={mobileDrawerExpanded}
               onToggleExpand={toggleMobileDrawer}
+              transitionDuration={transitionDuration}
+              transitionEasing={transitionEasing}
             />
           )}
         </LoadingCard>

--- a/src/components/QuickActionsPanel.tsx
+++ b/src/components/QuickActionsPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import { usePlayerSizing } from '@/hooks/usePlayerSizing';
@@ -6,19 +5,17 @@ import { ControlButton } from './controls/styled';
 import ColorPickerPopover from './ColorPickerPopover';
 import { useCustomAccentColors } from '@/hooks/useCustomAccentColors';
 import type { Track } from '@/services/spotify';
+import { BackToLibraryIcon, PlaylistIcon, VisualEffectsIcon } from './icons/QuickActionIcons';
+import { DebugSection, DebugLabel } from './styled/DebugComponents';
 
 interface QuickActionsPanelProps {
   accentColor: string;
   currentTrack: Track | null;
-  glowEnabled: boolean; // Keep for debug mode display
   onShowPlaylist: () => void;
   onShowVisualEffects: () => void;
-  onGlowToggle: () => void; // Keep for debug mode
   onAccentColorChange: (color: string) => void;
-  onBackgroundVisualizerToggle?: () => void; // Background visualizer toggle handler (kept for debug mode)
-  backgroundVisualizerEnabled?: boolean; // Background visualizer enabled state (kept for debug mode)
-  debugModeEnabled?: boolean; // Debug mode toggle
-  onBackToLibrary?: () => void; // Back to library navigation handler
+  debugModeEnabled?: boolean;
+  onBackToLibrary?: () => void;
   isVisible?: boolean;
 }
 
@@ -48,37 +45,16 @@ const PanelContainer = styled.div`
   backdrop-filter: blur(${theme.drawer.backdropBlur});
 `;
 
-const DebugSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.spacing.xs};
-  padding: ${theme.spacing.xs};
-  margin-top: ${theme.spacing.xs};
-  border-top: 1px dashed rgba(255, 255, 255, 0.2);
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
-`;
-
-const DebugLabel = styled.div`
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.6);
-  text-align: center;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-`;
-
-
-export const QuickActionsPanel: React.FC<QuickActionsPanelProps> = ({
+export const QuickActionsPanel = ({
   accentColor,
   currentTrack,
-  // glowEnabled, onGlowToggle, onBackgroundVisualizerToggle, backgroundVisualizerEnabled kept for API compatibility
   onShowPlaylist,
   onShowVisualEffects,
   onAccentColorChange,
   onBackToLibrary,
   debugModeEnabled = false,
   isVisible = true
-}) => {
+}: QuickActionsPanelProps) => {
   const { isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
 
   const { customAccentColorOverrides, handleCustomAccentColor, handleAccentColorChange } = useCustomAccentColors({
@@ -99,12 +75,7 @@ export const QuickActionsPanel: React.FC<QuickActionsPanelProps> = ({
             onClick={onBackToLibrary}
             title="Back to Library"
           >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-              <rect x="14" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
-            </svg>
+            <BackToLibraryIcon />
           </ControlButton>
         )}
 
@@ -115,29 +86,18 @@ export const QuickActionsPanel: React.FC<QuickActionsPanelProps> = ({
           onClick={onShowPlaylist}
           title="Show Playlist"
         >
-          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" />
-          </svg>
+          <PlaylistIcon />
         </ControlButton>
 
         <ControlButton
           $isMobile={isMobile}
           $isTablet={isTablet}
           accentColor={accentColor}
-          isActive={false}
           onClick={onShowVisualEffects}
           title="Visual effects"
           data-testid="quick-visual-effects-button"
         >
-          <svg viewBox="0 0 24 24" style={{ display: 'block' }} width="1.5rem" height="1.5rem" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              fill="currentColor"
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 00.12-.64l-2-3.46a.5.5 0 00-.6-.22l-2.49 1a7.03 7.03 0 00-1.7-.98l-.38-2.65A.488.488 0 0014 2h-4a.488.488 0 00-.5.42l-.38 2.65c-.63.25-1.21.57-1.77.98l-2.49-1a.5.5 0 00-.6.22l-2 3.46a.5.5 0 00.12.64l2.11 1.65c-.05.32-.08.65-.08.99s.03.67.08.99l-2.11 1.65a.5.5 0 00-.12.64l2 3.46c.14.24.44.33.7.22l2.49-1c.54.41 1.13.74 1.77.98l.38 2.65c.05.28.27.42.5.42h4c.23 0 .45-.14.5-.42l.38-2.65c.63-.25 1.22-.57 1.77-.98l2.49 1c.26.11.56.02.7-.22l2-3.46a.5.5 0 00-.12-.64l-2.11-1.65zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"
-            />
-            <circle cx="12" cy="12" r="2" fill="#fff" />
-          </svg>
+          <VisualEffectsIcon />
         </ControlButton>
 
         <ColorPickerPopover
@@ -150,11 +110,9 @@ export const QuickActionsPanel: React.FC<QuickActionsPanelProps> = ({
           $isTablet={isTablet}
         />
 
-        {/* Debug controls - only shown when debug mode is enabled (press 'D' to toggle) */}
         {debugModeEnabled && (
-          <DebugSection>
+          <DebugSection $withBorderBottom>
             <DebugLabel>Debug Mode</DebugLabel>
-            {/* Future debug tools can go here */}
           </DebugSection>
         )}
       </PanelContainer>

--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -1,0 +1,85 @@
+export const GlowIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M21 12H22M18.5 5.5L19.5 4.5M12 3V2M5.5 5.5L4.5 4.5M3 12H2M10 22H14M17 12C17 9.23858 14.7614 7 12 7C9.23858 7 7 9.23858 7 12C7 14.0503 8.2341 15.8124 10 16.584V19H14V16.584C15.7659 15.8124 17 14.0503 17 12Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+export const BackgroundVisualizerIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M13.4303 15.0014H4.40034C2.58034 15.0014 1.42034 13.0514 2.30034 11.4514L4.63034 7.21141L6.81034 3.24141C7.72034 1.59141 10.1003 1.59141 11.0103 3.24141L13.2003 7.21141L14.2503 9.12141L15.5303 11.4514C16.4103 13.0514 15.2503 15.0014 13.4303 15.0014Z"
+      fill="currentColor"
+    />
+    <path
+      d="M22.6507 15.999C22.6507 19.589 19.7407 22.499 16.1507 22.499C13.1007 22.499 10.5507 20.409 9.84075 17.569C9.77075 17.269 10.0007 16.999 10.3107 16.999H14.0807C15.4707 16.999 16.7307 16.279 17.4407 15.089C18.1407 13.889 18.1707 12.449 17.4907 11.229L16.9907 10.309C16.8007 9.96898 17.0707 9.55898 17.4507 9.62898C20.4107 10.229 22.6507 12.849 22.6507 15.999Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export const PlaylistIcon = () => (
+  <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+    <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" fill="currentColor" />
+  </svg>
+);
+
+export const VisualEffectsIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    style={{ display: 'block' }}
+    width="1.5rem"
+    height="1.5rem"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 00.12-.64l-2-3.46a.5.5 0 00-.6-.22l-2.49 1a7.03 7.03 0 00-1.7-.98l-.38-2.65A.488.488 0 0014 2h-4a.488.488 0 00-.5.42l-.38 2.65c-.63.25-1.21.57-1.77.98l-2.49-1a.5.5 0 00-.6.22l-2 3.46a.5.5 0 00.12.64l2.11 1.65c-.05.32-.08.65-.08.99s.03.67.08.99l-2.11 1.65a.5.5 0 00-.12.64l2 3.46c.14.24.44.33.7.22l2.49-1c.54.41 1.13.74 1.77.98l.38 2.65c.05.28.27.42.5.42h4c.23 0 .45-.14.5-.42l.38-2.65c.63-.25 1.22-.57 1.77-.98l2.49 1c.26.11.56.02.7-.22l2-3.46a.5.5 0 00-.12-.64l-2.11-1.65zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"
+    />
+    <circle cx="12" cy="12" r="2" fill="#fff" />
+  </svg>
+);
+
+export const BackToLibraryIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
+    <rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
+    <rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
+    <rect x="14" y="14" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+export const ChevronDownIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M7 10l5 5 5-5H7z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ColorPickerIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3Z" />
+    <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
+    <path d="M14.5 17.5 4.5 15" />
+  </svg>
+);

--- a/src/components/styled/DebugComponents.tsx
+++ b/src/components/styled/DebugComponents.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const DebugSection = styled.div<{ $withBorderBottom?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xs};
+  padding: ${theme.spacing.xs};
+  margin-top: ${theme.spacing.xs};
+  border-top: 1px dashed rgba(255, 255, 255, 0.2);
+  ${({ $withBorderBottom }) => $withBorderBottom && 'border-bottom: 1px dashed rgba(255, 255, 255, 0.2);'}
+  width: ${({ $withBorderBottom }) => $withBorderBottom ? 'auto' : '100%'};
+`;
+
+export const DebugLabel = styled.div`
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;


### PR DESCRIPTION
Extract SVG icons and debug components into shared modules to eliminate duplication across MobileQuickActionsDrawer, QuickActionsPanel, and LeftQuickActionsPanel.

Key improvements:
- Created QuickActionIcons.tsx with 7 shared icon components
- Created DebugComponents.tsx for shared debug UI elements
- Removed duplicate ControlButton from ColorPickerPopover
- Simplified transition property interpolations in DrawerContent
- Removed redundant usePlayerSizing call from mobile-only drawer
- Cleaned up unnecessary comments and React imports
- Fixed isActive prop handling on visual effects buttons

This reduces codebase by ~200 lines while improving maintainability and ensuring icon/style consistency across components.