### PR TITLE
refactor: move glow and visualizer toggles from bottom bar to VFX menu

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -7,8 +7,6 @@ import ColorPickerPopover from '../ColorPickerPopover';
 import { useCustomAccentColors } from '@/hooks/useCustomAccentColors';
 import { usePlayerSizing } from '@/hooks/usePlayerSizing';
 import {
-  GlowIcon,
-  BackgroundVisualizerIcon,
   VisualEffectsIcon,
   BackToLibraryIcon,
   PlaylistIcon,
@@ -22,16 +20,12 @@ const ZEN_HIDE_DELAY = 3000;
 interface BottomBarProps {
   accentColor: string;
   currentTrack: Track | null;
-  glowEnabled: boolean;
-  backgroundVisualizerEnabled?: boolean;
   zenModeEnabled?: boolean;
   isMuted: boolean;
   volume: number;
   onMuteToggle?: () => void;
   onVolumeChange?: (volume: number) => void;
   onShowVisualEffects: () => void;
-  onGlowToggle: () => void;
-  onBackgroundVisualizerToggle?: () => void;
   onAccentColorChange: (color: string) => void;
   onBackToLibrary?: () => void;
   onShowPlaylist: () => void;
@@ -43,16 +37,12 @@ interface BottomBarProps {
 export default function BottomBar({
   accentColor,
   currentTrack,
-  glowEnabled,
-  backgroundVisualizerEnabled,
   zenModeEnabled,
   isMuted,
   volume,
   onMuteToggle,
   onVolumeChange,
   onShowVisualEffects,
-  onGlowToggle,
-  onBackgroundVisualizerToggle,
   onAccentColorChange,
   onBackToLibrary,
   onShowPlaylist,
@@ -155,34 +145,6 @@ export default function BottomBar({
               aria-pressed={shuffleEnabled}
             >
               <ShuffleIcon />
-            </ControlButton>
-          )}
-
-          <ControlButton
-            $isMobile={isMobile}
-            $isTablet={isTablet}
-            $compact
-            accentColor={accentColor}
-            isActive={glowEnabled}
-            onClick={onGlowToggle}
-            title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
-            aria-pressed={glowEnabled}
-          >
-            <GlowIcon />
-          </ControlButton>
-
-          {onBackgroundVisualizerToggle && (
-            <ControlButton
-              $isMobile={isMobile}
-              $isTablet={isTablet}
-              $compact
-              accentColor={accentColor}
-              isActive={backgroundVisualizerEnabled}
-              onClick={onBackgroundVisualizerToggle}
-              title={`Background Visualizer ${backgroundVisualizerEnabled ? 'ON' : 'OFF'}`}
-              aria-pressed={backgroundVisualizerEnabled}
-            >
-              <BackgroundVisualizerIcon />
             </ControlButton>
           )}
 

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -530,16 +530,12 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
       <BottomBar
         accentColor={ui.accentColor}
         currentTrack={track.current}
-        glowEnabled={effects.enabled}
-        backgroundVisualizerEnabled={handlers.backgroundVisualizerEnabled}
         zenModeEnabled={ui.zenMode}
         isMuted={track.isMuted ?? false}
         volume={track.volume ?? 50}
         onMuteToggle={handlers.onMuteToggle}
         onVolumeChange={handlers.onVolumeChange}
         onShowVisualEffects={handlers.onShowVisualEffects}
-        onGlowToggle={handlers.onGlowToggle}
-        onBackgroundVisualizerToggle={handlers.onBackgroundVisualizerToggle}
         onAccentColorChange={handlers.onAccentColorChange}
         onBackToLibrary={handlers.onBackToLibrary}
         onShowPlaylist={handlers.onShowPlaylist}
@@ -572,11 +568,15 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ track, ui, effects, handl
             filters={effects.filters}
             onFilterChange={handlers.onFilterChange}
             onResetFilters={handlers.onResetFilters}
+            glowEnabled={effects.enabled}
+            onGlowToggle={handlers.onGlowToggle}
             glowIntensity={effects.glow.intensity}
             setGlowIntensity={handlers.onGlowIntensityChange}
             glowRate={effects.glow.rate}
             setGlowRate={handlers.onGlowRateChange}
             effectiveGlow={effects.glow}
+            backgroundVisualizerEnabled={handlers.backgroundVisualizerEnabled || false}
+            onBackgroundVisualizerToggle={handlers.onBackgroundVisualizerToggle || (() => {})}
             backgroundVisualizerStyle={(handlers.backgroundVisualizerStyle as VisualizerStyle) || 'particles'}
             onBackgroundVisualizerStyleChange={handlers.onBackgroundVisualizerStyleChange || (() => { })}
             backgroundVisualizerIntensity={handlers.backgroundVisualizerIntensity || 60}

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -40,12 +40,16 @@ interface VisualEffectsMenuProps {
   onFilterChange: (filterName: string, value: number) => void;
   onResetFilters: () => void;
   // Glow controls
+  glowEnabled: boolean;
+  onGlowToggle: () => void;
   glowIntensity: number;
   setGlowIntensity: (v: number) => void;
   glowRate: number;
   setGlowRate: (v: number) => void;
   effectiveGlow: { intensity: number; rate: number };
   // Background visualizer controls
+  backgroundVisualizerEnabled: boolean;
+  onBackgroundVisualizerToggle: () => void;
   backgroundVisualizerStyle: VisualizerStyle;
   onBackgroundVisualizerStyleChange: (style: VisualizerStyle) => void;
   backgroundVisualizerIntensity: number;
@@ -63,8 +67,10 @@ const areVisualEffectsPropsEqual = (
   if (
     prevProps.isOpen !== nextProps.isOpen ||
     prevProps.accentColor !== nextProps.accentColor ||
+    prevProps.glowEnabled !== nextProps.glowEnabled ||
     prevProps.glowIntensity !== nextProps.glowIntensity ||
-    prevProps.glowRate !== nextProps.glowRate
+    prevProps.glowRate !== nextProps.glowRate ||
+    prevProps.backgroundVisualizerEnabled !== nextProps.backgroundVisualizerEnabled
   ) {
     return false;
   }
@@ -107,10 +113,14 @@ const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
   filters,
   onFilterChange,
   onResetFilters,
+  glowEnabled,
+  onGlowToggle,
   glowIntensity,
   setGlowIntensity,
   glowRate,
   setGlowRate,
+  backgroundVisualizerEnabled,
+  onBackgroundVisualizerToggle,
   backgroundVisualizerStyle,
   onBackgroundVisualizerStyleChange,
   backgroundVisualizerIntensity,
@@ -272,6 +282,20 @@ const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
             <FilterGrid>
               <ControlGroup>
                 <ControlLabel>
+                  Glow
+                </ControlLabel>
+                <OptionButtonGroup>
+                  <OptionButton
+                    $accentColor={accentColor}
+                    $isActive={glowEnabled}
+                    onClick={onGlowToggle}
+                  >
+                    {glowEnabled ? 'On' : 'Off'}
+                  </OptionButton>
+                </OptionButtonGroup>
+              </ControlGroup>
+              <ControlGroup>
+                <ControlLabel>
                   Intensity
                   {/* <ControlValue>{getCurrentGlowIntensityLabel(glowIntensity)}</ControlValue> */}
                 </ControlLabel>
@@ -327,6 +351,20 @@ const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
           <FilterSection>
             <SectionTitle>Background Visualizer</SectionTitle>
             <FilterGrid>
+              <ControlGroup>
+                <ControlLabel>
+                  Visualizer
+                </ControlLabel>
+                <OptionButtonGroup>
+                  <OptionButton
+                    $accentColor={accentColor}
+                    $isActive={backgroundVisualizerEnabled}
+                    onClick={onBackgroundVisualizerToggle}
+                  >
+                    {backgroundVisualizerEnabled ? 'On' : 'Off'}
+                  </OptionButton>
+                </OptionButtonGroup>
+              </ControlGroup>
               <ControlGroup>
                 <ControlLabel>
                   Visualizer Style


### PR DESCRIPTION
## Summary

- Removes the standalone **Glow** and **Background Visualizer** toggle buttons from the bottom bar
- Adds **On/Off toggles** at the top of their respective sections in the Visual Effects Menu drawer, consistent with the existing Accent Color Background toggle pattern
- Keyboard shortcuts (`G` for glow, `V` for visualizer) remain fully functional — they are wired independently through `useKeyboardShortcuts` in `PlayerContent`

## Test plan

- [ ] Open the Visual Effects Menu and verify a "Glow / On / Off" toggle appears at the top of the Glow Effect section
- [ ] Verify toggling it on/off enables/disables the glow effect
- [ ] Verify a "Visualizer / On / Off" toggle appears at the top of the Background Visualizer section
- [ ] Verify toggling it on/off enables/disables the background visualizer
- [ ] Confirm neither toggle button appears in the bottom bar anymore
- [ ] Confirm `G` and `V` keyboard shortcuts still toggle glow and visualizer respectively

Made with [Cursor](https://cursor.com)