### PR TITLE
feat: add translucence visual effect for album art

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -55,17 +55,20 @@ interface AlbumArtProps {
     blur: number;
     sepia: number;
   };
+  translucenceEnabled?: boolean;
+  translucenceOpacity?: number;
 }
 
 
 const AlbumArtContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['accentColor', 'glowIntensity', 'glowRate', 'glowEnabled', '$zenMode'].includes(prop),
+  shouldForwardProp: (prop) => !['accentColor', 'glowIntensity', 'glowRate', 'glowEnabled', '$zenMode', '$translucenceOpacity'].includes(prop),
 }) <{
   accentColor?: string;
   glowIntensity?: number;
   glowRate?: number;
   glowEnabled?: boolean;
   $zenMode?: boolean;
+  $translucenceOpacity?: number;
 }>`
   border-radius: ${theme.borderRadius['3xl']};
   position: relative;
@@ -137,7 +140,8 @@ const AlbumArtContainer = styled.div.withConfig({
   }}
   border: none;
   z-index: ${theme.zIndex.docked};
-  transition: box-shadow 0.5s ease;
+  transition: box-shadow 0.5s ease, opacity 0.5s ease;
+  opacity: ${({ $translucenceOpacity }) => $translucenceOpacity ?? 1};
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
 `;
@@ -160,6 +164,10 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
   if (prevProps.zenMode !== nextProps.zenMode) {
     return false;
   }
+  if (prevProps.translucenceEnabled !== nextProps.translucenceEnabled ||
+      prevProps.translucenceOpacity !== nextProps.translucenceOpacity) {
+    return false;
+  }
   if (!prevProps.albumFilters && !nextProps.albumFilters) {
     return true;
   }
@@ -177,7 +185,7 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
   return true;
 };
 
