### PR TITLE
Add Web Media Session API support for OS-level media controls

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -9,6 +9,7 @@ import { cardBase } from '../styles/utils';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
 import { usePlayerSizing } from '../hooks/usePlayerSizing';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useMediaSession } from '@/hooks/useMediaSession';
 import { useSwipeGesture } from '@/hooks/useSwipeGesture';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
 import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
@@ -712,6 +713,12 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onOpenLibraryDrawer: handleArrowDown,
     onToggleZenMode: handleZenModeToggle,
   }, { prefersPointerInput: hasPointerInput });
+
+  useMediaSession(currentTrack, isPlaying, {
+    onPlayPause: handlePlayPause,
+    onNext: handlers.onNext,
+    onPrevious: handlers.onPrevious,
+  });
 
   return (
     <ContentWrapper

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -131,6 +131,17 @@ export const useKeyboardShortcuts = (
           onPrevious?.();
           break;
 
+        // Media keys (F7 = previous, F9 = next on macOS)
+        case 'F7':
+          event.preventDefault();
+          onPrevious?.();
+          break;
+
+        case 'F9':
+          event.preventDefault();
+          onNext?.();
+          break;
+
         // Menu toggles
         case 'KeyV':
           // V toggles background visualizations

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -1,0 +1,60 @@
+/**
+ * Registers Web Media Session API handlers for OS-level media key support.
+ * This enables F7 (previous), F8 (play/pause), and F9 (next) on macOS,
+ * as well as media controls in the browser's native media UI and system tray.
+ */
+
+import { useEffect } from 'react';
+import type { Track } from '@/services/spotify';
+
+interface MediaSessionHandlers {
+  onPlayPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+}
+
+export const useMediaSession = (
+  currentTrack: Track | null,
+  isPlaying: boolean,
+  handlers: MediaSessionHandlers
+) => {
+  const { onPlayPause, onNext, onPrevious } = handlers;
+
+  // Update metadata when track changes
+  useEffect(() => {
+    if (!('mediaSession' in navigator)) return;
+    if (!currentTrack) return;
+
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: currentTrack.name,
+      artist: currentTrack.artists,
+      album: currentTrack.album,
+      artwork: currentTrack.image
+        ? [{ src: currentTrack.image, sizes: '300x300', type: 'image/jpeg' }]
+        : undefined,
+    });
+  }, [currentTrack]);
+
+  // Update playback state
+  useEffect(() => {
+    if (!('mediaSession' in navigator)) return;
+    navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
+  }, [isPlaying]);
+
+  // Register action handlers
+  useEffect(() => {
+    if (!('mediaSession' in navigator)) return;
+
+    navigator.mediaSession.setActionHandler('play', onPlayPause);
+    navigator.mediaSession.setActionHandler('pause', onPlayPause);
+    navigator.mediaSession.setActionHandler('previoustrack', onPrevious);
+    navigator.mediaSession.setActionHandler('nexttrack', onNext);
+
+    return () => {
+      navigator.mediaSession.setActionHandler('play', null);
+      navigator.mediaSession.setActionHandler('pause', null);
+      navigator.mediaSession.setActionHandler('previoustrack', null);
+      navigator.mediaSession.setActionHandler('nexttrack', null);
+    };
+  }, [onPlayPause, onPrevious, onNext]);
+};


### PR DESCRIPTION
## Summary
This PR adds support for the Web Media Session API, enabling OS-level media key controls and system tray integration. Users can now control playback using F7 (previous), F8 (play/pause), and F9 (next) on macOS, as well as through native browser and system media controls.

## Key Changes
- **New `useMediaSession` hook** (`src/hooks/useMediaSession.ts`): Manages Web Media Session API integration with three main responsibilities:
  - Updates metadata (title, artist, album, artwork) when the current track changes
  - Syncs playback state (playing/paused) with the media session
  - Registers and cleans up action handlers for play, pause, previous, and next controls

- **Enhanced keyboard shortcuts** (`src/hooks/useKeyboardShortcuts.ts`): Added support for F7 (previous) and F9 (next) media keys to complement existing keyboard controls

- **Integration in PlayerContent** (`src/components/PlayerContent.tsx`): Wired up the new `useMediaSession` hook with existing playback handlers to enable seamless media control across all input methods

## Implementation Details
- The hook includes browser compatibility checks (`'mediaSession' in navigator`) to gracefully degrade on unsupported browsers
- Action handlers are properly cleaned up on unmount to prevent memory leaks
- Metadata updates are optimized to only trigger when the track changes
- Playback state is kept in sync with the player's internal state

https://claude.ai/code/session_018ZDjcjhiME1bXd4ky6o1Pj