### PR TITLE
Replace visibility CSS with conditional rendering for effects

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -289,8 +289,8 @@ function QuickEffectsRow({
             <SwitchKnob $on={glowEnabled} />
           </SwitchTrack>
         </SectionHeader>
-        {(hasGlowSubSettings || hasGlowRate) && (
-          <SubSettings style={{ visibility: glowEnabled ? 'visible' : 'hidden' }}>
+        {(hasGlowSubSettings || hasGlowRate) && glowEnabled && (
+          <SubSettings>
             {hasGlowSubSettings && (
               <SubSettingRow>
                 <SubLabel>Intensity</SubLabel>
@@ -323,7 +323,7 @@ function QuickEffectsRow({
             <SwitchKnob $on={backgroundVisualizerEnabled} />
           </SwitchTrack>
         </SectionHeader>
-        <SubSettings style={{ visibility: backgroundVisualizerEnabled ? 'visible' : 'hidden' }}>
+        {backgroundVisualizerEnabled && <SubSettings>
           <SubSettingRow>
             <SubLabel>Style</SubLabel>
             <OptionButtonGroup>
@@ -371,7 +371,7 @@ function QuickEffectsRow({
               </OptionButtonGroup>
             </SubSettingRow>
           )}
-        </SubSettings>
+        </SubSettings>}
       </SectionCard>
 
       {/* Translucent section */}


### PR DESCRIPTION
## Summary
Refactored the glow and background visualizer subsettings to use conditional rendering instead of CSS visibility toggling. This improves performance by removing DOM elements from the tree when disabled rather than just hiding them visually.

## Key Changes
- **Glow subsettings**: Changed from `visibility: hidden` CSS to conditional rendering with `&&` operator. Also added `glowEnabled` check to the existing condition to prevent rendering when disabled.
- **Background visualizer subsettings**: Changed from `visibility: hidden` CSS to conditional rendering, wrapping the `<SubSettings>` component with a conditional check.

## Implementation Details
- Replaced `style={{ visibility: condition ? 'visible' : 'hidden' }}` patterns with `{condition && <Component>}` syntax
- This approach reduces DOM complexity when settings are disabled and may improve rendering performance
- The conditional logic remains the same; only the implementation method changed from CSS-based hiding to React-based conditional rendering

