### PR TITLE
Fix album art flip card close behavior and click handling

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -25,6 +25,7 @@ interface AlbumArtQuickSwapBackProps {
   onTranslucenceToggle: () => void;
   isMobile: boolean;
   isTablet: boolean;
+  onClose: () => void;
 }
 
 const BacksideRoot = styled.div`
@@ -96,14 +97,16 @@ function AlbumArtQuickSwapBack({
   onTranslucenceToggle,
   isMobile,
   isTablet,
+  onClose,
 }: AlbumArtQuickSwapBackProps) {
   return (
     <BacksideRoot>
       <BlurredBg $image={currentTrack?.image} />
       <DarkOverlay />
 
-      <Content>
+      <Content onClick={onClose}>
         <Title>Visual Effects</Title>
+        <div onClick={(e) => e.stopPropagation()}>
         <QuickEffectsRow
           currentTrack={currentTrack}
           accentColor={accentColor}
@@ -127,6 +130,7 @@ function AlbumArtQuickSwapBack({
           isMobile={isMobile}
           isTablet={isTablet}
         />
+        </div>
       </Content>
     </BacksideRoot>
   );

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -644,7 +644,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                 $swipeEnabled={isTouchDevice}
                 $bothGestures={isTouchDevice}
                 {...(isTouchDevice ? gestureHandlers : {})}
-                onClick={!isSwiping && !isAnimating ? (isFlipped ? () => setIsFlipped(false) : toggleFlip) : undefined}
+                onClick={!isSwiping && !isAnimating && !isFlipped ? toggleFlip : undefined}
                 style={{
                   transform: `translateX(${offsetX}px)`,
                   transition: isAnimating ? 'transform 300ms cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
@@ -687,6 +687,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                     onTranslucenceToggle={handleTranslucenceToggle}
                     isMobile={isMobile}
                     isTablet={isTablet}
+                    onClose={() => setIsFlipped(false)}
                   />
                 </FlipInner>
               </ClickableAlbumArtContainer>


### PR DESCRIPTION
## Summary
Improved the album art flip card interaction by fixing click handling logic and adding a proper close mechanism for the back side of the card.

## Key Changes
- **AlbumArtQuickSwapBack component**: Added `onClose` prop to enable closing the flipped card state
  - Wrapped the Content div with an `onClick` handler that calls `onClose`
  - Added event propagation stop on the inner effects container to prevent unintended closes when interacting with controls
  
- **PlayerContent component**: Updated flip card click logic and wiring
  - Fixed the onClick condition to only allow flipping forward when not already flipped (`!isFlipped`)
  - Removed the ternary that allowed clicking to close the card from the front side
  - Connected the `onClose` callback to properly close the flipped state via `setIsFlipped(false)`

## Implementation Details
The changes implement a cleaner close mechanism where:
1. Clicking the back side content area (outside the effects controls) closes the card
2. Clicking on effect controls themselves doesn't trigger the close due to `stopPropagation()`
3. The front side can only flip forward, and the back side must be closed via the new `onClose` handler

https://claude.ai/code/session_01VDseVCz6zpaNLGCj6JZ1ch