### PR TITLE
Fix album pinning behavior when filters are active

### DIFF
--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -727,11 +727,11 @@ function PlaylistSelection({ onPlaylistSelect, inDrawer = false, swipeZoneRef, i
   }, [filteredPlaylists, pinnedPlaylistIds, hasActiveFilters]);
 
   const { pinned: pinnedAlbums, unpinned: unpinnedAlbums } = useMemo(() => {
-    if (hasActiveFilters || pinnedAlbumIds.length === 0) {
+    if (pinnedAlbumIds.length === 0) {
       return { pinned: [] as AlbumInfo[], unpinned: filteredAlbums };
     }
     return partitionByPinned(filteredAlbums, pinnedAlbumIds, (a) => a.id);
-  }, [filteredAlbums, pinnedAlbumIds, hasActiveFilters]);
+  }, [filteredAlbums, pinnedAlbumIds]);
 
   useEffect(() => {
     if (viewMode === 'playlists') {


### PR DESCRIPTION
## Summary
Fixed the album pinning logic to respect pinned albums even when active filters are applied, bringing it into alignment with the playlist pinning behavior.

## Key Changes
- Removed the `hasActiveFilters` condition from the album pinning check that was preventing pinned albums from being displayed when filters were active
- Updated the dependency array to remove the now-unused `hasActiveFilters` dependency, keeping only the necessary `filteredAlbums` and `pinnedAlbumIds` dependencies

## Implementation Details
Previously, when filters were active, the album list would ignore the pinned album configuration and show all filtered albums unsorted. Now pinned albums will be properly separated and displayed at the top of the list regardless of active filters, matching the existing behavior for playlists.

https://claude.ai/code/session_01WY1C7r3pNmJMM7WRjupbkS