### PR TITLE
Refactor Spotify SDK loading to dynamic on-demand initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 
 <body>
   <div id="root"></div>
-  <script src="https://sdk.scdn.co/spotify-player.js"></script>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import AudioPlayerComponent from './components/AudioPlayer';
 import { spotifyAuth } from './services/spotify';
-import './services/spotifyPlayer';
 import { ThemeProvider } from './styles/ThemeProvider';
 import { flexCenter, buttonPrimary } from './styles/utils';
 import { TrackProvider } from './contexts/TrackContext';

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -1,18 +1,5 @@
 import { spotifyAuth } from './spotify';
 
-// Global callback for Spotify SDK ready event
-let spotifySDKReadyCallback: (() => void) | null = null;
-
-// Define the global callback that the Spotify SDK will call
-if (typeof window !== 'undefined') {
-  window.onSpotifyWebPlaybackSDKReady = () => {
-    console.log('Spotify SDK ready callback triggered');
-    if (spotifySDKReadyCallback) {
-      spotifySDKReadyCallback();
-    }
-  };
-}
-
 // HMR-safe storage for player state
 interface HMRPlayerState {
   player: SpotifyPlayer | null;
@@ -67,6 +54,41 @@ class SpotifyPlayerService {
     });
   }
 
+  /**
+   * Dynamically load the Spotify Web Playback SDK script.
+   * Resolves once the SDK is ready (window.Spotify is available).
+   */
+  private loadSDK(): Promise<void> {
+    if (typeof window === 'undefined') {
+      return Promise.reject(new Error('Window object not available'));
+    }
+
+    // Already loaded
+    if (window.Spotify) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Spotify SDK failed to load within timeout'));
+      }, 10000);
+
+      window.onSpotifyWebPlaybackSDKReady = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+
+      const script = document.createElement('script');
+      script.src = 'https://sdk.scdn.co/spotify-player.js';
+      script.async = true;
+      script.onerror = () => {
+        clearTimeout(timeout);
+        reject(new Error('Failed to load Spotify SDK script'));
+      };
+      document.body.appendChild(script);
+    });
+  }
+
   async initialize(): Promise<void> {
     if (!spotifyAuth.isAuthenticated()) {
       throw new Error('User must be authenticated before initializing player');
@@ -76,35 +98,8 @@ class SpotifyPlayerService {
       return;
     }
 
-    return new Promise((resolve, reject) => {
-      const initPlayer = () => {
-        try {
-          this.setupPlayer();
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-
-      if (typeof window !== 'undefined' && window.Spotify) {
-        console.log('Spotify SDK already available, initializing player');
-        initPlayer();
-      } else if (typeof window !== 'undefined') {
-        console.log('Waiting for Spotify SDK to load...');
-        // Set the callback that will be called by the global onSpotifyWebPlaybackSDKReady
-        spotifySDKReadyCallback = initPlayer;
-        
-        setTimeout(() => {
-          if (!this.player) {
-            console.error('Spotify SDK failed to load within timeout');
-            spotifySDKReadyCallback = null; // Clear the callback
-            reject(new Error('Spotify SDK failed to load within timeout'));
-          }
-        }, 10000);
-      } else {
-        reject(new Error('Window object not available'));
-      }
-    });
+    await this.loadSDK();
+    this.setupPlayer();
   }
 
   private setupPlayer(): void {
@@ -410,8 +405,6 @@ class SpotifyPlayerService {
       this.isReady = false;
       this.saveState();
     }
-    // Clear the global callback
-    spotifySDKReadyCallback = null;
   }
 
   getDeviceId(): string | null {


### PR DESCRIPTION
## Summary
Refactored the Spotify Web Playback SDK loading mechanism from a static global callback approach to a dynamic, on-demand loading strategy. The SDK is now loaded only when the player service is initialized, rather than being loaded upfront in the HTML.

## Key Changes
- **Removed static SDK script tag** from `index.html` - the SDK is no longer loaded on every page load
- **Removed global callback pattern** - eliminated the `spotifySDKReadyCallback` global variable and the upfront `window.onSpotifyWebPlaybackSDKReady` setup
- **Added `loadSDK()` private method** to `SpotifyPlayerService` that:
  - Dynamically creates and appends the Spotify SDK script to the DOM
  - Returns a Promise that resolves when the SDK is ready
  - Includes a 10-second timeout to handle load failures
  - Checks if the SDK is already loaded to avoid duplicate loading
  - Properly handles script load errors
- **Simplified `initialize()` method** - now uses the new `loadSDK()` method instead of managing callbacks
- **Removed unnecessary import** of `spotifyPlayer` service from `App.tsx` since initialization is now handled internally

## Implementation Details
- The SDK is now loaded on-demand when `SpotifyPlayerService.initialize()` is called, improving initial page load performance
- The `loadSDK()` method uses a Promise-based approach with proper error handling and timeout management
- The implementation maintains backward compatibility while being more maintainable and testable
- Removed global state management in favor of instance-level state within the service class

https://claude.ai/code/session_0135JkeAd71YxKmcr1JMKUaA