### PR TITLE
feat: add Apple Music library sync engine with IndexedDB caching

### DIFF
--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -8,6 +8,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { librarySyncEngine } from '../services/cache/librarySyncEngine';
+import { appleMusicSyncEngine } from '../providers/apple-music/appleMusicSyncEngine';
 import type { CachedPlaylistInfo, SyncState } from '../services/cache/cacheTypes';
 import type { AlbumInfo } from '../services/spotify';
 import { useProviderContext } from '../contexts/ProviderContext';
@@ -94,9 +95,33 @@ export function useLibrarySync(): UseLibrarySyncResult {
     };
   }, [activeProviderId]);
 
-  // ── Non-Spotify path: call catalog.listCollections() ───────────────────
+  // ── Apple Music path: delegate to Apple Music sync engine ─────────────
   useEffect(() => {
-    if (activeProviderId === 'spotify') return;
+    if (activeProviderId !== 'apple-music') return;
+
+    const unsubscribe = appleMusicSyncEngine.subscribe((state, newPlaylists, newAlbums, newLikedCount) => {
+      setSyncState(state);
+      if (newPlaylists !== undefined) {
+        setPlaylists(newPlaylists.map(collectionToPlaylistInfo));
+      }
+      if (newAlbums !== undefined) {
+        setAlbums(newAlbums.map(collectionToAlbumInfo));
+      }
+      if (newLikedCount !== undefined) setLikedSongsCount(newLikedCount);
+    });
+
+    appleMusicSyncEngine.start().catch((err) => {
+      console.error('[useLibrarySync] Failed to start Apple Music sync engine:', err);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [activeProviderId]);
+
+  // ── Non-Spotify/Apple Music path: call catalog.listCollections() ──────
+  useEffect(() => {
+    if (activeProviderId === 'spotify' || activeProviderId === 'apple-music') return;
 
     const catalog = activeDescriptor?.catalog;
     const auth = activeDescriptor?.auth;
@@ -210,6 +235,8 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const refreshNow = useCallback(async () => {
     if (activeProviderId === 'spotify') {
       await engineRef.current.syncNow();
+    } else if (activeProviderId === 'apple-music') {
+      await appleMusicSyncEngine.syncNow();
     } else {
       // For non-Spotify providers, the effect above handles loading.
       // A refresh re-triggers by bumping syncState so the effect re-runs isn't

--- a/src/providers/apple-music/appleMusicCache.ts
+++ b/src/providers/apple-music/appleMusicCache.ts
@@ -1,0 +1,236 @@
+/**
+ * IndexedDB-based persistent cache for Apple Music library data.
+ *
+ * Stores playlists, albums, and metadata as individual records.
+ * Falls back to in-memory Maps if IndexedDB is unavailable.
+ */
+
+import type { MediaCollection } from '@/types/domain';
+
+const DB_NAME = 'vorbis-apple-music-library';
+const DB_VERSION = 1;
+
+const STORE_PLAYLISTS = 'playlists';
+const STORE_ALBUMS = 'albums';
+const STORE_META = 'meta';
+
+interface FallbackStores {
+  playlists: Map<string, MediaCollection>;
+  albums: Map<string, MediaCollection>;
+  meta: Map<string, AppleMusicCacheMeta>;
+}
+
+export interface AppleMusicCacheMeta {
+  key: string;
+  lastValidated: number;
+  totalCount: number;
+}
+
+const fallbackStores: FallbackStores = {
+  playlists: new Map(),
+  albums: new Map(),
+  meta: new Map(),
+};
+
+let db: IDBDatabase | null = null;
+let fallbackMode = false;
+let initPromise: Promise<void> | null = null;
+
+function openIDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = (event) => {
+      const database = (event.target as IDBOpenDBRequest).result;
+      if (!database.objectStoreNames.contains(STORE_PLAYLISTS)) {
+        database.createObjectStore(STORE_PLAYLISTS, { keyPath: 'id' });
+      }
+      if (!database.objectStoreNames.contains(STORE_ALBUMS)) {
+        database.createObjectStore(STORE_ALBUMS, { keyPath: 'id' });
+      }
+      if (!database.objectStoreNames.contains(STORE_META)) {
+        database.createObjectStore(STORE_META, { keyPath: 'key' });
+      }
+    };
+  });
+}
+
+export async function initCache(): Promise<void> {
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    try {
+      if (typeof indexedDB === 'undefined') {
+        throw new Error('IndexedDB not available');
+      }
+      db = await openIDB();
+    } catch (err) {
+      console.warn('[appleMusicCache] IndexedDB unavailable, using in-memory fallback:', err);
+      fallbackMode = true;
+      db = null;
+    }
+  })();
+  return initPromise;
+}
+
+export function closeCache(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+  fallbackMode = false;
+  initPromise = null;
+  fallbackStores.playlists.clear();
+  fallbackStores.albums.clear();
+  fallbackStores.meta.clear();
+}
+
+// -- IDB helpers --
+
+function idbGetAll<T>(storeName: string): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readonly');
+    const request = tx.objectStore(storeName).getAll();
+    request.onsuccess = () => resolve(request.result as T[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbPutAll<T>(storeName: string, items: T[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    for (const item of items) store.put(item);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function idbClear(storeName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readwrite');
+    const request = tx.objectStore(storeName).clear();
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbGet<T>(storeName: string, key: string): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readonly');
+    const request = tx.objectStore(storeName).get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbPut<T>(storeName: string, value: T): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readwrite');
+    const request = tx.objectStore(storeName).put(value);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// -- Public API --
+
+export async function getAllPlaylists(): Promise<MediaCollection[]> {
+  await initCache();
+  if (fallbackMode) return Array.from(fallbackStores.playlists.values());
+  try {
+    return await idbGetAll<MediaCollection>(STORE_PLAYLISTS);
+  } catch {
+    return Array.from(fallbackStores.playlists.values());
+  }
+}
+
+export async function putAllPlaylists(playlists: MediaCollection[]): Promise<void> {
+  await initCache();
+  if (fallbackMode) {
+    fallbackStores.playlists.clear();
+    for (const p of playlists) fallbackStores.playlists.set(p.id, p);
+    return;
+  }
+  try {
+    await idbClear(STORE_PLAYLISTS);
+    await idbPutAll(STORE_PLAYLISTS, playlists);
+  } catch {
+    for (const p of playlists) fallbackStores.playlists.set(p.id, p);
+  }
+}
+
+export async function getAllAlbums(): Promise<MediaCollection[]> {
+  await initCache();
+  if (fallbackMode) return Array.from(fallbackStores.albums.values());
+  try {
+    return await idbGetAll<MediaCollection>(STORE_ALBUMS);
+  } catch {
+    return Array.from(fallbackStores.albums.values());
+  }
+}
+
+export async function putAllAlbums(albums: MediaCollection[]): Promise<void> {
+  await initCache();
+  if (fallbackMode) {
+    fallbackStores.albums.clear();
+    for (const a of albums) fallbackStores.albums.set(a.id, a);
+    return;
+  }
+  try {
+    await idbClear(STORE_ALBUMS);
+    await idbPutAll(STORE_ALBUMS, albums);
+  } catch {
+    for (const a of albums) fallbackStores.albums.set(a.id, a);
+  }
+}
+
+export async function getMeta(key: string): Promise<AppleMusicCacheMeta | undefined> {
+  await initCache();
+  if (fallbackMode) return fallbackStores.meta.get(key);
+  try {
+    return await idbGet<AppleMusicCacheMeta>(STORE_META, key);
+  } catch {
+    return fallbackStores.meta.get(key);
+  }
+}
+
+export async function putMeta(key: string, meta: Omit<AppleMusicCacheMeta, 'key'>): Promise<void> {
+  const entry = { ...meta, key };
+  await initCache();
+  if (fallbackMode) {
+    fallbackStores.meta.set(key, entry);
+    return;
+  }
+  try {
+    await idbPut(STORE_META, entry);
+  } catch {
+    fallbackStores.meta.set(key, entry);
+  }
+}
+
+export async function clearAll(): Promise<void> {
+  await initCache();
+  if (fallbackMode) {
+    fallbackStores.playlists.clear();
+    fallbackStores.albums.clear();
+    fallbackStores.meta.clear();
+    return;
+  }
+  try {
+    await Promise.all([
+      idbClear(STORE_PLAYLISTS),
+      idbClear(STORE_ALBUMS),
+      idbClear(STORE_META),
+    ]);
+  } catch {
+    fallbackStores.playlists.clear();
+    fallbackStores.albums.clear();
+    fallbackStores.meta.clear();
+  }
+}

--- a/src/providers/apple-music/appleMusicSyncEngine.ts
+++ b/src/providers/apple-music/appleMusicSyncEngine.ts
@@ -1,0 +1,383 @@
+/**
+ * Background sync engine for Apple Music library data.
+ *
+ * Mirrors the Spotify LibrarySyncEngine pattern:
+ * 1. Warm start: load cached data from IndexedDB, emit immediately
+ * 2. Cold start: fetch from API with interleaved pagination, emit progressively
+ * 3. Background polling: lightweight count checks every ~90s to detect changes
+ * 4. Pauses when tab is hidden, syncs immediately on focus
+ */
+
+import type { MediaCollection } from '@/types/domain';
+import { appleMusicService } from './appleMusicService';
+import { AppleMusicCatalogAdapter } from './appleMusicCatalogAdapter';
+import * as cache from './appleMusicCache';
+
+const DEFAULT_POLL_INTERVAL_MS = 90_000;
+const PAGE_LIMIT = 100;
+
+export interface AppleMusicSyncState {
+  isInitialLoadComplete: boolean;
+  isSyncing: boolean;
+  lastSyncTimestamp: number | null;
+  error: string | null;
+}
+
+type SyncListener = (
+  state: AppleMusicSyncState,
+  playlists?: MediaCollection[],
+  albums?: MediaCollection[],
+  likedSongsCount?: number,
+) => void;
+
+export class AppleMusicSyncEngine {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private listeners = new Set<SyncListener>();
+  private abortController: AbortController | null = null;
+  private pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  private isSyncInProgress = false;
+  private catalogAdapter = new AppleMusicCatalogAdapter();
+
+  private state: AppleMusicSyncState = {
+    isInitialLoadComplete: false,
+    isSyncing: false,
+    lastSyncTimestamp: null,
+    error: null,
+  };
+
+  private lastKnownPlaylists: MediaCollection[] | undefined;
+  private lastKnownAlbums: MediaCollection[] | undefined;
+  private lastKnownLikedCount: number | undefined;
+
+  async start(intervalMs?: number): Promise<void> {
+    if (this.intervalId) return;
+    this.pollIntervalMs = intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    }
+
+    await this.initialLoad();
+    this.startPollingInterval();
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    }
+  }
+
+  async syncNow(): Promise<void> {
+    if (this.isSyncInProgress) return;
+    if (!appleMusicService.isAuthorized()) return;
+
+    this.isSyncInProgress = true;
+    this.abortController = new AbortController();
+    this.updateState({ isSyncing: true, error: null });
+
+    try {
+      const changed = await this.detectChanges(this.abortController.signal);
+
+      if (changed) {
+        await this.fullRefresh(this.abortController.signal);
+      }
+
+      this.updateState({
+        isSyncing: false,
+        lastSyncTimestamp: Date.now(),
+        error: null,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      console.warn('[appleMusicSyncEngine] Sync failed:', err);
+      this.updateState({
+        isSyncing: false,
+        error: err instanceof Error ? err.message : 'Sync failed',
+      });
+    } finally {
+      this.isSyncInProgress = false;
+      this.abortController = null;
+    }
+  }
+
+  subscribe(listener: SyncListener): () => void {
+    this.listeners.add(listener);
+    listener(this.state, this.lastKnownPlaylists, this.lastKnownAlbums, this.lastKnownLikedCount);
+    return () => { this.listeners.delete(listener); };
+  }
+
+  getState(): AppleMusicSyncState {
+    return { ...this.state };
+  }
+
+  // ── Initial Load ──────────────────────────────────────────────────────
+
+  private async initialLoad(): Promise<void> {
+    const [cachedPlaylists, cachedAlbums, likedMeta] = await Promise.all([
+      cache.getAllPlaylists(),
+      cache.getAllAlbums(),
+      cache.getMeta('likedSongs'),
+    ]);
+
+    const hasCache = cachedPlaylists.length > 0 || cachedAlbums.length > 0;
+
+    if (hasCache) {
+      this.updateState({ isInitialLoadComplete: true });
+      this.notifyListeners(cachedPlaylists, cachedAlbums, likedMeta?.totalCount ?? 0);
+
+      await this.syncNow().catch((err) => {
+        console.warn('[appleMusicSyncEngine] Background sync after warm start failed:', err);
+      });
+    } else {
+      await this.coldStartLoad();
+    }
+  }
+
+  private async coldStartLoad(): Promise<void> {
+    if (!appleMusicService.isAuthorized()) {
+      this.updateState({ isInitialLoadComplete: true });
+      return;
+    }
+
+    this.updateState({ isSyncing: true });
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
+    try {
+      const instance = await appleMusicService.ensureLoaded();
+
+      const allPlaylists: MediaCollection[] = [];
+      const allAlbums: MediaCollection[] = [];
+
+      // Interleaved loading: fetch one page of playlists, then one page of albums
+      let playlistOffset = 0;
+      let albumOffset = 0;
+      let playlistsDone = false;
+      let albumsDone = false;
+
+      while (!playlistsDone || !albumsDone) {
+        if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+
+        if (!playlistsDone) {
+          const page = await this.fetchPage(instance, '/v1/me/library/playlists', playlistOffset, signal);
+          for (const item of page.items) {
+            allPlaylists.push(this.toCollection(item, 'playlist'));
+          }
+          this.notifyListeners(allPlaylists, allAlbums);
+          if (!page.hasMore) {
+            playlistsDone = true;
+            cache.putAllPlaylists(allPlaylists).catch(() => {});
+            cache.putMeta('playlists', {
+              lastValidated: Date.now(),
+              totalCount: allPlaylists.length,
+            }).catch(() => {});
+          }
+          playlistOffset += PAGE_LIMIT;
+        }
+
+        if (!albumsDone) {
+          const page = await this.fetchPage(instance, '/v1/me/library/albums', albumOffset, signal);
+          for (const item of page.items) {
+            allAlbums.push(this.toCollection(item, 'album'));
+          }
+          this.notifyListeners(allPlaylists, allAlbums);
+          if (!page.hasMore) {
+            albumsDone = true;
+            cache.putAllAlbums(allAlbums).catch(() => {});
+            cache.putMeta('albums', {
+              lastValidated: Date.now(),
+              totalCount: allAlbums.length,
+            }).catch(() => {});
+          }
+          albumOffset += PAGE_LIMIT;
+        }
+      }
+
+      const likedCount = await this.catalogAdapter.getLikedCount(signal).catch(() => 0);
+      cache.putMeta('likedSongs', {
+        lastValidated: Date.now(),
+        totalCount: likedCount,
+      }).catch(() => {});
+
+      this.updateState({
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        lastSyncTimestamp: Date.now(),
+      });
+      this.notifyListeners(allPlaylists, allAlbums, likedCount);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      console.error('[appleMusicSyncEngine] Cold start load failed:', err);
+      this.updateState({
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        error: err instanceof Error ? err.message : 'Failed to load library',
+      });
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  // ── Change Detection ──────────────────────────────────────────────────
+
+  private async detectChanges(signal: AbortSignal): Promise<boolean> {
+    const [playlistsMeta, albumsMeta, likedMeta] = await Promise.all([
+      cache.getMeta('playlists'),
+      cache.getMeta('albums'),
+      cache.getMeta('likedSongs'),
+    ]);
+
+    const instance = await appleMusicService.ensureLoaded();
+
+    const [newPlaylistCount, newAlbumCount, newLikedCount] = await Promise.all([
+      this.fetchCount(instance, '/v1/me/library/playlists', signal),
+      this.fetchCount(instance, '/v1/me/library/albums', signal),
+      this.catalogAdapter.getLikedCount(signal).catch(() => 0),
+    ]);
+
+    const playlistsChanged = newPlaylistCount !== (playlistsMeta?.totalCount ?? -1);
+    const albumsChanged = newAlbumCount !== (albumsMeta?.totalCount ?? -1);
+    const likedChanged = newLikedCount !== (likedMeta?.totalCount ?? -1);
+
+    if (likedChanged) {
+      cache.putMeta('likedSongs', {
+        lastValidated: Date.now(),
+        totalCount: newLikedCount,
+      }).catch(() => {});
+      this.notifyListeners(undefined, undefined, newLikedCount);
+    }
+
+    return playlistsChanged || albumsChanged;
+  }
+
+  private async fullRefresh(signal: AbortSignal): Promise<void> {
+    const collections = await this.catalogAdapter.listCollections(signal);
+
+    const playlists = collections.filter(c => c.kind === 'playlist');
+    const albums = collections.filter(c => c.kind === 'album');
+
+    await Promise.all([
+      cache.putAllPlaylists(playlists),
+      cache.putAllAlbums(albums),
+      cache.putMeta('playlists', { lastValidated: Date.now(), totalCount: playlists.length }),
+      cache.putMeta('albums', { lastValidated: Date.now(), totalCount: albums.length }),
+    ]);
+
+    const likedCount = await this.catalogAdapter.getLikedCount(signal).catch(() => 0);
+    cache.putMeta('likedSongs', { lastValidated: Date.now(), totalCount: likedCount }).catch(() => {});
+
+    this.notifyListeners(playlists, albums, likedCount);
+  }
+
+  // ── API Helpers ───────────────────────────────────────────────────────
+
+  private async fetchCount(
+    instance: import('./appleMusicTypes').MKInstance,
+    path: string,
+    signal: AbortSignal,
+  ): Promise<number> {
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    try {
+      const response = await instance.api.music(`${path}?limit=1&offset=0`);
+      const data = response.data as import('./appleMusicTypes').MKPaginatedResponse<unknown>;
+      return data.meta?.total ?? data.data.length;
+    } catch {
+      return -1;
+    }
+  }
+
+  private async fetchPage(
+    instance: import('./appleMusicTypes').MKInstance,
+    path: string,
+    offset: number,
+    signal: AbortSignal,
+  ): Promise<{ items: import('./appleMusicTypes').MKLibraryCollection[]; hasMore: boolean }> {
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    const url = `${path}?limit=${PAGE_LIMIT}&offset=${offset}`;
+    const response = await instance.api.music(url);
+    const data = response.data as import('./appleMusicTypes').MKPaginatedResponse<import('./appleMusicTypes').MKLibraryCollection>;
+    return {
+      items: data.data,
+      hasMore: data.data.length >= PAGE_LIMIT && !!data.next,
+    };
+  }
+
+  private toCollection(
+    item: import('./appleMusicTypes').MKLibraryCollection,
+    kind: 'playlist' | 'album',
+  ): MediaCollection {
+    const attrs = item.attributes;
+    return {
+      id: item.id,
+      provider: 'apple-music',
+      kind,
+      name: attrs.name,
+      description: attrs.description?.standard ?? null,
+      imageUrl: attrs.artwork?.url
+        ? attrs.artwork.url.replace('{w}', '1200').replace('{h}', '1200')
+        : undefined,
+      trackCount: attrs.trackCount,
+      ownerName: attrs.artistName ?? null,
+    };
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private startPollingInterval(): void {
+    this.intervalId = setInterval(() => {
+      this.syncNow().catch((err) => {
+        console.warn('[appleMusicSyncEngine] Background sync error:', err);
+      });
+    }, this.pollIntervalMs);
+  }
+
+  private updateState(partial: Partial<AppleMusicSyncState>): void {
+    this.state = { ...this.state, ...partial };
+  }
+
+  private notifyListeners(
+    playlists?: MediaCollection[],
+    albums?: MediaCollection[],
+    likedSongsCount?: number,
+  ): void {
+    if (playlists !== undefined) this.lastKnownPlaylists = playlists;
+    if (albums !== undefined) this.lastKnownAlbums = albums;
+    if (likedSongsCount !== undefined) this.lastKnownLikedCount = likedSongsCount;
+
+    for (const listener of this.listeners) {
+      try {
+        listener(this.state, playlists, albums, likedSongsCount);
+      } catch (err) {
+        console.warn('[appleMusicSyncEngine] Listener error:', err);
+      }
+    }
+  }
+
+  private handleVisibilityChange = (): void => {
+    if (typeof document === 'undefined') return;
+
+    if (document.hidden) {
+      if (this.intervalId) {
+        clearInterval(this.intervalId);
+        this.intervalId = null;
+      }
+    } else {
+      if (!this.intervalId) {
+        this.startPollingInterval();
+      }
+      this.syncNow().catch((err) => {
+        console.warn('[appleMusicSyncEngine] Sync on focus failed:', err);
+      });
+    }
+  };
+}
+
+export const appleMusicSyncEngine = new AppleMusicSyncEngine();


### PR DESCRIPTION
## Summary

- Adds `appleMusicSyncEngine.ts` — sync engine that fetches the full Apple Music library and keeps it up to date incrementally
- Adds `appleMusicCache.ts` — IndexedDB caching layer for persisting library data between sessions
- Updates `useLibrarySync.ts` to wire the sync engine into the existing library sync hook

Closes #274

## Test plan

- [ ] Connect Apple Music and verify library loads from cache on subsequent visits
- [ ] Confirm incremental sync picks up new additions without a full re-fetch
- [ ] Verify IndexedDB `apple-music` store is populated after first sync
- [ ] All tests pass (`npm run test:run`)