### PR TITLE
Increase maximum pinned items limit from 4 to 8

### DIFF
--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -871,7 +871,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({ onPlaylistSele
             $isPinned={likedSongsPinned}
             $disabled={!canPinMorePlaylists && !likedSongsPinned}
             onClick={(e) => handlePinPlaylistClick(LIKED_SONGS_ID, e)}
-            title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (4)')}
+            title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
             aria-label={likedSongsPinned ? 'Unpin Liked Songs' : 'Pin Liked Songs to top'}
           >
             <PinIcon filled={likedSongsPinned} />
@@ -943,7 +943,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({ onPlaylistSele
                 $isPinned={pinned}
                 $disabled={!canPinMorePlaylists && !pinned}
                 onClick={(e) => handlePinPlaylistClick(playlist.id, e)}
-                title={pinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (4)')}
+                title={pinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
                 aria-label={pinned ? `Unpin ${playlist.name}` : `Pin ${playlist.name} to top`}
               >
                 <PinIcon filled={pinned} />
@@ -1021,7 +1021,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({ onPlaylistSele
                 $isPinned={pinned}
                 $disabled={!canPinMoreAlbums && !pinned}
                 onClick={(e) => handlePinAlbumClick(album.id, e)}
-                title={pinned ? 'Unpin' : (canPinMoreAlbums ? 'Pin to top' : 'Pin limit reached (4)')}
+                title={pinned ? 'Unpin' : (canPinMoreAlbums ? 'Pin to top' : 'Pin limit reached (8)')}
                 aria-label={pinned ? `Unpin ${album.name}` : `Pin ${album.name} to top`}
               >
                 <PinIcon filled={pinned} />

--- a/src/hooks/__tests__/usePinnedItems.test.ts
+++ b/src/hooks/__tests__/usePinnedItems.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/services/settings/pinnedItemsStorage', () => ({
   getPins: vi.fn().mockResolvedValue([]),
   setPins: vi.fn().mockResolvedValue(undefined),
   migratePinsFromLocalStorage: vi.fn().mockResolvedValue(undefined),
-  MAX_PINS: 4,
+  MAX_PINS: 8,
 }));
 
 vi.mock('@/contexts/ProviderContext', () => ({
@@ -85,20 +85,20 @@ describe('usePinnedItems', () => {
     expect(setPins).toHaveBeenCalledWith('spotify', 'playlists', ['p2']);
   });
 
-  it('should not pin beyond 4 playlists', async () => {
+  it('should not pin beyond 8 playlists', async () => {
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4']) : Promise.resolve([])
+        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4']));
+    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']));
 
     act(() => {
-      result.current.togglePinPlaylist('p5');
+      result.current.togglePinPlaylist('p9');
     });
 
-    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4']);
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']);
     expect(result.current.canPinMorePlaylists).toBe(false);
   });
 
@@ -134,20 +134,20 @@ describe('usePinnedItems', () => {
     expect(setPins).toHaveBeenCalledWith('spotify', 'albums', ['a2']);
   });
 
-  it('should not pin beyond 4 albums', async () => {
+  it('should not pin beyond 8 albums', async () => {
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'albums' ? Promise.resolve(['a1', 'a2', 'a3', 'a4']) : Promise.resolve([])
+        type === 'albums' ? Promise.resolve(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4']));
+    await waitFor(() => expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']));
 
     act(() => {
-      result.current.togglePinAlbum('a5');
+      result.current.togglePinAlbum('a9');
     });
 
-    expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4']);
+    expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']);
     expect(result.current.canPinMoreAlbums).toBe(false);
   });
 
@@ -163,12 +163,16 @@ describe('usePinnedItems', () => {
       result.current.togglePinPlaylist('p1');
       result.current.togglePinPlaylist('p2');
       result.current.togglePinPlaylist('p3');
+      result.current.togglePinPlaylist('p4');
+      result.current.togglePinPlaylist('p5');
+      result.current.togglePinPlaylist('p6');
+      result.current.togglePinPlaylist('p7');
     });
 
     expect(result.current.canPinMorePlaylists).toBe(true);
 
     act(() => {
-      result.current.togglePinPlaylist('p4');
+      result.current.togglePinPlaylist('p8');
     });
 
     expect(result.current.canPinMorePlaylists).toBe(false);
@@ -195,17 +199,17 @@ describe('usePinnedItems', () => {
   it('should allow unpinning even when at max capacity', async () => {
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4']) : Promise.resolve([])
+        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4']));
+    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']));
 
     act(() => {
       result.current.togglePinPlaylist('p2');
     });
 
-    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p3', 'p4']);
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']);
     expect(result.current.canPinMorePlaylists).toBe(true);
   });
 

--- a/src/services/settings/pinnedItemsStorage.ts
+++ b/src/services/settings/pinnedItemsStorage.ts
@@ -6,7 +6,7 @@
 
 import { STORE_NAMES, settingsGet, settingsPut, settingsClearStore } from './settingsDb';
 
-export const MAX_PINS = 4;
+export const MAX_PINS = 8;
 
 interface PinRecord {
   key: string;


### PR DESCRIPTION
## Summary
This PR increases the maximum number of pinned playlists and albums from 4 to 8, allowing users to pin more items to the top of their library.

## Key Changes
- Updated `MAX_PINS` constant from 4 to 8 in `src/services/settings/pinnedItemsStorage.ts`
- Updated all user-facing tooltip messages from "Pin limit reached (4)" to "Pin limit reached (8)" in `src/components/PlaylistSelection.tsx`
- Updated test suite in `src/hooks/__tests__/usePinnedItems.test.ts` to reflect the new limit:
  - Updated mock constant to `MAX_PINS: 8`
  - Updated test cases to verify the new 8-item limit for both playlists and albums
  - Updated test data to include 8 items instead of 4 when testing at capacity
  - Updated test descriptions to reference the new limit

## Implementation Details
The change is straightforward and consistent across all layers:
- The core limit is defined in one place (`MAX_PINS` constant)
- UI messages are updated to reflect the new limit
- All existing tests are updated to validate behavior at the new 8-item threshold
- The logic for enforcing the limit remains unchanged; only the threshold value is increased

https://claude.ai/code/session_01GkH3w23mNPQsZ8Ygv164dj