### PR TITLE
chore: add /knip slash command for dead code cleanup

### DIFF
--- a/.claude/commands/knip.md
+++ b/.claude/commands/knip.md
@@ -1,0 +1,8 @@
+Use knip to identify code that can be removed. Leverage that info to update the codebase accordingly. Do this on a chore branch. Once you're done, commit the changes, push, and open a PR for me to review.
+
+Important guidelines:
+- Verify each knip finding before acting. Knip can produce false positives, especially for ambient declaration files (`.d.ts`), service workers, and test infrastructure.
+- For unused files: delete them only after confirming no runtime or ambient usage exists.
+- For unused exports: if the symbol is still used internally in the same file, just remove the `export` keyword instead of deleting the code.
+- For unused dependencies: remove them via `npm uninstall`.
+- Run `npx tsc --noEmit` and `npm run test:run` to verify nothing is broken before committing.


### PR DESCRIPTION
## Summary

- Adds a `/knip` slash command at `.claude/commands/knip.md` that runs knip analysis, verifies findings, cleans up dead code, and opens a PR

## What it does

When invoked, the command will:
1. Run knip to identify unused files, exports, dependencies, and types
2. Verify each finding (knip can false-positive on `.d.ts` ambient files, service workers, test infra)
3. Delete truly unused files, unexport internally-used symbols, remove unused deps
4. Run `tsc` and tests to verify nothing broke
5. Commit, push, and open a PR