### PR TITLE
fix: desktop vertical sizing overflow

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -68,7 +68,7 @@ const AlbumArtContainer = styled.div.withConfig({
   border-radius: ${theme.borderRadius['3xl']};
   position: relative;
   width: 100%;
-  max-width: ${theme.breakpoints.lg};
+  max-width: min(${theme.breakpoints.lg}, calc(100dvh - 350px));
   aspect-ratio: 1;
   margin: 0 auto;
   overflow: hidden;


### PR DESCRIPTION
## Summary
Fixes vertical overflow on desktop where the player (album art + controls panel) exceeded viewport height and required scrolling.

## Root cause
Album art had a fixed `max-width: 700px` with `aspect-ratio: 1`, so it rendered 700×700px regardless of viewport height. Combined with the ~350px controls panel, total content often exceeded viewport height (e.g. 934px viewport → 900px content → scroll).

## Solution
Make album art max-width viewport-height-aware:
```css
max-width: min(700px, calc(100dvh - 350px));
```
The 350px reserve accounts for controls panel, padding, and margins. On shorter viewports the album art shrinks to fit; on taller viewports it stays at full 700px.

## Testing
- Verified on viewports 714px–1004px height
- Album art scales down appropriately when viewport height decreases
- No scroll required when player fits viewport

Made with [Cursor](https://cursor.com)