### PR TITLE
feat: store accent color overrides per album instead of per track

### DIFF
--- a/src/components/ColorPickerPopover.tsx
+++ b/src/components/ColorPickerPopover.tsx
@@ -23,8 +23,8 @@ const areColorPickerPropsEqual = (
   prevProps: ColorPickerPopoverProps,
   nextProps: ColorPickerPopoverProps
 ): boolean => {
-  // Check if track changed (most important check)
-  if (prevProps.currentTrack?.id !== nextProps.currentTrack?.id) {
+  // Check if album changed (accent colors are per-album)
+  if (prevProps.currentTrack?.album_id !== nextProps.currentTrack?.album_id) {
     return false;
   }
 
@@ -42,11 +42,11 @@ const areColorPickerPropsEqual = (
     return false;
   }
 
-  // Check if custom overrides for current track changed
-  const currentTrackId = prevProps.currentTrack?.id;
-  if (currentTrackId) {
-    if (prevProps.customAccentColorOverrides[currentTrackId] !==
-      nextProps.customAccentColorOverrides[currentTrackId]) {
+  // Check if custom overrides for current album changed
+  const currentAlbumId = prevProps.currentTrack?.album_id;
+  if (currentAlbumId) {
+    if (prevProps.customAccentColorOverrides[currentAlbumId] !==
+      nextProps.customAccentColorOverrides[currentAlbumId]) {
       return false;
     }
   }
@@ -73,9 +73,8 @@ export const ColorPickerPopover = memo<ColorPickerPopoverProps>(({
   const paletteBtnRef = useRef<HTMLButtonElement>(null);
   const [popoverPos, setPopoverPos] = useState<{ left: number; top: number } | null>(null);
 
-  // Get the last chosen custom color for the current track
   const getLastCustomColor = () => {
-    return currentTrack?.id ? customAccentColorOverrides[currentTrack.id] : null;
+    return currentTrack?.album_id ? customAccentColorOverrides[currentTrack.album_id] : null;
   };
 
   // Extract colors when popover opens or track changes
@@ -249,15 +248,8 @@ export const ColorPickerPopover = memo<ColorPickerPopoverProps>(({
           {/* Reset button */}
           <button
             onClick={() => {
-              if (currentTrack?.id) {
-                // Remove custom color override for this track
-                const newOverrides = { ...customAccentColorOverrides };
-                delete newOverrides[currentTrack.id];
-                onCustomAccentColor(''); // This will trigger a re-extraction
-
-                // We need to call the parent's reset function to force color re-extraction
-                // Since we don't have direct access to it, we'll use a placeholder color
-                // and let the parent component handle the reset
+              if (currentTrack?.album_id) {
+                onCustomAccentColor('');
                 onAccentColorChange?.('RESET_TO_DEFAULT');
               }
               setShowColorPopover(false);

--- a/src/components/MobileQuickActionsDrawer.tsx
+++ b/src/components/MobileQuickActionsDrawer.tsx
@@ -117,7 +117,7 @@ export const MobileQuickActionsDrawer = ({
   const isTablet = false;
 
   const { customAccentColorOverrides, handleCustomAccentColor, handleAccentColorChange } = useCustomAccentColors({
-    currentTrackId: currentTrack?.id,
+    currentAlbumId: currentTrack?.album_id,
     onAccentColorChange,
   });
 

--- a/src/components/QuickActionsPanel.tsx
+++ b/src/components/QuickActionsPanel.tsx
@@ -58,7 +58,7 @@ export const QuickActionsPanel = ({
   const { isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
 
   const { customAccentColorOverrides, handleCustomAccentColor, handleAccentColorChange } = useCustomAccentColors({
-    currentTrackId: currentTrack?.id,
+    currentAlbumId: currentTrack?.album_id,
     onAccentColorChange
   });
 

--- a/src/hooks/__tests__/useCustomAccentColors.test.ts
+++ b/src/hooks/__tests__/useCustomAccentColors.test.ts
@@ -2,13 +2,11 @@ import { renderHook, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useCustomAccentColors } from '../useCustomAccentColors';
 
-// Mock usePlayerState hook
 const mockUsePlayerState = vi.fn();
 vi.mock('../usePlayerState', () => ({
   usePlayerState: () => mockUsePlayerState()
 }));
 
-// Mock the theme module
 vi.mock('../../styles/theme', () => ({
   theme: {
     colors: {
@@ -17,10 +15,10 @@ vi.mock('../../styles/theme', () => ({
   }
 }));
 
-describe('useCustomAccentColors - Refactored Adapter Hook', () => {
+describe('useCustomAccentColors', () => {
   const mockAccentColorOverrides = {
-    'track-1': '#ff0000',
-    'track-2': '#00ff00'
+    'album-1': '#ff0000',
+    'album-2': '#00ff00'
   };
 
   const mockHandleSetAccentColorOverride = vi.fn();
@@ -29,8 +27,7 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    
-    // Setup default mock return values
+
     mockUsePlayerState.mockReturnValue({
       color: {
         overrides: mockAccentColorOverrides
@@ -52,98 +49,98 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
   describe('Hook Initialization', () => {
     it('should import and use usePlayerState hook', () => {
       renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(mockUsePlayerState).toHaveBeenCalled();
     });
 
     it('should return accent color overrides from usePlayerState', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(result.current.customAccentColorOverrides).toEqual(mockAccentColorOverrides);
     });
 
     it('should provide handleCustomAccentColor function', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(typeof result.current.handleCustomAccentColor).toBe('function');
     });
 
     it('should provide handleAccentColorChange function', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(typeof result.current.handleAccentColorChange).toBe('function');
     });
   });
 
   describe('handleCustomAccentColor', () => {
-    it('should delegate to usePlayerState when currentTrackId is provided', () => {
+    it('should delegate to usePlayerState when currentAlbumId is provided', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleCustomAccentColor('#ff0000');
       });
-      
-      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('track-1', '#ff0000');
+
+      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('album-1', '#ff0000');
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('#ff0000');
     });
 
     it('should handle empty string by removing override', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleCustomAccentColor('');
       });
-      
-      expect(mockHandleRemoveAccentColorOverride).toHaveBeenCalledWith('track-1');
+
+      expect(mockHandleRemoveAccentColorOverride).toHaveBeenCalledWith('album-1');
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('');
     });
 
-    it('should call onAccentColorChange even when no currentTrackId', () => {
+    it('should call onAccentColorChange even when no currentAlbumId', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: undefined,
+        currentAlbumId: undefined,
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleCustomAccentColor('#ff0000');
       });
-      
+
       expect(mockHandleSetAccentColorOverride).not.toHaveBeenCalled();
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('#ff0000');
     });
 
     it('should not call onAccentColorChange when it is not provided', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: undefined
       }));
-      
+
       act(() => {
         result.current.handleCustomAccentColor('#ff0000');
       });
-      
-      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('track-1', '#ff0000');
+
+      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('album-1', '#ff0000');
     });
   });
 
@@ -151,153 +148,114 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
     it('should handle RESET_TO_DEFAULT by calling reset method', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleAccentColorChange('RESET_TO_DEFAULT');
       });
-      
-      expect(mockHandleResetAccentColorOverride).toHaveBeenCalledWith('track-1');
+
+      expect(mockHandleResetAccentColorOverride).toHaveBeenCalledWith('album-1');
       expect(mockOnAccentColorChange).not.toHaveBeenCalled();
     });
 
     it('should handle regular color changes by setting override', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleAccentColorChange('#ff0000');
       });
-      
-      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('track-1', '#ff0000');
+
+      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('album-1', '#ff0000');
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('#ff0000');
     });
 
-    it('should call onAccentColorChange even when no currentTrackId', () => {
+    it('should call onAccentColorChange even when no currentAlbumId', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: undefined,
+        currentAlbumId: undefined,
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleAccentColorChange('#ff0000');
       });
-      
+
       expect(mockHandleSetAccentColorOverride).not.toHaveBeenCalled();
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('#ff0000');
     });
 
-    it('should handle RESET_TO_DEFAULT without currentTrackId', () => {
+    it('should handle RESET_TO_DEFAULT without currentAlbumId', () => {
       const mockOnAccentColorChange = vi.fn();
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: undefined,
+        currentAlbumId: undefined,
         onAccentColorChange: mockOnAccentColorChange
       }));
-      
+
       act(() => {
         result.current.handleAccentColorChange('RESET_TO_DEFAULT');
       });
-      
+
       expect(mockHandleResetAccentColorOverride).not.toHaveBeenCalled();
-      // onAccentColorChange should be called even for RESET_TO_DEFAULT without currentTrackId
       expect(mockOnAccentColorChange).toHaveBeenCalledWith('RESET_TO_DEFAULT');
     });
   });
 
   describe('API Compatibility', () => {
-    it('should maintain same API interface as before refactoring', () => {
+    it('should maintain expected API interface', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
-      // Verify all expected properties exist
+
       expect(result.current).toHaveProperty('customAccentColorOverrides');
       expect(result.current).toHaveProperty('handleCustomAccentColor');
       expect(result.current).toHaveProperty('handleAccentColorChange');
-      
-      // Verify types
+
       expect(typeof result.current.customAccentColorOverrides).toBe('object');
       expect(typeof result.current.handleCustomAccentColor).toBe('function');
       expect(typeof result.current.handleAccentColorChange).toBe('function');
     });
 
-    it('should return accentColorOverrides as customAccentColorOverrides for compatibility', () => {
+    it('should return accentColorOverrides as customAccentColorOverrides', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(result.current.customAccentColorOverrides).toBe(mockAccentColorOverrides);
     });
   });
 
-  describe('Performance and Optimization', () => {
-    it('should use useCallback for returned functions', () => {
-      const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
-        onAccentColorChange: vi.fn()
-      }));
-      
-      const firstRender = result.current.handleCustomAccentColor;
-      
-      // Trigger a re-render by changing props
-      const { result: result2 } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-2',
-        onAccentColorChange: vi.fn()
-      }));
-      
-      const secondRender = result2.current.handleCustomAccentColor;
-      
-      // Functions should be memoized (same reference for same dependencies)
-      expect(typeof firstRender).toBe('function');
-      expect(typeof secondRender).toBe('function');
-    });
-  });
-
   describe('Edge Cases', () => {
-    it('should handle undefined currentTrackId', () => {
+    it('should handle undefined currentAlbumId', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: undefined,
+        currentAlbumId: undefined,
         onAccentColorChange: vi.fn()
       }));
-      
+
       act(() => {
         result.current.handleCustomAccentColor('#ff0000');
       });
-      
+
       expect(mockHandleSetAccentColorOverride).not.toHaveBeenCalled();
     });
 
-    it('should handle null currentTrackId', () => {
+    it('should handle empty string currentAlbumId', () => {
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: null as unknown as string,
+        currentAlbumId: '',
         onAccentColorChange: vi.fn()
       }));
-      
-      act(() => {
-        result.current.handleCustomAccentColor('#ff0000');
-      });
-      
-      expect(mockHandleSetAccentColorOverride).not.toHaveBeenCalled();
-    });
 
-    it('should handle empty string currentTrackId', () => {
-      const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: '',
-        onAccentColorChange: vi.fn()
-      }));
-      
       act(() => {
         result.current.handleCustomAccentColor('#ff0000');
       });
-      
+
       expect(mockHandleSetAccentColorOverride).not.toHaveBeenCalled();
     });
   });
