### PR TITLE
Add keyboard shortcut (T) to toggle translucence effect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,7 @@ The application uses a centralized state management approach with custom React h
 | `ArrowDown` / `L` | Toggle library drawer | Volume down (ArrowDown only) |
 | `V` | Toggle background visualizer | Toggle background visualizer |
 | `G` | Toggle glow effect | Toggle glow effect |
+| `T` | Toggle translucence | Toggle translucence |
 | `O` | Open visual effects menu | Open visual effects menu |
 | `K` | Like/unlike current track | Like/unlike current track |
 | `M` | Mute/unmute | Mute/unmute |

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -705,6 +705,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onCloseVisualEffects: handleEscapeClose,
     onToggleBackgroundVisualizer: handleBackgroundVisualizerToggle,
     onToggleGlow: handleGlowToggle,
+    onToggleTranslucence: handleTranslucenceToggle,
     onMute: handleMuteToggle,
     onVolumeUp: handleVolumeUp,
     onVolumeDown: handleVolumeDown,

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -40,7 +40,10 @@ interface KeyboardShortcutHandlers {
   
   // Glow effect
   onToggleGlow?: () => void;
-  
+
+  // Translucence
+  onToggleTranslucence?: () => void;
+
   // Help
   onToggleHelp?: () => void;
   
@@ -81,6 +84,7 @@ export const useKeyboardShortcuts = (
     onCloseVisualEffects,
     onToggleBackgroundVisualizer,
     onToggleGlow,
+    onToggleTranslucence,
     onToggleHelp,
     onMute,
     onVolumeUp,
@@ -146,6 +150,14 @@ export const useKeyboardShortcuts = (
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleGlow?.();
+          }
+          break;
+
+        case 'KeyT':
+          // T toggles translucence
+          if (!event.ctrlKey && !event.metaKey) {
+            event.preventDefault();
+            onToggleTranslucence?.();
           }
           break;
 
@@ -236,6 +248,7 @@ export const useKeyboardShortcuts = (
     onCloseVisualEffects,
     onToggleBackgroundVisualizer,
     onToggleGlow,
+    onToggleTranslucence,
     onToggleHelp,
     onMute,
     onVolumeUp,


### PR DESCRIPTION
## Summary
Added support for toggling the translucence visual effect via the `T` keyboard shortcut, bringing it to parity with other visual effect toggles like glow and background visualizer.

## Key Changes
- Added `onToggleTranslucence` handler to the `KeyboardShortcutHandlers` interface in `useKeyboardShortcuts.ts`
- Implemented keyboard event handler for the `T` key to trigger translucence toggle
- Added `onToggleTranslucence` to the hook's dependency array to ensure proper reactivity
- Connected `handleTranslucenceToggle` callback from `PlayerContent` component to the keyboard shortcuts hook
- Updated documentation in `CLAUDE.md` to reflect the new `T` keyboard shortcut

## Implementation Details
- The `T` key handler follows the same pattern as existing visual effect toggles (G for glow, V for background visualizer)
- The shortcut is only active when `ctrlKey` and `metaKey` are not pressed, preventing conflicts with system shortcuts
- The handler prevents default browser behavior when the shortcut is triggered

https://claude.ai/code/session_014veUjPQkoVn7JSfQLjX9dS