### PR TITLE
Remove zenMode prop from ParticleVisualizer component

### DIFF
--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -29,7 +29,6 @@ interface Particle {
  *
  * Renders a particle system visualizer with floating particles that drift,
  * pulse, and change opacity based on playback state.
- * In zen mode, particles are more numerous, larger, faster, and more vibrant.
  *
  * @component
  */
@@ -37,20 +36,18 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
   intensity,
   accentColor,
   isPlaying,
-  zenMode
 }) => {
   // Calculate particle count based on viewport size
   const getParticleCount = useCallback((width: number, height: number): number => {
     const pixelCount = width * height;
     const isMobile = width < 768;
-    const zenMultiplier = zenMode ? 1.25 : 1;
 
     if (isMobile) {
-      return Math.min(Math.round(50 * zenMultiplier), Math.floor(pixelCount / (zenMode ? 6000 : 10000)));
+      return Math.min(63, Math.floor(pixelCount / 6000));
     }
 
-    return Math.min(Math.round(80 * zenMultiplier), Math.floor(pixelCount / (zenMode ? 4000 : 7500)));
-  }, [zenMode]);
+    return Math.min(100, Math.floor(pixelCount / 4000));
+  }, []);
 
   // Initialize particles
   const initializeParticles = useCallback((
@@ -59,9 +56,9 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     height: number,
     baseColor: string
   ): Particle[] => {
-    const minRadius = zenMode ? 2 : 3;
-    const maxRadius = zenMode ? 14 : 11;
-    const speedRange = zenMode ? 0.6 : 0.5;
+    const minRadius = 2;
+    const maxRadius = 14;
+    const speedRange = 0.6;
 
     return Array.from({ length: count }, () => ({
       x: Math.random() * width,
@@ -70,13 +67,13 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
       vy: (Math.random() - 0.5) * speedRange,
       radius: minRadius + Math.random() * (maxRadius - minRadius),
       baseRadius: minRadius + Math.random() * (maxRadius - minRadius),
-      opacity: (zenMode ? 0.4 : 0.3) + Math.random() * (zenMode ? 0.5 : 0.4),
-      baseOpacity: (zenMode ? 0.4 : 0.3) + Math.random() * (zenMode ? 0.5 : 0.4),
+      opacity: 0.4 + Math.random() * 0.5,
+      baseOpacity: 0.4 + Math.random() * 0.5,
       color: generateColorVariant(baseColor, Math.random() * 0.5 + 0.3),
       pulsePhase: Math.random() * Math.PI * 2,
-      pulseSpeed: (zenMode ? 0.02 : 0.01) + Math.random() * (zenMode ? 0.04 : 0.02)
+      pulseSpeed: 0.02 + Math.random() * 0.04
     }));
-  }, [zenMode]);
+  }, []);
 
   // Update particles
   const updateParticles = useCallback((
@@ -87,7 +84,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     height: number
   ): void => {
     const baseSpeed = isPlaying ? 1.0 : 0.3;
-    const speedMultiplier = zenMode ? baseSpeed * 1.2 : baseSpeed;
+    const speedMultiplier = baseSpeed * 1.2;
 
     particles.forEach(particle => {
       // Update position
@@ -106,12 +103,10 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
 
       // Calculate pulsing radius and opacity
       const pulseValue = (Math.sin(particle.pulsePhase) + 1) / 2;
-      const pulseVariation = zenMode ? 5 : 3;
-      particle.radius = Math.max(1.5, particle.baseRadius + (pulseValue - 0.5) * pulseVariation);
-      const opacityVariation = zenMode ? 0.6 : 0.4;
-      particle.opacity = Math.max(0.1, Math.min(1.0, particle.baseOpacity + (pulseValue - 0.5) * opacityVariation));
+      particle.radius = Math.max(1.5, particle.baseRadius + (pulseValue - 0.5) * 5);
+      particle.opacity = Math.max(0.1, Math.min(1.0, particle.baseOpacity + (pulseValue - 0.5) * 0.6));
     });
-  }, [zenMode]);
+  }, []);
 
   // Render particles
   const renderParticles = useCallback((


### PR DESCRIPTION
## Summary
Removes the `zenMode` prop from the ParticleVisualizer component and consolidates all particle behavior to use the previously zen-mode-specific values as defaults. This simplifies the component by eliminating conditional logic based on the zen mode state.

## Key Changes
- Removed `zenMode` prop from component interface and function signature
- Eliminated all conditional logic that branched on `zenMode` throughout the component
- Updated particle initialization to use zen-mode values as defaults:
  - Particle count: 63 on mobile, 100 on desktop (previously 50-62.5 and 80-100 with multiplier)
  - Particle radius range: 2-14px (previously 3-11px in normal mode)
  - Speed range: 0.6 (previously 0.5 in normal mode)
  - Opacity range: 0.4-0.9 (previously 0.3-0.7 in normal mode)
  - Pulse speed: 0.02-0.06 (previously 0.01-0.03 in normal mode)
- Updated particle animation to use zen-mode values:
  - Speed multiplier: always 1.2x when playing (previously conditional)
  - Pulse variation: 5 (previously 3 in normal mode)
  - Opacity variation: 0.6 (previously 0.4 in normal mode)
- Removed `zenMode` from dependency arrays in useCallback hooks

## Implementation Details
The changes effectively make the particle visualizer always behave with the more vibrant, numerous, and faster particle characteristics that were previously only enabled in zen mode. This appears to be a deliberate decision to improve the visual experience for all users rather than gating it behind a zen mode feature.

https://claude.ai/code/session_01FzjW3mYmmHYTPFMytKNpPz