### PR TITLE
Show zen mode toggle on mobile and tablet devices

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -170,7 +170,7 @@ const BottomBar = React.memo(function BottomBar({
             <PlaylistIcon />
           </ControlButton>
 
-          {!isMobile && onZenModeToggle && (
+          {onZenModeToggle && (
             <ControlButton
               $isMobile={isMobile}
               $isTablet={isTablet}


### PR DESCRIPTION
## Summary
Removed the mobile device check from the zen mode toggle button condition, allowing the zen mode toggle to be displayed on all device types including mobile and tablet.

## Key Changes
- Removed `!isMobile &&` condition from the zen mode toggle button rendering logic
- The button now displays whenever `onZenModeToggle` callback is provided, regardless of device type

## Implementation Details
Previously, the zen mode toggle was only shown on desktop devices. This change makes the feature available across all device sizes, improving consistency and allowing mobile/tablet users to access zen mode functionality.

https://claude.ai/code/session_01AqMbBxU5U7F4dVXQptkAZU