### PR TITLE
Add clickable artist links to track info display

### DIFF
--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -1,10 +1,12 @@
-import { memo } from 'react';
-import { PlayerTrackName, PlayerTrackArtist, TrackInfoOnlyRow } from './styled';
+import { memo, Fragment } from 'react';
+import type { ArtistInfo } from '../../services/spotify';
+import { PlayerTrackName, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 
 interface TrackInfoProps {
     track: {
         name?: string;
         artists?: string;
+        artistsData?: ArtistInfo[];
     } | null;
     isMobile: boolean;
     isTablet: boolean;
@@ -24,12 +26,30 @@ const areTrackInfoPropsEqual = (
 };
 
 export const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet }) => {
+    const renderArtists = () => {
+        if (track?.artistsData && track.artistsData.length > 0) {
+            return track.artistsData.map((artist, index) => (
+                <Fragment key={artist.spotifyUrl}>
+                    <ArtistLink
+                        href={artist.spotifyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {artist.name}
+                    </ArtistLink>
+                    {index < track.artistsData!.length - 1 && ', '}
+                </Fragment>
+            ));
+        }
+        return track?.artists || '';
+    };
+
     return (
         <TrackInfoOnlyRow>
             <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
                 {track?.name || 'No track selected'}
             </PlayerTrackName>
-            <PlayerTrackArtist>{track?.artists || ''}</PlayerTrackArtist>
+            <PlayerTrackArtist>{renderArtists()}</PlayerTrackArtist>
         </TrackInfoOnlyRow>
     );
 }, areTrackInfoPropsEqual);

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -103,6 +103,17 @@ export const PlayerTrackArtist = styled.div`
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 `;
 
+export const ArtistLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.8;
+    text-decoration: underline;
+  }
+`;
+
 // --- Track Info Row Layout ---
 export const TrackInfoRow = styled.div`
   display: flex;

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -97,10 +97,16 @@ interface TokenData {
   expires_at: number;
 }
 
+export interface ArtistInfo {
+  name: string;
+  spotifyUrl: string;
+}
+
 export interface Track {
   id: string;
   name: string;
   artists: string;
+  artistsData?: ArtistInfo[];
   album: string;
   album_id?: string;
   track_number?: number;
@@ -133,7 +139,9 @@ export interface AlbumInfo {
 }
 
 interface SpotifyArtist {
+  id?: string;
   name: string;
+  external_urls?: { spotify?: string };
 }
 
 export interface SpotifyImage {
@@ -185,6 +193,20 @@ function formatArtists(artists?: SpotifyArtist[]): string {
   }).join(', ');
 }
 
+function buildArtistsData(artists?: SpotifyArtist[]): ArtistInfo[] | undefined {
+  if (!artists || artists.length === 0) return undefined;
+
+  const data: ArtistInfo[] = [];
+  for (const artist of artists) {
+    const url = artist.external_urls?.spotify
+      ?? (artist.id ? `https://open.spotify.com/artist/${artist.id}` : '');
+    if (url) {
+      data.push({ name: artist.name, spotifyUrl: url });
+    }
+  }
+  return data.length > 0 ? data : undefined;
+}
+
 function transformTrackItem(
   item: SpotifyTrackItem,
   albumOverride?: { name: string; id?: string; image?: string }
@@ -197,6 +219,7 @@ function transformTrackItem(
     id: item.id,
     name: item.name,
     artists: formatArtists(item.artists),
+    artistsData: buildArtistsData(item.artists),
     album: albumOverride?.name ?? item.album?.name ?? 'Unknown Album',
     album_id: albumOverride?.id ?? item.album?.id,
     track_number: item.track_number,


### PR DESCRIPTION
## Summary
Enhanced the track information display to show artist names as clickable links to their Spotify profiles, improving user experience by allowing direct navigation to artist pages.

## Key Changes
- **TrackInfo Component**: Modified to render artists as interactive links instead of plain text
  - Added `renderArtists()` function that conditionally renders artist data with proper comma separation
  - Falls back to plain text artists string if detailed artist data is unavailable
  - Imported `Fragment` and new `ArtistLink` styled component

- **Spotify Service**: Extended track data structure to include artist metadata
  - Added `ArtistInfo` interface with `name` and `spotifyUrl` properties
  - Created `buildArtistsData()` function to extract artist URLs from Spotify API responses
  - Updated `SpotifyArtist` interface to include `id` and `external_urls` fields
  - Modified `transformTrackItem()` to populate `artistsData` field on tracks

- **Styled Components**: Added new `ArtistLink` component
  - Inherits text color from parent for visual consistency
  - Includes smooth opacity transition on hover with underline effect
  - Opens links in new tab with security attributes (`target="_blank"`, `rel="noopener noreferrer"`)

## Implementation Details
- Artist links prioritize Spotify's `external_urls.spotify` when available, with fallback to constructed URL using artist ID
- Graceful degradation: if artist data is unavailable, displays original plain text artist string
- Maintains backward compatibility with existing track data structure

https://claude.ai/code/session_018obHFf4pSbTPv7esEPMqJx