### PR TITLE
fix: speed up controls animation when exiting zen mode

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -223,7 +223,7 @@ const ZenControlsWrapper = styled.div.withConfig({
   /* Entering zen: controls fade out first. Exiting zen: controls appear after art finishes shrinking. */
   transition: ${({ $zenMode }) => $zenMode
     ? 'opacity 300ms ease, max-height 300ms ease, transform 300ms ease'
-    : 'opacity 500ms ease 1000ms, max-height 500ms ease 1000ms, transform 500ms ease 1000ms'
+    : 'opacity 350ms ease 500ms, max-height 350ms ease 500ms, transform 350ms ease 500ms'
   };
   pointer-events: ${({ $zenMode }) => $zenMode ? 'none' : 'auto'};
 `;


### PR DESCRIPTION
## Summary
Speeds up the controls animation when toggling from zen mode to normal mode.

## Changes
- **Delay**: 1000ms → 500ms (controls start appearing sooner)
- **Duration**: 500ms → 350ms (animation runs faster)

Controls now appear in ~850ms instead of ~1.5s when exiting zen mode.

## Location
`ZenControlsWrapper` in `src/components/PlayerContent.tsx`

Made with [Cursor](https://cursor.com)