### PR TITLE
feat: increase drawer vertical space to 80-90%

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -37,8 +37,8 @@ const DrawerContainer = styled.div.withConfig({
   top: 0;
   left: 0;
   right: 0;
-  height: 80vh;
-  max-height: 80vh;
+  height: 90vh;
+  max-height: 90vh;
   z-index: ${theme.zIndex.modal};
   display: flex;
   flex-direction: column;

--- a/src/components/PlaylistBottomSheet.tsx
+++ b/src/components/PlaylistBottomSheet.tsx
@@ -12,7 +12,7 @@ const TRANSITION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
 const DrawerOverlay = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== '$isOpen',
-})<{ $isOpen: boolean }>`
+}) <{ $isOpen: boolean }>`
   position: fixed;
   inset: 0;
   z-index: ${theme.zIndex.modal};
@@ -24,7 +24,7 @@ const DrawerOverlay = styled.div.withConfig({
 
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
-})<{
+}) <{
   $isOpen: boolean;
   $isDragging: boolean;
   $dragOffset: number;
@@ -33,8 +33,8 @@ const DrawerContainer = styled.div.withConfig({
   left: 0;
   right: 0;
   bottom: 0;
-  height: 50vh;
-  max-height: 50vh;
+  height: 80vh;
+  max-height: 80vh;
   z-index: ${theme.zIndex.modal};
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(${theme.drawer.backdropBlur});


### PR DESCRIPTION
## Changes
- **LibraryDrawer**: 80vh → 90vh
- **PlaylistBottomSheet**: 50vh → 80vh

Makes the playlist and album drawers use more vertical space for better usability.

Made with [Cursor](https://cursor.com)