### PR TITLE
Add PRD for provider toggles and session start flow redesign

### DIFF
--- a/tasks/0002-prd-provider-toggles.md
+++ b/tasks/0002-prd-provider-toggles.md
@@ -107,13 +107,10 @@ The session start flow currently has two modes: a welcome screen (first visit) a
 - Switch toggles in settings visually match the visual effects menu toggles.
 - No regressions in single-provider mode (only one provider registered).
 
-## Open Questions
+## Decisions (Resolved)
 
-1. **Toast vs. banner for auto-fallthrough notification**: Should the "switched provider" message be a floating toast that auto-dismisses, or a persistent banner at the top of the player that the user must dismiss? Toast is less intrusive; banner ensures the user sees it.
-   - **Proposed**: Auto-dismissing toast (5 seconds) with a "Reconnect" link that opens Settings.
+1. **Auto-fallthrough notification**: Auto-dismissing toast (5 seconds) with a "Reconnect" link that opens Settings. Non-blocking, minimal UI footprint.
 
-2. **Should the welcome screen auto-connect the only provider?** If only one provider is registered, should we skip the welcome screen entirely and go straight to OAuth? Currently the welcome screen is shown even for single-provider setups.
-   - **Proposed**: Keep the welcome screen for first-time users even with one provider — it sets expectations. But make the "Connect" button prominent and primary.
+2. **Single-provider welcome screen**: Keep the welcome screen for first-time users even with one provider — it sets expectations. The "Connect" button should be prominent and primary.
 
-3. **Provider enable state on first visit**: On first visit, should all registered providers be pre-enabled (toggled on) by default? Or should they start disabled until the user explicitly enables them?
-   - **Proposed**: All registered providers start enabled by default. The user can disable any they don't want from Settings after setup.
+3. **Default provider enable state**: All registered providers start enabled by default on first visit. Users can disable any they don't want from Settings after setup.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive Product Requirements Document (PRD) outlining a redesign of the provider management experience and session initialization flow. The document specifies improvements to both the settings menu UI and the first-time/returning user onboarding flows.

## Key Changes

- **Shared Switch Component**: Extract the iOS-style toggle switches from the visual effects menu into a reusable `Switch` component for consistent UI across the app
- **Settings Menu Redesign**: Replace pill-shaped provider buttons with switch-style toggles that clearly show connection status alongside enabled/disabled state
- **First-Time User Flow**: Redesign the welcome screen to let users enable and authenticate multiple providers before proceeding to the player
- **Partial Expiry Handling**: Add auto-fallthrough logic for returning users where one provider expires but others remain valid — seamlessly switch to a valid provider with a non-blocking notification
- **All-Expired Flow**: Create a dedicated connection status screen for users whose all enabled providers have expired tokens
- **State Model Clarification**: Separate "enabled" (user wants this provider) from "connected" (OAuth token is valid) concepts, with `enabledProviderIds` persisting independently of authentication state

## Notable Implementation Details

- The PRD specifies extracting `SwitchTrack` and `SwitchKnob` styled components from `QuickEffectsRow.tsx` into a new shared `Switch` component at `src/components/controls/Switch.tsx`
- Auto-fallthrough logic should be implemented as a `useEffect` in `ProviderContext.tsx` that reacts to auth state changes
- A lightweight toast/notification system is proposed for the auto-fallthrough notification (5-second auto-dismiss with optional "Reconnect" link)
- Backward compatibility with existing localStorage keys is maintained; `enabledProviderIds` no longer gets cleared on token expiry
- The document includes success metrics and resolves key design decisions (e.g., auto-dismissing toast for notifications, keeping welcome screen even for single-provider setups)

https://claude.ai/code/session_012RbgwybeDrjnFCUuJp2i68