### PR TITLE
refactor: replace FAB menu with always-visible inline toolbar

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -10,9 +10,10 @@ import { toAlbumPlaylistId } from '@/constants/playlist';
 
 const Container = styled.div`
   width: 100%;
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
   ${flexCenter};
+  overflow: hidden;
 `;
 
 const AudioPlayerComponent = () => {

--- a/src/components/FabMenu/FabMenuItems.tsx
+++ b/src/components/FabMenu/FabMenuItems.tsx
@@ -25,11 +25,8 @@ interface FabMenuItemsProps {
   onBackToLibrary?: () => void;
   onShowPlaylist: () => void;
   onItemAction: (action: () => void) => () => void;
-  isOpen: boolean;
   onColorPickerOpenChange?: (isOpen: boolean) => void;
 }
-
-const STAGGER_DELAY = 30;
 
 export const FabMenuItems = ({
   accentColor,
@@ -43,7 +40,6 @@ export const FabMenuItems = ({
   onBackToLibrary,
   onShowPlaylist,
   onItemAction,
-  isOpen,
   onColorPickerOpenChange,
 }: FabMenuItemsProps) => {
   const { isMobile } = usePlayerSizing();
@@ -62,43 +58,43 @@ export const FabMenuItems = ({
       content: React.ReactNode;
     }> = [];
 
-    list.push({
-      key: 'glow',
-      label: `Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`,
-      content: (
-        <ControlButton
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          accentColor={accentColor}
-          isActive={glowEnabled}
-          onClick={onItemAction(onGlowToggle)}
-          title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
-          aria-pressed={glowEnabled}
-        >
-          <GlowIcon />
-        </ControlButton>
-      ),
-    });
+    // list.push({
+    //   key: 'glow',
+    //   label: `Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`,
+    //   content: (
+    //     <ControlButton
+    //       $isMobile={isMobile}
+    //       $isTablet={isTablet}
+    //       accentColor={accentColor}
+    //       isActive={glowEnabled}
+    //       onClick={onItemAction(onGlowToggle)}
+    //       title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
+    //       aria-pressed={glowEnabled}
+    //     >
+    //       <GlowIcon />
+    //     </ControlButton>
+    //   ),
+    // });
 
-    if (onBackgroundVisualizerToggle && !isMobile) {
-      list.push({
-        key: 'visualizer',
-        label: `Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`,
-        content: (
-          <ControlButton
-            $isMobile={isMobile}
-            $isTablet={isTablet}
-            accentColor={accentColor}
-            isActive={backgroundVisualizerEnabled}
-            onClick={onItemAction(onBackgroundVisualizerToggle)}
-            title={`Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`}
-            aria-pressed={backgroundVisualizerEnabled}
-          >
-            <BackgroundVisualizerIcon />
-          </ControlButton>
-        ),
-      });
-    }
+    // if (onBackgroundVisualizerToggle && !isMobile) {
+    //   list.push({
+    //     key: 'visualizer',
+    //     label: `Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`,
+    //     content: (
+    //       <ControlButton
+    //         $isMobile={isMobile}
+    //         $isTablet={isTablet}
+    //         accentColor={accentColor}
+    //         isActive={backgroundVisualizerEnabled}
+    //         onClick={onItemAction(onBackgroundVisualizerToggle)}
+    //         title={`Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`}
+    //         aria-pressed={backgroundVisualizerEnabled}
+    //       >
+    //         <BackgroundVisualizerIcon />
+    //       </ControlButton>
+    //     ),
+    //   });
+    // }
 
     list.push({
       key: 'effects',
@@ -133,39 +129,39 @@ export const FabMenuItems = ({
       ),
     });
 
-    if (onBackToLibrary) {
-      list.push({
-        key: 'library',
-        label: 'Back to Library',
-        content: (
-          <ControlButton
-            $isMobile={isMobile}
-            $isTablet={isTablet}
-            accentColor={accentColor}
-            onClick={onItemAction(onBackToLibrary)}
-            title="Back to Library"
-          >
-            <BackToLibraryIcon />
-          </ControlButton>
-        ),
-      });
-    }
+    // if (onBackToLibrary) {
+    //   list.push({
+    //     key: 'library',
+    //     label: 'Back to Library',
+    //     content: (
+    //       <ControlButton
+    //         $isMobile={isMobile}
+    //         $isTablet={isTablet}
+    //         accentColor={accentColor}
+    //         onClick={onItemAction(onBackToLibrary)}
+    //         title="Back to Library"
+    //       >
+    //         <BackToLibraryIcon />
+    //       </ControlButton>
+    //     ),
+    //   });
+    // }
 
-    list.push({
-      key: 'playlist',
-      label: 'Show Playlist',
-      content: (
-        <ControlButton
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          accentColor={accentColor}
-          onClick={onItemAction(onShowPlaylist)}
-          title="Show Playlist"
-        >
-          <PlaylistIcon />
-        </ControlButton>
-      ),
-    });
+    // list.push({
+    //   key: 'playlist',
+    //   label: 'Show Playlist',
+    //   content: (
+    //     <ControlButton
+    //       $isMobile={isMobile}
+    //       $isTablet={isTablet}
+    //       accentColor={accentColor}
+    //       onClick={onItemAction(onShowPlaylist)}
+    //       title="Show Playlist"
+    //     >
+    //       <PlaylistIcon />
+    //     </ControlButton>
+    //   ),
+    // });
 
     return list;
   }, [
@@ -188,13 +184,8 @@ export const FabMenuItems = ({
 
   return (
     <>
-      {items.map((item, i) => (
-        <FabMenuItem
-          key={item.key}
-          $isOpen={isOpen}
-          $openDelay={(items.length - 1 - i) * STAGGER_DELAY}
-          $closeDelay={i * STAGGER_DELAY}
-        >
+      {items.map((item) => (
+        <FabMenuItem key={item.key}>
           {item.content}
           <FabMenuItemTooltip>{item.label}</FabMenuItemTooltip>
         </FabMenuItem>

--- a/src/components/FabMenu/index.tsx
+++ b/src/components/FabMenu/index.tsx
@@ -1,6 +1,5 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
-import { FabOverlay, FabContainer, FabButton } from './styled';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ToolbarContainer } from './styled';
 import FabMenuItems from './FabMenuItems';
 import type { Track } from '@/services/spotify';
 
@@ -29,92 +28,45 @@ export default function FabMenu({
   onBackToLibrary,
   onShowPlaylist,
 }: FabMenuProps) {
-  const [isOpen, setIsOpen] = useState(false);
   const [colorPickerActive, setColorPickerActive] = useState(false);
   const prevColorPickerActive = useRef(false);
+  const [colorPickerJustClosed, setColorPickerJustClosed] = useState(false);
 
-  const toggle = useCallback(() => {
-    setIsOpen((prev) => !prev);
-  }, []);
-
-  const collapse = useCallback(() => {
-    if (!colorPickerActive) {
-      setIsOpen(false);
+  useEffect(() => {
+    if (prevColorPickerActive.current && !colorPickerActive) {
+      setColorPickerJustClosed(true);
+      const timer = setTimeout(() => setColorPickerJustClosed(false), 100);
+      return () => clearTimeout(timer);
     }
+    prevColorPickerActive.current = colorPickerActive;
   }, [colorPickerActive]);
 
   const handleItemAction = useCallback(
     (action: () => void) => {
       return () => {
+        if (colorPickerJustClosed) return;
         action();
-        collapse();
       };
     },
-    [collapse]
+    [colorPickerJustClosed]
   );
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (prevColorPickerActive.current && !colorPickerActive && isOpen) {
-      setIsOpen(false);
-    }
-    prevColorPickerActive.current = colorPickerActive;
-  }, [colorPickerActive, isOpen]);
-
-  return createPortal(
-    <>
-      {isOpen && <FabOverlay onClick={collapse} />}
-      <FabContainer>
-        <FabMenuItems
-          isOpen={isOpen}
-          accentColor={accentColor}
-          currentTrack={currentTrack}
-          glowEnabled={glowEnabled}
-          backgroundVisualizerEnabled={backgroundVisualizerEnabled}
-          onShowVisualEffects={onShowVisualEffects}
-          onGlowToggle={onGlowToggle}
-          onBackgroundVisualizerToggle={onBackgroundVisualizerToggle}
-          onAccentColorChange={onAccentColorChange}
-          onBackToLibrary={onBackToLibrary}
-          onShowPlaylist={onShowPlaylist}
-          onItemAction={handleItemAction}
-          onColorPickerOpenChange={setColorPickerActive}
-        />
-        <FabButton
-          $isOpen={isOpen}
-          $accentColor={accentColor}
-          onClick={toggle}
-          aria-label={isOpen ? 'Close menu' : 'Open menu'}
-          aria-expanded={isOpen}
-          aria-haspopup="true"
-        >
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </FabButton>
-      </FabContainer>
-    </>,
-    document.body
+  return (
+    <ToolbarContainer>
+      <FabMenuItems
+        accentColor={accentColor}
+        currentTrack={currentTrack}
+        glowEnabled={glowEnabled}
+        backgroundVisualizerEnabled={backgroundVisualizerEnabled}
+        onShowVisualEffects={onShowVisualEffects}
+        onGlowToggle={onGlowToggle}
+        onBackgroundVisualizerToggle={onBackgroundVisualizerToggle}
+        onAccentColorChange={onAccentColorChange}
+        onBackToLibrary={onBackToLibrary}
+        onShowPlaylist={onShowPlaylist}
+        onItemAction={handleItemAction}
+        onColorPickerOpenChange={setColorPickerActive}
+      />
+    </ToolbarContainer>
   );
 }

--- a/src/components/FabMenu/styled.ts
+++ b/src/components/FabMenu/styled.ts
@@ -1,68 +1,27 @@
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 
-export const FabOverlay = styled.div`
-  position: fixed;
-  inset: 0;
-  z-index: ${theme.zIndex.mobileMenu};
-`;
-
-export const FabContainer = styled.div`
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: ${parseInt(theme.zIndex.mobileMenu) + 1};
-  display: flex;
-  align-items: center;
-  gap: ${theme.spacing.sm};
-
-  @media (max-width: ${theme.breakpoints.lg}) {
-    right: 12px;
-    bottom: 16px;
-  }
-`;
-
-export const FabButton = styled.button<{ $isOpen: boolean; $accentColor: string }>`
-  width: 56px;
-  height: 56px;
-  border-radius: ${theme.borderRadius.full};
-  border: 1px solid ${theme.colors.popover.border};
-  background: ${theme.colors.overlay.dark};
-  backdrop-filter: blur(${theme.drawer.backdropBlur});
-  color: ${theme.colors.white};
-  cursor: pointer;
+export const ToolbarContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  box-shadow: ${theme.shadows.lg};
+  gap: ${theme.spacing.xs};
+  padding: ${theme.spacing.xs} 0;
+  flex-shrink: 0;
 
-  svg {
-    transition: transform ${theme.transitions.normal};
-    transform: ${({ $isOpen }) => ($isOpen ? 'rotate(45deg)' : 'rotate(0deg)')};
-  }
+  button {
+    padding: ${theme.spacing.xs};
+    border-radius: ${theme.borderRadius.md};
 
-  &:hover {
-    background: ${theme.colors.control.backgroundHover};
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
   }
 `;
 
-export const FabMenuItem = styled.div<{
-  $isOpen: boolean;
-  $openDelay: number;
-  $closeDelay: number;
-}>`
+export const FabMenuItem = styled.div`
   position: relative;
-  transform: ${({ $isOpen }) => ($isOpen ? 'scale(1)' : 'scale(0)')};
-  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    opacity 0.2s ease;
-  transition-delay: ${({ $isOpen, $openDelay, $closeDelay }) =>
-    $isOpen ? `${$openDelay}ms` : `${$closeDelay}ms`};
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
-  }
 `;
 
 export const FabMenuItemTooltip = styled.span`

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -93,6 +93,7 @@ const ContentWrapper = styled.div.withConfig({
   width: ${props => props.useFluidSizing ? '100%' : `${props.width}px`};
   max-width: ${props => props.width}px;
 
+  height: 100%;
   margin: 0 auto;
   padding: ${props => props.padding}px;
   padding-bottom: ${props => props.padding}px;
@@ -126,15 +127,7 @@ const LoadingCard = styled.div.withConfig({
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-radius: 1.25rem;
-  /* Enhanced border with subtle highlight */
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  /* Multi-layer shadows for depth */
-  box-shadow: 
-    0 8px 32px rgba(0, 0, 0, 0.9),
-    0 4px 16px rgba(0, 0, 0, 0.8),
-    0 2px 8px rgba(0, 0, 0, 0.7),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  
   transition: box-shadow 0.3s ease, border-color 0.3s ease;
   ${({ backgroundImage }) => backgroundImage ? `
     &::after {
@@ -186,6 +179,8 @@ const PlayerContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  flex: 1;
+  min-height: 0;
 `;
 
 // Album art container with click handler
@@ -193,6 +188,10 @@ const ClickableAlbumArtContainer = styled.div<{ $swipeEnabled?: boolean; $bothGe
   position: relative;
   cursor: pointer;
   z-index: 3;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   /* Add subtle outer glow/shadow for separation from background */
   filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.4));
   ${({ $swipeEnabled, $bothGestures }) => $swipeEnabled && `
@@ -338,8 +337,11 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
         <CardContent style={{
           position: 'relative',
           zIndex: 2,
+          flex: 1,
           minHeight: 0,
+          display: 'flex',
           alignItems: 'center',
+          justifyContent: 'center',
           paddingTop: isMobile ? '0.25rem' : '1rem'
         }}>
           <ClickableAlbumArtContainer
@@ -400,19 +402,19 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
             </Suspense>
           </CardContent>
         </LoadingCard>
+        <FabMenu
+          accentColor={ui.accentColor}
+          currentTrack={track.current}
+          glowEnabled={effects.enabled}
+          backgroundVisualizerEnabled={handlers.backgroundVisualizerEnabled}
+          onShowVisualEffects={handlers.onShowVisualEffects}
+          onGlowToggle={handlers.onGlowToggle}
+          onBackgroundVisualizerToggle={handlers.onBackgroundVisualizerToggle}
+          onAccentColorChange={handlers.onAccentColorChange}
+          onBackToLibrary={handlers.onBackToLibrary}
+          onShowPlaylist={handlers.onShowPlaylist}
+        />
       </PlayerContainer>
-      <FabMenu
-        accentColor={ui.accentColor}
-        currentTrack={track.current}
-        glowEnabled={effects.enabled}
-        backgroundVisualizerEnabled={handlers.backgroundVisualizerEnabled}
-        onShowVisualEffects={handlers.onShowVisualEffects}
-        onGlowToggle={handlers.onGlowToggle}
-        onBackgroundVisualizerToggle={handlers.onBackgroundVisualizerToggle}
-        onAccentColorChange={handlers.onAccentColorChange}
-        onBackToLibrary={handlers.onBackToLibrary}
-        onShowPlaylist={handlers.onShowPlaylist}
-      />
       {ui.showVisualEffects && (
         <Suspense fallback={
           <div style={{

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -5,6 +5,7 @@ import { usePlayerSizing } from '../hooks/usePlayerSizing';
 import { PlayerControlsContainer } from './controls/styled';
 import TrackInfo from './controls/TrackInfo';
 import PlaybackControls from './controls/PlaybackControls';
+import LikeButton from './LikeButton';
 import TimelineControls from './controls/TimelineControls';
 import { TrackInfoRow, TrackInfoLeft, TrackInfoCenter, TrackInfoRight } from './controls/styled';
 
@@ -66,6 +67,7 @@ interface SpotifyPlayerControlsProps {
   trackCount: number;
   isLiked?: boolean;
   isLikePending?: boolean;
+  trackId?: string;
   isMuted?: boolean;
   volume?: number;
   onMuteToggle?: () => void;
@@ -117,7 +119,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
     onPause,
     onNext,
     onPrevious,
-    onLikeToggle: propOnToggleLike ?? (() => {}),
+    onLikeToggle: propOnToggleLike ?? (() => { }),
   });
 
   const effectiveIsLiked = propIsLiked ?? false;
@@ -126,7 +128,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   const effectiveVolume = typeof propVolume !== 'undefined' ? propVolume : volume;
   const effectiveHandleVolumeButtonClick = propOnMuteToggle || hookHandleVolumeButtonClick;
   const effectiveHandleLikeToggle = handleLikeToggle;
-  
+
   return (
     <PlayerControlsContainer $isMobile={isMobile} $isTablet={isTablet}>
       <TrackInfo
@@ -141,7 +143,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         <TrackInfoLeft>
           {/* Left side is empty - could be used for other controls if needed */}
         </TrackInfoLeft>
-        <TrackInfoCenter>
+        {/* <TrackInfoCenter>
           <PlaybackControls
             onPrevious={onPrevious}
             onPlay={onPlay}
@@ -152,9 +154,9 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
             isMobile={isMobile}
             isTablet={isTablet}
           />
-        </TrackInfoCenter>
+        </TrackInfoCenter> */}
         <TrackInfoRight>
-          {/* Quick actions moved to right-side panel */}
+
         </TrackInfoRight>
       </TrackInfoRow>
 
@@ -168,10 +170,6 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         onSliderChange={handleSliderChange}
         onSliderMouseDown={handleSliderMouseDown}
         onSliderMouseUp={handleSliderMouseUp}
-        trackId={currentTrack?.id}
-        isLiked={effectiveIsLiked}
-        isLikePending={effectiveIsLikePending}
-        onLikeToggle={effectiveHandleLikeToggle}
         accentColor={accentColor}
         isMobile={isMobile}
         isTablet={isTablet}

--- a/src/components/controls/TimelineControls.tsx
+++ b/src/components/controls/TimelineControls.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 import { TimelineLeft, TimelineRight, TimelineControlsContainer } from './styled';
 import VolumeControl from './VolumeControl';
-import LikeButton from '../LikeButton';
 import { TimelineSlider } from '../TimelineSlider';
 
 interface TimelineControlsProps {
@@ -16,11 +15,7 @@ interface TimelineControlsProps {
     onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     onSliderMouseDown: () => void;
     onSliderMouseUp: (e: React.MouseEvent<HTMLInputElement>) => void;
-    // Like button props
-    trackId?: string;
-    isLiked: boolean;
-    isLikePending: boolean;
-    onLikeToggle: () => void;
+
     // Accent color for slider/theming
     accentColor: string;
     // Responsive props
@@ -49,7 +44,7 @@ const areTimelineControlsPropsEqual = (
     );
 };
 
-export const TimelineControls = memo<TimelineControlsProps>(({ 
+export const TimelineControls = memo<TimelineControlsProps>(({
     isMuted,
     volume,
     onVolumeButtonClick,
@@ -90,15 +85,7 @@ export const TimelineControls = memo<TimelineControlsProps>(({
             />
 
             <TimelineRight>
-                <LikeButton
-                    trackId={trackId}
-                    isLiked={isLiked}
-                    isLoading={isLikePending}
-                    accentColor={accentColor}
-                    onToggleLike={onLikeToggle}
-                    $isMobile={isMobile}
-                    $isTablet={isTablet}
-                />
+
             </TimelineRight>
         </TimelineControlsContainer>
     );

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -74,12 +74,7 @@ export const buttonGhost = css`
 `;
 
 export const cardBase = css`
-  background-color: ${theme.colors.muted.background};
-  border: 1px solid ${theme.colors.border};
-  border-radius: ${theme.borderRadius.md};
-  padding: ${theme.spacing.sm};
-  margin: ${theme.spacing.sm};
-  margin-top: ${theme.spacing.md}; 
+  
   box-shadow: ${theme.shadows.sm};
 `;
 


### PR DESCRIPTION
## Summary
- Replaces the expandable FAB (floating action button) with an always-visible centered toolbar rendered inline within the player layout
- Constrains the entire layout to viewport height (`100dvh`) with the album art flexing to fill remaining space, preventing overflow/scrolling
- Simplifies controls layout by removing playback controls row and like button from timeline (WIP)

## Test plan
- [ ] Verify toolbar items are always visible and horizontally centered below controls
- [ ] Verify album art scales down on shorter viewports so controls + toolbar remain visible
- [ ] Verify no vertical scrolling occurs on any viewport size
- [ ] Test color picker popover still works from toolbar
- [ ] Test visual effects menu opens from toolbar
- [ ] Test on mobile and desktop viewports