### PR TITLE
refactor: simplify code for reuse, quality, and efficiency

### DIFF
--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { theme } from '../../styles/theme';
 
@@ -84,15 +84,6 @@ const OptionButton = styled.button`
 `;
 
 function TrackInfoPopover({ options, anchorRect, onClose }: TrackInfoPopoverProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const positionPopover = useCallback(() => {
-    if (!anchorRect) return { x: 0, y: 0 };
-    const x = anchorRect.left + anchorRect.width / 2;
-    const y = anchorRect.bottom + 8;
-    return { x, y };
-  }, [anchorRect]);
-
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -103,14 +94,15 @@ function TrackInfoPopover({ options, anchorRect, onClose }: TrackInfoPopoverProp
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
-  const { x, y } = positionPopover();
-
   if (!anchorRect) return null;
+
+  const x = anchorRect.left + anchorRect.width / 2;
+  const y = anchorRect.bottom + 8;
 
   return (
     <>
       <Overlay onClick={onClose} />
-      <PopoverContainer ref={containerRef} $x={x} $y={y}>
+      <PopoverContainer $x={x} $y={y}>
         {options.map((option, index) => (
           <OptionButton
             key={index}

--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -82,8 +82,6 @@ export const usePlaylistManager = ({
       await waitForSpotifyReady();
       await spotifyPlayer.transferPlaybackToDevice();
       
-      // Wait for device to become active
-      console.log('🎵 Waiting for device to become active...');
       await spotifyPlayer.ensureDeviceIsActive();
       
       let fetchedTracks: Track[] = [];
@@ -109,7 +107,6 @@ export const usePlaylistManager = ({
       // the track queue directly.
       if (fetchedTracks.length === 0 && !isAlbumId(playlistId) && playlistId !== LIKED_SONGS_ID) {
         try {
-          console.log('🎵 Trying context-based playback for playlist:', playlistId);
           await spotifyPlayer.playContext(`spotify:playlist:${playlistId}`);
 
           // Wait for SDK to start playing and report the first track
@@ -191,7 +188,6 @@ export const usePlaylistManager = ({
 
               // Try the next track if available
               if (trackIndex < tracksToPlay.length - 1) {
-                console.log('🎵 Trying next track...');
                 setCurrentTrackIndex(trackIndex + 1);
                 return await playWithRetry(trackIndex + 1, 0, maxRetries);
               }
@@ -202,8 +198,6 @@ export const usePlaylistManager = ({
             // For other 403 errors, try to recover with exponential backoff
             if (retryCount < maxRetries) {
               const backoffMs = 2000 * Math.pow(2, retryCount);
-              console.log(`🎵 Got 403 error, retrying in ${backoffMs}ms (attempt ${retryCount + 1}/${maxRetries})...`);
-              
               await spotifyPlayer.transferPlaybackToDevice();
               await new Promise(resolve => setTimeout(resolve, backoffMs));
               await spotifyPlayer.ensureDeviceIsActive(3, 1000);

--- a/src/hooks/useSpotifyPlayback.ts
+++ b/src/hooks/useSpotifyPlayback.ts
@@ -62,7 +62,7 @@ export const useSpotifyPlayback = ({
     if (activeDescriptor && activeDescriptor.id !== 'spotify') {
       const mediaTracks = mediaTracksRef?.current ?? [];
       if (!mediaTracks[index]) {
-        console.error(`[${activeDescriptor.id}] playTrack: No track at index`, index, 'mediaTracks length:', mediaTracks.length);
+        console.error(`[${activeDescriptor.id}] No track at index ${index} (mediaTracks length: ${mediaTracks.length})`);
         return;
       }
       try {
@@ -78,20 +78,13 @@ export const useSpotifyPlayback = ({
     }
 
     if (!tracks[index]) {
-      console.error('[DEBUG] playTrack: No track at index', index, 'tracks length:', tracks.length);
+      console.error(`[Spotify] No track at index ${index} (tracks length: ${tracks.length})`);
       return;
     }
 
     try {
-      const isAuthenticated = spotifyAuth.isAuthenticated();
+      if (!spotifyAuth.isAuthenticated()) return;
 
-      if (!isAuthenticated) {
-        console.warn('[DEBUG] playTrack: Not authenticated');
-        return;
-      }
-
-      console.log('[DEBUG] playTrack: Playing track', tracks[index].name);
-      
       // Retry logic for 403 errors
       const playWithRetry = async (trackUri: string, retryCount = 0, maxRetries = 2): Promise<boolean> => {
         try {
@@ -113,8 +106,6 @@ export const useSpotifyPlayback = ({
             // For other 403 errors, try to recover with exponential backoff
             if (retryCount < maxRetries) {
               const backoffMs = 1500 * Math.pow(2, retryCount);
-              console.log(`🎵 Got 403 error while switching songs, retrying in ${backoffMs}ms (attempt ${retryCount + 1}/${maxRetries})...`);
-              
               await spotifyPlayer.transferPlaybackToDevice();
               await new Promise(resolve => setTimeout(resolve, backoffMs));
               await spotifyPlayer.ensureDeviceIsActive(3, 1000);
@@ -133,7 +124,6 @@ export const useSpotifyPlayback = ({
       if (!success) {
         // Track is unavailable, skip to next if enabled
         if (skipOnError && index < tracks.length - 1) {
-          console.log('🎵 Skipping unavailable track, moving to next...');
           setTimeout(() => {
             playTrack(index + 1, skipOnError);
           }, 500);
@@ -161,7 +151,6 @@ export const useSpotifyPlayback = ({
       
       // If skipOnError is enabled and we have more tracks, try the next one
       if (skipOnError && index < tracks.length - 1) {
-        console.log('🎵 Error playing track, trying next track...');
         setTimeout(() => {
           playTrack(index + 1, skipOnError);
         }, 500);

--- a/src/providers/dropbox/dropboxProvider.ts
+++ b/src/providers/dropbox/dropboxProvider.ts
@@ -32,13 +32,6 @@ if (DROPBOX_CLIENT_ID) {
     auth,
     catalog,
     playback,
-    getExternalUrl({ type, name, artistName }) {
-      if (type === 'artist') {
-        return `https://www.discogs.com/search/?q=${encodeURIComponent(name)}&type=artist`;
-      }
-      const query = artistName ? `${artistName} ${name}` : name;
-      return `https://www.discogs.com/search/?q=${encodeURIComponent(query)}&type=release`;
-    },
     getExternalUrls({ type, name, artistName }) {
       const isArtist = type === 'artist';
       const query = isArtist ? name : (artistName ? `${artistName} ${name}` : name);


### PR DESCRIPTION
## Summary

- Remove unused `containerRef` and `positionPopover` useCallback from `TrackInfoPopover` — dead code left over from a prior refactor
- Remove dead `getExternalUrl` from Dropbox provider — `getExternalUrls` (plural) takes precedence and this single version was never called
- Remove `[DEBUG]` console.log/warn statements from `useSpotifyPlayback` and `usePlaylistManager` — debug logging left in from development

## Test plan

- [ ] Verify track info popover still renders and positions correctly
- [ ] Verify Dropbox external links still work
- [ ] Verify Spotify playback still functions normally (no missing logs that were load-bearing)
- [ ] `npm run test:run` passes (pre-existing test failures unrelated to this change)