-const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentColor, glowIntensity, glowRate, glowEnabled, albumFilters, zenMode }) => {
+const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentColor, glowIntensity, glowRate, glowEnabled, albumFilters, zenMode, translucenceEnabled, translucenceOpacity }) => {
   const [canvasUrl, setCanvasUrl] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const { processImage } = useImageProcessingWorker();
@@ -270,6 +278,7 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
       glowRate={glowRate}
       glowEnabled={glowEnabled}
       $zenMode={zenMode}
+      $translucenceOpacity={translucenceEnabled ? (translucenceOpacity ?? 0.6) : 1}
       className={glowClasses}
     >
       <AlbumArtFilters filters={albumFilters ? albumFilters : {

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -375,6 +375,10 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setBackgroundVisualizerIntensity,
     accentColorBackgroundPreferred,
     setAccentColorBackgroundPreferred,
+    translucenceEnabled,
+    setTranslucenceEnabled,
+    translucenceOpacity,
+    setTranslucenceOpacity,
     zenModeEnabled,
     setZenModeEnabled,
     showVisualEffects,
@@ -509,6 +513,14 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setBackgroundVisualizerStyle(style);
   }, [setBackgroundVisualizerStyle]);
 
+  const handleTranslucenceToggle = useCallback(() => {
+    setTranslucenceEnabled(prev => !prev);
+  }, [setTranslucenceEnabled]);
+
+  const handleTranslucenceOpacityChange = useCallback((v: number) => {
+    setTranslucenceOpacity(v);
+  }, [setTranslucenceOpacity]);
+
   // Stable quick-effects prop for SpotifyPlayerControls (compact color/glow/viz row)
   const quickEffects = useMemo(
     () => ({
@@ -521,6 +533,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
       onBackgroundVisualizerToggle: handleBackgroundVisualizerToggle,
       backgroundVisualizerStyle: backgroundVisualizerStyle as 'fireflies' | 'comet',
       onBackgroundVisualizerStyleChange: handleBackgroundVisualizerStyleChange,
+      translucenceEnabled: translucenceEnabled,
+      onTranslucenceToggle: handleTranslucenceToggle,
     }),
     [
       customAccentColors,
@@ -532,6 +546,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
       handleBackgroundVisualizerToggle,
       backgroundVisualizerStyle,
       handleBackgroundVisualizerStyleChange,
+      translucenceEnabled,
+      handleTranslucenceToggle,
     ]
   );
 
@@ -747,6 +763,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                       glowRate={effectiveGlow.rate}
                       glowEnabled={visualEffectsEnabled}
                       albumFilters={visualEffectsEnabled ? albumFilters : defaultFilters}
+                      translucenceEnabled={visualEffectsEnabled && translucenceEnabled}
+                      translucenceOpacity={translucenceOpacity}
                       zenMode={zenModeEnabled}
                     />
                   </ProfiledComponent>
@@ -813,6 +831,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                             onBackgroundVisualizerToggle={quickEffects.onBackgroundVisualizerToggle}
                             backgroundVisualizerStyle={quickEffects.backgroundVisualizerStyle}
                             onBackgroundVisualizerStyleChange={quickEffects.onBackgroundVisualizerStyleChange}
+                            translucenceEnabled={quickEffects.translucenceEnabled}
+                            onTranslucenceToggle={quickEffects.onTranslucenceToggle}
                             isMobile={isMobile}
                             isTablet={isTablet}
                           />
@@ -867,6 +887,10 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
             onBackgroundVisualizerIntensityChange={handleBackgroundVisualizerIntensityChange}
             accentColorBackgroundEnabled={accentColorBackgroundPreferred}
             onAccentColorBackgroundToggle={handleAccentColorBackgroundToggle}
+            translucenceEnabled={translucenceEnabled}
+            onTranslucenceToggle={handleTranslucenceToggle}
+            translucenceOpacity={translucenceOpacity}
+            onTranslucenceOpacityChange={handleTranslucenceOpacityChange}
           />
         </Suspense>
       )}

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -56,6 +56,11 @@ interface VisualEffectsMenuProps {
   onBackgroundVisualizerIntensityChange: (intensity: number) => void;
   accentColorBackgroundEnabled: boolean;
   onAccentColorBackgroundToggle: () => void;
+  // Translucence controls
+  translucenceEnabled: boolean;
+  onTranslucenceToggle: () => void;
+  translucenceOpacity: number;
+  onTranslucenceOpacityChange: (v: number) => void;
 }
 
 // Custom comparison function for memo optimization
@@ -70,7 +75,9 @@ const areVisualEffectsPropsEqual = (
     prevProps.glowEnabled !== nextProps.glowEnabled ||
     prevProps.glowIntensity !== nextProps.glowIntensity ||
     prevProps.glowRate !== nextProps.glowRate ||
-    prevProps.backgroundVisualizerEnabled !== nextProps.backgroundVisualizerEnabled
+    prevProps.backgroundVisualizerEnabled !== nextProps.backgroundVisualizerEnabled ||
+    prevProps.translucenceEnabled !== nextProps.translucenceEnabled ||
+    prevProps.translucenceOpacity !== nextProps.translucenceOpacity
   ) {
     return false;
   }
@@ -126,7 +133,11 @@ const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
   backgroundVisualizerIntensity,
   onBackgroundVisualizerIntensityChange,
   accentColorBackgroundEnabled,
