### PR TITLE
Rename playlist drawer to queue drawer throughout codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,14 @@ Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` 
 |-----|---------|------------|
 | `Space` | Play/Pause | Play/Pause |
 | `←` / `→` | Prev/Next track | Prev/Next track |
-| `↑` / `P` | Toggle playlist | Volume up (↑ only) |
+| `↑` / `Q` | Toggle queue | Volume up (↑ only) |
 | `↓` / `L` | Toggle library | Volume down (↓ only) |
 | `V` / `G` / `S` / `T` | Visualizer / Glow / Shuffle / Translucence | same |
 | `O` / `K` / `M` | Effects menu / Like / Mute | same |
 | `?` / `/` | Keyboard help | same |
 | `Escape` | Close all menus | same |
 
-`P` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.
+`Q` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.
 
 ## Tech Stack
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,7 +40,7 @@ On mobile and tablet:
 
 - **Tap** album art to flip and reveal quick-access controls (or play/pause in zen mode)
 - **Swipe left/right** on album art to change tracks
-- **Swipe up** on album art to toggle the playlist drawer
+- **Swipe up** on album art to toggle the queue drawer
 - **Swipe down** on album art to toggle the library drawer
 
 ## Library
@@ -99,7 +99,7 @@ Opened via the gear icon in the bottom bar. Provides full control over:
 |-----|-------------------|---------------------|
 | `Space` | Play/Pause | Play/Pause |
 | `ArrowRight` / `ArrowLeft` | Next / Previous track | Next / Previous track |
-| `ArrowUp` / `P` | Toggle playlist drawer | Volume up (ArrowUp only) |
+| `ArrowUp` / `Q` | Toggle queue drawer | Volume up (ArrowUp only) |
 | `ArrowDown` / `L` | Toggle library drawer | Volume down (ArrowDown only) |
 | `V` | Toggle background visualizer | Toggle background visualizer |
 | `G` | Toggle glow effect | Toggle glow effect |

--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -7,7 +7,7 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import {
   VisualEffectsIcon,
   BackToLibraryIcon,
-  PlaylistIcon,
+  QueueIcon,
   ZenModeIcon,
   ShuffleIcon,
   RadioIcon,
@@ -23,7 +23,7 @@ interface BottomBarProps {
   onVolumeChange?: (volume: number) => void;
   onShowVisualEffects: () => void;
   onBackToLibrary?: () => void;
-  onShowPlaylist: () => void;
+  onShowQueue: () => void;
   onZenModeToggle?: () => void;
   shuffleEnabled?: boolean;
   onShuffleToggle?: () => void;
@@ -39,7 +39,7 @@ const BottomBar = React.memo(function BottomBar({
   onVolumeChange,
   onShowVisualEffects,
   onBackToLibrary,
-  onShowPlaylist,
+  onShowQueue,
   onZenModeToggle,
   shuffleEnabled,
   onShuffleToggle,
@@ -185,10 +185,10 @@ const BottomBar = React.memo(function BottomBar({
             $isMobile={isMobile}
             $isTablet={isTablet}
             $compact
-            onClick={onShowPlaylist}
-            title="Show Playlist"
+            onClick={onShowQueue}
+            title="Show Queue"
           >
-            <PlaylistIcon />
+            <QueueIcon />
           </ControlButton>
 
           {onZenModeToggle && (

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -109,7 +109,7 @@ const shortcuts = [
   { key: 'Space', description: 'Play / Pause' },
   { key: '←', description: 'Previous track' },
   { key: '→', description: 'Next track' },
-  { key: '↑ / P', description: 'Toggle playlist' },
+  { key: '↑ / Q', description: 'Toggle queue' },
   { key: '↓ / L', description: 'Toggle library' },
   { key: 'K', description: 'Like / Unlike track' },
   { key: 'M', description: 'Mute / Unmute' },

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -27,8 +27,8 @@ import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import LibraryDrawer from './LibraryDrawer';
 import AlbumArtQuickSwapBack from './AlbumArtQuickSwapBack';
 
-const PlaylistDrawer = lazy(() => import('./PlaylistDrawer'));
-const PlaylistBottomSheet = lazy(() => import('./PlaylistBottomSheet'));
+const QueueDrawer = lazy(() => import('./QueueDrawer'));
+const QueueBottomSheet = lazy(() => import('./QueueBottomSheet'));
 const VisualEffectsMenu = lazy(() => import('./VisualEffectsMenu/index'));
 const KeyboardShortcutsHelp = lazy(() => import('./KeyboardShortcutsHelp'));
 
@@ -168,7 +168,7 @@ function ControlsLoadingFallback() {
   );
 }
 
-function PlaylistLoadingFallback() {
+function QueueLoadingFallback() {
   const theme = useTheme();
   return (
     <div style={{
@@ -183,7 +183,7 @@ function PlaylistLoadingFallback() {
       justifyContent: 'center',
       color: theme.colors.muted.foreground
     }}>
-      Loading playlist...
+      Loading queue...
     </div>
   );
 }
@@ -297,7 +297,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   const { tracks, shuffleEnabled, handleShuffleToggle, selectedPlaylistId } = useTrackListContext();
   const { isUnifiedLikedActive } = useUnifiedLikedTracks();
   const showProviderIcons = (isUnifiedLikedActive && selectedPlaylistId === LIKED_SONGS_ID) || !!radioActive;
-  const { currentTrack, currentTrackIndex, showPlaylist, setShowPlaylist } = useCurrentTrackContext();
+  const { currentTrack, currentTrackIndex, showQueue, setShowQueue } = useCurrentTrackContext();
 
   const {
     accentColor,
@@ -422,13 +422,13 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setAccentColor(color);
   }, [currentTrack?.album_id, handleSetAccentColorOverride, handleResetAccentColorOverride, setAccentColor]);
 
-  // --- Playlist visibility ---
-  const handleShowPlaylist = useCallback(() => {
+  // --- Queue visibility ---
+  const handleShowQueue = useCallback(() => {
     handlers.onCloseLibraryDrawer();
     setShowVisualEffects(false);
-    setShowPlaylist(prev => !prev);
-  }, [setShowPlaylist, handlers, setShowVisualEffects]);
-  const handleClosePlaylist = useCallback(() => setShowPlaylist(false), [setShowPlaylist]);
+    setShowQueue(prev => !prev);
+  }, [setShowQueue, handlers, setShowVisualEffects]);
+  const handleCloseQueue = useCallback(() => setShowQueue(false), [setShowQueue]);
 
   // --- App settings handlers ---
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
@@ -464,16 +464,16 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
 
   // --- VFX menu visibility ---
   const handleShowVisualEffects = useCallback(() => {
-    setShowPlaylist(false);
+    setShowQueue(false);
     handlers.onCloseLibraryDrawer();
     setShowVisualEffects(true);
-  }, [setShowPlaylist, handlers, setShowVisualEffects]);
+  }, [setShowQueue, handlers, setShowVisualEffects]);
   const handleCloseVisualEffects = useCallback(() => setShowVisualEffects(false), [setShowVisualEffects]);
   const handleToggleVisualEffectsMenu = useCallback(() => {
-    setShowPlaylist(false);
+    setShowQueue(false);
     handlers.onCloseLibraryDrawer();
     setShowVisualEffects(prev => !prev);
-  }, [setShowVisualEffects, setShowPlaylist, handlers]);
+  }, [setShowVisualEffects, setShowQueue, handlers]);
 
   // --- Glow toggle (re-enables VFX + restores saved state) ---
   const handleGlowToggle = useCallback(() => {
@@ -504,10 +504,10 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
 
   // --- Library drawer ---
   const handleOpenLibraryDrawer = useCallback(() => {
-    setShowPlaylist(false);
+    setShowQueue(false);
     setShowVisualEffects(false);
     handlers.onOpenLibraryDrawer();
-  }, [handlers, setShowPlaylist, setShowVisualEffects]);
+  }, [handlers, setShowQueue, setShowVisualEffects]);
 
   const handleArtistBrowse = useCallback((artistName: string) => {
     setLibrarySearchQuery(artistName);
@@ -568,12 +568,12 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   }, { enabled: isTouchDevice });
 
   const handleSwipeUp = useCallback(() => {
-    if (showPlaylist) {
-      handleClosePlaylist();
+    if (showQueue) {
+      handleCloseQueue();
     } else {
-      handleShowPlaylist();
+      handleShowQueue();
     }
-  }, [showPlaylist, handleShowPlaylist, handleClosePlaylist]);
+  }, [showQueue, handleShowQueue, handleCloseQueue]);
 
   const handleSwipeDown = useCallback(() => {
     if (showLibraryDrawer) {
@@ -610,24 +610,24 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   const handleArrowUp = useCallback(() => {
     if (showLibraryDrawer) {
       handlers.onCloseLibraryDrawer();
-      handleShowPlaylist();
-    } else if (showPlaylist) {
-      handleClosePlaylist();
+      handleShowQueue();
+    } else if (showQueue) {
+      handleCloseQueue();
     } else {
-      handleShowPlaylist();
+      handleShowQueue();
     }
-  }, [handlers, showLibraryDrawer, showPlaylist, handleShowPlaylist, handleClosePlaylist]);
+  }, [handlers, showLibraryDrawer, showQueue, handleShowQueue, handleCloseQueue]);
 
   const handleArrowDown = useCallback(() => {
-    if (showPlaylist) {
-      handleClosePlaylist();
+    if (showQueue) {
+      handleCloseQueue();
       handleOpenLibraryDrawer();
     } else if (showLibraryDrawer) {
       handlers.onCloseLibraryDrawer();
     } else {
       handleOpenLibraryDrawer();
     }
-  }, [handlers, showPlaylist, showLibraryDrawer, handleClosePlaylist, handleOpenLibraryDrawer]);
+  }, [handlers, showQueue, showLibraryDrawer, handleCloseQueue, handleOpenLibraryDrawer]);
 
   const handleVolumeUp = useCallback(() => {
     setVolumeLevel(Math.min(100, (volume ?? 50) + 5));
@@ -641,7 +641,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onPlayPause: handlePlayPause,
     onNext: handlers.onNext,
     onPrevious: handlers.onPrevious,
-    onClosePlaylist: handleClosePlaylist,
+    onCloseQueue: handleCloseQueue,
     onToggleVisualEffectsMenu: handleToggleVisualEffectsMenu,
     onCloseVisualEffects: handleEscapeClose,
     onToggleBackgroundVisualizer: handleBackgroundVisualizerToggle,
@@ -653,7 +653,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     onToggleLike: handleLikeToggle,
     onToggleShuffle: handleShuffleToggle,
     onToggleHelp: toggleHelp,
-    onShowPlaylist: handleArrowUp,
+    onShowQueue: handleArrowUp,
     onOpenLibraryDrawer: handleArrowDown,
     onToggleZenMode: handleZenModeToggle,
   }, { prefersPointerInput: hasPointerInput });
@@ -789,7 +789,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
         onVolumeChange={setVolumeLevel}
         onShowVisualEffects={handleShowVisualEffects}
         onBackToLibrary={handleOpenLibraryDrawer}
-        onShowPlaylist={handleShowPlaylist}
+        onShowQueue={handleShowQueue}
         onZenModeToggle={handleZenModeToggle}
         shuffleEnabled={shuffleEnabled}
         onShuffleToggle={handleShuffleToggle}
@@ -808,12 +808,12 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
           onVisualizerDebugToggle={handleVisualizerDebugToggle}
         />
       </Suspense>
-      <Suspense fallback={<PlaylistLoadingFallback />}>
+      <Suspense fallback={<QueueLoadingFallback />}>
         {isMobile ? (
-          <ProfiledComponent id="PlaylistBottomSheet">
-            <PlaylistBottomSheet
-              isOpen={showPlaylist}
-              onClose={handleClosePlaylist}
+          <ProfiledComponent id="QueueBottomSheet">
+            <QueueBottomSheet
+              isOpen={showQueue}
+              onClose={handleCloseQueue}
               tracks={tracks}
               currentTrackIndex={currentTrackIndex}
               onTrackSelect={handlers.onTrackSelect}
@@ -823,10 +823,10 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
             />
           </ProfiledComponent>
         ) : (
-          <ProfiledComponent id="PlaylistDrawer">
-            <PlaylistDrawer
-              isOpen={showPlaylist}
-              onClose={handleClosePlaylist}
+          <ProfiledComponent id="QueueDrawer">
+            <QueueDrawer
+              isOpen={showQueue}
+              onClose={handleCloseQueue}
               tracks={tracks}
               currentTrackIndex={currentTrackIndex}
               onTrackSelect={handlers.onTrackSelect}

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -83,7 +83,7 @@ const SheetContent = styled.div`
   }
 `;
 
-interface PlaylistBottomSheetProps {
+interface QueueBottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   tracks: Track[];
@@ -94,7 +94,7 @@ interface PlaylistBottomSheetProps {
   radioSeedDescription?: string | null;
 }
 
-const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function PlaylistBottomSheet({
+const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
   isOpen,
   onClose,
   tracks,
@@ -121,18 +121,18 @@ const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function PlaylistBott
         $dragOffset={effectiveDragOffset}
         role="dialog"
         aria-modal="true"
-        aria-label={radioActive ? 'Radio' : 'Playlist'}
+        aria-label={radioActive ? 'Radio' : 'Queue'}
       >
         <SheetHeader>
           <SwipeHandle
             ref={headerRef}
             role="button"
-            aria-label="Swipe down or tap to close playlist"
+            aria-label="Swipe down or tap to close queue"
             onClick={onClose}
           >
             <GripPill />
           </SwipeHandle>
-          <SheetTitle>{radioActive ? 'Radio' : 'Playlist'}</SheetTitle>
+          <SheetTitle>{radioActive ? 'Radio' : 'Queue'}</SheetTitle>
           {radioActive && radioSeedDescription && (
             <div style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.5)', textAlign: 'center', marginTop: '2px' }}>
               {radioSeedDescription}
@@ -152,7 +152,7 @@ const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function PlaylistBott
                         textAlign: 'center',
                       }}
                     >
-                      Loading playlist...
+                      Loading queue...
                     </div>
                   </DrawerFallbackCard>
                 </DrawerFallback>
@@ -177,4 +177,4 @@ const PlaylistBottomSheet = memo<PlaylistBottomSheetProps>(function PlaylistBott
   );
 });
 
-export default PlaylistBottomSheet;
+export default QueueBottomSheet;

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -8,7 +8,7 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const Playlist = React.lazy(() => import('./Playlist'));
 
-const PlaylistDrawerContainer = styled.div.withConfig({
+const QueueDrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['isOpen', 'width', 'transitionDuration', 'transitionEasing'].includes(prop),
 }) <{ isOpen: boolean; width: number; transitionDuration: number; transitionEasing: string }>`
   position: fixed;
