### PR TITLE
feat: streamline FAB menu for mobile and speed up animations

### DIFF
--- a/src/components/FabMenu/FabMenuItems.tsx
+++ b/src/components/FabMenu/FabMenuItems.tsx
@@ -29,7 +29,7 @@ interface FabMenuItemsProps {
   onColorPickerOpenChange?: (isOpen: boolean) => void;
 }
 
-const STAGGER_DELAY = 30;
+const STAGGER_DELAY = 15;
 
 export const FabMenuItems = ({
   accentColor,
@@ -133,7 +133,7 @@ export const FabMenuItems = ({
       ),
     });
 
-    if (onBackToLibrary) {
+    if (!isMobile && onBackToLibrary) {
       list.push({
         key: 'library',
         label: 'Back to Library',
@@ -151,21 +151,23 @@ export const FabMenuItems = ({
       });
     }
 
-    list.push({
-      key: 'playlist',
-      label: 'Show Playlist',
-      content: (
-        <ControlButton
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          accentColor={accentColor}
-          onClick={onItemAction(onShowPlaylist)}
-          title="Show Playlist"
-        >
-          <PlaylistIcon />
-        </ControlButton>
-      ),
-    });
+    if (!isMobile) {
+      list.push({
+        key: 'playlist',
+        label: 'Show Playlist',
+        content: (
+          <ControlButton
+            $isMobile={isMobile}
+            $isTablet={isTablet}
+            accentColor={accentColor}
+            onClick={onItemAction(onShowPlaylist)}
+            title="Show Playlist"
+          >
+            <PlaylistIcon />
+          </ControlButton>
+        ),
+      });
+    }
 
     return list;
   }, [

--- a/src/components/FabMenu/styled.ts
+++ b/src/components/FabMenu/styled.ts
@@ -55,8 +55,8 @@ export const FabMenuItem = styled.div<{
   position: relative;
   transform: ${({ $isOpen }) => ($isOpen ? 'scale(1)' : 'scale(0)')};
   opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    opacity 0.2s ease;
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.12s ease;
   transition-delay: ${({ $isOpen, $openDelay, $closeDelay }) =>
     $isOpen ? `${$openDelay}ms` : `${$closeDelay}ms`};
 


### PR DESCRIPTION
## Summary
- Hide library and playlist FAB menu items on mobile (only glow, VFX, and accent color picker remain)
- Speed up FAB expand/contract animations: stagger delay 30ms→15ms, transform 0.25s→0.15s, opacity 0.2s→0.12s

## Test plan
- [ ] Verify mobile view shows only 3 FAB items: glow toggle, visual effects, color picker
- [ ] Verify desktop/tablet view still shows all FAB items (glow, visualizer, effects, color, library, playlist)
- [ ] Verify FAB expand/contract animation feels snappier on all devices
- [ ] Verify `prefers-reduced-motion` still disables animations