### PR TITLE
Enable background visualizer by default

### DIFF
--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -155,7 +155,7 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
   const [savedAlbumFilters, setSavedAlbumFilters] = useState<AlbumFilters | null>(null);
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>(
     'vorbis-player-background-visualizer-enabled',
-    false
+    true
   );
   const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>(
     'vorbis-player-background-visualizer-style',


### PR DESCRIPTION
## Summary
Changed the default state of the background visualizer feature from disabled to enabled.

## Changes
- Updated the default value of `backgroundVisualizerEnabled` from `false` to `true` in the `usePlayerState` hook
- This affects the initial state when users first load the player or when the localStorage value is not yet set

## Details
The background visualizer will now be enabled by default for all users. Users can still disable it through the UI, and their preference will be persisted in localStorage.

https://claude.ai/code/session_014Xr3VF4MriLZdekQMyaMpk