### PR TITLE
Remove unused translucence and accent color background state

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -314,12 +314,9 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setBackgroundVisualizerStyle,
     backgroundVisualizerIntensity,
     setBackgroundVisualizerIntensity,
-    accentColorBackgroundPreferred,
-    setAccentColorBackgroundPreferred,
     translucenceEnabled,
     setTranslucenceEnabled,
     translucenceOpacity,
-    setTranslucenceOpacity,
     zenModeEnabled,
     setZenModeEnabled,
     showVisualEffects,
@@ -471,18 +468,9 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setTranslucenceEnabled(prev => !prev);
   }, [setTranslucenceEnabled]);
 
-  const handleTranslucenceOpacityChange = useCallback((v: number) => {
-    setTranslucenceOpacity(v);
-  }, [setTranslucenceOpacity]);
-
-
   const handleBackgroundVisualizerIntensityChange = useCallback((intensity: number) => {
     setBackgroundVisualizerIntensity(Math.max(0, Math.min(100, intensity)));
   }, [setBackgroundVisualizerIntensity]);
-
-  const handleAccentColorBackgroundToggle = useCallback(() => {
-    setAccentColorBackgroundPreferred(prev => !prev);
-  }, [setAccentColorBackgroundPreferred]);
 
   // --- Library drawer ---
   const handleArtistBrowse = useCallback((artistName: string) => {


### PR DESCRIPTION
## Summary
This PR removes unused state management code related to translucence opacity and accent color background preferences from the PlayerContent component.

## Key Changes
- Removed `accentColorBackgroundPreferred` and `setAccentColorBackgroundPreferred` from destructured props
- Removed `setTranslucenceOpacity` from destructured props
- Deleted `handleTranslucenceOpacityChange` callback function
- Deleted `handleAccentColorBackgroundToggle` callback function

## Details
These state variables and their associated handlers were not being used anywhere in the component. Removing them reduces unnecessary prop drilling and simplifies the component's interface. The `translucenceEnabled` and `translucenceOpacity` state remain available for reading, but the setter for opacity is no longer passed down, suggesting it may be managed elsewhere or no longer needed.

https://claude.ai/code/session_01393q7ULH9VcVHQByv4sq3a