### PR TITLE
fix: prevent FAB menu items from overflowing offscreen on mobile

### DIFF
--- a/src/components/FabMenu/FabMenuItems.tsx
+++ b/src/components/FabMenu/FabMenuItems.tsx
@@ -80,7 +80,7 @@ export const FabMenuItems = ({
       ),
     });
 
-    if (onBackgroundVisualizerToggle) {
+    if (onBackgroundVisualizerToggle && !isMobile) {
       list.push({
         key: 'visualizer',
         label: `Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`,

--- a/src/components/FabMenu/styled.ts
+++ b/src/components/FabMenu/styled.ts
@@ -15,6 +15,11 @@ export const FabContainer = styled.div`
   display: flex;
   align-items: center;
   gap: ${theme.spacing.sm};
+
+  @media (max-width: ${theme.breakpoints.lg}) {
+    right: 12px;
+    bottom: 16px;
+  }
 `;
 
 export const FabButton = styled.button<{ $isOpen: boolean; $accentColor: string }>`


### PR DESCRIPTION
- Hide background visualizer button on mobile to reduce item count
- Reduce FAB container right/bottom offset on mobile for more space

https://claude.ai/code/session_01XSHhxyrzVTKijVwDe44G95