### PR TITLE
fix: reduce mobile player controls top padding

### DIFF
--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -10,7 +10,7 @@ export const PlayerControlsContainer = styled.div<{ $isMobile: boolean; $isTable
   flex-direction: column;
   gap: ${({ theme, $isMobile }) => $isMobile ? theme.spacing.sm : theme.spacing.md};
   padding: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return `${theme.spacing.md} ${theme.spacing.sm}`;
+    if ($isMobile) return `${theme.spacing.xs} ${theme.spacing.sm}`;
     if ($isTablet) return `${theme.spacing.md} ${theme.spacing.md}`;
     return `${theme.spacing.md} ${theme.spacing.lg}`;
   }};


### PR DESCRIPTION
## Summary
Decreases top padding in PlayerControlsContainer from md to xs spacing on mobile devices for better screen space utilization. This helps prevent the bottom menu from overlapping player controls on smaller screens.

## Changes
- Modified `src/components/controls/styled.ts` to reduce mobile top padding from `theme.spacing.md` to `theme.spacing.xs`

## Testing
The change only affects mobile devices (viewport width < 700px) and reduces the vertical spacing above the player controls.

Made with [Cursor](https://cursor.com)