### PR TITLE
Cache track durations in IndexedDB and expose via playback metadata

### DIFF
--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -217,7 +217,7 @@ export function usePlayerLogic() {
 
           if (state.trackMetadata && trackIndex !== -1) {
             const meta = state.trackMetadata;
-            if (meta.name !== undefined || meta.artists !== undefined || meta.album !== undefined || meta.image !== undefined) {
+            if (meta.name !== undefined || meta.artists !== undefined || meta.album !== undefined || meta.image !== undefined || meta.durationMs !== undefined) {
               setTracks((prev: Track[]) =>
                 prev.map((t, i) =>
                   i === trackIndex
@@ -227,6 +227,7 @@ export function usePlayerLogic() {
                         ...(meta.artists !== undefined && { artists: meta.artists }),
                         ...(meta.album !== undefined && { album: meta.album }),
                         ...(meta.image !== undefined && { image: meta.image }),
+                        ...(meta.durationMs !== undefined && { duration_ms: meta.durationMs }),
                       }
                     : t
                 )

--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -5,7 +5,7 @@
  */
 
 const DB_NAME = 'vorbis-dropbox-art';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 const STORE = 'art';
 const ART_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -41,6 +41,9 @@ function openDb(): Promise<IDBDatabase | null> {
       }
       if (!database.objectStoreNames.contains('likes')) {
         database.createObjectStore('likes', { keyPath: 'trackId' });
+      }
+      if (!database.objectStoreNames.contains('durations')) {
+        database.createObjectStore('durations', { keyPath: 'trackId' });
       }
     };
   });
@@ -95,6 +98,44 @@ export async function clearArt(): Promise<void> {
       tx.onerror = () => resolve();
     } catch {
       resolve();
+    }
+  });
+}
+
+export async function putDurationMs(trackId: string, durationMs: number): Promise<void> {
+  const database = await getDb();
+  if (!database) return;
+  try {
+    const tx = database.transaction('durations', 'readwrite');
+    tx.objectStore('durations').put({ trackId, durationMs });
+  } catch {
+    // fire-and-forget
+  }
+}
+
+export async function getDurationsMap(trackIds: string[]): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  if (trackIds.length === 0) return result;
+  const database = await getDb();
+  if (!database) return result;
+  return new Promise((resolve) => {
+    try {
+      const tx = database.transaction('durations', 'readonly');
+      const store = tx.objectStore('durations');
+      let pending = trackIds.length;
+      for (const id of trackIds) {
+        const req = store.get(id);
+        req.onsuccess = () => {
+          const entry = req.result as { trackId: string; durationMs: number } | undefined;
+          if (entry && entry.durationMs > 0) result.set(id, entry.durationMs);
+          if (--pending === 0) resolve(result);
+        };
+        req.onerror = () => {
+          if (--pending === 0) resolve(result);
+        };
+      }
+    } catch {
+      resolve(result);
     }
   });
 }

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -17,7 +17,7 @@
 import type { CatalogProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, MediaCollection, CollectionRef } from '@/types/domain';
 import { DropboxAuthAdapter } from './dropboxAuthAdapter';
-import { getArt, putArt, clearArt } from './dropboxArtCache';
+import { getArt, putArt, clearArt, getDurationsMap } from './dropboxArtCache';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import {
   getLikedTracks,
@@ -362,6 +362,15 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         const bPath = b.playbackRef.ref;
         return aPath.localeCompare(bPath);
       });
+
+      // Hydrate any previously-discovered durations from IndexedDB cache.
+      const durationsMap = await getDurationsMap(tracks.map((t) => t.id));
+      if (durationsMap.size > 0) {
+        for (const t of tracks) {
+          const cached = durationsMap.get(t.id);
+          if (cached !== undefined) t.durationMs = cached;
+        }
+      }
 
       for (const t of tracks) this.knownTracks.set(t.id, t);
 

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -8,6 +8,7 @@ import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/typ
 import { DropboxCatalogAdapter } from './dropboxCatalogAdapter';
 import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
