### PR TITLE
fix: adjust particle speed multiplier in TrailVisualizer for zen mode

### DIFF
--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -173,7 +173,7 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
 
     // Each particle either drifts or is respawned at the ship (large divisor = long trail; 50% longer life)
     const lifeDrain = (deltaTime / 14250) * speedMult;
-    const particleSpeedMult = zenMode ? 1.55 : 1;
+    const particleSpeedMult = zenMode ? 1.15 : 1;
 
     particles.forEach(particle => {
       particle.life -= lifeDrain;


### PR DESCRIPTION
- Reduced particle speed multiplier in zen mode from 1.55 to 1.15 to enhance visual effect and performance consistency.