### PR TITLE
chore: remove SessionStart hook from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,1 @@
-{
-    "hooks": {
-        "SessionStart": [
-            {
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "bun x gh-setup-hooks",
-                        "timeout": 120
-                    }
-                ]
-            }
-        ]
-    }
-}
+{}


### PR DESCRIPTION
## Summary
- Removes the `SessionStart` hook (`bun x gh-setup-hooks`) from `.claude/settings.json`
- Resets the file to an empty config object `{}`

## Test plan
- [ ] Verify no regressions from the removed hook