### PR TITLE
Refactor playlist/album selection and extract shared drawer styles

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -3,6 +3,13 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
 import { theme } from '@/styles/theme';
+import {
+  DrawerOverlay,
+  GripPill,
+  SwipeHandle,
+  DRAWER_TRANSITION_DURATION,
+  DRAWER_TRANSITION_EASING
+} from './styled';
 import PlaylistSelection from './PlaylistSelection';
 
 interface LibraryDrawerProps {
@@ -11,24 +18,9 @@ interface LibraryDrawerProps {
   onPlaylistSelect: (playlistId: string, playlistName: string) => void;
 }
 
-const TRANSITION_DURATION = 300;
-const TRANSITION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
-
-const DrawerOverlay = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== '$isOpen',
-}) <{ $isOpen: boolean }>`
-  position: fixed;
-  inset: 0;
-  z-index: ${theme.zIndex.modal};
-  background: rgba(0, 0, 0, 0.6);
-  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
-  transition: opacity ${TRANSITION_DURATION}ms ${TRANSITION_EASING};
-`;
-
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
-}) <{
+})<{
   $isOpen: boolean;
   $isDragging: boolean;
   $dragOffset: number;
@@ -54,11 +46,10 @@ const DrawerContainer = styled.div.withConfig({
     return $isOpen ? 'translateY(0)' : 'translateY(-100%)';
   }};
   transition: ${({ $isDragging }) =>
-    $isDragging ? 'none' : `transform ${TRANSITION_DURATION}ms ${TRANSITION_EASING}`};
+    $isDragging ? 'none' : `transform ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING}`};
   will-change: ${({ $isDragging }) => ($isDragging ? 'transform' : 'auto')};
 `;
 
-/** Dedicated swipe-to-close zone; spans full width so edge swipes work. touch-action: none so gesture captures. */
 const DrawerHeader = styled.div`
   flex-shrink: 0;
   padding: ${theme.spacing.sm} ${theme.spacing.md};
