### PR TITLE
feat: add shuffle toggle keybinding (S key)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 - **Swipe Gestures**: Horizontal swipe on album art for track navigation; vertical swipe on album art for zen mode (up = exit zen, down = enter zen). Drawers are controlled by menu buttons only.
 - **Interactive Track Info**: Clickable artist/album names with popovers linking to Spotify and library filtering
 - **IndexedDB Caching**: Persistent library cache with background sync engine for instant startup
-- **Keyboard Shortcuts**: Context-aware keyboard control system (12 shortcuts with device-specific behavior)
+- **Keyboard Shortcuts**: Context-aware keyboard control system (13 shortcuts with device-specific behavior)
 - **Performance Optimized**: Web Workers, LRU caching, IndexedDB persistence, lazy loading, hardware-accelerated animations
 
 ## Development Commands
@@ -448,6 +448,7 @@ The application uses a centralized state management approach with custom React h
 | `ArrowDown` / `L` | Toggle library drawer | Volume down (ArrowDown only) |
 | `V` | Toggle background visualizer | Toggle background visualizer |
 | `G` | Toggle glow effect | Toggle glow effect |
+| `S` | Toggle shuffle | Toggle shuffle |
 | `T` | Toggle translucence | Toggle translucence |
 | `O` | Open visual effects menu | Open visual effects menu |
 | `K` | Like/unlike current track | Like/unlike current track |

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -710,6 +710,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onVolumeUp: handleVolumeUp,
     onVolumeDown: handleVolumeDown,
     onToggleLike: handleLikeToggle,
+    onToggleShuffle: handleShuffleToggle,
     onToggleHelp: toggleHelp,
     onShowPlaylist: handleArrowUp,
     onOpenLibraryDrawer: handleArrowDown,

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@
   * - V: Toggle background visualizations
   * - O: Toggle visual effects menu
   * - G: Toggle glow effect
+  * - S: Toggle shuffle
   * - ?: Show keyboard shortcuts help
   * - Escape: Close menus (playlist drawer and visual effects)
   * - M: Mute
@@ -52,6 +53,7 @@ interface KeyboardShortcutHandlers {
   onVolumeUp?: () => void;
   onVolumeDown?: () => void;
   onToggleLike?: () => void;
+  onToggleShuffle?: () => void;
   onCloseMobileMenu?: () => void;
   /** Open playlist drawer (desktop: ArrowUp) */
   onShowPlaylist?: () => void;
@@ -90,6 +92,7 @@ export const useKeyboardShortcuts = (
     onVolumeUp,
     onVolumeDown,
     onToggleLike,
+    onToggleShuffle,
     onCloseMobileMenu,
     onShowPlaylist,
     onOpenLibraryDrawer,
@@ -199,6 +202,14 @@ export const useKeyboardShortcuts = (
           }
           break;
 
+        case 'KeyS':
+          // S toggles shuffle
+          if (!event.ctrlKey && !event.metaKey) {
+            event.preventDefault();
+            onToggleShuffle?.();
+          }
+          break;
+
         case 'KeyP':
           // P toggles playlist drawer (alternative to ArrowUp on pointer devices)
           if (!event.ctrlKey && !event.metaKey) {
@@ -254,6 +265,7 @@ export const useKeyboardShortcuts = (
     onVolumeUp,
     onVolumeDown,
     onToggleLike,
+    onToggleShuffle,
     onCloseMobileMenu,
     onShowPlaylist,
     onOpenLibraryDrawer,


### PR DESCRIPTION
- Adds S key binding for shuffle toggle in useKeyboardShortcuts hook

- Connects shuffle toggle handler to keyboard shortcuts in PlayerContent

- Updates CLAUDE.md to document the new keybinding and increase shortcut count from 12 to 13