### PR TITLE
fix: center player vertically at all times

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ App.tsx (OAuth authentication, AppContainer with flex centering)
         ├── PlaylistSelection (search, sort, filter, lazy-loaded images)
         └── PlayerContent (main playing interface)
             └── ContentWrapper (position: relative, overflow: visible, container queries)
-                └── PlayerContainer (translateY(-4rem) when controls visible)
+                └── PlayerContainer (flex column, always centered)
                     ├── CardContent (album art zone)
                     │   ├── LeftQuickActionsPanel (absolute, right: 100%)
                     │   │   ├── Glow Toggle
@@ -226,7 +226,7 @@ AppContainer (flexCenter, min-height: 100dvh)
 **Important layout callouts:**
 - **`ContentWrapper` must use `position: relative`** (not absolute) so parent flex containers can center it
 - **`overflow: visible` is required on ContentWrapper** because `container-type: inline-size` establishes containment that would clip the absolutely-positioned side panels
-- **`translateY(-4rem)`** on PlayerContainer is an intentional design pattern that shifts the expanded view upward to create breathing room for the controls panel below
+- **Vertical centering** relies on the flex chain from root to ContentWrapper — the player (album art + controls) is always centered as a unit
 - **`100dvh`** (dynamic viewport height) is used throughout to account for iOS/mobile browser address bar changes
 - **Side panels** (LeftQuickActionsPanel, QuickActionsPanel) use `position: absolute` with `right: 100%` / `left: 100%` to extend outside the album art container
 - **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index values and do not affect layout flow


### PR DESCRIPTION
## Summary
- Removed the `translateY(-4rem)` hack from `PlayerContainer` — the player is now always vertically centered via the existing flex chain
- Removed `aspect-ratio` and `max-height` constraints from `ContentWrapper` so its box grows when controls expand, allowing the flex parent to recenter the whole unit
- Replaced `max-height` controls animation with `grid-template-rows: 0fr/1fr` at 150ms for smooth, GPU-friendly expand/collapse
- Moved `AnimatedControlsContainer` to wrap `LoadingCard` so the entire panel (including background/shadow) collapses in compact mode
- Net -33 lines (46 added, 79 removed)

## Test plan
- [ ] Verify player is vertically centered on desktop with controls visible
- [ ] Verify player stays centered when toggling controls on/off
- [ ] Verify compact mode fully hides the controls panel (no empty bar)
- [ ] Verify expand/collapse animation is smooth on mobile
- [ ] Verify side panels (quick actions) are not clipped
- [ ] Run `npm run test:run` — all 108 tests pass
- [ ] Run `npx tsc -b` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)