-  onAccentColorBackgroundToggle
+  onAccentColorBackgroundToggle,
+  translucenceEnabled,
+  onTranslucenceToggle,
+  translucenceOpacity,
+  onTranslucenceOpacityChange
 }) => {
   // Get responsive sizing information
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
@@ -346,7 +357,45 @@ const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
               </ControlGroup>
             </FilterGrid>
           </FilterSection>
-          
+
+          {/* Translucence Section */}
+          <FilterSection>
+            <SectionTitle>Translucence</SectionTitle>
+            <FilterGrid>
+              <ControlGroup>
+                <ControlLabel>Translucence</ControlLabel>
+                <OptionButtonGroup>
+                  <OptionButton
+                    $accentColor={accentColor}
+                    $isActive={translucenceEnabled}
+                    onClick={onTranslucenceToggle}
+                  >
+                    {translucenceEnabled ? 'On' : 'Off'}
+                  </OptionButton>
+                </OptionButtonGroup>
+              </ControlGroup>
+              <ControlGroup>
+                <ControlLabel>Opacity</ControlLabel>
+                <OptionButtonGroup>
+                  {[
+                    { label: 'Light', value: 0.8 },
+                    { label: 'Medium', value: 0.6 },
+                    { label: 'Strong', value: 0.4 },
+                  ].map((option) => (
+                    <OptionButton
+                      key={`translucence-${option.value}`}
+                      $accentColor={accentColor}
+                      $isActive={translucenceOpacity === option.value}
+                      onClick={() => onTranslucenceOpacityChange(option.value)}
+                    >
+                      {option.label}
+                    </OptionButton>
+                  ))}
+                </OptionButtonGroup>
+              </ControlGroup>
+            </FilterGrid>
+          </FilterSection>
+
           {/* Background Visualizer Options Section */}
           <FilterSection>
             <SectionTitle>Background Visualizer</SectionTitle>

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -20,6 +20,8 @@ export interface QuickEffectsRowProps {
   onBackgroundVisualizerToggle: () => void;
   backgroundVisualizerStyle: 'fireflies' | 'comet';
   onBackgroundVisualizerStyleChange: (style: 'fireflies' | 'comet') => void;
+  translucenceEnabled: boolean;
+  onTranslucenceToggle: () => void;
   isMobile: boolean;
   isTablet: boolean;
 }
@@ -154,6 +156,8 @@ function QuickEffectsRow({
   onBackgroundVisualizerToggle,
   backgroundVisualizerStyle,
   onBackgroundVisualizerStyleChange,
+  translucenceEnabled,
+  onTranslucenceToggle,
 }: QuickEffectsRowProps) {
   const [colorOptions, setColorOptions] = useState<ExtractedColor[]>([]);
   const [showEyedropper, setShowEyedropper] = useState(false);
@@ -233,6 +237,13 @@ function QuickEffectsRow({
           <QuickLabel>Viz</QuickLabel>
           <SwitchTrack $on={backgroundVisualizerEnabled} $accent={accentColor} onClick={onBackgroundVisualizerToggle} aria-label="Toggle visualizer" role="switch" aria-checked={backgroundVisualizerEnabled}>
             <SwitchKnob $on={backgroundVisualizerEnabled} />
+          </SwitchTrack>
+        </ToggleGroup>
+
+        <ToggleGroup>
+          <QuickLabel>Translucent</QuickLabel>
+          <SwitchTrack $on={translucenceEnabled} $accent={accentColor} onClick={onTranslucenceToggle} aria-label="Toggle translucence" role="switch" aria-checked={translucenceEnabled}>
+            <SwitchKnob $on={translucenceEnabled} />
           </SwitchTrack>
         </ToggleGroup>
       </RowLine>

--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -16,6 +16,8 @@ interface VisualEffectsContextValue {
   backgroundVisualizerIntensity: number;
   accentColorBackgroundPreferred: boolean;
   accentColorBackgroundEnabled: boolean;
+  translucenceEnabled: boolean;
+  translucenceOpacity: number;
   zenModeEnabled: boolean;
   showVisualEffects: boolean;
   // Setters
@@ -26,6 +28,8 @@ interface VisualEffectsContextValue {
   setBackgroundVisualizerStyle: (style: VisualizerStyle | ((prev: VisualizerStyle) => VisualizerStyle)) => void;
   setBackgroundVisualizerIntensity: (intensity: number | ((prev: number) => number)) => void;
   setAccentColorBackgroundPreferred: (preferred: boolean | ((prev: boolean) => boolean)) => void;
+  setTranslucenceEnabled: (enabled: boolean | ((prev: boolean) => boolean)) => void;
+  setTranslucenceOpacity: (opacity: number | ((prev: number) => number)) => void;
   setZenModeEnabled: (enabled: boolean | ((prev: boolean) => boolean)) => void;
   setShowVisualEffects: (visible: boolean | ((prev: boolean) => boolean)) => void;
   // Handlers
@@ -46,6 +50,8 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>('vorbis-player-background-visualizer-intensity', 60);
   const [accentColorBackgroundPreferred, setAccentColorBackgroundPreferred] = useLocalStorage<boolean>('vorbis-player-accent-color-background-preferred', false);
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
+  const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>('vorbis-player-translucence-enabled', false);
+  const [translucenceOpacity, setTranslucenceOpacity] = useLocalStorage<number>('vorbis-player-translucence-opacity', 0.6);
   const [zenModeEnabled, setZenModeEnabled] = useLocalStorage<boolean>('vorbis-player-zen-mode-enabled', false);
   const [showVisualEffects, setShowVisualEffects] = useState<boolean>(false);
 
@@ -100,6 +106,8 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     backgroundVisualizerIntensity,
     accentColorBackgroundPreferred,
     accentColorBackgroundEnabled,
+    translucenceEnabled,
+    translucenceOpacity,
     zenModeEnabled,
     showVisualEffects,
     setVisualEffectsEnabled,
@@ -109,6 +117,8 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     setBackgroundVisualizerStyle,
     setBackgroundVisualizerIntensity,
     setAccentColorBackgroundPreferred,
+    setTranslucenceEnabled,
+    setTranslucenceOpacity,
     setZenModeEnabled,
     setShowVisualEffects,
     handleFilterChange,
@@ -124,6 +134,8 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     backgroundVisualizerIntensity,
     accentColorBackgroundPreferred,
     accentColorBackgroundEnabled,
+    translucenceEnabled,
+    translucenceOpacity,
     zenModeEnabled,
     showVisualEffects,
     setVisualEffectsEnabled,
@@ -133,6 +145,8 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     setBackgroundVisualizerStyle,
     setBackgroundVisualizerIntensity,
     setAccentColorBackgroundPreferred,
+    setTranslucenceEnabled,
+    setTranslucenceOpacity,
     setZenModeEnabled,
     setShowVisualEffects,
     handleFilterChange,


### PR DESCRIPTION
## Summary

- Adds a **Translucence** visual effect that makes the album art semi-transparent, letting the background (accent color, visualizers, particles) bleed through
- Controllable from both the Quick Effects flip panel and the full Visual Effects menu
- Respects the master VFX toggle — disabled when visual effects are off

## Changes

- **`VisualEffectsContext.tsx`** — adds `translucenceEnabled` (default: `false`) and `translucenceOpacity` (default: `0.6`) persisted to localStorage
- **`AlbumArt.tsx`** — applies CSS `opacity` on `AlbumArtContainer` with a smooth 0.5s transition (glow box-shadow fades with the art for a cohesive ghost effect)
- **`VisualEffectsMenu/index.tsx`** — new "Translucence" section with On/Off toggle and Light / Medium / Strong opacity presets (0.8 / 0.6 / 0.4)
- **`controls/QuickEffectsRow.tsx`** — "Translucent" toggle switch in Row 2 of the flip panel (alongside Glow + Viz)
- **`PlayerContent.tsx`** — wires all props end-to-end

## Test plan

- [ ] Toggle translucence On/Off from the Quick Effects flip panel — album art should fade smoothly
- [ ] Toggle translucence On/Off from the Visual Effects menu
- [ ] Cycle through Light / Medium / Strong opacity levels in the VFX menu and verify art opacity matches (0.8 / 0.6 / 0.4)
- [ ] Disable master visual effects — translucence should revert to full opacity (1.0)
- [ ] Re-enable visual effects — translucence state should restore from localStorage
- [ ] Verify setting persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)