### PR TITLE
feat(spotify): use highest-resolution album art images

### DIFF
--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth } from '../services/spotify';
+import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth, getLargestImage } from '../services/spotify';
 import { spotifyPlayer } from '../services/spotifyPlayer';
 import { isAlbumId, extractAlbumId, LIKED_SONGS_ID } from '../constants/playlist';
 import { shuffleArray } from '../utils/shuffleArray';
@@ -30,7 +30,7 @@ function buildTracksFromWindow(state: SpotifyPlaybackState): Track[] {
       album_id: item.album?.uri?.split(':').pop(),
       duration_ms: item.duration_ms ?? 0,
       uri: item.uri,
-      image: item.album?.images?.[0]?.url,
+      image: getLargestImage(item.album?.images),
     };
   }
 

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -14,6 +14,7 @@ import {
   checkTrackSaved,
   saveTrack,
   unsaveTrack,
+  getLargestImage,
   type Track,
   type PlaylistInfo,
   type AlbumInfo,
@@ -51,7 +52,7 @@ function spotifyPlaylistToMediaCollection(pl: PlaylistInfo): MediaCollection {
     kind: 'playlist',
     name: pl.name,
     description: pl.description,
-    imageUrl: pl.images?.[0]?.url,
+    imageUrl: getLargestImage(pl.images),
     trackCount: pl.tracks?.total ?? undefined,
     ownerName: pl.owner?.display_name ?? undefined,
     revision: pl.snapshot_id,
@@ -66,7 +67,7 @@ function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
     kind: 'album',
     name: album.name,
     description: album.artists,
-    imageUrl: album.images?.[0]?.url,
+    imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
   };
 }

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -156,6 +156,11 @@ export interface SpotifyImage {
   width: number | null;
 }
 
+export function getLargestImage(images: SpotifyImage[] | undefined): string | undefined {
+  if (!images?.length) return undefined;
+  return images.reduce((best, img) => ((img.width ?? 0) > (best.width ?? 0) ? img : best)).url;
+}
+
 interface SpotifyAlbum {
   id?: string;
   name?: string;
@@ -219,7 +224,7 @@ function transformTrackItem(
 ): Track | null {
   if (!item.id || item.type !== 'track') return null;
 
-  const albumImage = albumOverride?.image ?? item.album?.images?.[0]?.url;
+  const albumImage = albumOverride?.image ?? getLargestImage(item.album?.images);
 
   return {
     id: item.id,
@@ -743,7 +748,7 @@ export async function getAlbumTracks(albumId: string): Promise<Track[]> {
     token
   );
 
-  const albumImage = album.images?.[0]?.url;
+  const albumImage = getLargestImage(album.images);
   const tracks: Track[] = [];
 
   for (const trackItem of album.tracks.items ?? []) {


### PR DESCRIPTION
## Summary

- Adds `getLargestImage()` helper to `spotify.ts` that picks the image with the greatest width from a Spotify image array
- Replaces all `images?.[0]?.url` accesses (which returns an arbitrary order) with `getLargestImage()` across track loading, album collection mapping, playlist collection mapping, and playback state parsing

## Test plan

- [ ] Play a Spotify track and confirm album art renders at full resolution
- [ ] Browse playlists/albums and confirm cover images are high-res
- [ ] Verify no regressions in track loading or playback