+import { putDurationMs } from './dropboxArtCache';
 
 export class DropboxPlaybackAdapter implements PlaybackProvider {
   readonly providerId: ProviderId = 'dropbox';
@@ -16,6 +17,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private listeners = new Set<(state: PlaybackState | null) => void>();
   private updateInterval: ReturnType<typeof setInterval> | null = null;
   private pendingMetadataUpdate: PlaybackState['trackMetadata'] | null = null;
+  private pendingDurationMs: number | null = null;
   private pendingError: PlaybackState['playbackError'] | null = null;
 
   private catalog: DropboxCatalogAdapter;
@@ -33,7 +35,15 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       this.audio.addEventListener('pause', () => this.notifyListeners());
       this.audio.addEventListener('ended', () => this.notifyListeners());
       this.audio.addEventListener('timeupdate', () => this.notifyListeners());
-      this.audio.addEventListener('loadedmetadata', () => this.notifyListeners());
+      this.audio.addEventListener('loadedmetadata', () => {
+        const dur = this.audio!.duration;
+        if (!isNaN(dur) && dur > 0 && this.currentTrack) {
+          const durationMs = Math.floor(dur * 1000);
+          this.pendingDurationMs = durationMs;
+          putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
+        }
+        this.notifyListeners();
+      });
       this.audio.addEventListener('error', () => {
         const mediaError = this.audio?.error;
         this.pendingError = {
@@ -54,6 +64,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
     this.currentTrack = track;
     this.pendingMetadataUpdate = null;
+    this.pendingDurationMs = null;
     this.audio!.src = streamUrl;
     await this.audio!.play();
 
@@ -189,9 +200,13 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       currentPlaybackRef: this.currentTrack.playbackRef,
     };
 
-    if (this.pendingMetadataUpdate) {
-      state.trackMetadata = this.pendingMetadataUpdate;
+    if (this.pendingMetadataUpdate || this.pendingDurationMs !== null) {
+      state.trackMetadata = {
+        ...this.pendingMetadataUpdate,
+        ...(this.pendingDurationMs !== null ? { durationMs: this.pendingDurationMs } : {}),
+      };
       this.pendingMetadataUpdate = null;
+      this.pendingDurationMs = null;
     }
 
     if (this.pendingError) {

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -76,7 +76,7 @@ export interface PlaybackState {
   currentTrackId: string | null;
   currentPlaybackRef: PlaybackItemRef | null;
   /** Enriched metadata read from audio file tags (e.g. ID3). Overrides filename-derived values. */
-  trackMetadata?: Partial<Pick<MediaTrack, 'name' | 'artists' | 'album' | 'image'>>;
+  trackMetadata?: Partial<Pick<MediaTrack, 'name' | 'artists' | 'album' | 'image' | 'durationMs'>>;
   /** Set when the provider encounters a playback error; cleared after one notification cycle. */
   playbackError?: { code: number; message: string };
 }


### PR DESCRIPTION
## Summary
This PR adds persistent caching of track durations discovered during playback and makes them available through the playback metadata system. When audio files are loaded, their durations are automatically cached in IndexedDB and reused when the same tracks are encountered again, improving the user experience by populating duration information without requiring re-playback.

## Key Changes
- **IndexedDB Schema Update**: Bumped `DB_VERSION` from 3 to 4 and added a new `durations` object store to persist track duration data
- **Duration Caching**: Added `putDurationMs()` function to store discovered durations and `getDurationsMap()` to retrieve cached durations for multiple tracks
- **Playback Integration**: Modified `DropboxPlaybackAdapter` to capture duration from the `loadedmetadata` event and cache it via `putDurationMs()`
- **Catalog Hydration**: Updated `DropboxCatalogAdapter` to populate track durations from the IndexedDB cache when loading collections
- **Metadata Exposure**: Extended `PlaybackState.trackMetadata` type to include `durationMs` and updated `usePlayerLogic` to apply cached durations to track objects
- **Type Safety**: Updated `domain.ts` to include `durationMs` in the `trackMetadata` type definition

## Implementation Details
- Duration caching is fire-and-forget to avoid blocking playback
- The `getDurationsMap()` function uses a Promise-based approach to handle asynchronous IndexedDB queries for multiple track IDs
- Only valid durations (> 0) are cached and retrieved
- The duration metadata flows through the playback state system and updates the UI track list via `duration_ms` field

