### PR TITLE
Handle nullable tracks and owner fields in playlist data

### DIFF
--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -958,8 +958,8 @@ function PlaylistSelection({ onPlaylistSelect, inDrawer = false, swipeZoneRef, i
               <GridCardTextArea>
                 <GridCardTitle>{playlist.name}</GridCardTitle>
                 <GridCardSubtitle>
-                  {playlist.tracks.total} tracks
-                  {playlist.owner.display_name && ` • ${playlist.owner.display_name}`}
+                  {playlist.tracks?.total ?? 0} tracks
+                  {playlist.owner?.display_name && ` • ${playlist.owner.display_name}`}
                 </GridCardSubtitle>
               </GridCardTextArea>
             </PinnableGridCard>
@@ -974,8 +974,8 @@ function PlaylistSelection({ onPlaylistSelect, inDrawer = false, swipeZoneRef, i
               <PlaylistInfo>
                 <PlaylistName>{playlist.name}</PlaylistName>
                 <PlaylistDetails>
-                  {playlist.tracks.total} tracks
-                  {playlist.owner.display_name && ` • by ${playlist.owner.display_name}`}
+                  {playlist.tracks?.total ?? 0} tracks
+                  {playlist.owner?.display_name && ` • by ${playlist.owner.display_name}`}
                 </PlaylistDetails>
               </PlaylistInfo>
               <PinButton

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -124,8 +124,8 @@ export interface PlaylistInfo {
   name: string;
   description: string | null;
   images: SpotifyImage[];
-  tracks: { total: number };
-  owner: { display_name: string };
+  tracks: { total: number } | null;
+  owner: { display_name: string } | null;
   added_at?: string; // ISO 8601 timestamp when added to library
   snapshot_id?: string; // Spotify revision identifier for change detection
 }
@@ -573,7 +573,12 @@ export async function getUserLibraryInterleaved(
   const fetchTimestamp = new Date().toISOString();
 
   function transformPlaylist(playlist: PlaylistInfo): PlaylistInfo {
-    return { ...playlist, added_at: playlist.added_at || fetchTimestamp };
+    return {
+      ...playlist,
+      added_at: playlist.added_at || fetchTimestamp,
+      tracks: playlist.tracks ?? { total: 0 },
+      owner: playlist.owner ?? { display_name: '' },
+    };
   }
 
   interface SavedAlbumItem {


### PR DESCRIPTION
## Summary
Updated the `PlaylistInfo` interface and related code to properly handle cases where the `tracks` and `owner` fields may be null or undefined from the Spotify API.

## Key Changes
- Modified `PlaylistInfo` interface to mark `tracks` and `owner` fields as nullable (`| null`)
- Updated `transformPlaylist()` function in `getUserLibraryInterleaved()` to provide default values when these fields are missing:
  - `tracks` defaults to `{ total: 0 }`
  - `owner` defaults to `{ display_name: '' }`
- Updated `PlaylistSelection.tsx` component to safely access nullable fields using optional chaining (`?.`) and nullish coalescing (`??`) operators in two locations where playlist information is displayed

## Implementation Details
The changes ensure that:
1. The type system accurately reflects that Spotify API responses may not always include complete `tracks` and `owner` data
2. Default values are applied at the service layer during data transformation, preventing null reference errors downstream
3. UI components defensively handle potentially missing data with appropriate fallbacks (0 tracks, empty owner name)

https://claude.ai/code/session_01PJpAs5A1852WGQjhmGwNTD