### PR TITLE
Add album information display to track info component

### DIFF
--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -1,12 +1,14 @@
 import { memo, Fragment } from 'react';
 import type { ArtistInfo } from '../../services/spotify';
-import { PlayerTrackName, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
+import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 
 interface TrackInfoProps {
     track: {
         name?: string;
         artists?: string;
         artistsData?: ArtistInfo[];
+        album?: string;
+        album_id?: string;
     } | null;
     isMobile: boolean;
     isTablet: boolean;
@@ -20,6 +22,8 @@ const areTrackInfoPropsEqual = (
     return (
         prevProps.track?.name === nextProps.track?.name &&
         prevProps.track?.artists === nextProps.track?.artists &&
+        prevProps.track?.album === nextProps.track?.album &&
+        prevProps.track?.album_id === nextProps.track?.album_id &&
         prevProps.isMobile === nextProps.isMobile &&
         prevProps.isTablet === nextProps.isTablet
     );
@@ -44,11 +48,30 @@ export const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet }) =>
         return track?.artists || '';
     };
 
+    const renderAlbum = () => {
+        if (!track?.album) return null;
+        if (track.album_id) {
+            return (
+                <AlbumLink
+                    href={`https://open.spotify.com/album/${track.album_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    {track.album}
+                </AlbumLink>
+            );
+        }
+        return track.album;
+    };
+
     return (
         <TrackInfoOnlyRow>
             <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
                 {track?.name || 'No track selected'}
             </PlayerTrackName>
+            {track?.album && (
+                <PlayerTrackAlbum>{renderAlbum()}</PlayerTrackAlbum>
+            )}
             <PlayerTrackArtist>{renderArtists()}</PlayerTrackArtist>
         </TrackInfoOnlyRow>
     );

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -89,6 +89,32 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 `;
 
+export const PlayerTrackAlbum = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  line-height: ${({ theme }) => theme.fontSize.sm};
+  color: ${({ theme }) => theme.colors.gray[400]};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  letter-spacing: 0.02em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  position: relative;
+  z-index: 11;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+`;
+
+export const AlbumLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.8;
+    text-decoration: underline;
+  }
+`;
+
 export const PlayerTrackArtist = styled.div`
   font-size: ${({ theme }) => theme.fontSize.sm};
   line-height: ${({ theme }) => theme.fontSize.sm};


### PR DESCRIPTION
## Summary
This PR adds album information display to the player track info section, allowing users to see which album a track belongs to and navigate directly to it on Spotify.

## Key Changes
- **New styled components**: Added `PlayerTrackAlbum` and `AlbumLink` styled components to display album information with appropriate styling and hover effects
- **Enhanced TrackInfo component**: Extended the `TrackInfoProps` interface to include `album` and `album_id` fields
- **Album rendering logic**: Implemented `renderAlbum()` function that conditionally renders the album name as a clickable link to Spotify (when `album_id` is available) or as plain text
- **Updated memoization**: Added album-related fields to the `areTrackInfoPropsEqual` comparison function to ensure proper re-rendering when album data changes
- **UI layout**: Album information is now displayed between the track name and artist information

## Implementation Details
- The album link opens Spotify's album page in a new tab with proper security attributes (`noopener noreferrer`)
- Album display uses ellipsis text overflow handling to maintain consistent layout
- Hover state on album links provides visual feedback with opacity change and underline
- The album section only renders when album data is available

https://claude.ai/code/session_01UzUWcgfk31TCAao1JSwiiD