### PR TITLE
fix: prevent descender clipping on track artist and album text

### DIFF
--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -90,7 +90,7 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
 
 export const PlayerTrackAlbum = styled.div`
   font-size: ${({ theme }) => theme.fontSize.sm};
-  line-height: ${({ theme }) => theme.fontSize.base};
+  line-height: 1.4;
   color: ${({ theme }) => theme.colors.gray[400]};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   letter-spacing: 0.02em;
@@ -121,7 +121,7 @@ export const AlbumLink = styled.a`
 
 export const PlayerTrackArtist = styled.div`
   font-size: ${({ theme }) => theme.fontSize.base};
-  line-height: ${({ theme }) => theme.fontSize.base};
+  line-height: 1.4;
   color: ${({ theme }) => theme.colors.gray[300]};
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- `PlayerTrackArtist` and `PlayerTrackAlbum` had `line-height` set equal to `font-size` (effectively 1.0), which left no room for descenders on letters like g, p, q, y
- Changed both to `line-height: 1.4` so text renders without clipping at the bottom

## Test plan

- [ ] Play a track where the artist name contains descender letters (g, p, q, y) and verify they render fully without clipping