### PR TITLE
fix: preserve ProviderContext across Vite HMR reloads

### DIFF
--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -25,7 +25,12 @@ interface ProviderContextValue {
   needsProviderSelection: boolean;
 }
 
-const ProviderContext = createContext<ProviderContextValue | null>(null);
+const ProviderContext =
+  (import.meta.hot?.data?.ProviderContext as React.Context<ProviderContextValue | null> | undefined) ??
+  createContext<ProviderContextValue | null>(null);
+if (import.meta.hot) {
+  import.meta.hot.data.ProviderContext = ProviderContext;
+}
 
 export function ProviderProvider({ children }: { children: React.ReactNode }) {
   const [storedProviderId, setStoredProviderId] = useLocalStorage<ProviderId | null>(


### PR DESCRIPTION
## Summary

- Persists the `ProviderContext` React context object across Vite HMR reloads using `import.meta.hot.data`
- Fixes the "useProviderContext must be used within ProviderProvider" error that occurs during hot module replacement

## Test plan

- [ ] Trigger HMR by editing a file in the provider context tree — no error should appear
- [ ] Verify provider selection still works after reload