### PR TITLE
fix: settings drawer slide animation matches playlist drawer

### DIFF
--- a/src/components/VisualEffectsMenu/styled.ts
+++ b/src/components/VisualEffectsMenu/styled.ts
@@ -26,7 +26,7 @@ export const DrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $t
   backdrop-filter: blur(${theme.drawer.backdropBlur});
   border-left: 1px solid ${theme.colors.popover.border};
   transform: translateX(${({ $isOpen }) => ($isOpen ? '0' : '100%')});
-  transition: all ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
+  transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
             width ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
   z-index: ${theme.zIndex.modal};
   overflow-y: auto;


### PR DESCRIPTION
Fixes #255

## Summary

- Changed `DrawerContainer` in `VisualEffectsMenu/styled.ts` from `transition: all` to `transition: transform`, matching the `PlaylistDrawer` approach
- Both drawers now only transition `transform` and `width`, which is GPU-accelerated and consistent

## Test plan

- [ ] Open the settings/visual effects drawer — verify it slides in/out smoothly, matching the playlist drawer animation
- [ ] Open the playlist drawer for comparison — both should feel identical
- [ ] Test on mobile and desktop