### PR TITLE
Shuffle generated tracks while keeping current track pinned

### DIFF
--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -566,7 +566,10 @@ export function usePlayerLogic() {
         (t) => t.id !== seedId && `${t.artists.toLowerCase()}||${t.name.toLowerCase()}` !== seedKey,
       );
 
-      const combinedQueue = [currentSeedMediaTrack, ...dedupedGenerated];
+      // Shuffle the generated tracks, keeping the current track pinned at index 0
+      // so playback is not interrupted.
+      const shuffledGenerated = shuffleArray(dedupedGenerated);
+      const combinedQueue = [currentSeedMediaTrack, ...shuffledGenerated];
 
       if (combinedQueue.length > 0) {
         const trackList = combinedQueue.map(mediaTrackToTrack);


### PR DESCRIPTION
## Summary
Modified the queue generation logic to shuffle generated tracks while preserving the current seed track at the beginning of the queue to prevent playback interruption.

## Key Changes
- Added shuffling of deduplicated generated tracks using `shuffleArray()`
- Current seed media track remains pinned at index 0 of the combined queue
- Playback continuity is maintained since the currently playing track is not affected by the shuffle

## Implementation Details
The shuffle is applied only to the generated tracks after deduplication, ensuring that:
1. The current track being played stays at the front of the queue
2. Subsequent tracks are randomized for variety
3. No playback interruption occurs during queue reorganization

https://claude.ai/code/session_011fbGJsvwRrJihyGZ9RMc5R