### PR TITLE
Refactor vertical swipe gestures to toggle playlist and library drawer

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -540,17 +540,25 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onSwipeRight: handlers.onPrevious,
   }, { enabled: isTouchDevice });
 
-  const handleZenSwipeUp = useCallback(() => {
-    if (zenModeEnabled) handleZenModeToggle();
-  }, [zenModeEnabled, handleZenModeToggle]);
+  const handleSwipeUp = useCallback(() => {
+    if (showPlaylist) {
+      handleClosePlaylist();
+    } else {
+      handleShowPlaylist();
+    }
+  }, [showPlaylist, handleShowPlaylist, handleClosePlaylist]);
 
-  const handleZenSwipeDown = useCallback(() => {
-    if (!zenModeEnabled) handleZenModeToggle();
-  }, [zenModeEnabled, handleZenModeToggle]);
+  const handleSwipeDown = useCallback(() => {
+    if (showLibraryDrawer) {
+      handlers.onCloseLibraryDrawer();
+    } else {
+      handlers.onOpenLibraryDrawer();
+    }
+  }, [showLibraryDrawer, handlers]);
 
-  const { ref: zenVerticalSwipeRef } = useVerticalSwipeGesture({
-    onSwipeUp: handleZenSwipeUp,
-    onSwipeDown: handleZenSwipeDown,
+  const { ref: drawerSwipeRef } = useVerticalSwipeGesture({
+    onSwipeUp: handleSwipeUp,
+    onSwipeDown: handleSwipeDown,
     threshold: 80,
     enabled: isTouchDevice,
   });
@@ -646,10 +654,10 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
               <ClickableAlbumArtContainer
                 ref={(el) => {
                   albumArtContainerRef.current = el;
-                  if (isTouchDevice && zenVerticalSwipeRef && typeof zenVerticalSwipeRef !== 'function') {
-                    (zenVerticalSwipeRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-                  } else if (isTouchDevice && typeof zenVerticalSwipeRef === 'function') {
-                    (zenVerticalSwipeRef as (instance: HTMLDivElement | null) => void)(el);
+                  if (isTouchDevice && drawerSwipeRef && typeof drawerSwipeRef !== 'function') {
+                    (drawerSwipeRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+                  } else if (isTouchDevice && typeof drawerSwipeRef === 'function') {
+                    (drawerSwipeRef as (instance: HTMLDivElement | null) => void)(el);
                   }
                 }}
                 $swipeEnabled={isTouchDevice}


### PR DESCRIPTION
## Summary
Refactored the vertical swipe gesture handlers in PlayerContent to control playlist and library drawer visibility instead of zen mode toggling. This provides more intuitive touch navigation for accessing key UI panels.

## Key Changes
- Renamed `handleZenSwipeUp` to `handleSwipeUp` and updated logic to toggle playlist visibility
- Renamed `handleZenSwipeDown` to `handleZenSwipeDown` and updated logic to toggle library drawer visibility
- Renamed `zenVerticalSwipeRef` to `drawerSwipeRef` for clarity and consistency with new functionality
- Updated all references to the swipe ref throughout the component to use the new name

## Implementation Details
- **Swipe Up**: Now toggles between showing and hiding the playlist instead of toggling zen mode
- **Swipe Down**: Now toggles between showing and hiding the library drawer instead of toggling zen mode
- Updated callback dependencies to reflect the new state variables (`showPlaylist`, `showLibraryDrawer`) and handlers (`handleShowPlaylist`, `handleClosePlaylist`, `onOpenLibraryDrawer`, `onCloseLibraryDrawer`)
- Maintained the same threshold (80) and touch device detection for gesture recognition

https://claude.ai/code/session_01GKqb2Yj6jLkyxMVJwnVX7j