### PR TITLE
fix: Apple Music playlist track selection ignored (#277)

### DIFF
--- a/src/hooks/useAutoAdvance.ts
+++ b/src/hooks/useAutoAdvance.ts
@@ -10,6 +10,8 @@ interface UseAutoAdvanceProps {
   playTrack: (index: number, skipOnError?: boolean) => void;
   enabled?: boolean;
   endThreshold?: number;
+  /** When set, auto-advance is suppressed until the expected track starts playing. */
+  expectedTrackIdRef?: React.RefObject<string | null>;
 }
 
 const PLAY_COOLDOWN_MS = 5000;
@@ -19,7 +21,8 @@ export const useAutoAdvance = ({
   currentTrackIndex,
   playTrack,
   enabled = true,
-  endThreshold = 2000
+  endThreshold = 2000,
+  expectedTrackIdRef,
 }: UseAutoAdvanceProps) => {
   const hasEnded = useRef(false);
   const wasPlayingRef = useRef(false);
@@ -49,6 +52,7 @@ export const useAutoAdvance = ({
     }
 
     function advanceToNext() {
+      if (expectedTrackIdRef?.current) return;
       hasEnded.current = true;
       const nextIndex = (currentTrackIndexRef.current + 1) % tracksRef.current.length;
       if (tracksRef.current[nextIndex]) {

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -177,7 +177,15 @@ export function usePlayerLogic() {
     ]
   );
 
-  useAutoAdvance({ tracks, currentTrackIndex, playTrack, enabled: true });
+  const guardedPlayTrack = useCallback((index: number, skipOnError?: boolean) => {
+    const targetTrack = tracksRef.current[index];
+    if (targetTrack) {
+      expectedTrackIdRef.current = targetTrack.id;
+    }
+    playTrack(index, skipOnError);
+  }, [playTrack]);
+
+  useAutoAdvance({ tracks, currentTrackIndex, playTrack: guardedPlayTrack, enabled: true, expectedTrackIdRef });
 
   // Auto-extract accent color from album artwork; respects overrides in ColorContext
   useAccentColor(currentTrack, accentColorOverrides, setAccentColor, setAccentColorOverrides);
@@ -266,18 +274,16 @@ export function usePlayerLogic() {
   const handleNext = useCallback(() => {
     if (tracks.length === 0) return;
     const nextIndex = (currentTrackIndexRef.current + 1) % tracks.length;
-    expectedTrackIdRef.current = tracksRef.current[nextIndex]?.id ?? null;
     setCurrentTrackIndex(nextIndex);
-    playTrack(nextIndex, true);
-  }, [tracks.length, playTrack, setCurrentTrackIndex]);
+    guardedPlayTrack(nextIndex, true);
+  }, [tracks.length, guardedPlayTrack, setCurrentTrackIndex]);
 
   const handlePrevious = useCallback(() => {
     if (tracks.length === 0) return;
     const newIndex = currentTrackIndexRef.current === 0 ? tracks.length - 1 : currentTrackIndexRef.current - 1;
-    expectedTrackIdRef.current = tracksRef.current[newIndex]?.id ?? null;
     setCurrentTrackIndex(newIndex);
-    playTrack(newIndex, true);
-  }, [tracks.length, playTrack, setCurrentTrackIndex]);
+    guardedPlayTrack(newIndex, true);
+  }, [tracks.length, guardedPlayTrack, setCurrentTrackIndex]);
 
   const handlePlay = useCallback(async () => {
     try {
@@ -318,7 +324,7 @@ export function usePlayerLogic() {
       handlePause,
       handleNext,
       handlePrevious,
-      playTrack,
+      playTrack: guardedPlayTrack,
       handleOpenLibraryDrawer,
       handleCloseLibraryDrawer,
       handleBackToLibrary,
@@ -329,7 +335,7 @@ export function usePlayerLogic() {
       handlePause,
       handleNext,
       handlePrevious,
-      playTrack,
+      guardedPlayTrack,
       handleOpenLibraryDrawer,
       handleCloseLibraryDrawer,
       handleBackToLibrary,


### PR DESCRIPTION
## Summary

- Fixes an issue where clicking a track in the Apple Music playlist had no effect
- Updates `usePlayerLogic.ts` to correctly route track selection for non-Spotify providers
- Updates `useAutoAdvance.ts` to handle auto-advance correctly for Apple Music

Closes #277

## Test plan

- [ ] Open Apple Music playlist and click a track — confirm it starts playing
- [ ] Let a track finish — confirm auto-advance plays the next track
- [ ] Verify Spotify playback is unaffected
- [ ] All tests pass (`npm run test:run`)