### PR TITLE
chore: fix worktree skill scripts to avoid cd && chaining

### DIFF
--- a/.claude/skills/close-worktree/SKILL.md
+++ b/.claude/skills/close-worktree/SKILL.md
@@ -17,10 +17,16 @@ Run the cleanup script from the **main repo session** (not from inside the workt
 
 ## Steps
 
-1. Run the script via Bash, passing the worktree name:
+1. Get the repo root:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)" && bash scripts/close-worktree.sh <name>
+git rev-parse --show-toplevel
 ```
 
-2. Confirm to the user that the branch was merged and the worktree was removed.
+2. Run the cleanup script (use the path from step 1, do NOT chain with `&&`):
+
+```bash
+bash /path/to/repo/scripts/close-worktree.sh <name>
+```
+
+3. Confirm to the user that the branch was merged and the worktree was removed.

--- a/.claude/skills/new-worktree/SKILL.md
+++ b/.claude/skills/new-worktree/SKILL.md
@@ -17,10 +17,16 @@ Run the setup script, then tell the user the path to open in a new terminal.
 
 ## Steps
 
-1. Run the script via Bash:
+1. Get the repo root:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)" && bash scripts/new-worktree.sh [name]
+git rev-parse --show-toplevel
 ```
 
-2. Show the user the output, including the `cd ... && claude` line to open in a new terminal.
+2. Run the setup script (use the path from step 1, do NOT chain with `&&`):
+
+```bash
+bash /path/to/repo/scripts/new-worktree.sh [name]
+```
+
+3. Show the user the output, including the `cd ... && claude` line to open in a new terminal.


### PR DESCRIPTION
## Summary

- Split the worktree script invocation into two steps: first get the repo root path, then run the script using the absolute path
- Avoids issues with `cd "$(git rev-parse --show-toplevel)" && bash ...` chaining in the Bash tool, which can silently fail or behave unexpectedly

## Test plan

- [ ] Run `/new-worktree` skill and verify the steps produce correct output
- [ ] Run `/close-worktree` skill and verify the steps produce correct output