### PR TITLE
feat: use vertical swipe on album art for zen mode instead of drawers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 - **Fully Responsive Design**: Fluid sizing with aspect-ratio calculations, container queries, and mobile-optimized layout
 - **Playlist Management**: Search, sort, filter, and pin playlists and albums with multiple sort criteria
 - **FAB Menu**: Expandable floating action button replacing traditional menus, unified across all devices
-- **Swipe Gestures**: Horizontal swipe for track navigation, vertical swipe for drawer toggles (mobile)
+- **Swipe Gestures**: Horizontal swipe on album art for track navigation; vertical swipe on album art for zen mode (up = exit zen, down = enter zen). Drawers are controlled by menu buttons only.
 - **Interactive Track Info**: Clickable artist/album names with popovers linking to Spotify and library filtering
 - **IndexedDB Caching**: Persistent library cache with background sync engine for instant startup
 - **Keyboard Shortcuts**: Context-aware keyboard control system (12 shortcuts with device-specific behavior)
@@ -135,7 +135,7 @@ vorbis-player/
 │   │   ├── useSpotifyControls.ts
 │   │   ├── useSpotifyPlayback.ts
 │   │   ├── useSwipeGesture.ts           # Horizontal swipe for track navigation
-│   │   ├── useVerticalSwipeGesture.ts   # Vertical swipe for drawer toggles
+│   │   ├── useVerticalSwipeGesture.ts   # Vertical swipe for zen mode on album art
 │   │   ├── useVisualEffectsState.ts
 │   │   └── useVolume.ts
 │   ├── services/                # External service integrations
@@ -346,7 +346,7 @@ The application uses a centralized state management approach with custom React h
 - **useKeyboardShortcuts.ts** - Context-aware keyboard shortcut handling with pointer input detection
 - **useLocalStorage.ts** - Generic localStorage hook with error handling and type safety
 - **useSwipeGesture.ts** - Horizontal swipe gesture detection for track navigation (mobile/tablet)
-- **useVerticalSwipeGesture.ts** - Vertical swipe gesture detection for drawer toggles (mobile)
+- **useVerticalSwipeGesture.ts** - Vertical swipe gesture detection for zen mode on album art (up = exit zen, down = enter zen)
 
 **Library & Data Hooks**:
 - **useLibrarySync.ts** - Background library sync with IndexedDB cache, exposes playlists/albums/sync state

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A visually immersive Spotify music player built with React, featuring customizab
 - **Album Art Filters**: Real-time CSS filters (brightness, contrast, saturation, sepia, hue rotation, blur)
 - **Background Visualizers**: Animated particle and geometric visualizer backgrounds (enabled by default)
 - **Custom Colors**: Pick accent colors per album from a color picker or eyedropper tool
-- **Swipe Gestures**: Swipe album art horizontally to change tracks, vertically to open drawers (mobile)
+- **Swipe Gestures**: Swipe album art horizontally to change tracks; swipe up to exit zen mode, down to enter zen mode. Library and playlist drawers are opened via the FAB menu.
 - **Interactive Track Info**: Click artist/album names for Spotify links and library filtering
 - **Instant Startup**: IndexedDB-based library cache with background sync for fast loading
 - **Responsive Design**: Fluid layout that adapts from mobile phones to ultra-wide desktops
@@ -93,8 +93,9 @@ The player displays album artwork with controls always visible below:
 **Touch Gestures** (mobile/tablet):
 - Tap album art to play/pause
 - Swipe album art left/right to change tracks
-- Swipe up on album art to open playlist
-- Swipe down on album art to open library
+- Swipe up on album art to exit zen mode
+- Swipe down on album art to enter zen mode
+- Library and playlist drawers: use FAB menu buttons
 
 ### Library
 


### PR DESCRIPTION
## Summary

Updates swipe gesture behavior on the album art:

- **Swipe up** on album art → exit zen mode (zen → normal)
- **Swipe down** on album art → enter zen mode (normal → zen)
- **Removed**: Vertical swipe no longer opens library or playlist drawers
- **Drawers**: Library and playlist drawers are now controlled only by FAB menu buttons

## Changes

- `PlayerContent.tsx`: Move vertical swipe from ContentWrapper to ClickableAlbumArtContainer; change handlers from drawer toggles to zen mode toggles
- `CLAUDE.md`: Update gesture documentation
- `README.md`: Update features and touch gestures sections

Made with [Cursor](https://cursor.com)