### PR TITLE
Increase PlaylistBottomSheet height from 50dvh to 66dvh

### DIFF
--- a/src/components/PlaylistBottomSheet.tsx
+++ b/src/components/PlaylistBottomSheet.tsx
@@ -27,8 +27,8 @@ const DrawerContainer = styled.div.withConfig({
   left: 0;
   right: 0;
   bottom: 0;
-  height: 50dvh;
-  max-height: 50dvh;
+  height: 66dvh;
+  max-height: 66dvh;
   z-index: ${theme.zIndex.modal};
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(${theme.drawer.backdropBlur});


### PR DESCRIPTION
## Summary
Increased the height of the playlist bottom sheet drawer to provide more vertical space for displaying playlist content.

## Changes
- Updated `DrawerContainer` height from `50dvh` to `66dvh`
- Updated `DrawerContainer` max-height from `50dvh` to `66dvh`

## Details
This change allows the playlist bottom sheet to occupy more of the viewport (66% instead of 50%), giving users better visibility of playlist items and reducing the need to scroll within the drawer.

https://claude.ai/code/session_017Mm4YW4W7HSaMBP39S9sfk