### PR TITLE
fix: eliminate false 'no playlists found' error when library drawer opens

### DIFF
--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -54,7 +54,11 @@ export function useLibrarySync(): UseLibrarySyncResult {
 
     return () => {
       unsubscribe();
-      engine.stop();
+      // Do not stop the singleton engine here — it should keep running in the
+      // background (polling every ~90s) regardless of which component is mounted.
+      // Stopping it caused a race where isInitialLoadComplete stayed true in the
+      // engine's state but the next subscriber got no data, showing a false
+      // "no playlists found" error until the async IndexedDB read completed.
     };
   }, []);
 

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -52,6 +52,12 @@ export class LibrarySyncEngine {
     error: null,
   };
 
+  // Last-known data, kept in memory so new subscribers get data immediately
+  // instead of seeing an empty state while IndexedDB is read asynchronously.
+  private lastKnownPlaylists: CachedPlaylistInfo[] | undefined;
+  private lastKnownAlbums: AlbumInfo[] | undefined;
+  private lastKnownLikedCount: number | undefined;
+
   // =========================================================================
   // Public API
   // =========================================================================
@@ -122,8 +128,10 @@ export class LibrarySyncEngine {
   /** Subscribe to state and data changes. Returns unsubscribe function. */
   subscribe(listener: SyncListener): () => void {
     this.listeners.add(listener);
-    // Immediately emit current state
-    listener(this.state);
+    // Immediately emit current state AND last-known data so new subscribers
+    // (e.g. when LibraryDrawer reopens and remounts PlaylistSelection) don't
+    // see an empty list while isInitialLoadComplete is already true.
+    listener(this.state, this.lastKnownPlaylists, this.lastKnownAlbums, this.lastKnownLikedCount);
     return () => {
       this.listeners.delete(listener);
     };
@@ -429,6 +437,11 @@ export class LibrarySyncEngine {
     albums?: AlbumInfo[],
     likedSongsCount?: number,
   ): void {
+    // Cache the data so it can be replayed to future subscribers immediately.
+    if (playlists !== undefined) this.lastKnownPlaylists = playlists;
+    if (albums !== undefined) this.lastKnownAlbums = albums;
+    if (likedSongsCount !== undefined) this.lastKnownLikedCount = likedSongsCount;
+
     for (const listener of this.listeners) {
       try {
         listener(this.state, playlists, albums, likedSongsCount);


### PR DESCRIPTION
- LibrarySyncEngine.subscribe() now emits last-known playlists/albums/likedCount
  immediately to new subscribers, not just the sync state
- This prevents the race where isInitialLoadComplete=true was emitted with no
  data (from the engine's persisted state) while IndexedDB read was pending
- LibrarySyncEngine.notifyListeners() caches the data it emits so future
  subscribers can replay it synchronously
- Removed engine.stop() from useLibrarySync cleanup: the singleton engine
  should keep polling in the background regardless of which component is
  mounted; stopping it was the root cause of the stale-state race condition