### PR TITLE
fix(dropbox): Refresh Art now updates library thumbnails

### DIFF
--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -6,6 +6,7 @@ import { ProfiledComponent } from '@/components/ProfiledComponent';
 import { usePlayerSizing } from '../../hooks/usePlayerSizing';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import type { DropboxCatalogAdapter } from '@/providers/dropbox/dropboxCatalogAdapter';
+import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 
 import {
   DrawerOverlay,
@@ -172,8 +173,9 @@ const DropboxDataSection = memo(({ accentColor, catalog }: { accentColor: string
 
   const handleRefreshArt = async () => {
     setArtStatus('working');
-    await catalog.clearArtCache();
-    catalog.listCollections().catch(() => {});
+    const { clearCatalogCache } = await import('@/providers/dropbox/dropboxCatalogCache');
+    await Promise.all([catalog.clearArtCache(), clearCatalogCache()]);
+    window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
     setArtStatus('done');
     setTimeout(() => setArtStatus('idle'), 1500);
   };

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -14,6 +14,8 @@ import { useProviderContext } from '../contexts/ProviderContext';
 import type { MediaCollection } from '../types/domain';
 import { LIKES_CHANGED_EVENT } from '../providers/dropbox/dropboxLikesCache';
 
+export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
+
 interface UseLibrarySyncResult {
   playlists: CachedPlaylistInfo[];
   albums: AlbumInfo[];
@@ -243,6 +245,12 @@ export function useLibrarySync(): UseLibrarySyncResult {
       }
     }
   }, [activeProviderId, activeDescriptor]);
+
+  useEffect(() => {
+    const handleArtRefresh = () => { refreshNow().catch(() => {}); };
+    window.addEventListener(ART_REFRESHED_EVENT, handleArtRefresh);
+    return () => window.removeEventListener(ART_REFRESHED_EVENT, handleArtRefresh);
+  }, [refreshNow]);
 
   return {
     playlists,


### PR DESCRIPTION
## Summary

- `handleRefreshArt` was calling `catalog.listCollections()` as fire-and-forget — the result was discarded, so React state never received the fresh `imageUrl`s
- Library thumbnails (from `MediaCollection.imageUrl` in React state) stayed stale while cover art updated correctly (it's loaded lazily from `MediaTrack.image` via `listTracks()`, which hits the freshly-repopulated art store)
- Also missing: the catalog cache was not cleared, so the stale embedded data URLs would survive until the 1-hour TTL expired

## Fix

- Clear both the `art` and `catalog` IndexedDB stores on Refresh Art
- Dispatch a `vorbis-art-refreshed` DOM event (same pattern as `vorbis-dropbox-likes-changed`)
- `useLibrarySync` listens for the event and calls `refreshNow()`, which re-fetches collections, updates React state, and writes the fresh catalog back to IndexedDB

## Test plan

- [ ] Connect Dropbox, let library load with thumbnails
- [ ] Change a cover image in Dropbox
- [ ] Open Settings → Dropbox Data → Refresh Art
- [ ] Verify both the library thumbnail and the large cover art update without a page reload