### PR TITLE
Add pin-to-top feature for playlists and albums

### DIFF
--- a/src/hooks/__tests__/usePinnedItems.test.ts
+++ b/src/hooks/__tests__/usePinnedItems.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePinnedItems } from '../usePinnedItems';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    }
+  };
+})();
+
+describe('usePinnedItems', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true
+    });
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('should initialize with empty arrays', () => {
+    const { result } = renderHook(() => usePinnedItems());
+    expect(result.current.pinnedPlaylistIds).toEqual([]);
+    expect(result.current.pinnedAlbumIds).toEqual([]);
+  });
+
+  it('should read existing pinned IDs from localStorage', () => {
+    localStorageMock.setItem('vorbis-player-pinned-playlists', JSON.stringify(['p1', 'p2']));
+    localStorageMock.setItem('vorbis-player-pinned-albums', JSON.stringify(['a1']));
+
+    const { result } = renderHook(() => usePinnedItems());
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2']);
+    expect(result.current.pinnedAlbumIds).toEqual(['a1']);
+  });
+
+  it('should pin an unpinned playlist', () => {
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p1');
+    });
+
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1']);
+    expect(result.current.isPlaylistPinned('p1')).toBe(true);
+  });
+
+  it('should unpin a pinned playlist', () => {
+    localStorageMock.setItem('vorbis-player-pinned-playlists', JSON.stringify(['p1', 'p2']));
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p1');
+    });
+
+    expect(result.current.pinnedPlaylistIds).toEqual(['p2']);
+    expect(result.current.isPlaylistPinned('p1')).toBe(false);
+  });
+
+  it('should not pin beyond 4 playlists', () => {
+    localStorageMock.setItem('vorbis-player-pinned-playlists', JSON.stringify(['p1', 'p2', 'p3', 'p4']));
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p5');
+    });
+
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4']);
+    expect(result.current.canPinMorePlaylists).toBe(false);
+  });
+
+  it('should pin an unpinned album', () => {
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinAlbum('a1');
+    });
+
+    expect(result.current.pinnedAlbumIds).toEqual(['a1']);
+    expect(result.current.isAlbumPinned('a1')).toBe(true);
+  });
+
+  it('should unpin a pinned album', () => {
+    localStorageMock.setItem('vorbis-player-pinned-albums', JSON.stringify(['a1', 'a2']));
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinAlbum('a1');
+    });
+
+    expect(result.current.pinnedAlbumIds).toEqual(['a2']);
+    expect(result.current.isAlbumPinned('a1')).toBe(false);
+  });
+
+  it('should not pin beyond 4 albums', () => {
+    localStorageMock.setItem('vorbis-player-pinned-albums', JSON.stringify(['a1', 'a2', 'a3', 'a4']));
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinAlbum('a5');
+    });
+
+    expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4']);
+    expect(result.current.canPinMoreAlbums).toBe(false);
+  });
+
+  it('should report canPinMore correctly', () => {
+    const { result } = renderHook(() => usePinnedItems());
+
+    expect(result.current.canPinMorePlaylists).toBe(true);
+    expect(result.current.canPinMoreAlbums).toBe(true);
+
+    act(() => {
+      result.current.togglePinPlaylist('p1');
+      result.current.togglePinPlaylist('p2');
+      result.current.togglePinPlaylist('p3');
+    });
+
+    expect(result.current.canPinMorePlaylists).toBe(true);
+
+    act(() => {
+      result.current.togglePinPlaylist('p4');
+    });
+
+    expect(result.current.canPinMorePlaylists).toBe(false);
+  });
+
+  it('should persist to localStorage on change', () => {
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p1');
+    });
+
+    expect(localStorageMock.getItem('vorbis-player-pinned-playlists')).toBe(JSON.stringify(['p1']));
+
+    act(() => {
+      result.current.togglePinAlbum('a1');
+    });
+
+    expect(localStorageMock.getItem('vorbis-player-pinned-albums')).toBe(JSON.stringify(['a1']));
+  });
+
+  it('should allow unpinning even when at max capacity', () => {
+    localStorageMock.setItem('vorbis-player-pinned-playlists', JSON.stringify(['p1', 'p2', 'p3', 'p4']));
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p2');
+    });
+
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p3', 'p4']);
+    expect(result.current.canPinMorePlaylists).toBe(true);
+  });
+
+  it('should preserve pin order (appended at end)', () => {
+    const { result } = renderHook(() => usePinnedItems());
+
+    act(() => {
+      result.current.togglePinPlaylist('p3');
+    });
+    act(() => {
+      result.current.togglePinPlaylist('p1');
+    });
+    act(() => {
+      result.current.togglePinPlaylist('p2');
+    });
+
+    expect(result.current.pinnedPlaylistIds).toEqual(['p3', 'p1', 'p2']);
+  });
+});

