### PR TITLE
fix: prevent mobile bottom menu from overlapping player controls

### DIFF
--- a/src/components/MobileBottomMenu/styled.ts
+++ b/src/components/MobileBottomMenu/styled.ts
@@ -1,6 +1,12 @@
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 
+/**
+ * Height of the mobile bottom menu content area (padding + icon size + padding).
+ * Used by other components to reserve space so the fixed menu doesn't overlap content.
+ */
+export const MOBILE_BOTTOM_MENU_HEIGHT = '3.75rem';
+
 export const MenuWrapper = styled.div`
   position: fixed;
   bottom: 0;
@@ -16,5 +22,5 @@ export const ContentArea = styled.div`
   align-items: center;
   justify-content: center;
   gap: ${theme.spacing.sm};
-  padding: ${theme.spacing.md} ${theme.spacing.md};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
 `;

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -6,6 +6,7 @@ import PlayerControls from './PlayerControls';
 import QuickActionsPanel from './QuickActionsPanel';
 import LeftQuickActionsPanel from './LeftQuickActionsPanel';
 import MobileBottomMenu from './MobileBottomMenu';
+import { MOBILE_BOTTOM_MENU_HEIGHT } from './MobileBottomMenu/styled';
 import { theme } from '@/styles/theme';
 import { cardBase } from '../styles/utils';
 import { usePlayerSizing } from '../hooks/usePlayerSizing';
@@ -84,19 +85,23 @@ interface PlayerContentProps {
 }
 
 const ContentWrapper = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['width', 'padding', 'useFluidSizing', 'transitionDuration', 'transitionEasing'].includes(prop),
+  shouldForwardProp: (prop) => !['width', 'padding', 'useFluidSizing', 'transitionDuration', 'transitionEasing', '$isMobile'].includes(prop),
 }) <{
   width: number;
   padding: number;
   useFluidSizing: boolean;
   transitionDuration: number;
   transitionEasing: string;
+  $isMobile: boolean;
 }>`
   width: ${props => props.useFluidSizing ? '100%' : `${props.width}px`};
   max-width: ${props => props.width}px;
 
   margin: 0 auto;
   padding: ${props => props.padding}px;
+  padding-bottom: ${props => props.$isMobile
+    ? `calc(${props.padding}px + ${MOBILE_BOTTOM_MENU_HEIGHT} + env(safe-area-inset-bottom, 0px))`
+    : `${props.padding}px`};
   box-sizing: border-box;
   position: relative;
   z-index: 2;
@@ -281,6 +286,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
       useFluidSizing={useFluidSizing}
       transitionDuration={transitionDuration}
       transitionEasing={transitionEasing}
+      $isMobile={isMobile}
     >
       <PlayerContainer>
 


### PR DESCRIPTION
## Summary
- Fixes the mobile bottom menu (glow, VFX, color picker, library, playlist buttons) overlapping onto the player controls panel on vertically constrained viewports (e.g. Chrome on iPhone with address bar visible)
- Exports a `MOBILE_BOTTOM_MENU_HEIGHT` constant and uses it to add `padding-bottom` to `ContentWrapper` on mobile, reserving space for the fixed menu + safe area inset
- Reduces the bottom menu's vertical padding (`md` → `sm`) for a more compact footprint

## Test plan
- [ ] Open on iPhone in Chrome (or other mobile browser with address bar)
- [ ] Verify the bottom menu row no longer overlaps the player controls panel
- [ ] Verify the player remains vertically centered with adequate spacing
- [ ] Check that `env(safe-area-inset-bottom)` works correctly on devices with home indicator (iPhone X+)
- [ ] Verify desktop layout is unaffected (no extra bottom padding)

Made with [Cursor](https://cursor.com)