### PR TITLE
fix: silence console error spam from touchmove, theme access, and unmount

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -211,6 +211,10 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
       ctx.putImageData(processedImageData, 0, 0);
       setCanvasUrl(canvas.toDataURL());
     } catch (error) {
+      // Ignore expected errors from component unmounting during processing
+      if (error instanceof Error && error.message === 'Component unmounted') {
+        return;
+      }
       console.error('Image processing failed:', error);
       setCanvasUrl(null);
     } finally {

--- a/src/components/PlaylistDrawer.tsx
+++ b/src/components/PlaylistDrawer.tsx
@@ -116,14 +116,14 @@ const CloseButton = styled.button`
 
 const PlaylistFallback = styled.div`
   width: 100%;
-  margin-top: ${({ theme }) => theme.spacing.lg};
+  margin-top: ${theme.spacing.lg};
 `;
 
 const PlaylistFallbackCard = styled.div`
-  background-color: ${({ theme }) => theme.colors.gray[800]};
+  background-color: ${theme.colors.gray[800]};
   border-radius: ${theme.borderRadius['2xl']};
-  padding: ${({ theme }) => theme.spacing.md};
-  border: 1px solid ${({ theme }) => theme.colors.gray[700]};
+  padding: ${theme.spacing.md};
+  border: 1px solid ${theme.colors.gray[700]};
 `;
 
 interface PlaylistDrawerProps {

--- a/src/hooks/useVerticalSwipeGesture.ts
+++ b/src/hooks/useVerticalSwipeGesture.ts
@@ -91,7 +91,9 @@ export function useVerticalSwipeGesture(
         setIsDragging(true);
       }
 
-      e.preventDefault();
+      if (e.cancelable) {
+        e.preventDefault();
+      }
       currentDeltaYRef.current = deltaY;
       setDragOffset(deltaY);
       onDragRef.current?.(deltaY);


### PR DESCRIPTION
## Summary

- **useVerticalSwipeGesture**: Guard `e.preventDefault()` with `e.cancelable` check to stop hundreds of `[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false` warnings flooding the console
- **PlaylistDrawer**: Fix `Cannot read properties of undefined (reading 'lg')` crash by using the direct `theme` import instead of the styled-components theme prop (which was undefined since these components don't receive the SC theme context)
- **AlbumArt**: Suppress expected "Component unmounted" errors during image processing — these occur during normal component lifecycle when tracks change quickly and are not actionable errors

## Test plan

- [ ] Open the app on mobile (or DevTools touch simulation) and swipe — verify no `[Intervention]` warnings in console
- [ ] Open the playlist drawer — verify no crash / no `Cannot read properties of undefined` errors
- [ ] Switch tracks rapidly — verify no "Image processing failed" errors in console
- [ ] Confirm all three components still function correctly after the changes


Made with [Cursor](https://cursor.com)