### PR TITLE
fix: reduce track switch delay for Dropbox provider

### DIFF
--- a/src/hooks/useSpotifyPlayback.ts
+++ b/src/hooks/useSpotifyPlayback.ts
@@ -212,6 +212,14 @@ export const useSpotifyPlayback = ({
     try {
       await trackDescriptor.playback.playTrack(mediaTrack);
       setCurrentTrackIndex(index);
+
+      // Prefetch the next track's resources (e.g. Dropbox temporary link)
+      const nextIndex = (index + 1) % mediaTracks.length;
+      const nextTrack = mediaTracks[nextIndex];
+      if (nextTrack && nextIndex !== index) {
+        const nextDescriptor = providerRegistry.get(nextTrack.provider);
+        nextDescriptor?.playback.prepareTrack?.(nextTrack);
+      }
     } catch (error) {
       console.error(`[${trackProvider}] Failed to play track:`, error);
       if (skipOnError && index < mediaTracks.length - 1) {

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -95,6 +95,15 @@ function parseFilename(filename: string): { name: string; trackNumber?: number }
   return { name: base };
 }
 
+/** Cached temporary link with expiry timestamp. */
+interface CachedLink {
+  url: string;
+  expiresAt: number;
+}
+
+/** Dropbox temporary links are valid for 4 hours; cache for 3.5 h to be safe. */
+const TEMP_LINK_TTL_MS = 3.5 * 60 * 60 * 1000;
+
 export class DropboxCatalogAdapter implements CatalogProvider {
   readonly providerId: ProviderId = 'dropbox';
   private auth: DropboxAuthAdapter;
@@ -102,6 +111,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
   private pendingArtFetches = new Map<string, Promise<string | null>>();
   // Tracks seen during listTracks calls, used to provide full MediaTrack data when liking
   private knownTracks = new Map<string, MediaTrack>();
+  /** In-memory cache of Dropbox temporary links keyed by path. */
+  private tempLinkCache = new Map<string, CachedLink>();
 
   constructor(auth: DropboxAuthAdapter) {
     this.auth = auth;
@@ -428,11 +439,32 @@ export class DropboxCatalogAdapter implements CatalogProvider {
   }
 
   async getTemporaryLink(path: string): Promise<string> {
+    const cached = this.tempLinkCache.get(path);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.url;
+    }
+
     const result = await this.dropboxApi<{ link: string }>(
       '/files/get_temporary_link',
       { path },
     );
+
+    this.tempLinkCache.set(path, {
+      url: result.link,
+      expiresAt: Date.now() + TEMP_LINK_TTL_MS,
+    });
     return result.link;
+  }
+
+  /**
+   * Pre-warm the temporary link cache for a path.
+   * Returns immediately if already cached; otherwise fetches in the background.
+   */
+  prefetchTemporaryLink(path: string): void {
+    const cached = this.tempLinkCache.get(path);
+    if (cached && Date.now() < cached.expiresAt) return;
+    // Fire-and-forget; errors are silently ignored
+    this.getTemporaryLink(path).catch(() => {});
   }
 
   // ── Liked songs ──────────────────────────────────────────────────────

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -74,8 +74,13 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
   private enrichMetadataInBackground(track: MediaTrack, streamUrl: string): void {
     const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
+    const ENRICHMENT_DELAY_MS = 2000; // Wait for audio to buffer before fetching ID3 tags
 
     const doEnrich = async () => {
+      // Let the audio element buffer first before competing for bandwidth
+      await new Promise((resolve) => setTimeout(resolve, ENRICHMENT_DELAY_MS));
+      // Bail if track changed during the delay
+      if (this.currentTrack?.id !== track.id) return;
       let res: Response;
       try {
         res = await fetch(streamUrl, { headers: { Range: `bytes=0-${FETCH_LIMIT - 1}` } });
@@ -143,6 +148,10 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     doEnrich().catch(() => {
       // Metadata enrichment is best-effort; ignore failures
     });
+  }
+
+  prepareTrack(track: MediaTrack): void {
+    this.catalog.prefetchTemporaryLink(track.playbackRef.ref);
   }
 
   async playCollection(

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -60,6 +60,8 @@ export interface PlaybackProvider {
   getState(): Promise<PlaybackState | null>;
   /** Subscribe to state changes (returns unsubscribe). */
   subscribe(listener: (state: PlaybackState | null) => void): () => void;
+  /** Optional: pre-warm resources for an upcoming track (e.g. fetch temporary links). */
+  prepareTrack?(track: MediaTrack): void;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Cache Dropbox temporary links in memory (3.5h TTL, valid for 4h)
  so repeated plays skip the API call entirely
- Prefetch next track's temporary link when current track starts playing
- Delay ID3 metadata enrichment by 2s to avoid bandwidth contention
  with initial audio buffering
- Add optional prepareTrack() to PlaybackProvider interface for
  pre-warming resources ahead of playback

https://claude.ai/code/session_0163Hbpo5oHqMjTQw3JJBvYv