### PR TITLE
Add fallback context playback for restricted playlists

### DIFF
--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -12,6 +12,45 @@ async function waitForSpotifyReady(timeout = 10000): Promise<void> {
   }
 }
 
+/**
+ * Build a Track[] from the Spotify SDK's track window state.
+ * Used as a fallback when the API can't return the full track list
+ * (e.g. for Spotify-made playlists with restricted track access).
+ */
+function buildTracksFromWindow(state: SpotifyPlaybackState): Track[] {
+  const tracks: Track[] = [];
+
+  function toTrack(item: SpotifyTrack): Track {
+    return {
+      id: item.id || '',
+      name: item.name,
+      artists: item.artists.map(a => a.name).join(', '),
+      album: item.album?.name ?? 'Unknown Album',
+      album_id: item.album?.uri?.split(':').pop(),
+      duration_ms: item.duration_ms ?? 0,
+      uri: item.uri,
+      image: item.album?.images?.[0]?.url,
+    };
+  }
+
+  // Build from previous + current + next tracks in the window
+  for (const t of state.track_window.previous_tracks ?? []) {
+    tracks.push(toTrack(t));
+  }
+  tracks.push(toTrack(state.track_window.current_track));
+  for (const t of state.track_window.next_tracks ?? []) {
+    tracks.push(toTrack(t));
+  }
+
+  // Deduplicate by id (SDK can return duplicates)
+  const seen = new Set<string>();
+  return tracks.filter(t => {
+    if (!t.id || seen.has(t.id)) return false;
+    seen.add(t.id);
+    return true;
+  });
+}
+
 function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