@@ -103,30 +94,6 @@ const DrawerContent = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: column;
-`;
-
-/** Grip handle at bottom; swipe up to dismiss. touch-action: none so gesture captures. */
-const DrawerHandle = styled.div`
-  flex-shrink: 0;
-  width: 100%;
-  min-height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${theme.spacing.sm} 0;
-  cursor: grab;
-  touch-action: none;
-
-  &:active {
-    cursor: grabbing;
-  }
-`;
-
-const GripPill = styled.div`
-  width: 40px;
-  height: 4px;
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
 `;
 
 export function LibraryDrawer({ isOpen, onClose, onPlaylistSelect }: LibraryDrawerProps) {
@@ -186,14 +153,14 @@ export function LibraryDrawer({ isOpen, onClose, onPlaylistSelect }: LibraryDraw
                 inDrawer
               />
             </DrawerContent>
-            <DrawerHandle
+            <SwipeHandle
               ref={handleRef}
               role="button"
               aria-label="Swipe up or tap to close library"
               onClick={onClose}
             >
               <GripPill />
-            </DrawerHandle>
+            </SwipeHandle>
           </>
         )}
       </DrawerContainer>

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { memo, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import type { Track } from '../services/spotify';
 import { Card, CardHeader, CardContent, CardDescription } from '../components/styled';
@@ -211,27 +211,11 @@ const PlaylistItem = memo<PlaylistItemProps>(({
 });
 
 const Playlist = memo<PlaylistProps>(({ tracks, currentTrackIndex, accentColor, onTrackSelect, isOpen = false }) => {
-  const sortedTracks = useMemo(() => tracks, [tracks]);
   const currentTrackRef = useRef<HTMLDivElement>(null);
-  
-  const currentTrack = tracks[currentTrackIndex];
-  const sortedCurrentTrackIndex = useMemo(() => {
-    if (!currentTrack) return -1;
-    return sortedTracks.findIndex((track: Track) => track === currentTrack);
-  }, [sortedTracks, currentTrack]);
-
-  const handleTrackSelect = useCallback((sortedIndex: number) => {
-    const selectedTrack = sortedTracks[sortedIndex];
-    const originalIndex = tracks.findIndex((track: Track) => track === selectedTrack);
-    if (originalIndex !== -1) {
-      onTrackSelect(originalIndex);
-    }
-  }, [sortedTracks, tracks, onTrackSelect]);
 
   // Auto-scroll to current track when playlist opens
   useEffect(() => {
-    if (isOpen && currentTrackRef.current && sortedCurrentTrackIndex >= 0) {
-      // Add a slight delay to ensure the playlist is fully rendered
+    if (isOpen && currentTrackRef.current && currentTrackIndex >= 0) {
       const timeoutId = setTimeout(() => {
         currentTrackRef.current?.scrollIntoView({
           behavior: 'smooth',
@@ -242,27 +226,27 @@ const Playlist = memo<PlaylistProps>(({ tracks, currentTrackIndex, accentColor, 
 
       return () => clearTimeout(timeoutId);
     }
-  }, [isOpen, sortedCurrentTrackIndex]);
+  }, [isOpen, currentTrackIndex]);
 
   return (
     <PlaylistContainer>
       <PlaylistCard>
         <PlaylistHeader>
-          <PlaylistDescription>{sortedTracks.length} tracks</PlaylistDescription>
+          <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
         </PlaylistHeader>
-        
+
         <PlaylistContent>
           <PlaylistScrollArea>
             <PlaylistItems>
-              {sortedTracks.map((track: Track, index: number) => (
+              {tracks.map((track: Track, index: number) => (
                 <PlaylistItem
                   key={`${track.name}-${track.id}`}
                   track={track}
                   index={index}
-                  isSelected={index === sortedCurrentTrackIndex}
+                  isSelected={index === currentTrackIndex}
                   accentColor={accentColor}
-                  onSelect={handleTrackSelect}
-                  itemRef={index === sortedCurrentTrackIndex ? currentTrackRef : undefined}
+                  onSelect={onTrackSelect}
+                  itemRef={index === currentTrackIndex ? currentTrackRef : undefined}
                 />
               ))}
             </PlaylistItems>

--- a/src/components/PlaylistBottomSheet.tsx
+++ b/src/components/PlaylistBottomSheet.tsx
@@ -3,28 +3,22 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
 import { theme } from '@/styles/theme';
+import {
+  DrawerOverlay,
+  GripPill,
+  SwipeHandle,
+  DrawerFallback,
+  DrawerFallbackCard,
+  DRAWER_TRANSITION_DURATION,
+  DRAWER_TRANSITION_EASING
+} from './styled';
 import type { Track } from '../services/spotify';
 
 const Playlist = React.lazy(() => import('./Playlist'));
 
-const TRANSITION_DURATION = 300;
-const TRANSITION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
-
-const DrawerOverlay = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== '$isOpen',
-}) <{ $isOpen: boolean }>`
-  position: fixed;
-  inset: 0;
-  z-index: ${theme.zIndex.modal};
-  background: rgba(0, 0, 0, 0.6);
-  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
-  transition: opacity ${TRANSITION_DURATION}ms ${TRANSITION_EASING};
-`;
-
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
-}) <{
+})<{
   $isOpen: boolean;
   $isDragging: boolean;
   $dragOffset: number;
@@ -54,32 +48,8 @@ const DrawerContainer = styled.div.withConfig({
     return $isOpen ? 'translateY(0)' : 'translateY(100%)';
   }};
   transition: ${({ $isDragging }) =>
-    $isDragging ? 'none' : `transform ${TRANSITION_DURATION}ms ${TRANSITION_EASING}`};
+    $isDragging ? 'none' : `transform ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING}`};
   will-change: ${({ $isDragging }) => ($isDragging ? 'transform' : 'auto')};
-`;
-
-/** Grip handle at top; swipe down to dismiss. touch-action: none so gesture captures. */
-const SheetHandle = styled.div`
-  flex-shrink: 0;
-  width: 100%;
-  min-height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${theme.spacing.sm} 0;
-  cursor: grab;
-  touch-action: none;
-
-  &:active {
-    cursor: grabbing;
-  }
-`;
-
-const GripPill = styled.div`
-  width: 40px;
-  height: 4px;
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
 `;
 
 const SheetHeader = styled.div`
@@ -111,18 +81,6 @@ const SheetContent = styled.div`
   > div:last-child {
     margin-bottom: 0;
   }
