### PR TITLE
Fix auto-advance track selection after shuffle toggle

### DIFF
--- a/src/hooks/useAutoAdvance.ts
+++ b/src/hooks/useAutoAdvance.ts
@@ -28,6 +28,8 @@ export const useAutoAdvance = ({
   const playTrackRef = useRef(playTrack);
   /** Tracks when advanceToNext last initiated playback (used as cooldown for non-Spotify). */
   const lastPlayInitiatedRef = useRef(0);
+  /** ID for cancelling pending advance timeouts (e.g. when shuffle is toggled). */
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { activeDescriptor, activeProviderId } = useProviderContext();
 
@@ -36,10 +38,24 @@ export const useAutoAdvance = ({
   useEffect(() => { currentTrackIndexRef.current = currentTrackIndex; }, [currentTrackIndex]);
   useEffect(() => { playTrackRef.current = playTrack; }, [playTrack]);
 
-  // Reset hasEnded flag when track changes
+  // Reset hasEnded flag and cancel pending advance when track changes
+  // (includes shuffle toggle which changes currentTrackIndex).
   useEffect(() => {
     hasEnded.current = false;
+    if (advanceTimerRef.current !== null) {
+      clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
   }, [currentTrackIndex]);
+
+  // Also cancel pending advance when the tracks array changes (e.g. shuffle toggle)
+  // to prevent a stale-index timeout from playing the wrong track.
+  useEffect(() => {
+    if (advanceTimerRef.current !== null) {
+      clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
+  }, [tracks]);
 
   // Use event-based detection via the provider's playback subscribe
   useEffect(() => {
@@ -49,17 +65,20 @@ export const useAutoAdvance = ({
 
     function advanceToNext() {
       hasEnded.current = true;
-      const nextIndex = (currentTrackIndexRef.current + 1) % tracksRef.current.length;
-      if (tracksRef.current[nextIndex]) {
-        setTimeout(() => {
+      // Compute nextIndex inside the timeout callback (not here) so that
+      // if shuffle is toggled during the delay, we use the latest refs.
+      advanceTimerRef.current = setTimeout(() => {
+        advanceTimerRef.current = null;
+        const nextIndex = (currentTrackIndexRef.current + 1) % tracksRef.current.length;
+        if (tracksRef.current[nextIndex]) {
           lastPlayInitiatedRef.current = Date.now();
           playTrackRef.current(nextIndex, true);
           // Don't reset hasEnded here — playTrack is async and the audio element
           // still has the old track's ended state until the new track loads.
           // The useEffect on currentTrackIndex resets hasEnded when the track
           // actually changes (after playTrack succeeds and calls setCurrentTrackIndex).
-        }, 500);
-      }
+        }
+      }, 500);
     }
 
     function handleProviderStateChange(state: PlaybackState | null) {

--- a/src/hooks/useSpotifyPlayback.ts
+++ b/src/hooks/useSpotifyPlayback.ts
@@ -21,6 +21,11 @@ export const useSpotifyPlayback = ({
   mediaTracksRef,
 }: UseSpotifyPlaybackProps) => {
 
+  // Use a ref for tracks so playTrack always reads the latest array,
+  // even if called from a stale closure (e.g. auto-advance timer after shuffle toggle).
+  const tracksRef = useRef(tracks);
+  tracksRef.current = tracks;
+
   /** Tracks which provider is currently handling playback (may differ from activeDescriptor during cross-provider queues). */
   const currentPlaybackProviderRef = useRef<ProviderId | null>(null);
 
@@ -190,8 +195,12 @@ export const useSpotifyPlayback = ({
     }
 
     // Standard Spotify-as-active-provider path
-    if (!tracks[index]) {
-      console.error(`[Spotify] No track at index ${index} (tracks length: ${tracks.length})`);
+    // Read tracks from ref to always get the latest array (avoids stale closure
+    // after shuffle toggle when called from auto-advance timer).
+    const currentTracks = tracksRef.current;
+
+    if (!currentTracks[index]) {
+      console.error(`[Spotify] No track at index ${index} (tracks length: ${currentTracks.length})`);
       return;
     }
 
@@ -213,7 +222,7 @@ export const useSpotifyPlayback = ({
             const isRestrictionViolated = errorMessage.includes('Restriction violated');
 
             if (isRestrictionViolated) {
-              console.warn(`Track "${tracks[index].name}" is unavailable (region-locked or removed)`);
+              console.warn(`Track "${currentTracks[index].name}" is unavailable (region-locked or removed)`);
               return false;
             }
 
@@ -232,16 +241,16 @@ export const useSpotifyPlayback = ({
         }
       };
 
-      const success = await playWithRetry(tracks[index].uri);
+      const success = await playWithRetry(currentTracks[index].uri);
 
       if (!success) {
-        if (skipOnError && index < tracks.length - 1) {
+        if (skipOnError && index < currentTracks.length - 1) {
           setTimeout(() => {
             playTrack(index + 1, skipOnError);
           }, 500);
           return;
         } else {
-          throw new Error(`Track "${tracks[index].name}" is unavailable for playback`);
+          throw new Error(`Track "${currentTracks[index].name}" is unavailable for playback`);
         }
       }
 
@@ -260,13 +269,13 @@ export const useSpotifyPlayback = ({
     } catch (error) {
       console.error('Failed to play track:', error);
 
-      if (skipOnError && index < tracks.length - 1) {
+      if (skipOnError && index < currentTracks.length - 1) {
         setTimeout(() => {
           playTrack(index + 1, skipOnError);
         }, 500);
       }
     }
-  }, [tracks, setCurrentTrackIndex, handlePlaybackResume, activeDescriptor, mediaTracksRef, playSpotifyTrack]);
+  }, [setCurrentTrackIndex, handlePlaybackResume, activeDescriptor, mediaTracksRef, playSpotifyTrack]);
 
   const resumePlayback = useCallback(async () => {
     // Resume the provider that's currently playing


### PR DESCRIPTION
## Summary
Fixes a bug where toggling shuffle during the auto-advance delay (500ms after a track ends) could cause the wrong track to play. The issue occurred because the auto-advance timer captured stale track indices and array references in its closure.

## Key Changes

- **useAutoAdvance.ts**
  - Added `advanceTimerRef` to track and cancel pending advance timeouts
  - Cancel pending advance when `currentTrackIndex` changes (includes shuffle toggle)
  - Cancel pending advance when `tracks` array changes (shuffle reorders tracks)
  - Moved `nextIndex` computation inside the timeout callback so it uses the latest `currentTrackIndexRef` and `tracksRef` values at execution time, not at scheduling time

- **useSpotifyPlayback.ts**
  - Added `tracksRef` to maintain a current reference to the tracks array
  - Updated `playTrack` to read from `tracksRef.current` instead of the stale `tracks` prop from closure
  - Removed `tracks` from the `useCallback` dependency array since we now read from the ref, preventing unnecessary callback recreation on shuffle

## Implementation Details

The fix uses two complementary strategies:
1. **Cancellation**: Clear any pending timeouts when the track or tracks array changes, preventing stale callbacks from executing
2. **Fresh references**: Use refs to ensure that when callbacks do execute, they read the latest track data rather than relying on closure values that may be stale after a shuffle toggle

This ensures that auto-advance always plays the correct next track, even if shuffle is toggled during the 500ms delay after a track ends.

https://claude.ai/code/session_01SB75N4uKM91khiSxjH2AQx