### PR TITLE
Remove redundant visualEffectsEnabled check from translucenceEnabled prop

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -763,7 +763,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                       glowRate={effectiveGlow.rate}
                       glowEnabled={visualEffectsEnabled}
                       albumFilters={visualEffectsEnabled ? albumFilters : defaultFilters}
-                      translucenceEnabled={visualEffectsEnabled && translucenceEnabled}
+                      translucenceEnabled={translucenceEnabled}
                       translucenceOpacity={translucenceOpacity}
                       zenMode={zenModeEnabled}
                     />


### PR DESCRIPTION
## Summary
Simplified the logic for passing the `translucenceEnabled` prop to the AlbumArt component by removing a redundant conditional check.

## Key Changes
- Changed `translucenceEnabled={visualEffectsEnabled && translucenceEnabled}` to `translucenceEnabled={translucenceEnabled}`
- This removes the unnecessary coupling of translucence to the `visualEffectsEnabled` flag, allowing translucence to be controlled independently

## Implementation Details
The `translucenceEnabled` state is already managed separately from `visualEffectsEnabled`, and the component should respect the user's explicit preference for translucence regardless of the overall visual effects setting. This change decouples these two concerns and gives more granular control over visual effects.

https://claude.ai/code/session_011gt8ix1g5UgSWtP9jSrPCz