-`;
-
-const PlaylistFallback = styled.div`
-  width: 100%;
-  padding: ${theme.spacing.lg};
-`;
-
-const PlaylistFallbackCard = styled.div`
-  background-color: ${theme.colors.gray[800]};
-  border-radius: ${theme.borderRadius['2xl']};
-  padding: ${theme.spacing.md};
-  border: 1px solid ${theme.colors.gray[700]};
 `;
 
 interface PlaylistBottomSheetProps {
@@ -162,22 +120,22 @@ export const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function Playl
         aria-label="Playlist"
       >
         <SheetHeader>
-          <SheetHandle
+          <SwipeHandle
             ref={headerRef}
             role="button"
             aria-label="Swipe down or tap to close playlist"
             onClick={onClose}
           >
             <GripPill />
-          </SheetHandle>
+          </SwipeHandle>
           <SheetTitle>Playlist</SheetTitle>
         </SheetHeader>
         <SheetContent>
           {isOpen && (
             <Suspense
               fallback={
-                <PlaylistFallback>
-                  <PlaylistFallbackCard>
+                <DrawerFallback>
+                  <DrawerFallbackCard>
                     <div
                       style={{
                         animation: theme.animations.pulse,
@@ -187,8 +145,8 @@ export const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function Playl
                     >
                       Loading playlist...
                     </div>
-                  </PlaylistFallbackCard>
-                </PlaylistFallback>
+                  </DrawerFallbackCard>
+                </DrawerFallback>
               }
             >
               <Playlist

--- a/src/components/PlaylistDrawer.tsx
+++ b/src/components/PlaylistDrawer.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, memo, useMemo } from 'react';
 import styled from 'styled-components';
 import type { Track } from '../services/spotify';
 import { theme } from '../styles/theme';
+import { DrawerFallback, DrawerFallbackCard } from './styled';
 import { usePlayerSizing } from '../hooks/usePlayerSizing';
 
 const Playlist = React.lazy(() => import('./Playlist'));
@@ -114,18 +115,6 @@ const CloseButton = styled.button`
   }
 `;
 
-const PlaylistFallback = styled.div`
-  width: 100%;
-  margin-top: ${theme.spacing.lg};
-`;
-
-const PlaylistFallbackCard = styled.div`
-  background-color: ${theme.colors.gray[800]};
-  border-radius: ${theme.borderRadius['2xl']};
-  padding: ${theme.spacing.md};
-  border: 1px solid ${theme.colors.gray[700]};
-`;
-
 interface PlaylistDrawerProps {
   isOpen: boolean;
   onClose: () => void;
@@ -201,8 +190,8 @@ export const PlaylistDrawer = memo<PlaylistDrawerProps>(({
 
         <PlaylistContent>
           <Suspense fallback={
-            <PlaylistFallback>
-              <PlaylistFallbackCard>
+            <DrawerFallback>
+              <DrawerFallbackCard>
                 <div style={{
                   animation: theme.animations.pulse,
                   color: theme.colors.muted.foreground,
@@ -210,8 +199,8 @@ export const PlaylistDrawer = memo<PlaylistDrawerProps>(({
                 }}>
                   Loading playlist...
                 </div>
-              </PlaylistFallbackCard>
-            </PlaylistFallback>
+              </DrawerFallbackCard>
+            </DrawerFallback>
           }>
             <Playlist
               tracks={tracks}

--- a/src/components/styled/Drawer.tsx
+++ b/src/components/styled/Drawer.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const DRAWER_TRANSITION_DURATION = 300;
+export const DRAWER_TRANSITION_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+export const DrawerOverlay = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== '$isOpen',
+})<{ $isOpen: boolean }>`
+  position: fixed;
+  inset: 0;
+  z-index: ${theme.zIndex.modal};
+  background: rgba(0, 0, 0, 0.6);
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  transition: opacity ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING};
+`;
+
+export const GripPill = styled.div`
+  width: 40px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+`;
+
+export const SwipeHandle = styled.div`
+  flex-shrink: 0;
+  width: 100%;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${theme.spacing.sm} 0;
+  cursor: grab;
+  touch-action: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+export const DrawerFallback = styled.div`
+  width: 100%;
+  padding: ${theme.spacing.lg};
+`;
+
+export const DrawerFallbackCard = styled.div`
+  background-color: ${theme.colors.gray[800]};
+  border-radius: ${theme.borderRadius['2xl']};
+  padding: ${theme.spacing.md};
+  border: 1px solid ${theme.colors.gray[700]};
+`;