@@ -63,7 +102,41 @@ export const usePlaylistManager = ({
       } else if (playlistId === LIKED_SONGS_ID) {
         fetchedTracks = await getLikedSongs(200);
       } else {
-        fetchedTracks = await getPlaylistTracks(playlistId);
+        try {
+          fetchedTracks = await getPlaylistTracks(playlistId);
+        } catch (trackError) {
+          // Track fetching may fail for non-owned playlists (e.g. Spotify-made)
+          // due to API restrictions — will fall through to context playback below
+          console.warn('Failed to fetch playlist tracks, will try context playback:', trackError);
+          fetchedTracks = [];
+        }
+      }
+
+      // For regular playlists where tracks couldn't be fetched (e.g. Spotify-made
+      // playlists), fall back to context-based playback which lets Spotify manage
+      // the track queue directly.
+      if (fetchedTracks.length === 0 && !isAlbumId(playlistId) && playlistId !== LIKED_SONGS_ID) {
+        try {
+          console.log('🎵 Trying context-based playback for playlist:', playlistId);
+          await spotifyPlayer.playContext(`spotify:playlist:${playlistId}`);
+
+          // Wait for SDK to start playing and report the first track
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          const state = await spotifyPlayer.getCurrentState();
+
+          if (state?.track_window?.current_track) {
+            const tracksFromWindow = buildTracksFromWindow(state);
+            setOriginalTracks(tracksFromWindow);
+            setTracks(tracksFromWindow);
+            setCurrentTrackIndex(0);
+          }
+          // Playback started successfully via context — return without error
+          return;
+        } catch (contextError) {
+          console.error('Context playback also failed:', contextError);
+          setError("No tracks found in this playlist. It may be empty or unavailable.");
+          return;
+        }
       }
 
       if (fetchedTracks.length === 0) {

--- a/src/services/cache/__tests__/librarySyncEngine.test.ts
+++ b/src/services/cache/__tests__/librarySyncEngine.test.ts
@@ -12,6 +12,8 @@ vi.mock('../../spotify', () => ({
   getLikedSongsCount: vi.fn(),
   getPlaylistsPage: vi.fn(),
   getAlbumsPage: vi.fn(),
+  getAllUserPlaylists: vi.fn(),
+  getAllUserAlbums: vi.fn(),
   getUserLibraryInterleaved: vi.fn(),
   invalidateLikedSongsCaches: vi.fn(),
   spotifyAuth: {
@@ -24,8 +26,8 @@ import {
   getPlaylistCount,
   getAlbumCount,
   getLikedSongsCount,
-  getPlaylistsPage,
-  getAlbumsPage,
+  getAllUserPlaylists,
+  getAllUserAlbums,
   getUserLibraryInterleaved,
   invalidateLikedSongsCaches,
 } from '../../spotify';
@@ -33,8 +35,8 @@ import {
 const mockGetPlaylistCount = vi.mocked(getPlaylistCount);
 const mockGetAlbumCount = vi.mocked(getAlbumCount);
 const mockGetLikedSongsCount = vi.mocked(getLikedSongsCount);
-const mockGetPlaylistsPage = vi.mocked(getPlaylistsPage);
-const mockGetAlbumsPage = vi.mocked(getAlbumsPage);
+const mockGetAllUserPlaylists = vi.mocked(getAllUserPlaylists);
+const mockGetAllUserAlbums = vi.mocked(getAllUserAlbums);
 const mockGetUserLibraryInterleaved = vi.mocked(getUserLibraryInterleaved);
 const mockInvalidateLikedSongsCaches = vi.mocked(invalidateLikedSongsCaches);
 
@@ -188,8 +190,8 @@ describe('LibrarySyncEngine', () => {
 
       await engine.syncNow();
 
-      expect(mockGetPlaylistsPage).not.toHaveBeenCalled();
-      expect(mockGetAlbumsPage).not.toHaveBeenCalled();
+      expect(mockGetAllUserPlaylists).not.toHaveBeenCalled();
+      expect(mockGetAllUserAlbums).not.toHaveBeenCalled();
       expect(mockInvalidateLikedSongsCaches).not.toHaveBeenCalled();
     });
 
@@ -212,18 +214,14 @@ describe('LibrarySyncEngine', () => {
       mockGetPlaylistCount.mockResolvedValue(2);
       mockGetAlbumCount.mockResolvedValue(0);
       mockGetLikedSongsCount.mockResolvedValue(0);
-      mockGetPlaylistsPage.mockResolvedValue({
-        playlists: [
-          makePlaylist('p1', 'Existing', 'snap1'),
-          makePlaylist('p2', 'New Playlist', 'snap2'),
-        ],
-        total: 2,
-        hasMore: false,
-      });
+      mockGetAllUserPlaylists.mockResolvedValue([
+        makePlaylist('p1', 'Existing', 'snap1'),
+        makePlaylist('p2', 'New Playlist', 'snap2'),
+      ]);
 
       await engine.syncNow();
 
-      expect(mockGetPlaylistsPage).toHaveBeenCalled();
+      expect(mockGetAllUserPlaylists).toHaveBeenCalled();
       const cachedPlaylists = await cache.getAllPlaylists();
       expect(cachedPlaylists).toHaveLength(2);
       expect(cachedPlaylists.find(p => p.id === 'p2')?.name).toBe('New Playlist');
@@ -278,11 +276,9 @@ describe('LibrarySyncEngine', () => {
       mockGetPlaylistCount.mockResolvedValue(1);
       mockGetAlbumCount.mockResolvedValue(0);
       mockGetLikedSongsCount.mockResolvedValue(0);
-      mockGetPlaylistsPage.mockResolvedValue({
-        playlists: [makePlaylist('p1', 'Keep', 'snap1')],
-        total: 1,
-        hasMore: false,
-      });
+      mockGetAllUserPlaylists.mockResolvedValue([
+        makePlaylist('p1', 'Keep', 'snap1'),
+      ]);
 
       await engine.syncNow();
 
@@ -312,14 +308,10 @@ describe('LibrarySyncEngine', () => {
       mockGetPlaylistCount.mockResolvedValue(2);
       mockGetAlbumCount.mockResolvedValue(0);
       mockGetLikedSongsCount.mockResolvedValue(0);
-      mockGetPlaylistsPage.mockResolvedValue({
-        playlists: [
-          makePlaylist('p1', 'Modified', 'snap-new'),
-          makePlaylist('p2', 'New', 'snap2'),
-        ],
-        total: 2,
-        hasMore: false,
-      });
+      mockGetAllUserPlaylists.mockResolvedValue([
+        makePlaylist('p1', 'Modified', 'snap-new'),
+        makePlaylist('p2', 'New', 'snap2'),
+      ]);
 
       await engine.syncNow();
 

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -14,8 +14,8 @@ import {
   getPlaylistCount,
   getAlbumCount,
   getLikedSongsCount,
-  getPlaylistsPage,
-  getAlbumsPage,
+  getAllUserPlaylists,
+  getAllUserAlbums,
   getUserLibraryInterleaved,
   invalidateLikedSongsCaches,
   spotifyAuth,
@@ -333,7 +333,6 @@ export class LibrarySyncEngine {
     this.notifyListeners(playlists, albums, changes.newLikedSongsCount);
   }
 
-  // getPlaylistsPage only fetches from offset 0; libraries > 50 playlists get a partial sync
   private async syncPlaylists(newTotal: number, signal: AbortSignal): Promise<CachedPlaylistInfo[]> {
     const [cachedPlaylists, meta] = await Promise.all([
       cache.getAllPlaylists(),
@@ -345,7 +344,9 @@ export class LibrarySyncEngine {
     );
 
     if (signal.aborted) throw new DOMException('Request aborted', 'AbortError');
-    const { playlists } = await getPlaylistsPage(50, signal);
+
+    // Fetch ALL pages so libraries with >50 playlists are fully synced
+    const playlists = await getAllUserPlaylists(signal);
     const allFetched = playlists as CachedPlaylistInfo[];
 
     const fetchTimestamp = new Date().toISOString();
@@ -385,10 +386,11 @@ export class LibrarySyncEngine {
     return allFetched;
   }
 
-  // getAlbumsPage only fetches from offset 0; libraries > 50 albums get a partial sync
   private async syncAlbums(newTotal: number, signal: AbortSignal): Promise<AlbumInfo[]> {
     const cachedAlbums = await cache.getAllAlbums();
-    const { albums: allFetched } = await getAlbumsPage(50, signal);
+
+    // Fetch ALL pages so libraries with >50 albums are fully synced
+    const allFetched = await getAllUserAlbums(signal);
 
     const fetchedIds = new Set(allFetched.map(a => a.id));
 

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -933,6 +933,62 @@ export async function getAlbumsPage(
   };
 }
 
+/** Fetch ALL user playlists with full pagination (not capped at 50). */
+export async function getAllUserPlaylists(signal?: AbortSignal): Promise<PlaylistInfo[]> {
+  const token = await spotifyAuth.ensureValidToken();
+  const fetchTimestamp = new Date().toISOString();
+  const playlists: PlaylistInfo[] = [];
+  let nextUrl: string | null = 'https://api.spotify.com/v1/me/playlists?limit=50';
+
+  while (nextUrl) {
+    if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
+    const url = nextUrl;
+    const data: PaginatedResponse<PlaylistInfo> = await spotifyApiRequest(url, token, { signal });
+    for (const item of data.items ?? []) {
+      playlists.push({ ...item, added_at: item.added_at || fetchTimestamp });
+    }
+    nextUrl = data.next;
+  }
+
+  return playlists;
+}
+
+/** Fetch ALL user saved albums with full pagination (not capped at 50). */
+export async function getAllUserAlbums(signal?: AbortSignal): Promise<AlbumInfo[]> {
+  const token = await spotifyAuth.ensureValidToken();
+
+  interface SavedAlbumItem {
+    added_at: string;
+    album: SpotifyAlbum;
+  }
+
+  const albums: AlbumInfo[] = [];
+  let nextUrl: string | null = 'https://api.spotify.com/v1/me/albums?limit=50';
+
+  while (nextUrl) {
+    if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
+    const url = nextUrl;
+    const data: PaginatedResponse<SavedAlbumItem> = await spotifyApiRequest(url, token, { signal });
+    for (const item of data.items ?? []) {
+      const album = item.album;
+      albums.push({
+        id: album.id ?? '',
+        name: album.name ?? 'Unknown Album',
+        artists: formatArtists(album.artists),
+        images: album.images ?? [],
+        release_date: album.release_date ?? '',
+        total_tracks: album.total_tracks ?? 0,
+        uri: album.uri ?? '',
+        album_type: album.album_type,
+        added_at: item.added_at,
+      });
+    }
+    nextUrl = data.next;
+  }
+
+  return albums;
+}
+
 /** Invalidate the in-memory liked songs caches (used by sync engine). */
 export function invalidateLikedSongsCaches(): void {
   likedSongsCache = null;

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -208,6 +208,53 @@ class SpotifyPlayerService {
     }
   }
 
+  /**
+   * Play a Spotify context (playlist, album, artist) by its URI.
+   * This lets Spotify manage the track queue, useful for playlists where
+   * the API may not return individual tracks (e.g. Spotify-made playlists).
+   */
+  async playContext(contextUri: string, offsetPosition?: number): Promise<void> {
+    if (!this.deviceId || !this.isReady) {
+      throw new Error('Spotify player not ready');
+    }
+    this.lastPlayTrackTime = Date.now();
+
+    const token = await spotifyAuth.ensureValidToken();
+
+    const body: Record<string, unknown> = { context_uri: contextUri };
+    if (offsetPosition !== undefined) {
+      body.offset = { position: offsetPosition };
+    }
+
+    console.log('🎵 Playing context:', { contextUri, offsetPosition, deviceId: this.deviceId });
+
+    const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${this.deviceId}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('🎵 Context playback error:', errorText);
+
+      let errorReason = '';
+      try {
+        const errorJson = JSON.parse(errorText);
+        if (errorJson.error?.message) {
+          errorReason = ` - ${errorJson.error.message}`;
+        }
+      } catch {
+        errorReason = errorText ? ` - ${errorText}` : '';
+      }
+
+      throw new Error(`Spotify API error: ${response.status}${errorReason}`);
+    }
+  }
+
   async playPlaylist(uris: string[]): Promise<void> {
     if (!this.deviceId || !this.isReady) {
       throw new Error('Spotify player not ready');


### PR DESCRIPTION
## Summary
This PR adds support for playing Spotify-made and other restricted playlists that don't expose individual tracks via the API. When track fetching fails, the app now falls back to context-based playback, letting Spotify manage the queue directly. Additionally, library syncing is improved to fetch all playlists and albums instead of being capped at 50 items.

## Key Changes

- **Context-based playback fallback**: Added `playContext()` method to `SpotifyPlayerService` to play playlists/albums by URI when individual track data isn't available
- **Track window extraction**: Implemented `buildTracksFromWindow()` to construct a track list from the Spotify SDK's playback state (previous, current, and next tracks) with deduplication
- **Graceful error handling**: Modified playlist loading in `usePlaylistManager` to catch track fetch failures and attempt context playback as a fallback
- **Full library pagination**: Replaced `getPlaylistsPage()` and `getAlbumsPage()` with `getAllUserPlaylists()` and `getAllUserAlbums()` that fetch all pages, fixing incomplete syncing for libraries with >50 items
- **Updated tests**: Modified `librarySyncEngine.test.ts` to mock and test the new pagination functions

## Implementation Details

- The fallback flow: attempt API track fetch → if empty/failed, try context playback → extract tracks from SDK state
- Context playback waits 2 seconds for Spotify to start playing before reading the current state
- Track deduplication in `buildTracksFromWindow()` handles SDK quirks where the same track may appear multiple times
- Full pagination uses a `while` loop to follow `next` URLs until all items are fetched
- Maintains backward compatibility with album and liked songs playback paths

https://claude.ai/code/session_013N4Po6kGsU2yr1YE9QcRxB