### PR TITLE
Increase ship speed and velocity variance in trail visualizer

### DIFF
--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -146,7 +146,7 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     // Update ship heading: smooth curve + random wobble so path isn't predictable
     const turnRate = 0.00012 * deltaTime + (Math.random() - 0.5) * 0.025;
     ship.angle += turnRate;
-    const shipSpeed = 1.35 + (Math.random() - 0.5) * 0.25;
+    const shipSpeed = 2.0 + (Math.random() - 0.5) * 0.3;
     ship.vx = Math.cos(ship.angle) * shipSpeed + (Math.random() - 0.5) * 0.2;
     ship.vy = Math.sin(ship.angle) * shipSpeed + (Math.random() - 0.5) * 0.2;
 


### PR DESCRIPTION
## Summary
Updated the ship movement parameters in the TrailVisualizer to increase overall speed and add more dynamic velocity variation to the animation.

## Key Changes
- Increased base ship speed from `1.35` to `2.0` (48% faster)
- Increased velocity randomness range from `0.25` to `0.3` (20% more variance)

## Implementation Details
These changes affect the ship's movement behavior in the trail visualization:
- The base speed multiplier now produces faster overall movement across the canvas
- The increased random variance (±0.15 instead of ±0.125) creates more unpredictable and dynamic path variations, making the animation feel less mechanical and more organic
- The turn rate wobble remains unchanged, so the directional changes maintain their current smoothness characteristics

https://claude.ai/code/session_01KV4WDnHyJh85nG2YPbPakD