### PR TITLE
Stop playback before switching active provider

### DIFF
--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -46,11 +46,13 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
 
   const setActiveProviderId = useCallback(
     (id: ProviderId) => {
-      if (providerRegistry.has(id)) {
+      if (providerRegistry.has(id) && id !== validProviderId) {
+        // Stop playback on the outgoing provider before switching
+        activeDescriptor?.playback.pause().catch(() => {});
         setActiveProviderIdRaw(id);
       }
     },
-    [setActiveProviderIdRaw],
+    [setActiveProviderIdRaw, validProviderId, activeDescriptor],
   );
 
   const value = useMemo<ProviderContextValue>(


### PR DESCRIPTION
## Summary
Updated the provider switching logic to pause playback on the current provider before switching to a new one, preventing audio/playback conflicts when changing providers.

## Key Changes
- Added a check to prevent switching to the same provider (`id !== validProviderId`)
- Added playback pause call on the outgoing provider before switching (`activeDescriptor?.playback.pause().catch(() => {})`)
- Updated the dependency array to include `validProviderId` and `activeDescriptor` to ensure the callback has access to the latest values

## Implementation Details
- The pause operation is wrapped in a `.catch(() => {})` to gracefully handle any errors that might occur during the pause operation
- The condition now prevents unnecessary provider switches when the selected provider is already active

https://claude.ai/code/session_01VmargBbYfSZB8Ne8avBmFX