### PR TITLE
fix: reduce Spotify track switch delay

### DIFF
--- a/src/hooks/__tests__/useSpotifyPlayback.test.ts
+++ b/src/hooks/__tests__/useSpotifyPlayback.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/services/spotifyPlayer', () => ({
     resume: vi.fn().mockResolvedValue(undefined),
     transferPlaybackToDevice: vi.fn().mockResolvedValue(undefined),
     ensureDeviceIsActive: vi.fn().mockResolvedValue(true),
+    waitForPlaybackOrResume: vi.fn(),
     getDeviceId: vi.fn().mockReturnValue('device-1'),
   },
 }));

--- a/src/hooks/useSpotifyPlayback.ts
+++ b/src/hooks/useSpotifyPlayback.ts
@@ -52,21 +52,6 @@ export const useSpotifyPlayback = ({
     }
   }, []);
 
-  const handlePlaybackResume = useCallback(async () => {
-    const state = await spotifyPlayer.getCurrentState();
-    if (state) {
-      if (state.paused && state.position === 0) {
-        try {
-          await spotifyPlayer.resume();
-        } catch (resumeError) {
-          console.error('Failed to resume after playback attempt:', resumeError);
-        }
-      }
-    } else {
-      await activateDevice();
-    }
-  }, [activateDevice]);
-
   /**
    * Play a Spotify track via the Spotify playback adapter.
    * Handles SDK initialization, retry logic, and device activation.
@@ -127,16 +112,11 @@ export const useSpotifyPlayback = ({
 
     setCurrentTrackIndex(index);
 
-    setTimeout(() => {
-      void (async () => {
-        try {
-          await handlePlaybackResume();
-        } catch (error) {
-          console.error('Failed to resume playback:', error);
-        }
-      })();
-    }, 1500);
-  }, [setCurrentTrackIndex, handlePlaybackResume]);
+    // Listen for the SDK state change instead of blind-waiting 1500ms.
+    // If the SDK ends up paused at position 0 (a known quirk), resume.
+    // Falls back to a manual check after 3s if no event fires.
+    spotifyPlayer.waitForPlaybackOrResume(activateDevice);
+  }, [setCurrentTrackIndex, activateDevice]);
 
   const playTrack = useCallback(async (index: number, skipOnError = false) => {
     const mediaTracks = mediaTracksRef?.current ?? [];
@@ -226,7 +206,7 @@ export const useSpotifyPlayback = ({
         setTimeout(() => playTrack(index + 1, skipOnError), 500);
       }
     }
-  }, [setCurrentTrackIndex, handlePlaybackResume, activeDescriptor, mediaTracksRef, playSpotifyTrack]);
+  }, [setCurrentTrackIndex, activeDescriptor, mediaTracksRef, playSpotifyTrack]);
 
   const resumePlayback = useCallback(async () => {
     // Resume the provider that's currently playing

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -34,6 +34,8 @@ class SpotifyPlayerService {
   private masterListenerAttached = false;
   private pendingSDKLoad: Promise<void> | null = null;
   lastPlayTrackTime = 0;
+  /** Timestamp of last confirmed device-active check. */
+  private lastDeviceActiveAt = 0;
 
   constructor() {
     // Restore state from HMR if available
@@ -458,9 +460,17 @@ class SpotifyPlayerService {
     }
   }
 
+  /** How long a successful device-active check remains valid. */
+  private static readonly DEVICE_ACTIVE_TTL_MS = 30_000;
+
   async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 800): Promise<boolean> {
+    // Skip the API call if device was recently confirmed active
+    if (this.isReady && Date.now() - this.lastDeviceActiveAt < SpotifyPlayerService.DEVICE_ACTIVE_TTL_MS) {
+      return true;
+    }
+
     const token = await spotifyAuth.ensureValidToken();
-    
+
     for (let i = 0; i < maxRetries; i++) {
       try {
         const response = await fetch('https://api.spotify.com/v1/me/player', {
@@ -473,6 +483,7 @@ class SpotifyPlayerService {
           const data = await response.json();
           if (data.device?.id === this.deviceId && data.device?.is_active) {
             console.log('🎵 Device is active and ready');
+            this.lastDeviceActiveAt = Date.now();
             return true;
           }
         } else if (response.status === 204) {
@@ -496,6 +507,57 @@ class SpotifyPlayerService {
 
     console.warn('🎵 Device not confirmed active after polling, proceeding anyway');
     return false;
+  }
+
+  /**
+   * Wait for the SDK to report a state change after playTrack(), then
+   * resume if the SDK ended up paused at position 0 (a known SDK quirk).
+   * Falls back to device activation if no SDK state is available.
+   * Times out after `timeoutMs` to avoid hanging indefinitely.
+   */
+  waitForPlaybackOrResume(activateDevice: () => Promise<void>, timeoutMs = 3000): void {
+    let settled = false;
+    let unsub: (() => void) | null = null;
+
+    const cleanup = () => {
+      if (unsub) { unsub(); unsub = null; }
+    };
+
+    const onStateChange = async (state: SpotifyPlaybackState | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+
+      if (state) {
+        if (state.paused && state.position === 0) {
+          try { await this.resume(); } catch { /* ignore */ }
+        }
+        // else: track is already playing, nothing to do
+      } else {
+        await activateDevice();
+      }
+    };
+
+    unsub = this.onPlayerStateChanged((state) => {
+      void onStateChange(state);
+    });
+
+    // Fallback: if the SDK never fires a state change, check manually
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      void (async () => {
+        const state = await this.getCurrentState();
+        if (state) {
+          if (state.paused && state.position === 0) {
+            try { await this.resume(); } catch { /* ignore */ }
+          }
+        } else {
+          await activateDevice();
+        }
+      })();
+    }, timeoutMs);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace 1500ms hardcoded setTimeout with event-driven resume via SDK `player_state_changed` events — zero delay in the common case
- Cache device-active status for 30s so `ensureDeviceIsActive()` skips the API round-trip on consecutive track switches
- Clean up dead `handlePlaybackResume` callback

## Test plan
- [x] All 404 tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify Spotify track switching is noticeably faster in real usage
- [ ] Verify tracks that hit the "paused at position 0" SDK quirk still auto-resume within 3s

https://claude.ai/code/session_0163Hbpo5oHqMjTQw3JJBvYv