### PR TITLE
fix(dropbox): handle IndexedDB onblocked to prevent library loading hang

### DIFF
--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -27,6 +27,7 @@ function openDb(): Promise<IDBDatabase | null> {
     }
     const req = indexedDB.open(DB_NAME, DB_VERSION);
     req.onerror = () => resolve(null);
+    req.onblocked = () => resolve(null);
     req.onsuccess = () => {
       db = req.result;
       resolve(db);


### PR DESCRIPTION
## Summary

- Adds missing `onblocked` handler to `indexedDB.open()` in `dropboxArtCache.ts`
- When the DB version upgrade (v4→v5 for the `tags` store added in #292) is blocked by an existing connection (e.g. another tab with the old build), `openDb()` now resolves to `null` instead of hanging forever
- This causes the cache to gracefully degrade (no art/tag caching for that session) rather than preventing the library from loading entirely

## Root Cause

Commit 8473758 (#292) bumped the IndexedDB version from 4→5 to add a `tags` store. If a user has the old production build open in another tab, `indexedDB.open()` fires `onblocked` instead of `onsuccess`/`onerror`. With no handler, the promise never resolves, and `listCollections` hangs at the `Promise.all` for album art fetches — producing the "Loading your library..." skeleton state indefinitely.

## Test plan

- [ ] Deploy to production, open app in two tabs with Dropbox provider
- [ ] Verify library loads even when another tab holds an old DB connection
- [ ] Verify art caching works normally on fresh single-tab loads
- [ ] All 398 existing tests pass