@@ -29,20 +29,20 @@ const PlaylistDrawerContainer = styled.div.withConfig({
   
   /* Enable container queries */
   container-type: inline-size;
-  container-name: playlist;
-  
+  container-name: queue;
+
   /* Container query responsive adjustments */
-  @container playlist (max-width: ${theme.breakpoints.md}) {
+  @container queue (max-width: ${theme.breakpoints.md}) {
     width: ${theme.drawer.widths.mobile};
     padding: ${theme.spacing.sm};
   }
   
-  @container playlist (min-width: ${theme.breakpoints.md}) and (max-width: ${theme.drawer.breakpoints.mobile}) {
+  @container queue (min-width: ${theme.breakpoints.md}) and (max-width: ${theme.drawer.breakpoints.mobile}) {
     width: ${theme.drawer.widths.tablet};
     padding: ${theme.spacing.md};
   }
   
-  @container playlist (min-width: ${theme.drawer.breakpoints.mobile}) {
+  @container queue (min-width: ${theme.drawer.breakpoints.mobile}) {
     width: ${theme.drawer.widths.desktop};
     padding: ${theme.spacing.lg};
   }
@@ -55,7 +55,7 @@ const PlaylistDrawerContainer = styled.div.withConfig({
   }
 `;
 
-const PlaylistContent = styled.div`
+const QueueContent = styled.div`
   padding: ${theme.spacing.sm} 0 ${theme.spacing.md} 0;
   
   /* Ensure playlist cards have proper spacing from top and bottom */
@@ -68,7 +68,7 @@ const PlaylistContent = styled.div`
   }
 `;
 
-const PlaylistOverlay = styled.div.withConfig({
+const QueueOverlay = styled.div.withConfig({
   shouldForwardProp: (prop) => !['isOpen'].includes(prop),
 }) <{ isOpen: boolean }>`
   position: fixed;
@@ -84,7 +84,7 @@ const PlaylistOverlay = styled.div.withConfig({
   z-index: ${theme.zIndex.overlay};
 `;
 
-const PlaylistHeader = styled.div`
+const QueueHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -93,7 +93,7 @@ const PlaylistHeader = styled.div`
   border-bottom: 1px solid ${theme.colors.popover.border};
 `;
 
-const PlaylistTitle = styled.h3`
+const QueueTitle = styled.h3`
   color: ${theme.colors.white};
   margin: 0;
   font-size: ${theme.fontSize.xl};
@@ -116,7 +116,7 @@ const CloseButton = styled.button`
   }
 `;
 
-interface PlaylistDrawerProps {
+interface QueueDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   tracks: Track[];
@@ -127,10 +127,10 @@ interface PlaylistDrawerProps {
   radioSeedDescription?: string | null;
 }
 
-// Custom comparison function for PlaylistDrawer memo optimization
-const arePlaylistDrawerPropsEqual = (
-  prevProps: PlaylistDrawerProps,
-  nextProps: PlaylistDrawerProps
+// Custom comparison function for QueueDrawer memo optimization
+const areQueueDrawerPropsEqual = (
+  prevProps: QueueDrawerProps,
+  nextProps: QueueDrawerProps
 ): boolean => {
   // Check if open state changed
   if (prevProps.isOpen !== nextProps.isOpen) {
@@ -158,7 +158,7 @@ const arePlaylistDrawerPropsEqual = (
   return true;
 };
 
-const PlaylistDrawer = memo<PlaylistDrawerProps>(({
+const QueueDrawer = memo<QueueDrawerProps>(({
   isOpen,
   onClose,
   tracks,
@@ -179,20 +179,20 @@ const PlaylistDrawer = memo<PlaylistDrawerProps>(({
   }, [viewport.width, isMobile, isTablet]);
   return createPortal(
     <>
-      <PlaylistOverlay
+      <QueueOverlay
         isOpen={isOpen}
         onClick={onClose}
       />
 
-      <PlaylistDrawerContainer
+      <QueueDrawerContainer
         isOpen={isOpen}
         width={drawerWidth}
         transitionDuration={transitionDuration}
         transitionEasing={transitionEasing}
       >
-        <PlaylistHeader>
+        <QueueHeader>
           <div>
-            <PlaylistTitle>{radioActive ? 'Radio' : 'Playlist'}</PlaylistTitle>
+            <QueueTitle>{radioActive ? 'Radio' : 'Queue'}</QueueTitle>
             {radioActive && radioSeedDescription && (
               <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.muted.foreground, marginTop: '2px' }}>
                 {radioSeedDescription}
@@ -200,9 +200,9 @@ const PlaylistDrawer = memo<PlaylistDrawerProps>(({
             )}
           </div>
           <CloseButton onClick={onClose}>×</CloseButton>
-        </PlaylistHeader>
+        </QueueHeader>
 
-        <PlaylistContent>
+        <QueueContent>
           <Suspense fallback={
             <DrawerFallback>
               <DrawerFallbackCard>
@@ -211,7 +211,7 @@ const PlaylistDrawer = memo<PlaylistDrawerProps>(({
                   color: theme.colors.muted.foreground,
                   textAlign: 'center'
                 }}>
-                  Loading playlist...
+                  Loading queue...
                 </div>
               </DrawerFallbackCard>
             </DrawerFallback>
@@ -227,13 +227,13 @@ const PlaylistDrawer = memo<PlaylistDrawerProps>(({
               showProviderIcons={showProviderIcons}
             />
           </Suspense>
-        </PlaylistContent>
-      </PlaylistDrawerContainer>
+        </QueueContent>
+      </QueueDrawerContainer>
     </>,
     document.body
   );
-}, arePlaylistDrawerPropsEqual);
+}, areQueueDrawerPropsEqual);
 
-PlaylistDrawer.displayName = 'PlaylistDrawer';
+QueueDrawer.displayName = 'QueueDrawer';
 
-export default PlaylistDrawer;
+export default QueueDrawer;

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -58,7 +58,7 @@ const defaultProps = {
   onVolumeChange: vi.fn(),
   onShowVisualEffects: vi.fn(),
   onBackToLibrary: vi.fn(),
-  onShowPlaylist: vi.fn(),
+  onShowQueue: vi.fn(),
   onZenModeToggle: vi.fn(),
   shuffleEnabled: false,
   onShuffleToggle: vi.fn(),
@@ -126,10 +126,10 @@ describe('BottomBar', () => {
     expect(props.onShowVisualEffects).toHaveBeenCalledOnce();
   });
 
-  it('playlist button calls onShowPlaylist when clicked', () => {
+  it('queue button calls onShowQueue when clicked', () => {
     const { props } = renderBottomBar();
-    fireEvent.click(screen.getByTitle('Show Playlist'));
-    expect(props.onShowPlaylist).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTitle('Show Queue'));
+    expect(props.onShowQueue).toHaveBeenCalledOnce();
   });
 
   it('zen mode button calls onZenModeToggle when clicked', () => {

--- a/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
@@ -98,7 +98,7 @@ describe('Keyboard Shortcuts Integration', () => {
       onPlayPause: vi.fn(),
       onNext: vi.fn(),
       onPrevious: vi.fn(),
-      onClosePlaylist: vi.fn(),
+      onCloseQueue: vi.fn(),
       onToggleVisualEffectsMenu: vi.fn(),
       onCloseVisualEffects: vi.fn(),
       onToggleBackgroundVisualizer: vi.fn(),

--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -1,4 +1,4 @@
-export const PlaylistIcon = () => (
+export const QueueIcon = () => (
   <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
     <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" fill="currentColor" />
   </svg>

--- a/src/contexts/TrackContext.tsx
+++ b/src/contexts/TrackContext.tsx
@@ -28,8 +28,8 @@ interface CurrentTrackContextValue {
   currentTrack: Track | null;
   currentTrackIndex: number;
   setCurrentTrackIndex: (index: number | ((prev: number) => number)) => void;
-  showPlaylist: boolean;
-  setShowPlaylist: (visible: boolean | ((prev: boolean) => boolean)) => void;
+  showQueue: boolean;
+  setShowQueue: (visible: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 const TrackListContext = createContext<TrackListContextValue | null>(null);
@@ -43,7 +43,7 @@ export function TrackProvider({ children }: { children: React.ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [shuffleEnabled, setShuffleEnabled] = useLocalStorage('vorbis-player-shuffle-enabled', false);
   const [selectedPlaylistId, setSelectedPlaylistId] = useState<string | null>(null);
-  const [showPlaylist, setShowPlaylist] = useState(false);
+  const [showQueue, setShowQueue] = useState(false);
 
   const currentTrack = useMemo(
     () => tracks[currentTrackIndex] || null,
@@ -105,9 +105,9 @@ export function TrackProvider({ children }: { children: React.ReactNode }) {
     currentTrack,
     currentTrackIndex,
     setCurrentTrackIndex,
-    showPlaylist,
-    setShowPlaylist,
-  }), [currentTrack, currentTrackIndex, showPlaylist]);
+    showQueue,
+    setShowQueue,
+  }), [currentTrack, currentTrackIndex, showQueue]);
 
   const profilingRef = useRef(0);
   useEffect(() => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,9 +11,9 @@
   * - G: Toggle glow effect
   * - S: Toggle shuffle
   * - ?: Show keyboard shortcuts help
-  * - Escape: Close menus (playlist drawer and visual effects)
+  * - Escape: Close menus (queue drawer and visual effects)
   * - M: Mute
-  * - ArrowUp / P: (Pointer device) Toggle playlist drawer; (Touch) ArrowUp = Volume up
+  * - ArrowUp / Q: (Pointer device) Toggle queue drawer; (Touch) ArrowUp = Volume up
   * - ArrowDown / L: (Pointer device) Toggle library drawer; (Touch) ArrowDown = Volume down
   * - K: Like/Unlike track
   */
@@ -32,7 +32,7 @@ interface KeyboardShortcutHandlers {
   onPrevious?: () => void;
   
   // Menu toggles
-  onClosePlaylist?: () => void;
+  onCloseQueue?: () => void;
   onToggleVisualEffectsMenu?: () => void;
   onCloseVisualEffects?: () => void;
   
@@ -55,8 +55,8 @@ interface KeyboardShortcutHandlers {
   onToggleLike?: () => void;
   onToggleShuffle?: () => void;
   onCloseMobileMenu?: () => void;
-  /** Open playlist drawer (desktop: ArrowUp) */
-  onShowPlaylist?: () => void;
+  /** Open queue drawer (desktop: ArrowUp) */
+  onShowQueue?: () => void;
   /** Open library drawer (desktop: ArrowDown) */
   onOpenLibraryDrawer?: () => void;
   /** Toggle zen mode */
@@ -81,7 +81,7 @@ export const useKeyboardShortcuts = (
     onPlayPause,
     onNext,
     onPrevious,
-    onClosePlaylist,
+    onCloseQueue,
     onToggleVisualEffectsMenu,
     onCloseVisualEffects,
     onToggleBackgroundVisualizer,
@@ -94,7 +94,7 @@ export const useKeyboardShortcuts = (
     onToggleLike,
     onToggleShuffle,
     onCloseMobileMenu,
-    onShowPlaylist,
+    onShowQueue,
     onOpenLibraryDrawer,
     onToggleZenMode,
   } = handlers;
@@ -176,7 +176,7 @@ export const useKeyboardShortcuts = (
         case 'Escape':
           event.preventDefault();
           onCloseVisualEffects?.();
-          onClosePlaylist?.();
+          onCloseQueue?.();
           onCloseMobileMenu?.();
           break;
 
@@ -210,11 +210,11 @@ export const useKeyboardShortcuts = (
           }
           break;
 
-        case 'KeyP':
-          // P toggles playlist drawer (alternative to ArrowUp on pointer devices)
+        case 'KeyQ':
+          // Q toggles queue drawer (alternative to ArrowUp on pointer devices)
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
-            onShowPlaylist?.();
+            onShowQueue?.();
           }
           break;
 
@@ -227,9 +227,9 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'ArrowUp':
-          if (prefersPointerInput && onShowPlaylist) {
+          if (prefersPointerInput && onShowQueue) {
             event.preventDefault();
-            onShowPlaylist();
+            onShowQueue();
           } else if (onVolumeUp) {
             event.preventDefault();
             onVolumeUp();
@@ -254,7 +254,7 @@ export const useKeyboardShortcuts = (
     onPlayPause,
     onNext,
     onPrevious,
-    onClosePlaylist,
+    onCloseQueue,
     onToggleVisualEffectsMenu,
     onCloseVisualEffects,
     onToggleBackgroundVisualizer,
@@ -267,7 +267,7 @@ export const useKeyboardShortcuts = (
     onToggleLike,
     onToggleShuffle,
     onCloseMobileMenu,
-    onShowPlaylist,
+    onShowQueue,
     onOpenLibraryDrawer,
     onToggleZenMode,
     prefersPointerInput,

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -92,7 +92,7 @@ export function usePlayerLogic() {
     currentTrack,
     currentTrackIndex,
     setCurrentTrackIndex,
-    setShowPlaylist,
+    setShowQueue,
   } = useCurrentTrackContext();
 
   const {
@@ -501,9 +501,9 @@ export function usePlayerLogic() {
 
   const handleOpenLibraryDrawer = useCallback(() => {
     setShowLibraryDrawer(true);
-    setShowPlaylist(false);
+    setShowQueue(false);
     setShowVisualEffects(false);
-  }, [setShowPlaylist, setShowVisualEffects]);
+  }, [setShowQueue, setShowVisualEffects]);
 
   const handleCloseLibraryDrawer = useCallback(() => {
     setShowLibraryDrawer(false);
@@ -601,9 +601,9 @@ export function usePlayerLogic() {
     setTracks([]);
     setCurrentTrackIndex(0);
     mediaTracksRef.current = [];
-    setShowPlaylist(false);
+    setShowQueue(false);
     setShowVisualEffects(false);
-  }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowPlaylist, setShowVisualEffects]);
+  }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowQueue, setShowVisualEffects]);
 
   /**
    * Start a radio session from the currently playing track.

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -24,7 +24,7 @@ interface TrackState {
   shuffleEnabled: boolean;
 }
 
-interface PlaylistState {
+interface QueueState {
   selectedId: string | null;
   isVisible: boolean;
 }
@@ -58,7 +58,7 @@ interface TrackActions {
   setShuffleEnabled: (enabled: boolean) => void;
 }
 
-interface PlaylistActions {
+interface QueueActions {
   setSelectedId: (id: string | null | ((prev: string | null) => string | null)) => void;
   setVisible: (visible: boolean | ((prev: boolean) => boolean)) => void;
 }
@@ -95,7 +95,7 @@ interface ZenModeActions {
 
 interface PlayerState {
   track: TrackState;
-  playlist: PlaylistState;
+  queue: QueueState;
   color: ColorState;
   visualEffects: VisualEffectsState;
   zenMode: ZenModeState;
@@ -104,7 +104,7 @@ interface PlayerState {
 interface PlayerStateSetters {
   actions: {
     track: TrackActions;
-    playlist: PlaylistActions;
+    queue: QueueActions;
     color: ColorActions;
     visualEffects: VisualEffectsActions;
     zenMode: ZenModeActions;
@@ -129,7 +129,7 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
     false
   );
   const [selectedPlaylistId, setSelectedPlaylistId] = useState<string | null>(null);
-  const [showPlaylist, setShowPlaylist] = useState(false);
+  const [showQueue, setShowQueue] = useState(false);
   const [accentColor, setAccentColor] = useState<string>(theme.colors.accent);
   const [showVisualEffects, setShowVisualEffects] = useState(false);
 
@@ -204,9 +204,9 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
       error,
       shuffleEnabled
     },
-    playlist: {
+    queue: {
       selectedId: selectedPlaylistId,
-      isVisible: showPlaylist
+      isVisible: showQueue
     },
     color: {
       current: accentColor,
@@ -238,9 +238,9 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
         setError,
         setShuffleEnabled
       },
-      playlist: {
+      queue: {
         setSelectedId: setSelectedPlaylistId,
-        setVisible: setShowPlaylist
+        setVisible: setShowQueue
       },
       color: {
         setCurrent: setAccentColor,


### PR DESCRIPTION
## Summary
This PR renames all references to "playlist drawer" to "queue drawer" throughout the codebase to better reflect the component's actual purpose of displaying the playback queue rather than a saved playlist.

## Key Changes

- **Component Renames**: 
  - `PlaylistDrawer.tsx` → `QueueDrawer.tsx`
  - `PlaylistBottomSheet.tsx` → `QueueBottomSheet.tsx`
  - All styled components and interfaces updated accordingly

- **Variable & Function Renames**:
  - `showPlaylist` → `showQueue`
  - `setShowPlaylist` → `setShowQueue`
  - `handleShowPlaylist` → `handleShowQueue`
  - `handleClosePlaylist` → `handleCloseQueue`
  - `PlaylistLoadingFallback` → `QueueLoadingFallback`
  - `PlaylistState` → `QueueState`
  - `PlaylistActions` → `QueueActions`

- **UI Text Updates**:
  - "Show Playlist" button title → "Show Queue"
  - "Loading playlist..." → "Loading queue..."
  - Drawer header text "Playlist" → "Queue" (except when radio is active)
  - Keyboard shortcut help text updated

- **Keyboard Shortcut Changes**:
  - Changed keyboard shortcut from `P` to `Q` for toggling the queue drawer
  - Updated documentation and help text to reflect the new shortcut

- **Container Query Names**:
  - CSS container name `playlist` → `queue`

- **Documentation Updates**:
  - Updated CLAUDE.md and user-guide.md to reflect new terminology and keyboard shortcuts
  - Updated test files and keyboard shortcuts help component

## Implementation Details

The renaming is comprehensive and touches:
- Core player state management (`usePlayerState.ts`, `TrackContext.tsx`)
- Player logic hooks (`usePlayerLogic.ts`)
- Keyboard shortcuts handling (`useKeyboardShortcuts.ts`)
- UI components and styling
- Tests and documentation

All functionality remains unchanged; this is purely a nomenclature update to improve clarity about what the drawer displays.

https://claude.ai/code/session_01XoeuTFqaosG7nEtAXW41oK