--- a/src/components/styled/index.ts
+++ b/src/components/styled/index.ts
@@ -4,3 +4,12 @@ export { Skeleton } from './Skeleton';
 export { Alert, AlertDescription } from './Alert';
 export { ScrollArea } from './ScrollArea';
 export { Avatar, AvatarImage, AvatarFallback } from './Avatar';
+export {
+  DrawerOverlay,
+  GripPill,
+  SwipeHandle,
+  DrawerFallback,
+  DrawerFallbackCard,
+  DRAWER_TRANSITION_DURATION,
+  DRAWER_TRANSITION_EASING
+} from './Drawer';

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -1,0 +1,23 @@
+/** Prefix used when encoding an album ID as a playlist selection ID */
+export const ALBUM_ID_PREFIX = 'album:';
+
+/** Special playlist ID representing the user's Liked Songs */
+export const LIKED_SONGS_ID = 'liked-songs';
+
+/** Display name for the Liked Songs collection */
+export const LIKED_SONGS_NAME = 'Liked Songs';
+
+/** Check whether a playlist selection ID represents an album */
+export function isAlbumId(playlistId: string): boolean {
+  return playlistId.startsWith(ALBUM_ID_PREFIX);
+}
+
+/** Extract the Spotify album ID from an album playlist selection ID */
+export function extractAlbumId(playlistId: string): string {
+  return playlistId.slice(ALBUM_ID_PREFIX.length);
+}
+
+/** Create an album playlist selection ID from a Spotify album ID */
+export function toAlbumPlaylistId(albumId: string): string {
+  return `${ALBUM_ID_PREFIX}${albumId}`;
+}

--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth } from '../services/spotify';
 import { spotifyPlayer } from '../services/spotifyPlayer';
