### PR TITLE
fix: reduce mobile playlist drawer height to 50% of viewport

### DIFF
--- a/src/components/PlaylistBottomSheet.tsx
+++ b/src/components/PlaylistBottomSheet.tsx
@@ -27,8 +27,8 @@ const DrawerContainer = styled.div.withConfig({
   left: 0;
   right: 0;
   bottom: 0;
-  height: 80vh;
-  max-height: 80vh;
+  height: 50dvh;
+  max-height: 50dvh;
   z-index: ${theme.zIndex.modal};
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(${theme.drawer.backdropBlur});


### PR DESCRIPTION
- Change DrawerContainer height from 80vh to 50dvh
- Use dvh unit for correct mobile browser address bar handling

https://claude.ai/code/session_01Spfw8aCf3T85Q3216b9hwi