--- a/src/hooks/usePinnedItems.ts
+++ b/src/hooks/usePinnedItems.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+
+const MAX_PINS_PER_TAB = 4;
+
+interface UsePinnedItemsReturn {
+  pinnedPlaylistIds: string[];
+  pinnedAlbumIds: string[];
+  isPlaylistPinned: (id: string) => boolean;
+  isAlbumPinned: (id: string) => boolean;
+  togglePinPlaylist: (id: string) => void;
+  togglePinAlbum: (id: string) => void;
+  canPinMorePlaylists: boolean;
+  canPinMoreAlbums: boolean;
+}
+
+export function usePinnedItems(): UsePinnedItemsReturn {
+  const [pinnedPlaylistIds, setPinnedPlaylistIds] = useLocalStorage<string[]>(
+    'vorbis-player-pinned-playlists',
+    []
+  );
+  const [pinnedAlbumIds, setPinnedAlbumIds] = useLocalStorage<string[]>(
+    'vorbis-player-pinned-albums',
+    []
+  );
+
+  const isPlaylistPinned = useCallback(
+    (id: string) => pinnedPlaylistIds.includes(id),
+    [pinnedPlaylistIds]
+  );
+
+  const isAlbumPinned = useCallback(
+    (id: string) => pinnedAlbumIds.includes(id),
+    [pinnedAlbumIds]
+  );
+
+  const togglePinPlaylist = useCallback((id: string) => {
+    setPinnedPlaylistIds(prev => {
+      if (prev.includes(id)) {
+        return prev.filter(pid => pid !== id);
+      }
+      if (prev.length >= MAX_PINS_PER_TAB) return prev;
+      return [...prev, id];
+    });
+  }, [setPinnedPlaylistIds]);
+
+  const togglePinAlbum = useCallback((id: string) => {
+    setPinnedAlbumIds(prev => {
+      if (prev.includes(id)) {
+        return prev.filter(pid => pid !== id);
+      }
+      if (prev.length >= MAX_PINS_PER_TAB) return prev;
+      return [...prev, id];
+    });
+  }, [setPinnedAlbumIds]);
+
+  const canPinMorePlaylists = pinnedPlaylistIds.length < MAX_PINS_PER_TAB;
+  const canPinMoreAlbums = pinnedAlbumIds.length < MAX_PINS_PER_TAB;
+
+  return {
+    pinnedPlaylistIds,
+    pinnedAlbumIds,
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+    canPinMorePlaylists,
+    canPinMoreAlbums,
+  };
+}

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -230,3 +230,41 @@ export function getAvailableDecades(albums: AlbumInfo[]): YearFilterOption[] {
   const order: YearFilterOption[] = ['2020s', '2010s', '2000s', '1990s', '1980s', 'older'];
   return order.filter(d => decades.has(d));
 }
+
+/**
+ * Partition items into pinned (in pin order) and unpinned (in original order).
+ * Pinned items that don't exist in the items array are silently ignored.
+ */
+export function partitionByPinned<T>(
+  items: T[],
+  pinnedIds: string[],
+  getId: (item: T) => string
+): { pinned: T[]; unpinned: T[] } {
+  if (pinnedIds.length === 0) {
+    return { pinned: [], unpinned: items };
+  }
+
+  const pinnedSet = new Set(pinnedIds);
+  const pinnedMap = new Map<string, T>();
+  const unpinned: T[] = [];
+
+  for (const item of items) {
+    const id = getId(item);
+    if (pinnedSet.has(id)) {
+      pinnedMap.set(id, item);
+    } else {
+      unpinned.push(item);
+    }
+  }
+
+  // Preserve pin insertion order
+  const pinned: T[] = [];
+  for (const id of pinnedIds) {
+    const item = pinnedMap.get(id);
+    if (item) {
+      pinned.push(item);
+    }
+  }
+
+  return { pinned, unpinned };
+}


### PR DESCRIPTION
## Summary
Adds the ability for users to pin their favorite playlists and albums to the top of the list for quick access. Users can pin up to 4 items per category, with pinned items appearing in a dedicated section above unpinned items.

## Key Changes

- **New `usePinnedItems` hook**: Manages pinned playlist and album IDs with localStorage persistence. Enforces a maximum of 4 pins per category and provides utilities to check pin status and toggle pins.

- **New `partitionByPinned` utility**: Partitions items into pinned (in pin order) and unpinned (in original order) arrays. Handles edge cases like non-existent IDs gracefully.

- **UI Components for pinning**:
  - `PinButton`: Styled button for list view with hover effects and disabled state
  - `GridCardPinOverlay`: Overlay button for grid view with circular background
  - `PinnedSectionLabel`: Visual separator between pinned and unpinned sections
  - `PinIcon`: SVG icon with filled/outline variants

- **Updated `PlaylistSelection` component**:
  - Integrates pinning functionality for both playlists and albums
  - Renders pinned items first, followed by a section divider, then unpinned items
  - Hides pinned section when filters are active (search, year, artist)
  - Supports both grid (drawer) and list views
  - Includes accessibility labels and tooltips for pin buttons

- **Comprehensive test coverage**: Added 11 test cases for `usePinnedItems` covering initialization, persistence, pin limits, and edge cases. Added 7 test cases for `partitionByPinned` covering various partitioning scenarios.

## Implementation Details

- Pin state is persisted to localStorage with keys `vorbis-player-pinned-playlists` and `vorbis-player-pinned-albums`
- Pinned items maintain insertion order (appended at end when pinned)
- Pin buttons are hidden by default in list view and shown on hover; always visible on touch devices
- Pin limit is enforced at 4 items per category, with disabled state when limit is reached
- Pinned section is automatically hidden when any filter is active to avoid confusion
- Liked Songs can be pinned like any other playlist

https://claude.ai/code/session_01VQoThVVoVNzgUXcgBxzPLi