### PR TITLE
fix: Apple Music timeline stuck at 0 (#268)

### DIFF
--- a/src/providers/apple-music/appleMusicPlaybackAdapter.ts
+++ b/src/providers/apple-music/appleMusicPlaybackAdapter.ts
@@ -103,10 +103,12 @@ export class AppleMusicPlaybackAdapter implements PlaybackProvider {
 
   private mapState(instance: MKInstance): PlaybackState {
     const item = instance.nowPlayingItem;
+    const durationMs =
+      instance.currentPlaybackDuration * 1000 || (item?.attributes?.durationInMillis ?? 0);
     return {
       isPlaying: instance.playbackState === MKPlaybackStates.playing,
       positionMs: instance.currentPlaybackTime * 1000,
-      durationMs: instance.currentPlaybackDuration * 1000,
+      durationMs,
       currentTrackId: item?.id ?? null,
       currentPlaybackRef: item
         ? { provider: 'apple-music', ref: item.attributes.playParams?.catalogId ?? item.id }


### PR DESCRIPTION
## Summary

- `MusicKit JS v3` `currentPlaybackDuration` returns `0` until the track fully loads into the player engine
- With `max="0"` on the range input, the browser clamps `value` to `0` — freezing the timeline and causing every seek to fire at position `0`
- Falls back to `nowPlayingItem.attributes.durationInMillis` (always populated from the Apple Music API track metadata) so the slider has a valid max immediately when playback starts

## Test plan

- [ ] Play a track in Apple Music provider
- [ ] Confirm the timeline shows correct track duration immediately (not 0:00 / 0:00)
- [ ] Confirm the timeline position advances as the track plays
- [ ] Confirm dragging/clicking the timeline seeks to the correct position
- [ ] Confirm behavior is the same for Spotify and Dropbox (no regression)

Closes #268