### PR TITLE
Improve liked songs caching to support fetching all songs

### DIFF
--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -61,7 +61,7 @@ export const usePlaylistManager = ({
       if (isAlbumId(playlistId)) {
         fetchedTracks = await getAlbumTracks(extractAlbumId(playlistId));
       } else if (playlistId === LIKED_SONGS_ID) {
-        fetchedTracks = await getLikedSongs(200);
+        fetchedTracks = await getLikedSongs();
       } else {
         fetchedTracks = await getPlaylistTracks(playlistId);
       }

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -79,7 +79,7 @@ const TRACK_LIST_PERSIST_TTL = 24 * 60 * 60 * 1000; // 24 hours (IndexedDB L2)
 let likedSongsCountCache: { count: number; timestamp: number } | null = null;
 const LIKED_SONGS_COUNT_TTL = 2 * 60 * 1000; // 2 minutes
 
-/** Cache for liked songs list */
+/** Cache for liked songs list — limit is Infinity when all songs were fetched */
 let likedSongsCache: { data: Track[]; limit: number; timestamp: number } | null = null;
 const LIKED_SONGS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
@@ -752,9 +752,14 @@ export async function getAlbumTracks(albumId: string): Promise<Track[]> {
   return sorted;
 }
 
-export async function getLikedSongs(limit: number = 50): Promise<Track[]> {
-  if (likedSongsCache && likedSongsCache.limit >= limit && Date.now() - likedSongsCache.timestamp < LIKED_SONGS_CACHE_TTL) {
-    return likedSongsCache.data.slice(0, limit);
+export async function getLikedSongs(limit?: number): Promise<Track[]> {
+  if (likedSongsCache && Date.now() - likedSongsCache.timestamp < LIKED_SONGS_CACHE_TTL) {
+    if (limit === undefined && likedSongsCache.limit === Infinity) {
+      return likedSongsCache.data;
+    }
+    if (limit !== undefined && likedSongsCache.limit >= limit) {
+      return likedSongsCache.data.slice(0, limit);
+    }
   }
 
   const token = await spotifyAuth.ensureValidToken();
@@ -770,15 +775,14 @@ export async function getLikedSongs(limit: number = 50): Promise<Track[]> {
     return transformTrackItem(item.track);
   }
 
-  const maxLimit = Math.min(limit, 50);
   const tracks = await fetchAllPaginated<SavedTrackItem, Track>(
-    `https://api.spotify.com/v1/me/tracks?limit=${maxLimit}`,
+    'https://api.spotify.com/v1/me/tracks?limit=50',
     token,
     transformSavedTrack,
-    { maxItems: limit }
+    limit !== undefined ? { maxItems: limit } : undefined
   );
 
-  likedSongsCache = { data: tracks, limit, timestamp: Date.now() };
+  likedSongsCache = { data: tracks, limit: limit ?? Infinity, timestamp: Date.now() };
   return tracks;
 }
 


### PR DESCRIPTION
## Summary
This PR improves the liked songs caching mechanism to support fetching all available liked songs without a limit, while maintaining backward compatibility with limited requests.

## Key Changes
- **Modified `getLikedSongs()` signature**: Changed `limit` parameter from required with default value (50) to optional (`limit?: number`)
- **Enhanced cache logic**: 
  - When `limit` is undefined and all songs have been fetched (cache limit is `Infinity`), return the complete cached data
  - When `limit` is defined, only use cache if it contains at least that many items
- **Simplified API call**: Removed dynamic limit calculation and always use a fixed limit of 50 per request, letting `fetchAllPaginated` handle pagination based on the `maxItems` option
- **Updated cache storage**: Store `Infinity` as the limit when all songs are fetched (no `maxItems` constraint), allowing future calls without a limit to use the complete cached dataset
- **Updated caller**: Changed `usePlaylistManager` to call `getLikedSongs()` without arguments to fetch all liked songs

## Implementation Details
- The cache now distinguishes between partial (limited) and complete (all songs fetched) states using `Infinity` as a sentinel value
- This allows efficient reuse of cached data: if all songs were previously fetched, subsequent calls without a limit return immediately without making API requests
- The change maintains the 5-minute TTL for cache validity

https://claude.ai/code/session_011A6kWWizkLUwmQdxiR3pnU