### PR TITLE
Clarify swipe gestures, Dropbox likes, and token refresh behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 
 **Vorbis Player** is a React/TypeScript music player with customizable visual effects and a pluggable provider architecture. Supports **Spotify** (streaming, Premium required) and **Dropbox** (personal files via HTML5 Audio).
 
-Key capabilities: multi-provider auth/catalog/playback adapters, background visualizers, album art flip menu, bottom bar, swipe gestures, keyboard shortcuts, IndexedDB caching, responsive layout.
+Key capabilities: multi-provider auth/catalog/playback adapters, background visualizers, album art flip menu, bottom bar, swipe gestures (drawer toggles), keyboard shortcuts, IndexedDB caching, responsive layout.
 
 ## Build Verification
 
@@ -63,7 +63,7 @@ src/
 ├── constants/       # playlist.ts — ALBUM_ID_PREFIX, LIKED_SONGS_ID, helpers
 ├── providers/       # Multi-provider system; spotify/ and dropbox/ subdirs
 ├── hooks/           # 22 custom hooks
-├── services/        # spotify.ts, spotifyPlayer.ts, cache/ (IndexedDB)
+├── services/        # spotify.ts (auth + API), spotifyPlayer.ts (lazy SDK loading + playback), cache/ (IndexedDB)
 ├── utils/           # colorExtractor, colorUtils, sizingUtils, playlistFilters, etc.
 ├── workers/         # imageProcessor.worker.ts
 ├── types/           # domain.ts, providers.ts, filters.ts
@@ -86,7 +86,7 @@ AppContainer (flexCenter, min-height: 100dvh)
 - **`overflow: visible` is required on ContentWrapper** — `container-type: inline-size` creates containment that clips absolutely-positioned children
 - **`100dvh`** throughout to handle iOS address bar changes
 - **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
-- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss
+- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle playlist (up) and library (down) drawers
 - **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout
 
 ### Multi-Provider Architecture
@@ -102,7 +102,7 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 - `MediaCollection` — provider-agnostic collection (playlist or album)
 - `CollectionRef` — `{ provider, kind, id }`; serialized via `collectionRefToKey` / `keyToCollectionRef`
 
-**Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`).
+**Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`). Both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection`.
 
 **Dropbox folder structure**:
 ```
