### PR TITLE
Add focus-visible styles to ControlsFlipWrapper

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -286,6 +286,11 @@ const ControlsFlipWrapper = styled.div`
   min-height: 180px;
   perspective: 1000px;
   cursor: pointer;
+  outline: none;
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    border-radius: 1.25rem;
+  }
 `;
 
 const ControlsFlipInner = styled.div.withConfig({


### PR DESCRIPTION
## Summary
Added keyboard focus indicator styles to the `ControlsFlipWrapper` component to improve accessibility and keyboard navigation experience.

## Key Changes
- Added `outline: none` to remove default browser outline
- Implemented `focus-visible` pseudo-selector with:
  - 2px solid white outline at 40% opacity
  - 1.25rem border-radius to match component styling

## Implementation Details
The focus styles are applied only when the element receives keyboard focus (via `focus-visible`), ensuring the indicator appears for keyboard users while maintaining the cleaner appearance for mouse users. The semi-transparent white outline provides sufficient contrast against the player background while maintaining visual consistency with the component's design.

https://claude.ai/code/session_01LxNAJPgGwKjTjEPezFng7x