### PR TITLE
fix: move color chooser to middle position in mobile FAB menu

### DIFF
--- a/src/components/FabMenu/FabMenuItems.tsx
+++ b/src/components/FabMenu/FabMenuItems.tsx
@@ -101,22 +101,6 @@ export const FabMenuItems = ({
     }
 
     list.push({
-      key: 'effects',
-      label: 'Visual effects',
-      content: (
-        <ControlButton
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          accentColor={accentColor}
-          onClick={onItemAction(onShowVisualEffects)}
-          title="Visual effects"
-        >
-          <VisualEffectsIcon />
-        </ControlButton>
-      ),
-    });
-
-    list.push({
       key: 'color',
       label: 'Theme options',
       content: (
@@ -130,6 +114,22 @@ export const FabMenuItems = ({
           $isTablet={isTablet}
           onOpenChange={onColorPickerOpenChange}
         />
+      ),
+    });
+
+    list.push({
+      key: 'effects',
+      label: 'Visual effects',
+      content: (
+        <ControlButton
+          $isMobile={isMobile}
+          $isTablet={isTablet}
+          accentColor={accentColor}
+          onClick={onItemAction(onShowVisualEffects)}
+          title="Visual effects"
+        >
+          <VisualEffectsIcon />
+        </ControlButton>
       ),
     });
 


### PR DESCRIPTION
Reorder FAB menu items so the color chooser icon is the second (middle) one on mobile view.

**Before:** Glow | Visual effects | Color chooser  
**After:** Glow | Color chooser | Visual effects

Desktop/tablet layout unchanged (background visualizer, back to library, playlist remain in their positions).

Made with [Cursor](https://cursor.com)