### PR TITLE
Improve token refresh handling for Dropbox and Spotify auth

### DIFF
--- a/src/providers/dropbox/__tests__/dropboxAuthAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxAuthAdapter.test.ts
@@ -218,6 +218,96 @@ describe('DropboxAuthAdapter', () => {
     });
   });
 
+  describe('getAccessToken', () => {
+    it('calls ensureValidToken to refresh when near expiry', async () => {
+      localStorageMock.setItem('vorbis-player-dropbox-token', 'old-token');
+      localStorageMock.setItem('vorbis-player-dropbox-refresh-token', 'my-refresh');
+      localStorageMock.setItem('vorbis-player-dropbox-token-expiry', String(Date.now() - 1000));
+
+      const adapter = new DropboxAuthAdapter();
+      vi.spyOn(adapter, 'refreshAccessToken').mockResolvedValue('new-token');
+
+      const token = await adapter.getAccessToken();
+      expect(token).toBe('new-token');
+      expect(adapter.refreshAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns current token when not expired', async () => {
+      localStorageMock.setItem('vorbis-player-dropbox-token', 'valid-token');
+      localStorageMock.setItem('vorbis-player-dropbox-token-expiry', String(Date.now() + 3600000));
+
+      const adapter = new DropboxAuthAdapter();
+      const token = await adapter.getAccessToken();
+      expect(token).toBe('valid-token');
+    });
+
+    it('returns null when no token exists', async () => {
+      const adapter = new DropboxAuthAdapter();
+      const token = await adapter.getAccessToken();
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    // DROPBOX_CLIENT_ID is a module-level const evaluated at static import time,
+    // so we need dynamic imports after vi.stubEnv to test the real refresh logic.
+    async function freshAdapter(storageInit: Record<string, string>) {
+      vi.resetModules();
+      for (const [k, v] of Object.entries(storageInit)) {
+        localStorageMock.setItem(k, v);
+      }
+      const mod = await import('../dropboxAuthAdapter');
+      return new mod.DropboxAuthAdapter();
+    }
+
+    it('preserves refresh token on server error (5xx)', async () => {
+      const adapter = await freshAdapter({
+        'vorbis-player-dropbox-token': 'old-token',
+        'vorbis-player-dropbox-refresh-token': 'my-refresh',
+      });
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }));
+
+      const result = await adapter.refreshAccessToken();
+      expect(result).toBeNull();
+      expect(localStorageMock.getItem('vorbis-player-dropbox-refresh-token')).toBe('my-refresh');
+      expect(localStorageMock.getItem('vorbis-player-dropbox-token')).toBeNull();
+    });
+
+    it('calls full logout on 401 (invalid/revoked token)', async () => {
+      const adapter = await freshAdapter({
+        'vorbis-player-dropbox-token': 'old-token',
+        'vorbis-player-dropbox-refresh-token': 'my-refresh',
+      });
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      }));
+
+      const result = await adapter.refreshAccessToken();
+      expect(result).toBeNull();
+      expect(localStorageMock.getItem('vorbis-player-dropbox-refresh-token')).toBeNull();
+      expect(localStorageMock.getItem('vorbis-player-dropbox-token')).toBeNull();
+    });
+
+    it('preserves refresh token on network error', async () => {
+      const adapter = await freshAdapter({
+        'vorbis-player-dropbox-token': 'old-token',
+        'vorbis-player-dropbox-refresh-token': 'my-refresh',
+      });
+
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+
+      const result = await adapter.refreshAccessToken();
+      expect(result).toBeNull();
+      expect(localStorageMock.getItem('vorbis-player-dropbox-refresh-token')).toBe('my-refresh');
+    });
+  });
+
   describe('logout', () => {
     it('clears the oauth state from sessionStorage', () => {
       // #given

--- a/src/providers/dropbox/dropboxAuthAdapter.ts
+++ b/src/providers/dropbox/dropboxAuthAdapter.ts
@@ -62,7 +62,8 @@ export class DropboxAuthAdapter implements AuthProvider {
   }
 
   async getAccessToken(): Promise<string | null> {
-    return this.accessToken;
+    if (!this.accessToken) return null;
+    return this.ensureValidToken();
   }
 
   async beginLogin(): Promise<void> {
@@ -183,15 +184,35 @@ export class DropboxAuthAdapter implements AuthProvider {
       client_id: DROPBOX_CLIENT_ID,
     });
 
-    const response = await fetch('https://api.dropboxapi.com/oauth2/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body.toString(),
-    });
+    let response: Response;
+    try {
+      response = await fetch('https://api.dropboxapi.com/oauth2/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+    } catch (error) {
+      // Network error — preserve refresh token for future retry.
+      console.warn('[DropboxAuth] Token refresh network error:', error);
+      this.accessToken = null;
+      localStorage.removeItem(TOKEN_KEY);
+      this.tokenExpiresAt = null;
+      localStorage.removeItem(TOKEN_EXPIRY_KEY);
+      return null;
+    }
 
     if (!response.ok) {
       console.warn('[DropboxAuth] Token refresh failed:', response.status);
-      this.logout();
+      if (response.status === 400 || response.status === 401) {
+        // Invalid or revoked grant — full logout.
+        this.logout();
+      } else {
+        // Transient failure — clear access token but keep refresh token for retry.
+        this.accessToken = null;
+        localStorage.removeItem(TOKEN_KEY);
+        this.tokenExpiresAt = null;
+        localStorage.removeItem(TOKEN_EXPIRY_KEY);
+      }
       return null;
     }
 

--- a/src/services/__tests__/spotifyAuth.test.ts
+++ b/src/services/__tests__/spotifyAuth.test.ts
@@ -44,10 +44,21 @@ describe('SpotifyAuth', () => {
       expect(auth.isAuthenticated()).toBe(true);
     });
 
-    it('returns false when token is expired', async () => {
+    it('returns true when token is expired but refresh token exists', async () => {
       const token = {
         access_token: 'expired-token',
         refresh_token: 'refresh',
+        expires_at: Date.now() - 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+      expect(auth.isAuthenticated()).toBe(true);
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith('spotify_token');
+    });
+
+    it('returns false and clears storage when token is expired without refresh token', async () => {
+      const token = {
+        access_token: 'expired-token',
         expires_at: Date.now() - 1000,
       };
       vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
@@ -78,6 +89,26 @@ describe('SpotifyAuth', () => {
       const result = await auth.ensureValidToken();
       expect(result).toBe('my-token');
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('refreshes token when access token is already expired', async () => {
+      const token = {
+        access_token: 'expired-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() - 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+
+      mockFetchResponse({
+        access_token: 'new-token',
+        refresh_token: 'new-refresh',
+        expires_in: 3600,
+      });
+
+      const result = await auth.ensureValidToken();
+      expect(result).toBe('new-token');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('calls refresh when within 5-minute buffer of expiry', async () => {

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -349,7 +349,13 @@ class SpotifyAuth {
     try {
       const tokenData = JSON.parse(stored);
       if (tokenData.expires_at && Date.now() > tokenData.expires_at) {
-        localStorage.removeItem('spotify_token');
+        if (tokenData.refresh_token) {
+          // Access token expired but refresh token is still valid.
+          // Keep the data so ensureValidToken() can refresh on first API call.
+          this.tokenData = tokenData;
+        } else {
+          localStorage.removeItem('spotify_token');
+        }
         return;
       }
       this.tokenData = tokenData;
@@ -486,7 +492,7 @@ class SpotifyAuth {
   }
 
   public isAuthenticated(): boolean {
-    return !!this.tokenData?.access_token;
+    return !!(this.tokenData?.access_token || this.tokenData?.refresh_token);
   }
 
   public async redirectToAuth(): Promise<void> {


### PR DESCRIPTION
## Summary
This PR improves token refresh logic for both Dropbox and Spotify authentication providers to better handle expired tokens and network failures. The changes ensure that refresh tokens are preserved during transient failures while being cleared only when truly invalid.

## Key Changes

**Dropbox Authentication:**
- Modified `getAccessToken()` to call `ensureValidToken()` for automatic token refresh when needed
- Enhanced `refreshAccessToken()` error handling to distinguish between different failure scenarios:
  - **401/400 errors**: Perform full logout (clear both access and refresh tokens) as the grant is invalid/revoked
  - **Other 5xx errors**: Clear only the access token while preserving the refresh token for future retry attempts
  - **Network errors**: Preserve refresh token to allow retry on next API call
- Added try-catch block around the token refresh fetch request to handle network failures gracefully

**Spotify Authentication:**
- Updated `isAuthenticated()` to return `true` if either an access token OR a refresh token exists, allowing automatic refresh on first API call
- Modified token initialization logic to preserve expired token data when a refresh token is available, enabling `ensureValidToken()` to refresh on demand
- Added test coverage for refreshing already-expired tokens and for the case where an expired token has no refresh token

## Implementation Details
- Both providers now follow a consistent pattern: preserve refresh tokens on transient failures, clear them only on authentication failures (401/400)
- The Dropbox adapter uses dynamic imports in tests to properly test the refresh logic with environment variables
- Spotify's `isAuthenticated()` now acts as a "can potentially authenticate" check rather than strictly "has valid token"

