### PR TITLE
fix: add .env.test so unit tests pass without local Spotify credentials

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+VITE_SPOTIFY_CLIENT_ID=test-client-id
+VITE_SPOTIFY_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback


### PR DESCRIPTION
## Summary

- Adds `.env.test` with dummy `VITE_SPOTIFY_CLIENT_ID` and `VITE_SPOTIFY_REDIRECT_URI` values
- Fixes 5 unit tests that fail on remote/CI hosts where `.env.local` is not present

## Root cause

`spotify.ts` captures `import.meta.env.VITE_SPOTIFY_CLIENT_ID` into a module-level constant at import time. The existing `Object.defineProperty` patch in `setup.ts` runs too late to intercept that capture on machines without `.env.local`.

Vitest's `.env.test` file is loaded through Vite's env pipeline *before* any module is imported, so the value is defined when those module-level constants are first evaluated.

## Test plan

- [ ] Run `npm run test:run` on a machine without `.env.local` — all 301 tests should pass
- [ ] Confirm `.env.test` is not gitignored (only `.env.local` and `*.local` variants are excluded)