### PR TITLE
Add granular cache clearing options with confirmation dialog

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -1,5 +1,7 @@
 import React, { Suspense, lazy, useState, useCallback, useRef, useEffect } from 'react';
-import { clearAll } from '@/services/cache/libraryCache';
+import { clearCacheWithOptions } from '@/services/cache/libraryCache';
+import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
+import type { ClearCacheOptions } from '@/components/VisualEffectsMenu';
 import styled, { useTheme } from 'styled-components';
 import { CardContent } from './styled';
 import AlbumArt from './AlbumArt';
@@ -422,8 +424,15 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   const handleClosePlaylist = useCallback(() => setShowPlaylist(false), [setShowPlaylist]);
 
   // --- App settings handlers ---
-  const handleClearCache = useCallback(async () => {
-    await clearAll();
+  const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
+    await clearCacheWithOptions({ clearLikes: options.clearLikes });
+    if (options.clearPins) {
+      await clearAllPins();
+    }
+    if (options.clearAccentColors) {
+      localStorage.removeItem('vorbis-player-accent-color-overrides');
+      localStorage.removeItem('vorbis-player-custom-accent-colors');
+    }
   }, []);
 
   const handleProfilerToggle = useCallback(() => {

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -25,13 +25,25 @@ import {
   ProviderStatusDot,
   ProviderName,
   ProviderActiveLabel,
+  CacheOptionsList,
+  CacheOptionItem,
+  CacheCheckbox,
+  CacheOptionLabel,
+  CacheConfirmButtons,
+  CacheCancelButton,
 } from './styled';
+
+export interface ClearCacheOptions {
+  clearLikes: boolean;
+  clearPins: boolean;
+  clearAccentColors: boolean;
+}
 
 interface AppSettingsMenuProps {
   isOpen: boolean;
   onClose: () => void;
   accentColor: string;
-  onClearCache: () => Promise<void>;
+  onClearCache: (options: ClearCacheOptions) => Promise<void>;
   profilerEnabled: boolean;
   onProfilerToggle: () => void;
   visualizerDebugEnabled: boolean;
@@ -149,7 +161,10 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
   onVisualizerDebugToggle
 }) => {
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizing();
-  const [clearState, setClearState] = useState<'idle' | 'success'>('idle');
+  const [clearState, setClearState] = useState<'idle' | 'confirming' | 'success'>('idle');
+  const [clearLikes, setClearLikes] = useState(false);
+  const [clearPins, setClearPins] = useState(false);
+  const [clearAccentColors, setClearAccentColors] = useState(false);
 
   const drawerWidth = useMemo(() => {
     if (isMobile) return Math.min(viewport.width, parseInt(theme.breakpoints.xs));
@@ -157,11 +172,25 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
     return Math.min(viewport.width * 0.3, parseInt(theme.drawer.widths.desktop));
   }, [viewport.width, isMobile, isTablet]);
 
-  const handleClearCache = useCallback(async () => {
-    await onClearCache();
+  const handleClearCacheClick = useCallback(() => {
+    setClearState('confirming');
+  }, []);
+
+  const handleClearCacheCancel = useCallback(() => {
+    setClearState('idle');
+    setClearLikes(false);
+    setClearPins(false);
+    setClearAccentColors(false);
+  }, []);
+
+  const handleClearCacheConfirm = useCallback(async () => {
+    await onClearCache({ clearLikes, clearPins, clearAccentColors });
     setClearState('success');
+    setClearLikes(false);
+    setClearPins(false);
+    setClearAccentColors(false);
     setTimeout(() => setClearState('idle'), 1500);
-  }, [onClearCache]);
+  }, [onClearCache, clearLikes, clearPins, clearAccentColors]);
 
   return (
     <ProfiledComponent id="app-settings-menu">
@@ -193,9 +222,54 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
             <SectionTitle>Advanced</SectionTitle>
             <ControlGroup>
               <ControlLabel>Clear Library Cache</ControlLabel>
-              <ResetButton onClick={handleClearCache} $accentColor={accentColor}>
-                {clearState === 'success' ? 'Cleared!' : 'Clear Cache'}
-              </ResetButton>
+              {clearState === 'confirming' ? (
+                <>
+                  <CacheOptionsList>
+                    <CacheOptionItem>
+                      <CacheCheckbox
+                        id="clear-likes"
+                        type="checkbox"
+                        checked={clearLikes}
+                        onChange={(e) => setClearLikes(e.target.checked)}
+                        $accentColor={accentColor}
+                      />
+                      <CacheOptionLabel htmlFor="clear-likes">Also clear Likes</CacheOptionLabel>
+                    </CacheOptionItem>
+                    <CacheOptionItem>
+                      <CacheCheckbox
+                        id="clear-pins"
+                        type="checkbox"
+                        checked={clearPins}
+                        onChange={(e) => setClearPins(e.target.checked)}
+                        $accentColor={accentColor}
+                      />
+                      <CacheOptionLabel htmlFor="clear-pins">Also clear Pins</CacheOptionLabel>
+                    </CacheOptionItem>
+                    <CacheOptionItem>
+                      <CacheCheckbox
+                        id="clear-accent-colors"
+                        type="checkbox"
+                        checked={clearAccentColors}
+                        onChange={(e) => setClearAccentColors(e.target.checked)}
+                        $accentColor={accentColor}
+                      />
+                      <CacheOptionLabel htmlFor="clear-accent-colors">Also clear Accent Colors</CacheOptionLabel>
+                    </CacheOptionItem>
+                  </CacheOptionsList>
+                  <CacheConfirmButtons>
+                    <CacheCancelButton onClick={handleClearCacheCancel} $accentColor={accentColor}>
+                      Cancel
+                    </CacheCancelButton>
+                    <ResetButton onClick={handleClearCacheConfirm} $accentColor={accentColor}>
+                      Confirm Clear
+                    </ResetButton>
+                  </CacheConfirmButtons>
+                </>
+              ) : (
+                <ResetButton onClick={clearState === 'success' ? undefined : handleClearCacheClick} $accentColor={accentColor}>
+                  {clearState === 'success' ? 'Cleared!' : 'Clear Cache'}
+                </ResetButton>
+              )}
             </ControlGroup>
             <ControlGroup>
               <ControlLabel>Performance Profiler</ControlLabel>

--- a/src/components/VisualEffectsMenu/styled.ts
+++ b/src/components/VisualEffectsMenu/styled.ts
@@ -207,6 +207,86 @@ export const ProviderActiveLabel = styled.span`
   opacity: 0.7;
 `;
 
+export const CacheOptionsList = styled.ul`
+  list-style: none;
+  margin: ${({ theme }) => theme.spacing.sm} 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const CacheOptionItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const CacheCheckbox = styled.input<{ $accentColor: string }>`
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  background: ${({ theme }) => theme.colors.control.background};
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: all ${({ theme }) => theme.transitions.fast};
+
+  &:checked {
+    background: ${({ $accentColor }) => $accentColor};
+    border-color: ${({ $accentColor }) => $accentColor};
+  }
+
+  &:checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 5px;
+    height: 9px;
+    border: 2px solid #fff;
+    border-top: none;
+    border-left: none;
+    transform: rotate(45deg);
+  }
+`;
+
+export const CacheOptionLabel = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: ${({ theme }) => theme.colors.muted.foreground};
+  cursor: pointer;
+  user-select: none;
+`;
+
+export const CacheConfirmButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+  margin-top: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const CacheCancelButton = styled.button<{ $accentColor: string }>`
+  background: ${({ theme }) => theme.colors.control.background};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  color: ${({ theme }) => theme.colors.muted.foreground};
+  padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.md};
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  transition: all ${({ theme }) => theme.transitions.fast};
+  flex: 1;
+  margin-top: ${({ theme }) => theme.spacing.lg};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.muted.background};
+    color: ${({ theme }) => theme.colors.foreground};
+    transform: translateY(-1px);
+  }
+`;
+
 export const OptionButton = styled.button<{ $accentColor: string; $isActive: boolean }>`
   background: ${({ $isActive, $accentColor }: { $isActive: boolean; $accentColor: string }) => $isActive ? $accentColor : theme.colors.muted.background};
   border: 1px solid ${({ $isActive, $accentColor }: { $isActive: boolean; $accentColor: string }) => $isActive ? $accentColor : theme.colors.border};

--- a/src/services/cache/libraryCache.ts
+++ b/src/services/cache/libraryCache.ts
@@ -440,6 +440,32 @@ async function migrateFromLocalStorage(): Promise<void> {
 // Clear All
 // =============================================================================
 
+const LIKED_SONGS_TRACK_LIST_ID = 'liked-songs';
+
+export interface ClearCacheOptions {
+  /** When true, liked songs track list is also cleared. Default: false (preserve). */
+  clearLikes?: boolean;
+}
+
+/**
+ * Clear the library cache with optional preservation of liked songs data.
+ * By default, liked songs are preserved so they don't need to be re-fetched.
+ */
+export async function clearCacheWithOptions(options: ClearCacheOptions = {}): Promise<void> {
+  const { clearLikes = false } = options;
+
+  let savedLikedSongs: CachedTrackList | undefined;
+  if (!clearLikes) {
+    savedLikedSongs = await getTrackList(LIKED_SONGS_TRACK_LIST_ID);
+  }
+
+  await clearAll();
+
+  if (!clearLikes && savedLikedSongs) {
+    await putTrackList(LIKED_SONGS_TRACK_LIST_ID, savedLikedSongs.tracks, savedLikedSongs.snapshotId);
+  }
+}
+
 export async function clearAll(): Promise<void> {
   await initCache();
   if (fallbackMode) {

--- a/src/services/settings/pinnedItemsStorage.ts
+++ b/src/services/settings/pinnedItemsStorage.ts
@@ -4,7 +4,7 @@
  * Key format: "${providerId}:${type}" (e.g. "spotify:playlists", "dropbox:albums").
  */
 
-import { STORE_NAMES, settingsGet, settingsPut } from './settingsDb';
+import { STORE_NAMES, settingsGet, settingsPut, settingsClearStore } from './settingsDb';
 
 export const MAX_PINS = 4;
 
@@ -28,6 +28,11 @@ export async function setPins(providerId: string, type: 'playlists' | 'albums', 
 
 const LS_PINNED_PLAYLISTS = 'vorbis-player-pinned-playlists';
 const LS_PINNED_ALBUMS = 'vorbis-player-pinned-albums';
+
+/** Clear all pinned items for all providers. */
+export async function clearAllPins(): Promise<void> {
+  await settingsClearStore(STORE_NAMES.PINS);
+}
 
 /**
  * One-time migration: move pinned playlists/albums from localStorage into IDB

--- a/src/services/settings/settingsDb.ts
+++ b/src/services/settings/settingsDb.ts
@@ -84,6 +84,19 @@ export async function settingsPut<T extends { key: string }>(store: string, valu
   }
 }
 
+export async function settingsClearStore(store: string): Promise<void> {
+  await initSettingsDb();
+  if (fallbackMode) {
+    fallbackStores[store]?.clear();
+    return;
+  }
+  try {
+    await idbClear(store);
+  } catch {
+    fallbackStores[store]?.clear();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Internal IDB helpers
 // ---------------------------------------------------------------------------
@@ -105,6 +118,17 @@ function idbPut<T>(storeName: string, value: T): Promise<void> {
     const tx = db.transaction(storeName, 'readwrite');
     const store = tx.objectStore(storeName);
     const request = store.put(value);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbClear(storeName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    const request = store.clear();
     request.onsuccess = () => resolve();
     request.onerror = () => reject(request.error);
   });


### PR DESCRIPTION
## Summary
This PR adds a confirmation dialog to the cache clearing feature that allows users to selectively clear different types of cached data (likes, pins, and accent colors) instead of clearing everything at once.

## Key Changes

- **New confirmation UI**: When users click "Clear Cache", a dialog now appears with checkboxes for optional data to clear (likes, pins, accent colors) and confirm/cancel buttons
- **Granular cache clearing**: 
  - Added `ClearCacheOptions` interface to specify what data to clear
  - Modified `clearCacheWithOptions()` to preserve liked songs by default unless explicitly cleared
  - Added `clearAllPins()` function to clear pinned items from settings storage
  - Added support for clearing accent color overrides from localStorage
- **Settings storage improvements**:
  - Added `settingsClearStore()` function to clear entire IndexedDB stores with fallback support
  - Added `idbClear()` helper for clearing object stores
- **UI state management**: Added 'confirming' state to track when the confirmation dialog is open, with separate handlers for cancel and confirm actions
- **Styled components**: Added new styled components for the cache options list, checkboxes, labels, and confirmation buttons

## Implementation Details

- The confirmation dialog only appears when the user clicks "Clear Cache"
- All checkbox states are reset when canceling or after confirming
- Liked songs are preserved by default to avoid unnecessary re-fetching
- The implementation maintains backward compatibility with fallback storage mechanisms

https://claude.ai/code/session_01J8kPGFJmtTNMLSJjVZT9g9