### PR TITLE
perf: reduce unnecessary re-renders across component tree

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { flexCenter } from '@/styles/utils';
 import PlayerStateRenderer from './PlayerStateRenderer';
@@ -39,6 +39,19 @@ const AudioPlayerComponent = () => {
     handlers.handlePlaylistSelect(toAlbumPlaylistId(albumId));
   }, [handlers]);
 
+  const playbackHandlers = useMemo(() => ({
+    onPlay: handlers.handlePlay,
+    onPause: handlers.handlePause,
+    onNext: handlers.handleNext,
+    onPrevious: handlers.handlePrevious,
+    onTrackSelect: handlers.playTrack,
+    onOpenLibraryDrawer: handlers.handleOpenLibraryDrawer,
+    onCloseLibraryDrawer: handlers.handleCloseLibraryDrawer,
+    onPlaylistSelect: handlers.handlePlaylistSelect,
+    onAlbumPlay: handleAlbumPlay,
+    onBackToLibrary: handlers.handleBackToLibrary,
+  }), [handlers, handleAlbumPlay]);
+
   const isMainPlayerActive = !state.isLoading && !state.error && !!selectedPlaylistId && tracks.length > 0;
 
   const renderContent = () => {
@@ -61,19 +74,8 @@ const AudioPlayerComponent = () => {
         <PlayerContent
           isPlaying={state.isPlaying}
           showLibraryDrawer={state.showLibraryDrawer}
-          handlers={{
-          onPlay: handlers.handlePlay,
-          onPause: handlers.handlePause,
-          onNext: handlers.handleNext,
-          onPrevious: handlers.handlePrevious,
-          onTrackSelect: handlers.playTrack,
-          onOpenLibraryDrawer: handlers.handleOpenLibraryDrawer,
-          onCloseLibraryDrawer: handlers.handleCloseLibraryDrawer,
-          onPlaylistSelect: handlers.handlePlaylistSelect,
-          onAlbumPlay: handleAlbumPlay,
-          onBackToLibrary: handlers.handleBackToLibrary,
-        }}
-      />
+          handlers={playbackHandlers}
+        />
       </ProfiledComponent>
     );
   };

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -50,7 +50,7 @@ const VisualizerContainer = styled.div`
  * - isPlaying: Whether music is currently playing
  * - playbackPosition: Current playback position in milliseconds (optional)
  */
-const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = ({
+const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   enabled,
   style,
   intensity,
@@ -89,7 +89,9 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = ({
       />
     </VisualizerContainer>
   );
-};
+});
+
+BackgroundVisualizer.displayName = 'BackgroundVisualizer';
 
 export default BackgroundVisualizer;
 

--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { BottomBarContainer, BottomBarInner, ZenTriggerZone } from './styled';
 import { ControlButton } from '../controls/styled';
@@ -29,7 +29,7 @@ interface BottomBarProps {
   onShuffleToggle?: () => void;
 }
 
-export default function BottomBar({
+const BottomBar = React.memo(function BottomBar({
   accentColor,
   zenModeEnabled,
   isMuted,
@@ -189,4 +189,6 @@ export default function BottomBar({
     </>,
     document.body
   );
-}
+});
+
+export default BottomBar;

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
@@ -109,7 +109,7 @@ const DrawerContent = styled.div`
   flex-direction: column;
 `;
 
-function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, initialSearchQuery, initialViewMode }: LibraryDrawerProps) {
+const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, initialSearchQuery, initialViewMode }: LibraryDrawerProps) {
   const selectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handlePlaylistSelectWrapper = useCallback(
@@ -182,6 +182,6 @@ function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, initialSearchQuery, 
     </>,
     document.body
   );
-}
+});
 
 export default LibraryDrawer;

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -287,7 +287,7 @@ const defaultFilters = {
   sepia: 0,
 };
 
-const PlayerContent: React.FC<PlayerContentProps> = ({ isPlaying, showLibraryDrawer, onAlbumArtBoundsChange, handlers }) => {
+const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, showLibraryDrawer, onAlbumArtBoundsChange, handlers }) => {
   // --- Context hooks ---
   const {
     tracks,
@@ -784,6 +784,8 @@ const PlayerContent: React.FC<PlayerContentProps> = ({ isPlaying, showLibraryDra
       </ProfiledComponent>
     </ContentWrapper>
   );
-};
+});
+
+PlayerContent.displayName = 'PlayerContent';
 
 export default PlayerContent;


### PR DESCRIPTION
## Summary

Profiling (from #182) revealed cascading re-renders driven by an unstable `handlers` object literal in `AudioPlayer`, causing the entire component tree to re-render ~2x/second even when props hadn't changed.

- **Memoize `playbackHandlers`** with `useMemo` in `AudioPlayer.tsx` — eliminates the root cause of cascading re-renders by stabilizing the prop reference
- **Wrap `PlayerContent` in `React.memo`** — the most expensive component (166 renders, 215ms total, 25ms max spike)
- **Wrap `BottomBar` in `React.memo`** — 77% of its renders were unnecessary
- **Wrap `LibraryDrawer` in `React.memo`** — 33% unnecessary renders, 67 renders while hidden
- **Wrap `BackgroundVisualizer` in `React.memo`** — 49% unnecessary renders

`PlaylistDrawer` and `PlaylistBottomSheet` were already memoized with custom comparators.

## Expected impact

Based on the profiling session (~80s), these changes should reduce total component render work by ~50%+ and eliminate frame-dropping 25ms spikes from the cascade.

## Test plan

- [ ] Verify playback controls (play/pause, next/prev) still work correctly
- [ ] Verify BottomBar interactions (volume, shuffle, visual effects, library, playlist, zen mode)
- [ ] Verify LibraryDrawer opens/closes and playlist selection works
- [ ] Verify BackgroundVisualizer responds to accent color and style changes
- [ ] Run profiling mode again to confirm reduced render counts and eliminated unnecessary renders


Made with [Cursor](https://cursor.com)