### PR TITLE
fix: guard import.meta.hot.data to prevent test crashes

### DIFF
--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -28,7 +28,7 @@ interface ProviderContextValue {
 const ProviderContext =
   (import.meta.hot?.data?.ProviderContext as React.Context<ProviderContextValue | null> | undefined) ??
   createContext<ProviderContextValue | null>(null);
-if (import.meta.hot) {
+if (import.meta.hot?.data) {
   import.meta.hot.data.ProviderContext = ProviderContext;
 }
 


### PR DESCRIPTION
## Summary

- `import.meta.hot` is truthy in the vitest environment, but `import.meta.hot.data` is `undefined`
- This caused a `TypeError: Cannot set properties of undefined (setting 'ProviderContext')` in `ProviderContext.tsx` that crashed 7 test suites (all 349 tests were passing but couldn't run)
- Fix: guard the assignment with `import.meta.hot?.data` so it only runs when `.data` is actually available (i.e. real Vite HMR, not vitest)

## Test plan

- [ ] `npm run test:run` — all 36 test files pass (was 7 failing)
- [ ] Verify HMR still works in dev (`npm run dev`, edit a file, context should be preserved across hot reloads)