### PR TITLE
chore: sync visualizer trail defaults from debug export

### DIFF
--- a/src/constants/visualizerDebugConfig.ts
+++ b/src/constants/visualizerDebugConfig.ts
@@ -86,11 +86,11 @@ const DEFAULT_PARTICLE: ParticleVisualizerConfig = {
 const DEFAULT_TRAIL: TrailVisualizerConfig = {
   particleMinRadius: 3.5,
   particleMaxRadius: 29,
-  lifeDrainDivisor: 11000,
+  lifeDrainDivisor: 17000,
   lifeRespawnMin: 0.8,
   lifeRespawnSpread: 0.2,
   shipTurnRate: 0.00013,
-  shipSpeedBase: 2.7,
+  shipSpeedBase: 4,
   shipSpeedSpread: 1.3,
   shipWobble: 0.025,
   pausedSpeedMult: 0.1,
@@ -102,7 +102,7 @@ const DEFAULT_TRAIL: TrailVisualizerConfig = {
   glowRadius: 16,
   minVisibleRadius: 11,
   countBaseMobile: 160,
-  countBaseDesktop: 120,
+  countBaseDesktop: 255,
   countPixelDivisor: 5000,
   countPixelDivisorMobile: 5000,
 };


### PR DESCRIPTION
## Summary
- Align `DEFAULT_TRAIL` in `visualizerDebugConfig.ts` with the latest exported visualizer debug JSON.
- Update `lifeDrainDivisor`, `shipSpeedBase`, and `countBaseDesktop` to match tuned values.
- Keep all other visualizer defaults unchanged.

## Test plan
- [x] Run `npm run test:run`
- [ ] Open app and verify Trail visualizer behavior with default config
- [ ] Confirm debug panel values for Trail match exported JSON defaults

Made with [Cursor](https://cursor.com)