### PR TITLE
fix: ensure border-radius is inherited in GlowBackgroundLayer

### DIFF
--- a/src/components/AccentColorGlowOverlay.tsx
+++ b/src/components/AccentColorGlowOverlay.tsx
@@ -15,6 +15,7 @@ const GlowBackgroundLayer = styled.div<{
   background: var(--accent-color);
   pointer-events: none;
   z-index: -1;
+  border-radius: inherit;
 `;
 
 interface AccentColorGlowOverlayProps {


### PR DESCRIPTION
## Changes

- Added `border-radius: inherit;` to `GlowBackgroundLayer` styled component
- This ensures the glow overlay respects the border-radius of its parent container

## Files Modified

- `src/components/AccentColorGlowOverlay.tsx`