+import { isAlbumId, extractAlbumId, LIKED_SONGS_ID } from '../constants/playlist';
 import type { Track } from '../services/spotify';
 
 async function waitForSpotifyReady(timeout = 10000): Promise<void> {
@@ -53,11 +54,10 @@ export const usePlaylistManager = ({
       let fetchedTracks: Track[] = [];
 
       // Check if this is an album selection
-      if (playlistId.startsWith('album:')) {
-        const albumId = playlistId.replace('album:', '');
-        fetchedTracks = await getAlbumTracks(albumId);
+      if (isAlbumId(playlistId)) {
+        fetchedTracks = await getAlbumTracks(extractAlbumId(playlistId));
         // Albums are already sorted by track number, don't shuffle
-      } else if (playlistId === 'liked-songs') {
+      } else if (playlistId === LIKED_SONGS_ID) {
         fetchedTracks = await getLikedSongs(200);
         fetchedTracks = shuffleArray(fetchedTracks);
       } else {
@@ -65,9 +65,9 @@ export const usePlaylistManager = ({
       }
 
       if (fetchedTracks.length === 0) {
-        if (playlistId.startsWith('album:')) {
+        if (isAlbumId(playlistId)) {
           setError("No tracks found in this album.");
-        } else if (playlistId === 'liked-songs') {
+        } else if (playlistId === LIKED_SONGS_ID) {
           setError("No liked songs found. Please like some songs in Spotify first.");
         } else {
           setError("No tracks found in this playlist.");

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -117,7 +117,7 @@ export function filterAndSortPlaylists(
   sortOption: PlaylistSortOption
 ): PlaylistInfo[] {
   // Step 1: Filter by search query
-  let result = playlists.filter(p => matchesSearch(p, searchQuery));
+  const result = playlists.filter(p => matchesSearch(p, searchQuery));
 
   // Step 2: Sort
   switch (sortOption) {


### PR DESCRIPTION
## Summary
This PR refactors the playlist and album selection UI to reduce code duplication and improve maintainability. It extracts shared drawer styling components, consolidates playlist constant definitions, and simplifies the rendering logic for both mobile grid and desktop list layouts.

## Key Changes

- **Extract shared drawer styles**: Created new `src/components/styled/Drawer.tsx` with reusable components (`DrawerOverlay`, `SwipeHandle`, `GripPill`, `DrawerFallback`, `DrawerFallbackCard`) and transition constants. These are now imported by `PlaylistBottomSheet.tsx`, `LibraryDrawer.tsx`, and `PlaylistDrawer.tsx` instead of being duplicated.

- **Create playlist constants module**: Added `src/constants/playlist.ts` with:
  - `LIKED_SONGS_ID` and `LIKED_SONGS_NAME` constants
  - `ALBUM_ID_PREFIX` constant
  - Helper functions: `isAlbumId()`, `extractAlbumId()`, `toAlbumPlaylistId()`
  - Updated `PlaylistSelection.tsx`, `spotify.ts`, and `usePlaylistManager.ts` to use these constants

- **Refactor lazy image loading**: Extracted `useLazyImage()` hook in `PlaylistSelection.tsx` to eliminate duplicate IntersectionObserver logic between `PlaylistImage` and `GridCardImageComponent`. The hook accepts configurable `targetSize` and `rootMargin` parameters.

- **Consolidate playlist/album rendering**: Refactored `PlaylistSelection.tsx` to use IIFE patterns that generate consistent UI for both mobile grid and desktop list layouts, reducing ~240 lines of duplicated JSX for playlists and albums.

- **Add EmptyState styled component**: Created reusable `EmptyState` component with `$fullWidth` prop to handle empty state messages consistently across grid and list views.

- **Simplify Playlist component**: Removed unnecessary `useMemo` and `useCallback` hooks in `Playlist.tsx` that were not providing performance benefits.

- **Update imports**: Modified `src/components/styled/index.ts` to export new drawer components.

## Notable Implementation Details

- The `useLazyImage()` hook maintains the same IntersectionObserver behavior while accepting parameters for different image sizes (64px for list items, 300px for grid cards) and root margins (50px vs 100px).
- The refactored playlist/album rendering uses conditional ternary operators within IIFE to generate appropriate UI based on `inDrawer` prop, eliminating four separate conditional render blocks.
- All playlist ID encoding/decoding logic is now centralized in the constants module for easier maintenance and testing.
- Drawer styling constants (`DRAWER_TRANSITION_DURATION`, `DRAWER_TRANSITION_EASING`) are now exported for consistent animation timing across components.

https://claude.ai/code/session_018wFLL9MyXXwGouuoY1Jn6z