### PR TITLE
refactor: remove unused hue and blur filter fields

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -51,8 +51,6 @@ interface AlbumArtProps {
     brightness: number;
     contrast: number;
     saturation: number;
-    hue: number;
-    blur: number;
     sepia: number;
   };
   translucenceEnabled?: boolean;
@@ -175,7 +173,7 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
     return false;
   }
   const filterKeys: (keyof typeof prevProps.albumFilters)[] = [
-    'brightness', 'contrast', 'saturation', 'blur', 'sepia'
+    'brightness', 'contrast', 'saturation', 'sepia'
   ];
   for (const key of filterKeys) {
     if (prevProps.albumFilters[key] !== nextProps.albumFilters[key]) {

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -328,8 +328,6 @@ const defaultFilters = {
   brightness: 110,
   contrast: 100,
   saturation: 100,
-  hue: 0,
-  blur: 0,
   sepia: 0,
 };
 

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -34,7 +34,6 @@ interface VisualEffectsMenuProps {
     brightness: number;
     contrast: number;
     saturation: number;
-    hue: number;
     sepia: number;
   };
   onFilterChange: (filterName: string, value: number) => void;

--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -87,7 +87,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   }, [setAlbumFilters]);
 
   const handleResetFilters = useCallback(() => {
-    setAlbumFilters({ brightness: 100, contrast: 100, saturation: 100, hue: 0, blur: 0, sepia: 0 });
+    setAlbumFilters({ brightness: 100, contrast: 100, saturation: 100, sepia: 0 });
   }, [setAlbumFilters]);
 
   const restoreSavedFilters = useCallback(() => {

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -208,8 +208,6 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
       brightness: 100,
       contrast: 100,
       saturation: 100,
-      hue: 0,
-      blur: 0,
       sepia: 0
     });
   }, [setAlbumFilters]);

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,23 +1,19 @@
 /**
  * @interface AlbumFilters
- * 
+ *
  * Defines the image filter properties applied to album artwork.
- * 
+ *
  * @property {number} brightness - Brightness adjustment (0-200, 100 = normal)
  * @property {number} contrast - Contrast adjustment (0-200, 100 = normal)
  * @property {number} saturation - Saturation adjustment (0-200, 100 = normal)
- * @property {number} hue - Hue rotation in degrees (0-360)
- * @property {number} blur - Blur radius in pixels (0-20)
  * @property {number} sepia - Sepia effect intensity (0-100)
- * 
+ *
  * @example
  * ```typescript
  * const filters: AlbumFilters = {
  *   brightness: 110,  // 10% brighter
  *   contrast: 120,    // 20% more contrast
  *   saturation: 90,   // 10% less saturation
- *   hue: 180,         // 180° hue rotation
- *   blur: 2,          // 2px blur
  *   sepia: 30         // 30% sepia effect
  * };
  * ```
@@ -26,8 +22,6 @@ export interface AlbumFilters {
   brightness: number;
   contrast: number;
   saturation: number;
-  hue: number;
-  blur: number;
   sepia: number;
 }
 
@@ -38,7 +32,5 @@ export const DEFAULT_ALBUM_FILTERS: AlbumFilters = {
   brightness: 100,
   contrast: 100,
   saturation: 100,
-  hue: 0,
-  blur: 0,
   sepia: 0,
 };


### PR DESCRIPTION
## Summary

- `hue` and `blur` were defined in `AlbumFilters` and carried through types, state, and reset logic, but no UI controls existed for them in the Visual Effects Menu — they were dead code
- Removes both fields from `AlbumFilters` interface, all default/reset objects, `AlbumArt` prop type, and the `arePropsEqual` comparison function

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] All 301 tests pass (`npm run test:run`)
- [x] No filter UI or behavior changes — only dead fields removed