### PR TITLE
feat: declutter mobile/tablet player by hiding playback controls

### DIFF
--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -92,7 +92,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   onAlbumPlay,
 }) => {
   // Get responsive sizing information
-  const { isMobile, isTablet } = usePlayerSizing();
+  const { isMobile, isTablet, isDesktop } = usePlayerSizing();
 
   // Color picker and overrides are managed in the quick actions panel
 
@@ -128,7 +128,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   const effectiveHandleLikeToggle = handleLikeToggle;
   
   return (
-    <PlayerControlsContainer $isMobile={isMobile} $isTablet={isTablet}>
+    <PlayerControlsContainer $isMobile={isMobile} $isTablet={isTablet} $compact={!isDesktop}>
       <TrackInfo
         track={currentTrack}
         isMobile={isMobile}
@@ -137,26 +137,24 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         onAlbumPlay={onAlbumPlay}
       />
 
-      <TrackInfoRow style={{ position: 'relative' }}>
-        <TrackInfoLeft>
-          {/* Left side is empty - could be used for other controls if needed */}
-        </TrackInfoLeft>
-        <TrackInfoCenter>
-          <PlaybackControls
-            onPrevious={onPrevious}
-            onPlay={onPlay}
-            onPause={onPause}
-            onNext={onNext}
-            isPlaying={isPlaying}
-            accentColor={accentColor}
-            isMobile={isMobile}
-            isTablet={isTablet}
-          />
-        </TrackInfoCenter>
-        <TrackInfoRight>
-          {/* Quick actions moved to right-side panel */}
-        </TrackInfoRight>
-      </TrackInfoRow>
+      {isDesktop && (
+        <TrackInfoRow style={{ position: 'relative' }}>
+          <TrackInfoLeft />
+          <TrackInfoCenter>
+            <PlaybackControls
+              onPrevious={onPrevious}
+              onPlay={onPlay}
+              onPause={onPause}
+              onNext={onNext}
+              isPlaying={isPlaying}
+              accentColor={accentColor}
+              isMobile={isMobile}
+              isTablet={isTablet}
+            />
+          </TrackInfoCenter>
+          <TrackInfoRight />
+        </TrackInfoRow>
+      )}
 
       <TimelineControls
         isMuted={effectiveIsMuted}

--- a/src/components/controls/TimelineControls.tsx
+++ b/src/components/controls/TimelineControls.tsx
@@ -68,7 +68,7 @@ export const TimelineControls = memo<TimelineControlsProps>(({
     isTablet
 }) => {
     return (
-        <TimelineControlsContainer>
+        <TimelineControlsContainer $isMobile={isMobile}>
             <TimelineLeft>
                 <VolumeControl
                     isMuted={isMuted}

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -135,7 +135,7 @@ export const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onAr
 
     return (
         <>
-            <TrackInfoOnlyRow>
+            <TrackInfoOnlyRow $compact={isMobile || isTablet}>
                 <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
                     {track?.name || 'No track selected'}
                 </PlayerTrackName>

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -3,12 +3,12 @@ import { theme } from '../../styles/theme';
 import { getContrastColor } from '../../utils/colorUtils';
 
 // --- Main Container ---
-export const PlayerControlsContainer = styled.div<{ $isMobile: boolean; $isTablet: boolean }>`
+export const PlayerControlsContainer = styled.div<{ $isMobile: boolean; $isTablet: boolean; $compact?: boolean }>`
   position: relative;
   z-index: 2;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme, $isMobile }) => $isMobile ? theme.spacing.sm : theme.spacing.md};
+  gap: ${({ theme, $isMobile, $compact }) => $compact ? theme.spacing.xs : $isMobile ? theme.spacing.sm : theme.spacing.md};
   padding: ${({ $isMobile, $isTablet }) => {
     if ($isMobile) return `${theme.spacing.xs} ${theme.spacing.sm}`;
     if ($isTablet) return `${theme.spacing.md} ${theme.spacing.md}`;
@@ -45,14 +45,14 @@ export const PlayerControlsContainer = styled.div<{ $isMobile: boolean; $isTable
 `;
 
 // --- Track Info Components ---
-export const TrackInfoOnlyRow = styled.div`
+export const TrackInfoOnlyRow = styled.div<{ $compact?: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
   gap: ${({ theme }) => theme.spacing.xs};
   padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
-  margin-bottom: ${({ theme }) => theme.spacing.xl};
+  margin-bottom: ${({ $compact }) => $compact ? '0' : theme.spacing.xl};
   margin-top: ${({ theme }) => theme.spacing.sm};
   position: relative;
   z-index: 10;
@@ -61,7 +61,7 @@ export const TrackInfoOnlyRow = styled.div`
 
   @media (max-width: ${theme.breakpoints.lg}) {
     margin-top: ${theme.spacing.xs};
-    margin-bottom: ${theme.spacing.lg};
+    margin-bottom: ${({ $compact }) => $compact ? '0' : theme.spacing.lg};
     padding: ${theme.spacing.xs} ${theme.spacing.sm};
   }
 `;
@@ -90,8 +90,8 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
 `;
 
 export const PlayerTrackAlbum = styled.div`
-  font-size: ${({ theme }) => theme.fontSize.xs};
-  line-height: ${({ theme }) => theme.fontSize.sm};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  line-height: ${({ theme }) => theme.fontSize.base};
   color: ${({ theme }) => theme.colors.gray[400]};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   letter-spacing: 0.02em;
@@ -121,8 +121,8 @@ export const AlbumLink = styled.a`
 `;
 
 export const PlayerTrackArtist = styled.div`
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  line-height: ${({ theme }) => theme.fontSize.sm};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  line-height: ${({ theme }) => theme.fontSize.base};
   color: ${({ theme }) => theme.colors.gray[300]};
   overflow: hidden;
   text-overflow: ellipsis;
@@ -270,12 +270,12 @@ export const VolumeButton = styled.button<{ $isMobile: boolean; $isTablet: boole
 `;
 
 // --- Timeline Components ---
-export const TimelineControlsContainer = styled.div`
+export const TimelineControlsContainer = styled.div<{ $isMobile?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: ${({ theme }) => theme.spacing.xs};
-  margin-top: ${({ theme }) => theme.spacing.lg};
+  margin-top: ${({ $isMobile }) => $isMobile ? '0' : theme.spacing.lg};
 `;
 
 export const TimelineLeft = styled.div`


### PR DESCRIPTION
## Summary
- Hide prev/play|pause/next buttons on mobile and tablet (< 1024px) since tap-to-play and swipe gestures already cover this functionality
- Tighten vertical spacing between track info and timeline in compact mode
- Bump album name font size (12px → 14px) and artist name font size (14px → 16px)

## Test plan
- [ ] Verify playback controls are hidden on mobile viewport (< 700px)
- [ ] Verify playback controls are hidden on tablet viewport (700px-1024px)
- [ ] Verify playback controls still appear on desktop (>= 1024px)
- [ ] Verify tap on album art still toggles play/pause on mobile
- [ ] Verify swipe left/right still navigates tracks on mobile/tablet
- [ ] Verify spacing between track info and timeline is tightened on mobile
- [ ] Verify album and artist font sizes are slightly larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)