### PR TITLE
Disable translucence controls when background visualizer is off

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -374,11 +374,11 @@ function QuickEffectsRow({
         </SubSettings>
       </SectionCard>
 
-      {/* Translucent section */}
-      <SectionCard>
+      {/* Translucent section — only applicable when visualizer is enabled */}
+      <SectionCard style={{ opacity: backgroundVisualizerEnabled ? 1 : 0.4, pointerEvents: backgroundVisualizerEnabled ? 'auto' : 'none' }}>
         <SectionHeader>
           <SectionTitle>Translucent</SectionTitle>
-          <SwitchTrack $on={translucenceEnabled} $accent={accentColor} onClick={onTranslucenceToggle} aria-label="Toggle translucence" role="switch" aria-checked={translucenceEnabled}>
+          <SwitchTrack $on={translucenceEnabled} $accent={accentColor} onClick={onTranslucenceToggle} aria-label="Toggle translucence" role="switch" aria-checked={translucenceEnabled} disabled={!backgroundVisualizerEnabled}>
             <SwitchKnob $on={translucenceEnabled} />
           </SwitchTrack>
         </SectionHeader>


### PR DESCRIPTION
## Summary
Updated the Translucent section in QuickEffectsRow to be disabled when the background visualizer is not enabled, improving UX by preventing users from configuring translucence settings that have no visual effect.

## Key Changes
- Added conditional styling to the Translucent SectionCard that reduces opacity to 0.4 and disables pointer events when `backgroundVisualizerEnabled` is false
- Added `disabled` attribute to the translucence toggle switch that prevents interaction when the visualizer is disabled
- Updated the section comment to clarify that translucence is only applicable when the visualizer is enabled

## Implementation Details
- The disabled state is controlled by the `backgroundVisualizerEnabled` prop
- Visual feedback is provided through reduced opacity (0.4) when disabled
- Pointer events are disabled to prevent accidental interactions with the disabled controls
- The switch component respects the disabled state through the `disabled` prop

https://claude.ai/code/session_01Wpio8iGBmUaxFxs1ysAbU2