@@ -305,11 +263,11 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
   describe('Integration with usePlayerState', () => {
     it('should pass through all accent color overrides from usePlayerState', () => {
       const customOverrides = {
-        'track-1': '#ff0000',
-        'track-2': '#00ff00',
-        'track-3': '#0000ff'
+        'album-1': '#ff0000',
+        'album-2': '#00ff00',
+        'album-3': '#0000ff'
       };
-      
+
       mockUsePlayerState.mockReturnValue({
         color: {
           overrides: customOverrides
@@ -322,12 +280,12 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
           }
         }
       });
-      
+
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(result.current.customAccentColorOverrides).toEqual(customOverrides);
     });
 
@@ -344,12 +302,12 @@ describe('useCustomAccentColors - Refactored Adapter Hook', () => {
           }
         }
       });
-      
+
       const { result } = renderHook(() => useCustomAccentColors({
-        currentTrackId: 'track-1',
+        currentAlbumId: 'album-1',
         onAccentColorChange: vi.fn()
       }));
-      
+
       expect(result.current.customAccentColorOverrides).toEqual({});
     });
   });

--- a/src/hooks/__tests__/usePlayerState.test.ts
+++ b/src/hooks/__tests__/usePlayerState.test.ts
@@ -46,19 +46,19 @@ describe('usePlayerState - Accent Color Management', () => {
 
     it('should load accent color overrides from localStorage on mount', () => {
       const mockOverrides = {
-        'track-1': '#ff0000',
-        'track-2': '#00ff00'
+        'album-1': '#ff0000',
+        'album-2': '#00ff00'
       };
-      store['accentColorOverrides'] = JSON.stringify(mockOverrides);
-      
+      store['vorbis-player-accent-color-overrides'] = JSON.stringify(mockOverrides);
+
       const { result } = renderHook(() => usePlayerState());
-      
+
       expect(result.current.color.overrides).toEqual(mockOverrides);
-      expect(localStorage.getItem).toHaveBeenCalledWith('accentColorOverrides');
+      expect(localStorage.getItem).toHaveBeenCalledWith('vorbis-player-accent-color-overrides');
     });
 
     it('should handle invalid JSON in localStorage gracefully', () => {
-      store['accentColorOverrides'] = 'invalid-json';
+      store['vorbis-player-accent-color-overrides'] = 'invalid-json';
       
       const { result } = renderHook(() => usePlayerState());
       
@@ -67,151 +67,144 @@ describe('usePlayerState - Accent Color Management', () => {
 
     it('should save accent color overrides to localStorage when state changes', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       expect(localStorage.setItem).toHaveBeenCalledWith(
-        'accentColorOverrides',
-        JSON.stringify({ 'track-1': '#ff0000' })
+        'vorbis-player-accent-color-overrides',
+        JSON.stringify({ 'album-1': '#ff0000' })
       );
     });
   });
 
   describe('Accent Color Helper Methods', () => {
-    it('should set accent color override for a track', () => {
+    it('should set accent color override for an album', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       expect(result.current.color.overrides).toEqual({
-        'track-1': '#ff0000'
+        'album-1': '#ff0000'
       });
     });
 
-    it('should update existing accent color override for a track', () => {
+    it('should update existing accent color override for an album', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#00ff00');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#00ff00');
       });
-      
+
       expect(result.current.color.overrides).toEqual({
-        'track-1': '#00ff00'
+        'album-1': '#00ff00'
       });
     });
 
-    it('should remove accent color override for a track', () => {
+    it('should remove accent color override for an album', () => {
       const { result } = renderHook(() => usePlayerState());
-      
-      // Set multiple overrides
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-2', '#00ff00');
+        result.current.actions.color.handleSetAccentColorOverride('album-2', '#00ff00');
       });
-      
-      // Verify both are set
-      expect(result.current.color.overrides).toHaveProperty('track-1');
-      expect(result.current.color.overrides).toHaveProperty('track-2');
-      
-      // Remove one
+
+      expect(result.current.color.overrides).toHaveProperty('album-1');
+      expect(result.current.color.overrides).toHaveProperty('album-2');
+
       act(() => {
-        result.current.actions.color.handleRemoveAccentColorOverride('track-1');
+        result.current.actions.color.handleRemoveAccentColorOverride('album-1');
       });
-      
-      // Verify track-1 is removed and track-2 remains
-      expect(result.current.color.overrides).not.toHaveProperty('track-1');
-      expect(result.current.color.overrides).toHaveProperty('track-2');
-      expect(result.current.color.overrides['track-2']).toBe('#00ff00');
+
+      expect(result.current.color.overrides).not.toHaveProperty('album-1');
+      expect(result.current.color.overrides).toHaveProperty('album-2');
+      expect(result.current.color.overrides['album-2']).toBe('#00ff00');
     });
 
     it('should handle removing non-existent override gracefully', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleRemoveAccentColorOverride('non-existent-track');
+        result.current.actions.color.handleRemoveAccentColorOverride('non-existent-album');
       });
-      
+
       expect(result.current.color.overrides).toEqual({});
     });
 
-    it('should reset accent color override for a track', () => {
+    it('should reset accent color override for an album', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-2', '#00ff00');
+        result.current.actions.color.handleSetAccentColorOverride('album-2', '#00ff00');
       });
-      
-      // Verify both are set
-      expect(result.current.color.overrides).toHaveProperty('track-1');
-      expect(result.current.color.overrides).toHaveProperty('track-2');
-      
+
+      expect(result.current.color.overrides).toHaveProperty('album-1');
+      expect(result.current.color.overrides).toHaveProperty('album-2');
+
       act(() => {
-        result.current.actions.color.handleResetAccentColorOverride('track-1');
+        result.current.actions.color.handleResetAccentColorOverride('album-1');
       });
-      
-      // Verify track-1 is removed and track-2 remains
-      expect(result.current.color.overrides).not.toHaveProperty('track-1');
-      expect(result.current.color.overrides).toHaveProperty('track-2');
-      expect(result.current.color.overrides['track-2']).toBe('#00ff00');
+
+      expect(result.current.color.overrides).not.toHaveProperty('album-1');
+      expect(result.current.color.overrides).toHaveProperty('album-2');
+      expect(result.current.color.overrides['album-2']).toBe('#00ff00');
     });
 
-    it('should maintain multiple track overrides independently', () => {
+    it('should maintain multiple album overrides independently', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-2', '#00ff00');
+        result.current.actions.color.handleSetAccentColorOverride('album-2', '#00ff00');
       });
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-3', '#0000ff');
+        result.current.actions.color.handleSetAccentColorOverride('album-3', '#0000ff');
       });
