### PR TITLE
Add artist filtering to album view

### DIFF
--- a/src/utils/__tests__/playlistFilters.test.ts
+++ b/src/utils/__tests__/playlistFilters.test.ts
@@ -177,6 +177,36 @@ describe('filterAndSortAlbums', () => {
     });
   });
 
+  describe('artist filtering', () => {
+    it('returns all albums when artist filter is empty', () => {
+      const result = filterAndSortAlbums(mockAlbums, '', 'recently-added', 'all', '');
+      expect(result).toHaveLength(3);
+    });
+
+    it('filters by exact artist name', () => {
+      const result = filterAndSortAlbums(mockAlbums, '', 'recently-added', 'all', 'The Beatles');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Abbey Road');
+    });
+
+    it('filters by partial artist name (case-insensitive)', () => {
+      const result = filterAndSortAlbums(mockAlbums, '', 'recently-added', 'all', 'daft');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Random Access Memories');
+    });
+
+    it('filters by artist name (case-insensitive uppercase)', () => {
+      const result = filterAndSortAlbums(mockAlbums, '', 'recently-added', 'all', 'MICHAEL JACKSON');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Thriller');
+    });
+
+    it('returns empty array when artist not found', () => {
+      const result = filterAndSortAlbums(mockAlbums, '', 'recently-added', 'all', 'Nonexistent Artist');
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('sorting', () => {
     it('sorts by artist ascending', () => {
       const result = filterAndSortAlbums(mockAlbums, '', 'artist-asc');
@@ -212,6 +242,30 @@ describe('filterAndSortAlbums', () => {
       const result = filterAndSortAlbums(mockAlbums, '', 'name-asc', '1980s');
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Thriller');
+    });
+
+    it('applies search, year filter, artist filter, and sort together', () => {
+      // Add an album by The Beatles from the 1960s
+      const extendedMockAlbums: AlbumInfo[] = [
+        ...mockAlbums,
+        {
+          id: '4',
+          name: 'Let It Be',
+          artists: 'The Beatles',
+          images: [],
+          release_date: '1970-05-08',
+          total_tracks: 12,
+          uri: 'spotify:album:4',
+          added_at: '2024-03-10T10:00:00Z'
+        }
+      ];
+
+      // Filter by artist "The Beatles" (should get 2 Beatles albums)
+      // Filter by decade "older" (should only get pre-1980 albums)
+      const result = filterAndSortAlbums(extendedMockAlbums, '', 'name-asc', 'older', 'The Beatles');
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Abbey Road');
+      expect(result[1].name).toBe('Let It Be');
     });
   });
 });

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -141,13 +141,14 @@ export function filterAndSortPlaylists(
 }
 
 /**
- * Filter and sort albums based on search query, sort option, and year filter
+ * Filter and sort albums based on search query, sort option, year filter, and artist filter
  */
 export function filterAndSortAlbums(
   albums: AlbumInfo[],
   searchQuery: string,
   sortOption: AlbumSortOption,
-  yearFilter: YearFilterOption = 'all'
+  yearFilter: YearFilterOption = 'all',
+  artistFilter: string = ''
 ): AlbumInfo[] {
   // Step 1: Filter by search query
   let result = albums.filter(a => matchesSearch(a, searchQuery));
@@ -160,7 +161,13 @@ export function filterAndSortAlbums(
     });
   }
 
-  // Step 3: Sort
+  // Step 3: Filter by artist
+  if (artistFilter) {
+    const normalizedArtistFilter = normalizeText(artistFilter);
+    result = result.filter(a => normalizeText(a.artists).includes(normalizedArtistFilter));
+  }
+
+  // Step 4: Sort
   switch (sortOption) {
     case 'name-asc':
       result.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
This PR adds the ability to filter albums by artist name in the album view. Users can now click on an artist name to filter the displayed albums to only those by that artist.

## Key Changes
- **Artist Filter State**: Added `artistFilter` state to track the currently selected artist filter
- **Clickable Artist Names**: Made artist names clickable in both grid and list album views with visual feedback (hover and active states)
- **Filter Logic**: Extended `filterAndSortAlbums()` function to support artist filtering with case-insensitive partial matching
- **UI Updates**: 
  - Added `$clickable` prop to `GridCardSubtitle` styled component with cursor and hover/active styling
  - Created new `ClickableArtist` styled component for list view artist names
  - Updated "Clear" button to reset artist filter along with search and year filters
- **Filter Coordination**: Ensured artist filter is cleared when switching from album view to playlist view (similar to year filter behavior)
- **Comprehensive Tests**: Added test cases covering artist filtering scenarios including exact matches, partial matches, case-insensitivity, and combined filtering with other filters

## Implementation Details
- Artist filtering uses case-insensitive partial matching via the existing `normalizeText()` utility
- Click handlers use `event.stopPropagation()` to prevent triggering album selection when clicking artist names
- Artist filter integrates seamlessly with existing search, year filter, and sort functionality
- All filter combinations work together correctly as verified by new test cases

https://claude.ai/code/session_01MhJuz5g4Y8MdVQUydC8wF3