### PR TITLE
Constrain LibraryDrawer width on desktop to match player

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -50,6 +50,17 @@ const DrawerContainer = styled.div.withConfig({
   transition: ${({ $isDragging }) =>
     $isDragging ? 'none' : `transform ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING}`};
   will-change: ${({ $isDragging }) => ($isDragging ? 'transform' : 'auto')};
+
+  /* Constrain width on desktop to match player content area */
+  @media (min-width: ${theme.breakpoints.lg}) {
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+    border-radius: 0 0 ${theme.borderRadius.xl} ${theme.borderRadius.xl};
+    border-left: 1px solid ${theme.colors.popover.border};
+    border-right: 1px solid ${theme.colors.popover.border};
+    border-bottom: 1px solid ${theme.colors.popover.border};
+  }
 `;
 
 const DrawerHeader = styled.div`


### PR DESCRIPTION
## Summary
Updated the LibraryDrawer component to constrain its width on desktop viewports, aligning it with the player content area for a more cohesive layout.

## Key Changes
- Added responsive styling for desktop breakpoints (min-width: lg) that:
  - Sets a maximum width of 700px to match the player content area
  - Centers the drawer using auto margins
  - Adds rounded bottom corners with theme border radius
  - Adds subtle borders on left, right, and bottom edges using theme colors

## Implementation Details
- The constraints only apply on desktop (lg breakpoint and above), preserving the full-width drawer behavior on mobile/tablet
- Uses existing theme values for consistency (breakpoints, borderRadius, colors)
- Borders are applied selectively (left, right, bottom) to create a contained appearance while maintaining visual separation from surrounding content

https://claude.ai/code/session_01EXAMjUFft8CcZHvhV8yaC2