### PR TITLE
fix(radio): use primary artist for Last.fm lookups

### DIFF
--- a/src/services/__tests__/radioService.test.ts
+++ b/src/services/__tests__/radioService.test.ts
@@ -34,6 +34,32 @@ describe('RadioService', () => {
   }
 
   describe('generateRadioQueue — track seed', () => {
+    it('uses the primary artist for Last.fm track lookups', async () => {
+      const { generateRadioQueue, lastfm } = await freshRadioService();
+
+      const catalog = [
+        makeTrack('Karma Police', 'Radiohead'),
+        makeTrack('Lucky', 'Radiohead'),
+        makeTrack('No Surprises', 'Radiohead'),
+        makeTrack('Exit Music', 'Radiohead'),
+        makeTrack('Airbag', 'Radiohead'),
+      ];
+
+      vi.mocked(lastfm.getSimilarTracks).mockResolvedValue([
+        { name: 'Karma Police', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.9 },
+        { name: 'Lucky', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.8 },
+        { name: 'No Surprises', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.7 },
+        { name: 'Exit Music', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.65 },
+        { name: 'Airbag', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.6 },
+      ]);
+      vi.mocked(lastfm.getSimilarArtists).mockResolvedValue([]);
+
+      const seed: RadioSeed = { type: 'track', artist: 'Radiohead, Thom Yorke', track: 'Creep' };
+      await generateRadioQueue(seed, catalog);
+
+      expect(lastfm.getSimilarTracks).toHaveBeenCalledWith('Radiohead', 'Creep', 25);
+    });
+
     it('matches Last.fm similar tracks against catalog', async () => {
       const { generateRadioQueue, lastfm } = await freshRadioService();
 
@@ -222,6 +248,29 @@ describe('RadioService', () => {
   });
 
   describe('generateRadioQueue — album seed', () => {
+    it('uses the primary artist for Last.fm album-track lookups', async () => {
+      const { generateRadioQueue, lastfm } = await freshRadioService();
+
+      const catalog = [
+        makeTrack('Lucky', 'Radiohead'),
+        makeTrack('Karma Police', 'Radiohead'),
+      ];
+
+      vi.mocked(lastfm.getSimilarTracks).mockResolvedValue([
+        { name: 'Lucky', artist: 'Radiohead', trackMbid: null, artistMbid: null, matchScore: 0.9 },
+      ]);
+
+      const seed: RadioSeed = {
+        type: 'album',
+        artist: 'Radiohead',
+        album: 'The Bends',
+        tracks: [{ artist: 'Radiohead, Thom Yorke', name: 'Fake Plastic Trees' }],
+      };
+      await generateRadioQueue(seed, catalog);
+
+      expect(lastfm.getSimilarTracks).toHaveBeenCalledWith('Radiohead', 'Fake Plastic Trees', 25);
+    });
+
     it('matches similar tracks from album tracks', async () => {
       const { generateRadioQueue, lastfm } = await freshRadioService();
 

--- a/src/services/radioService.ts
+++ b/src/services/radioService.ts
@@ -46,7 +46,8 @@ async function generateFromTrack(
   const seenIds = new Set<string>();
   const seenUnmatchedKeys = new Set<string>();
 
-  const candidates = await getSimilarTracks(seed.artist, seed.track, 25);
+  const seedArtistForLastFm = getPrimaryArtist(seed.artist);
+  const candidates = await getSimilarTracks(seedArtistForLastFm, seed.track, 25);
   const lastfmCandidates = candidates.length;
 
   for (const candidate of candidates) {
@@ -64,7 +65,7 @@ async function generateFromTrack(
   }
 
   if (matches.length < MIN_TRACK_THRESHOLD) {
-    const similarArtists = await getSimilarArtists(seed.artist, 10);
+    const similarArtists = await getSimilarArtists(seedArtistForLastFm, 10);
     for (const artist of similarArtists) {
       const artistTracks = findTracksByArtist(artist.name, artist.mbid, indexes);
       let added = 0;
@@ -96,7 +97,8 @@ async function generateFromArtist(
   const matches: MatchResult[] = [];
   const seenIds = new Set<string>();
 
-  const similarArtists = await getSimilarArtists(seed.artist, 30);
+  const seedArtistForLastFm = getPrimaryArtist(seed.artist);
+  const similarArtists = await getSimilarArtists(seedArtistForLastFm, 30);
   let lastfmCandidates = 0;
 
   for (const artist of similarArtists) {
@@ -149,7 +151,7 @@ async function generateFromAlbum(
   for (const chunk of chunks) {
     const results = await Promise.all(
       chunk.map(async (albumTrack) => {
-        const candidates = await getSimilarTracks(albumTrack.artist, albumTrack.name, 25);
+        const candidates = await getSimilarTracks(getPrimaryArtist(albumTrack.artist), albumTrack.name, 25);
         return candidates;
       }),
     );
@@ -224,4 +226,28 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
     chunks.push(arr.slice(i, i + size));
   }
   return chunks;
+}
+
+function getPrimaryArtist(artists: string): string {
+  const normalized = artists.trim();
+  if (!normalized) return artists;
+
+  const separators = [
+    /\s*,\s*/,
+    /\s+feat\.?\s+/i,
+    /\s+featuring\s+/i,
+    /\s*&\s*/,
+    /\s+and\s+/i,
+    /\s*\/\s*/,
+    /\s*;\s*/,
+  ];
+
+  for (const separator of separators) {
+    const [first] = normalized.split(separator);
+    if (first && first.trim() !== normalized) {
+      return first.trim();
+    }
+  }
+
+  return normalized;
 }


### PR DESCRIPTION
## Summary
- normalize multi-artist seed strings to a primary artist before Last.fm queries in radio generation
- apply the same primary-artist normalization for track, artist, and album-based radio lookups
- add radio service tests covering multi-artist seed handling for track and album flows

## Test plan
- [x] `npm run test:run -- src/services/__tests__/radioService.test.ts`
- [x] `npx tsc --noEmit`

Made with [Cursor](https://cursor.com)