### PR TITLE
Fix album art image height to fill container

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -272,6 +272,7 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
             alt={currentTrack?.name}
             style={{
               width: '100%',
+              height: '100%',
               objectFit: 'cover',
               display: 'block',
               zIndex: theme.zIndex.docked,


### PR DESCRIPTION
## Summary
Added explicit height styling to the album art image element to ensure it fills its container properly.

## Key Changes
- Added `height: '100%'` to the image style object in AlbumArt component, complementing the existing `width: '100%'` property

## Implementation Details
The album art image now has both width and height set to 100%, ensuring it scales to fill its parent container in both dimensions while maintaining the cover fit behavior. This prevents potential layout issues where the image might not properly fill the available vertical space.

https://claude.ai/code/session_012ffYdTdkKsnZrNaPwYzDSo