@@ -112,6 +112,12 @@ Dropbox root/
     └── 01 - Track.mp3
 ```
 Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection is always prepended.
+
+**Dropbox Liked Songs**: Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
+
+**Token refresh**: Both providers preserve refresh tokens during transient failures and proactively refresh before expiry. Spotify uses a 5-minute buffer; Dropbox uses a 60-second buffer. On 401/400 errors Dropbox performs full logout; on 5xx or network errors it preserves the refresh token for retry.
+
+**Spotify SDK loading**: The Spotify Web Playback SDK is loaded lazily by `SpotifyPlayerService.loadSDK()` — no global script tag in `index.html`. The SDK is only injected when the Spotify provider activates.
 
 ### Responsive Sizing
 
@@ -178,12 +184,15 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 **Spotify:**
 - Auth issues → use `127.0.0.1` not `localhost`
 - Track skipping → auto-skip handles 403 Restriction Violated errors
+- Expired tokens → refresh token is preserved; `isAuthenticated()` returns true if refresh token exists
 
 **Dropbox:**
 - Provider not visible → `VITE_DROPBOX_CLIENT_ID` must be set; restart dev server
 - No collections → audio files must be in subfolders (root-level files are skipped)
 - Stale catalog → 1-hour IndexedDB TTL; clear site data to force refresh
 - Art missing → place `cover.jpg` (or `folder.jpg`, `album.jpg`, `front.jpg`) alongside audio files
+- Liked songs missing → check IndexedDB `likes` store; use Settings → Refresh Metadata to re-sync
+- Auth loop → on 401/400 Dropbox performs full logout; on 5xx/network errors refresh token is preserved for retry
 
 **Visual Effects:**
 - Album art filters not working → always pass `albumFilters={albumFilters}` to `AlbumArt`

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ A visually immersive Spotify music player built with React, featuring customizab
 - **Spotify Integration**: Stream music from your Spotify account (Premium required)
 - **Dropbox Integration**: Browse and play audio files (MP3, FLAC, OGG, M4A, WAV) stored in your Dropbox
 - **Playlists & Albums**: Browse, search, sort, filter, and pin your playlists and albums
-- **Liked Songs**: Play your Liked Songs collection with automatic shuffle
+- **Liked Songs**: Play your Liked Songs collection with automatic shuffle (both Spotify and Dropbox)
 - **Visual Effects**: Dynamic glow effects with configurable intensity and animation rate
 - **Album Art Filters**: Real-time CSS filters (brightness, contrast, saturation, sepia, hue rotation, blur)
 - **Background Visualizers**: Animated particle and geometric visualizer backgrounds (enabled by default)
 - **Custom Colors**: Pick accent colors per album from a color picker or eyedropper tool
 - **Album Art Flip Menu**: Tap album art to flip and reveal quick-access controls (color chooser, glow toggle, visualizer toggle, visualizer style)
-- **Swipe Gestures**: Swipe album art horizontally to change tracks; swipe up to exit zen mode, down to enter zen mode. Library and playlist drawers are opened via the bottom bar.
+- **Swipe Gestures**: Swipe album art horizontally to change tracks; swipe up to toggle the playlist drawer, swipe down to toggle the library drawer
 - **Interactive Track Info**: Click artist/album names for Spotify links and library filtering
 - **Instant Startup**: IndexedDB-based library cache with background sync for fast loading
 - **Responsive Design**: Fluid layout that adapts from mobile phones to ultra-wide desktops
@@ -112,9 +112,8 @@ The player displays album artwork with controls always visible below:
 **Touch Gestures** (mobile/tablet):
 - Tap album art to flip and reveal quick-access controls (or play/pause when in zen mode)
 - Swipe album art left/right to change tracks
-- Swipe up on album art to exit zen mode
-- Swipe down on album art to enter zen mode
-- Library and playlist drawers: use bottom bar buttons
+- Swipe up on album art to toggle the playlist drawer
+- Swipe down on album art to toggle the library drawer
 
 ### Library
 
@@ -139,7 +138,8 @@ When Dropbox is active:
 - Supported audio formats: MP3, FLAC, OGG/Vorbis, M4A/AAC, WAV (unsupported formats are skipped)
 - Album art is read from image files (`cover.jpg`, `folder.png`, etc.) found alongside your audio files
 - Track metadata (title, artist, album, cover art) is read from ID3 tags embedded in MP3 files
-- Provider-specific actions (Like, "Open in Spotify") are hidden for Dropbox tracks
+- Liked Songs are supported for Dropbox — like/unlike tracks, browse your liked collection, and manage via Export/Import and Refresh Metadata in settings
+- "Open in Spotify" links are hidden for Dropbox tracks
 
 ### Visual Effects Menu
 
@@ -224,7 +224,7 @@ src/
 
 - **Frontend**: React 18 + TypeScript + Vite
 - **Styling**: styled-components with theme system + Radix UI primitives
-- **Audio**: Spotify Web Playback SDK + Web API; HTML5 Audio for Dropbox streams
+- **Audio**: Spotify Web Playback SDK (lazy-loaded on demand) + Web API; HTML5 Audio for Dropbox streams
 - **Authentication**: PKCE OAuth 2.0 (Spotify and Dropbox)
 - **Testing**: Vitest + React Testing Library
 - **Performance**: Web Workers, LRU caching, IndexedDB persistence, lazy loading, container queries


### PR DESCRIPTION
## Summary
Updated documentation to clarify existing functionality around swipe gestures, Dropbox liked songs support, token refresh mechanisms, and lazy SDK loading. These changes reflect the actual implementation without modifying source code behavior.

## Key Changes
- **Swipe Gestures**: Clarified that vertical swipes on album art toggle playlist (up) and library (down) drawers, replacing the previous zen mode terminology
- **Dropbox Liked Songs**: Documented that liked songs are fully supported for Dropbox tracks with IndexedDB persistence, export/import, and metadata refresh capabilities
- **Token Refresh**: Added details on how both Spotify (5-minute buffer) and Dropbox (60-second buffer) handle token refresh, including error handling strategies (401/400 = full logout, 5xx/network = preserve token for retry)
- **Spotify SDK Loading**: Clarified that the Spotify Web Playback SDK is lazy-loaded on demand via `SpotifyPlayerService.loadSDK()` rather than injected globally
- **Capability Awareness**: Noted that both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection` capabilities

## Notable Details
- Dropbox liked songs use the `vorbis-dropbox-art` IndexedDB database (v3) with a `likes` store
- Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI synchronization
- Settings menu provides Export/Import (JSON) and Refresh Metadata operations for Dropbox likes management
- Documentation now accurately reflects the swipe gesture behavior as implemented in the codebase

