### PR TITLE
perf: memoize handlers object in usePlayerLogic

### DIFF
--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { spotifyAuth } from '@/services/spotify';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
 import { useTrackContext } from '@/contexts/TrackContext';
@@ -146,6 +146,31 @@ export function usePlayerLogic() {
     setShowVisualEffects(false);
   }, [handlePause, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowPlaylist, setShowVisualEffects]);
 
+  const handlers = useMemo(
+    () => ({
+      handlePlaylistSelect,
+      handlePlay,
+      handlePause,
+      handleNext,
+      handlePrevious,
+      playTrack,
+      handleOpenLibraryDrawer,
+      handleCloseLibraryDrawer,
+      handleBackToLibrary,
+    }),
+    [
+      handlePlaylistSelect,
+      handlePlay,
+      handlePause,
+      handleNext,
+      handlePrevious,
+      playTrack,
+      handleOpenLibraryDrawer,
+      handleCloseLibraryDrawer,
+      handleBackToLibrary,
+    ]
+  );
+
   return {
     state: {
       isLoading,
@@ -156,16 +181,6 @@ export function usePlayerLogic() {
       isPlaying,
       playbackPosition,
     },
-    handlers: {
-      handlePlaylistSelect,
-      handlePlay,
-      handlePause,
-      handleNext,
-      handlePrevious,
-      playTrack,
-      handleOpenLibraryDrawer,
-      handleCloseLibraryDrawer,
-      handleBackToLibrary,
-    },
+    handlers,
   };
 }


### PR DESCRIPTION
## Summary

`usePlayerLogic` previously returned a new `handlers` object on every render. That forced `AudioPlayer`'s `playbackHandlers` useMemo to recompute every time and `PlayerContent`'s React.memo to always re-render (new `handlers` prop reference).

This change wraps the returned `handlers` in `useMemo` with dependencies on the individual callback refs (all already `useCallback`-wrapped). The `handlers` reference is now stable across renders unless a callback's dependencies actually change (e.g. `tracks.length`, context setters).

## Effect

- `AudioPlayer` gets a stable `handlers` → `playbackHandlers` stays stable.
- `PlayerContent` receives stable `handlers` → React.memo can skip re-renders when only `isPlaying` / `playbackPosition` (timeline tick) change.

Profiling showed PlayerContent still re-rendering ~2–3/sec after the earlier memo/useMemo work; stabilizing `handlers` at the source addresses that.

## Test plan

- [ ] Play/pause, next/prev, timeline scrubbing work.
- [ ] Library drawer open/close, playlist select work.
- [ ] Re-run profiler and confirm fewer PlayerContent re-renders during playback.


Made with [Cursor](https://cursor.com)