### PR TITLE
feat: move search and sort controls to bottom of Library drawer

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -37,8 +37,8 @@ const DrawerContainer = styled.div.withConfig({
   top: 0;
   left: 0;
   right: 0;
-  height: 90vh;
-  max-height: 90vh;
+  height: 85vh;
+  max-height: 85vh;
   z-index: ${theme.zIndex.modal};
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Moves the search input and sorting/filter dropdowns to the **bottom** of the Library drawer, so the grid content is immediately visible when the drawer opens
- Extracts `searchAndSortControls` and `tabsBar` into reusable variables for conditional placement — standalone playlist selection page keeps controls at the top (unchanged)
- Reduces drawer height from 90vh to 85vh for better visual proportion

## Test plan
- [ ] Open the Library drawer and verify search + sort controls appear at the bottom
- [ ] Verify the Playlists/Albums tabs remain at the top
- [ ] Test search and sort functionality still works correctly from the bottom position
- [ ] Verify the standalone playlist selection page (non-drawer) is unchanged — controls at top
- [ ] Check drawer scrolling behavior with many items
- [ ] Test on mobile viewport sizes


Made with [Cursor](https://cursor.com)