### PR TITLE
Remove year filter and reorganize search controls layout

### DIFF
--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -6,7 +6,7 @@ import {
   type PlaylistInfo,
   type AlbumInfo
 } from '../services/spotify';
-import { Card, CardHeader, CardContent, Button, Skeleton, Alert, AlertDescription } from './styled';
+import { Card, CardContent, Button, Skeleton, Alert, AlertDescription } from './styled';
 import { theme } from '@/styles/theme';
 import { usePlayerSizing } from '../hooks/usePlayerSizing';
 import { useLocalStorage } from '../hooks/useLocalStorage';


### PR DESCRIPTION
## Summary
This PR removes the year/decade filtering functionality from the album view and reorganizes the layout of search and sort controls in the PlaylistSelection component.

## Key Changes
- **Removed year filter feature**: Deleted the `yearFilter` state, `getAvailableDecades` utility function, and the decade dropdown UI component that was only shown in album view mode
- **Simplified album filtering**: Updated `filterAndSortAlbums` calls to pass a hardcoded `'all'` value instead of the dynamic `yearFilter` state
- **Reorganized search controls layout**: 
  - Moved search and sort controls from the top of the main content area to a new section below the main content with `marginTop: '1.5rem'`
  - Controls now render conditionally based on `!inDrawer` state
- **Updated active filter detection**: Removed year filter from the `hasActiveFilters` logic, now only checks `searchQuery` and `artistFilter`
- **Cleaned up imports**: Removed unused imports for `getAvailableDecades` and `YearFilterOption` types
- **Removed header section**: Deleted the "Choose Your Music" header with title and subtitle from the SelectionCard

## Implementation Details
- The year filter removal simplifies the album filtering logic while maintaining artist filtering capability
- The search controls repositioning improves the UI layout by moving them below the tabs and main content area
- All references to `yearFilter` state management and related effects have been removed

https://claude.ai/code/session_01STnC2f9ULbKY4S8jM14bvD