### PR TITLE
Refactor QuickEffectsRow to use section cards for better UI organization

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -171,13 +171,14 @@ const SectionTitle = styled.span`
 const SubSettings = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 5px;
-  padding-left: 2px;
 `;
 
 const SubSettingRow = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: ${theme.spacing.sm};
   flex-wrap: wrap;
 `;


### PR DESCRIPTION
## Summary
Restructured the QuickEffectsRow component to organize effect toggles and their sub-settings into visually distinct section cards, improving the UI hierarchy and user experience.

## Key Changes
- **Removed `ToggleGroup` styled component** and replaced it with a new card-based layout system
- **Added new styled components** for better organization:
  - `SectionCard`: Container for a feature toggle with its sub-settings
  - `SectionHeader`: Header area containing the section title and toggle switch
  - `SectionTitle`: Styled title text for each section
  - `SubSettings`: Container for sub-setting rows (hidden when parent toggle is off)
  - `SubSettingRow`: Individual setting row within a section
  - `SubLabel`: Label for sub-settings with consistent styling
- **Reorganized layout structure**:
  - Glow, Visualizer, and Translucent toggles now each have their own `SectionCard`
  - Sub-settings (intensity, rate, style) are now nested within their parent section cards
  - Improved visual hierarchy with consistent spacing and borders
- **Simplified visibility logic**: Sub-settings use `visibility: hidden` within their parent section cards instead of separate conditional rows
- **Added helper variables** to check for glow and visualizer sub-settings availability

## Implementation Details
- The new card-based layout provides better visual grouping of related controls
- Sub-settings remain in the DOM but are hidden when their parent toggle is disabled, preventing layout shifts
- Consistent styling across all sections with proper spacing and typography
- Maintains all existing functionality while improving the visual organization

https://claude.ai/code/session_01ULP3yAxx3PSnuUjD4TFLKV