-      
-      // Verify all three tracks have their overrides set correctly
-      expect(result.current.color.overrides['track-1']).toBe('#ff0000');
-      expect(result.current.color.overrides['track-2']).toBe('#00ff00');
-      expect(result.current.color.overrides['track-3']).toBe('#0000ff');
+
+      expect(result.current.color.overrides['album-1']).toBe('#ff0000');
+      expect(result.current.color.overrides['album-2']).toBe('#00ff00');
+      expect(result.current.color.overrides['album-3']).toBe('#0000ff');
     });
   });
 
   describe('localStorage Integration', () => {
     it('should persist overrides across multiple state changes', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
-      
+
       expect(localStorage.setItem).toHaveBeenCalledWith(
-        'accentColorOverrides',
-        JSON.stringify({ 'track-1': '#ff0000' })
+        'vorbis-player-accent-color-overrides',
+        JSON.stringify({ 'album-1': '#ff0000' })
       );
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-2', '#00ff00');
+        result.current.actions.color.handleSetAccentColorOverride('album-2', '#00ff00');
       });
-      
+
       expect(localStorage.setItem).toHaveBeenCalledWith(
-        'accentColorOverrides',
-        JSON.stringify({ 'track-1': '#ff0000', 'track-2': '#00ff00' })
+        'vorbis-player-accent-color-overrides',
+        JSON.stringify({ 'album-1': '#ff0000', 'album-2': '#00ff00' })
       );
     });
   });
