### PR TITLE
Reduce particle animation speed for smoother visual effect

### DIFF
--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -58,7 +58,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
   ): Particle[] => {
     const minRadius = 2;
     const maxRadius = 14;
-    const speedRange = 0.6;
+    const speedRange = 0.3;
 
     return Array.from({ length: count }, () => ({
       x: Math.random() * width,
@@ -71,7 +71,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
       baseOpacity: 0.4 + Math.random() * 0.5,
       color: generateColorVariant(baseColor, Math.random() * 0.5 + 0.3),
       pulsePhase: Math.random() * Math.PI * 2,
-      pulseSpeed: 0.02 + Math.random() * 0.04
+      pulseSpeed: 0.01 + Math.random() * 0.02
     }));
   }, []);
 
@@ -84,7 +84,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     height: number
   ): void => {
     const baseSpeed = isPlaying ? 1.0 : 0.3;
-    const speedMultiplier = baseSpeed * 1.2;
+    const speedMultiplier = baseSpeed * 0.6;
 
     particles.forEach(particle => {
       // Update position


### PR DESCRIPTION
## Summary
This PR reduces the animation speed of particles in the ParticleVisualizer component to create a slower, more subtle visual effect.

## Key Changes
- **Particle speed range**: Decreased from `0.6` to `0.3` to reduce base movement velocity
- **Pulse speed**: Reduced from `0.02 + Math.random() * 0.04` to `0.01 + Math.random() * 0.02` for slower opacity pulsing
- **Speed multiplier**: Decreased from `1.2x` to `0.6x` the base speed during animation updates

## Implementation Details
These changes affect the particle generation and animation loop:
- Particles will move more slowly across the canvas
- The pulsing opacity effect will be more gradual and less noticeable
- Overall animation will appear calmer and less frenetic while maintaining the same visual structure

https://claude.ai/code/session_015TY5Gw7DrG1buPiPmRWBc8