@@ -219,12 +212,11 @@ describe('usePlayerState - Accent Color Management', () => {
   describe('Performance and Optimization', () => {
     it('should use useCallback for helper methods', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       const firstRender = result.current.actions.color.handleSetAccentColorOverride;
-      
-      // Trigger a re-render
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '#ff0000');
       });
       
       const secondRender = result.current.actions.color.handleSetAccentColorOverride;
@@ -237,25 +229,25 @@ describe('usePlayerState - Accent Color Management', () => {
   describe('Edge Cases', () => {
     it('should handle empty string color values', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-1', '');
+        result.current.actions.color.handleSetAccentColorOverride('album-1', '');
       });
-      
+
       expect(result.current.color.overrides).toEqual({
-        'track-1': ''
+        'album-1': ''
       });
     });
 
-    it('should handle special characters in track IDs', () => {
+    it('should handle special characters in album IDs', () => {
       const { result } = renderHook(() => usePlayerState());
-      
+
       act(() => {
-        result.current.actions.color.handleSetAccentColorOverride('track-with-special-chars-!@#$%', '#ff0000');
+        result.current.actions.color.handleSetAccentColorOverride('album-with-special-chars-!@#$%', '#ff0000');
       });
-      
+
       expect(result.current.color.overrides).toEqual({
-        'track-with-special-chars-!@#$%': '#ff0000'
+        'album-with-special-chars-!@#$%': '#ff0000'
       });
     });
   });

--- a/src/hooks/useAccentColor.ts
+++ b/src/hooks/useAccentColor.ts
@@ -113,9 +113,9 @@ export const useAccentColor = (
       return;
     }
 
-    // Check if we have a manual override for this track
-    if (currentTrack.id && accentColorOverrides[currentTrack.id]) {
-      setAccentColor(accentColorOverrides[currentTrack.id]);
+    // Check if we have a manual override for this album
+    if (currentTrack.album_id && accentColorOverrides[currentTrack.album_id]) {
+      setAccentColor(accentColorOverrides[currentTrack.album_id]);
       return;
     }
 
@@ -147,17 +147,17 @@ export const useAccentColor = (
    * @param color - The new accent color ('auto' for extraction, or hex color)
    */
   const handleAccentColorChange = useCallback((color: string) => {
+    const albumId = currentTrack?.album_id;
+
     if (color === 'auto') {
-      // Remove any override and re-extract from image
-      if (currentTrack?.id) {
+      if (albumId) {
         setAccentColorOverrides(prev => {
           const newOverrides = { ...prev };
-          delete newOverrides[currentTrack.id];
+          delete newOverrides[albumId];
           return newOverrides;
         });
       }
 
-      // Re-extract color from current track
       if (currentTrack?.image) {
         extractDominantColor(currentTrack.image)
           .then(dominantColor => {
@@ -176,14 +176,13 @@ export const useAccentColor = (
       return;
     }
 
-    // Set manual color override
-    if (currentTrack?.id) {
-      setAccentColorOverrides(prev => ({ ...prev, [currentTrack.id]: color }));
+    if (albumId) {
+      setAccentColorOverrides(prev => ({ ...prev, [albumId]: color }));
       setAccentColor(color);
     } else {
       setAccentColor(color);
     }
-  }, [currentTrack?.id, currentTrack?.image, setAccentColorOverrides, setAccentColor]);
+  }, [currentTrack?.album_id, currentTrack?.image, setAccentColorOverrides, setAccentColor]);
 
   /**
    * Reset to automatically extracted color

--- a/src/hooks/useCustomAccentColors.ts
+++ b/src/hooks/useCustomAccentColors.ts
@@ -2,15 +2,14 @@ import { useCallback } from 'react';
 import { usePlayerState } from './usePlayerState';
 
 interface UseCustomAccentColorsProps {
-  currentTrackId?: string;
+  currentAlbumId?: string;
   onAccentColorChange?: (color: string) => void;
 }
 
 export const useCustomAccentColors = ({
-  currentTrackId,
+  currentAlbumId,
   onAccentColorChange
 }: UseCustomAccentColorsProps) => {
-  // Get accent color state and helper methods from usePlayerState
   const {
     color: { overrides: accentColorOverrides },
     actions: {
@@ -22,37 +21,32 @@ export const useCustomAccentColors = ({
     }
   } = usePlayerState();
 
-  // When user picks a color with the eyedropper, store it as the custom color for this track
   const handleCustomAccentColor = useCallback((color: string) => {
-    if (currentTrackId) {
+    if (currentAlbumId) {
       if (color === '') {
-        // Empty string means reset - remove the override
-        handleRemoveAccentColorOverride(currentTrackId);
+        handleRemoveAccentColorOverride(currentAlbumId);
       } else {
-        handleSetAccentColorOverride(currentTrackId, color);
+        handleSetAccentColorOverride(currentAlbumId, color);
       }
       onAccentColorChange?.(color);
     } else {
       onAccentColorChange?.(color);
     }
-  }, [currentTrackId, onAccentColorChange, handleSetAccentColorOverride, handleRemoveAccentColorOverride]);
+  }, [currentAlbumId, onAccentColorChange, handleSetAccentColorOverride, handleRemoveAccentColorOverride]);
 
-  // Handle accent color changes, including reset
   const handleAccentColorChange = useCallback((color: string) => {
-    if (color === 'RESET_TO_DEFAULT' && currentTrackId) {
-      // Remove custom color override for this track
-      handleResetAccentColorOverride(currentTrackId);
-      // Don't call onAccentColorChange here - let the parent re-extract the color
+    if (color === 'RESET_TO_DEFAULT' && currentAlbumId) {
+      handleResetAccentColorOverride(currentAlbumId);
       return;
     }
 
-    if (currentTrackId) {
-      handleSetAccentColorOverride(currentTrackId, color);
+    if (currentAlbumId) {
+      handleSetAccentColorOverride(currentAlbumId, color);
       onAccentColorChange?.(color);
     } else {
       onAccentColorChange?.(color);
     }
-  }, [currentTrackId, onAccentColorChange, handleSetAccentColorOverride, handleResetAccentColorOverride]);
+  }, [currentAlbumId, onAccentColorChange, handleSetAccentColorOverride, handleResetAccentColorOverride]);
 
   return {
     customAccentColorOverrides: accentColorOverrides,

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -70,9 +70,9 @@ interface PlaylistActions {
 interface ColorActions {
   setCurrent: (color: string | ((prev: string) => string)) => void;
   setOverrides: (overrides: Record<string, string> | ((prev: Record<string, string>) => Record<string, string>)) => void;
-  handleSetAccentColorOverride: (trackId: string, color: string) => void;
-  handleRemoveAccentColorOverride: (trackId: string) => void;
-  handleResetAccentColorOverride: (trackId: string) => void;
+  handleSetAccentColorOverride: (albumId: string, color: string) => void;
+  handleRemoveAccentColorOverride: (albumId: string) => void;
+  handleResetAccentColorOverride: (albumId: string) => void;
 }
 
 interface VisualEffectsActions {
@@ -143,7 +143,7 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
   );
   
   const [accentColorOverrides, setAccentColorOverrides] = useLocalStorage<Record<string, string>>(
-    'accentColorOverrides',
+    'vorbis-player-accent-color-overrides',
     {}
   );
   
@@ -211,23 +211,23 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
     }
   }, [savedAlbumFilters, setAlbumFilters]);
 
-  const handleSetAccentColorOverride = useCallback((trackId: string, color: string) => {
+  const handleSetAccentColorOverride = useCallback((albumId: string, color: string) => {
     setAccentColorOverrides(prev => ({
       ...prev,
-      [trackId]: color
+      [albumId]: color
     }));
   }, [setAccentColorOverrides]);
 
-  const handleRemoveAccentColorOverride = useCallback((trackId: string) => {
+  const handleRemoveAccentColorOverride = useCallback((albumId: string) => {
     setAccentColorOverrides(prev => {
       const newOverrides = { ...prev };
-      delete newOverrides[trackId];
+      delete newOverrides[albumId];
       return newOverrides;
     });
   }, [setAccentColorOverrides]);
 
-  const handleResetAccentColorOverride = useCallback((trackId: string) => {
-    handleRemoveAccentColorOverride(trackId);
+  const handleResetAccentColorOverride = useCallback((albumId: string) => {
+    handleRemoveAccentColorOverride(albumId);
   }, [handleRemoveAccentColorOverride]);
 
   const trackState: TrackState = {


### PR DESCRIPTION
## Summary
- Custom accent color overrides are now stored per album ID instead of per track ID, since the accent color derives from album art shared across all tracks in an album
- Uses a new localStorage key (`vorbis-player-accent-color-overrides`) so existing per-track overrides are cleanly ignored
- If a track has no `album_id`, custom color storage is skipped gracefully

## Test plan
- [ ] Set a custom accent color on a track, then navigate to another track in the same album — color should persist
- [ ] Navigate to a track in a different album — should use auto-extracted or its own override
- [ ] Reset to default on any track — should clear the override for the entire album
- [ ] Verify the eyedropper color picker still works correctly
- [ ] Verify the color palette popover shows the correct "last custom color" for the album

🤖 Generated with [Claude Code](https://claude.com/claude-code)