### PR TITLE
feat: add queue item management — remove and reorder tracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "vap",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "styled-components": "^6.1.12"
@@ -503,6 +506,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6125,9 +6181,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "capture:mobile": "playwright test --config playwright/capture/capture.config.ts --project mobile"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "styled-components": "^6.1.12"

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -81,6 +81,8 @@ const AudioPlayerComponent = () => {
     onAlbumPlay: handleAlbumPlay,
     onBackToLibrary: handlers.handleBackToLibrary,
     onStartRadio: handlers.handleStartRadio,
+    onRemoveFromQueue: handlers.handleRemoveFromQueue,
+    onReorderQueue: handlers.handleReorderQueue,
   }), [handlers, handleAlbumPlay]);
 
   const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification } = useProviderContext();

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -50,6 +50,8 @@ interface PlaybackHandlers {
   onAlbumPlay: (albumId: string, albumName: string) => void;
   onBackToLibrary: () => void;
   onStartRadio?: () => void;
+  onRemoveFromQueue?: (index: number) => void;
+  onReorderQueue?: (fromIndex: number, toIndex: number) => void;
 }
 
 interface AlbumArtBounds {
@@ -857,6 +859,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
               tracks={tracks}
               currentTrackIndex={currentTrackIndex}
               onTrackSelect={handlers.onTrackSelect}
+              onRemoveTrack={handlers.onRemoveFromQueue}
+              onReorderTracks={handlers.onReorderQueue}
               showProviderIcons={showProviderIcons}
               radioActive={radioActive}
               radioSeedDescription={radioState?.seedDescription}
@@ -872,6 +876,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
               tracks={tracks}
               currentTrackIndex={currentTrackIndex}
               onTrackSelect={handlers.onTrackSelect}
+              onRemoveTrack={handlers.onRemoveFromQueue}
+              onReorderTracks={handlers.onReorderQueue}
               showProviderIcons={showProviderIcons}
               radioActive={radioActive}
               radioSeedDescription={radioState?.seedDescription}

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,10 +1,26 @@
-import React, { memo, useRef, useEffect } from 'react';
+import React, { memo, useRef, useEffect, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import type { Track } from '../services/spotify';
 import { Card, CardHeader, CardContent, CardDescription } from '../components/styled';
 import { ScrollArea } from '../components/styled';
 import { Avatar } from '../components/styled';
 import ProviderIcon from './ProviderIcon';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useHorizontalSwipeToRemove } from '@/hooks/useHorizontalSwipeToRemove';
 
 // Styled components
 const PlaylistContainer = styled.div`
@@ -39,7 +55,7 @@ const PlaylistDescription = styled(CardDescription)`
   margin: 0;
 `;
 
-const PlaylistContent = styled(CardContent)`
+const PlaylistContentArea = styled(CardContent)`
   padding: 0;
   overflow: hidden;
   flex: 1;
@@ -69,7 +85,7 @@ const PlaylistItemContainer = styled.div.withConfig({
   padding: ${({ theme }) => theme.spacing.sm};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease;
   border: 1px solid transparent;
 
   ${({ theme, isSelected }) => isSelected ? `
@@ -110,7 +126,7 @@ const TrackName = styled.div.withConfig({
   font-size: ${({ theme }) => theme.fontSize.base};
   line-height: 1.25;
   color: ${({ isSelected, theme }) => isSelected ? theme.colors.white : '#f5f5f5'};
-  
+
   /* Allow up to 2 lines with ellipsis on overflow */
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -139,10 +155,100 @@ const Duration = styled.span.withConfig({
   flex-shrink: 0;
 `;
 
+const DragHandle = styled.div`
+  flex-shrink: 0;
+  cursor: grab;
+  color: ${({ theme }) => theme.colors.gray[500]};
+  display: flex;
+  align-items: center;
+  padding: 0 2px;
+  touch-action: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+const RemoveButton = styled.button`
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: ${({ theme }) => theme.colors.gray[500]};
+  cursor: pointer;
+  padding: 4px;
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+  ${PlaylistItemContainer}:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.error};
+    background: ${({ theme }) => `color-mix(in srgb, ${theme.colors.error} 15%, transparent)`};
+  }
+`;
+
+const SwipeableWrapper = styled.div`
+  position: relative;
+  overflow: hidden;
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+`;
+
+const SwipeableContent = styled.div.withConfig({
+  shouldForwardProp: (prop) => !['$offsetX', '$isSwiping'].includes(prop),
+})<{ $offsetX: number; $isSwiping: boolean }>`
+  transform: translateX(${({ $offsetX }) => $offsetX}px);
+  transition: ${({ $isSwiping }) => $isSwiping ? 'none' : 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)'};
+  position: relative;
+  z-index: 1;
+`;
+
+const SwipeRemoveBackdrop = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 80px;
+  background: ${({ theme }) => theme.colors.error};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.white};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  border-radius: 0 ${({ theme }) => theme.borderRadius.lg} ${({ theme }) => theme.borderRadius.lg} 0;
+`;
+
+// Drag handle grip icon (6 dots)
+const GripIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <circle cx="5" cy="3" r="1.5" />
+    <circle cx="11" cy="3" r="1.5" />
+    <circle cx="5" cy="8" r="1.5" />
+    <circle cx="11" cy="8" r="1.5" />
+    <circle cx="5" cy="13" r="1.5" />
+    <circle cx="11" cy="13" r="1.5" />
+  </svg>
+);
+
+// Remove X icon
+const RemoveIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <path d="M18 6L6 18M6 6l12 12" />
+  </svg>
+);
+
 interface PlaylistProps {
   tracks: Track[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
+  onRemoveTrack?: (index: number) => void;
+  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
   isOpen?: boolean;
   showProviderIcons?: boolean;
 }
@@ -152,67 +258,267 @@ interface PlaylistItemProps {
   index: number;
   isSelected: boolean;
   onSelect: (index: number) => void;
+  onRemove?: (index: number) => void;
   itemRef?: React.RefObject<HTMLDivElement>;
   showProviderIcon?: boolean;
+  isDragActive?: boolean;
 }
 
-const PlaylistItem = memo<PlaylistItemProps>(({
+// Desktop playlist item with sortable + hover remove
+const SortablePlaylistItem = memo<PlaylistItemProps>(({
   track,
   index,
   isSelected,
   onSelect,
+  onRemove,
   itemRef,
-  showProviderIcon
+  showProviderIcon,
+  isDragActive,
 }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `${track.name}-${track.id}` });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined,
+    position: 'relative' as const,
+  };
+
+  const handleClick = useCallback(() => {
+    if (!isDragActive) {
+      onSelect(index);
+    }
+  }, [onSelect, index, isDragActive]);
+
+  const handleRemoveClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove?.(index);
+  }, [onRemove, index]);
+
   return (
-    <PlaylistItemContainer
-      ref={itemRef}
-      onClick={() => onSelect(index)}
-      isSelected={isSelected}
-    >
-      <AlbumArtContainer>
-        <Avatar
-          src={track.image}
-          alt={track.album}
-          style={{ width: '3rem', height: '3rem' }}
-          fallback={
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-              <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 2a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7zm0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z" fill="currentColor"/>
-            </svg>
-          }
-        />
-        {isSelected && (
-          <PlayIcon>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M8 5v14l11-7z"/>
-            </svg>
-          </PlayIcon>
+    <div ref={setNodeRef} style={style}>
+      <PlaylistItemContainer
+        ref={itemRef}
+        onClick={handleClick}
+        isSelected={isSelected}
+      >
+        {onRemove && (
+          <DragHandle {...attributes} {...listeners}>
+            <GripIcon />
+          </DragHandle>
         )}
-        {showProviderIcon && track.provider && (
-          <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
-            <ProviderIcon provider={track.provider} size={16} />
-          </div>
+
+        <AlbumArtContainer>
+          <Avatar
+            src={track.image}
+            alt={track.album}
+            style={{ width: '3rem', height: '3rem' }}
+            fallback={
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 2a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7zm0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z" fill="currentColor"/>
+              </svg>
+            }
+          />
+          {isSelected && (
+            <PlayIcon>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M8 5v14l11-7z"/>
+              </svg>
+            </PlayIcon>
+          )}
+          {showProviderIcon && track.provider && (
+            <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+              <ProviderIcon provider={track.provider} size={16} />
+            </div>
+          )}
+        </AlbumArtContainer>
+
+        <TrackInfo>
+          <TrackName isSelected={isSelected}>
+            {track.name}
+          </TrackName>
+          <TrackArtist isSelected={isSelected}>
+            {track.artists}
+          </TrackArtist>
+        </TrackInfo>
+
+        <Duration isSelected={isSelected}>
+          {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
+        </Duration>
+
+        {onRemove && !isSelected && (
+          <RemoveButton onClick={handleRemoveClick} aria-label={`Remove ${track.name}`}>
+            <RemoveIcon />
+          </RemoveButton>
         )}
-      </AlbumArtContainer>
-
-      <TrackInfo>
-        <TrackName isSelected={isSelected}>
-          {track.name}
-        </TrackName>
-        <TrackArtist isSelected={isSelected}>
-          {track.artists}
-        </TrackArtist>
-      </TrackInfo>
-
-      <Duration isSelected={isSelected}>
-        {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
-      </Duration>
-    </PlaylistItemContainer>
+      </PlaylistItemContainer>
+    </div>
   );
 });
 
-const Playlist = memo<PlaylistProps>(({ tracks, currentTrackIndex, onTrackSelect, isOpen = false, showProviderIcons = false }) => {
+// Mobile playlist item with swipe-to-remove
+const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
+  track,
+  index,
+  isSelected,
+  onSelect,
+  onRemove,
+  itemRef,
+  showProviderIcon,
+}) => {
+  const canRemove = onRemove && !isSelected;
+
+  const handleRemove = useCallback(() => {
+    onRemove?.(index);
+  }, [onRemove, index]);
+
+  const { ref: swipeRef, offsetX, isSwiping, isRevealed, reset } = useHorizontalSwipeToRemove({
+    onRemove: handleRemove,
+    enabled: !!canRemove,
+  });
+
+  const handleRemoveClick = useCallback(() => {
+    reset();
+    onRemove?.(index);
+  }, [onRemove, index, reset]);
+
+  if (!canRemove) {
+    // No swipe for current track — render without swipe wrapper
+    return (
+      <PlaylistItemContainer
+        ref={itemRef}
+        onClick={() => onSelect(index)}
+        isSelected={isSelected}
+      >
+        <AlbumArtContainer>
+          <Avatar
+            src={track.image}
+            alt={track.album}
+            style={{ width: '3rem', height: '3rem' }}
+            fallback={
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 2a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7zm0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z" fill="currentColor"/>
+              </svg>
+            }
+          />
+          {isSelected && (
+            <PlayIcon>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M8 5v14l11-7z"/>
+              </svg>
+            </PlayIcon>
+          )}
+          {showProviderIcon && track.provider && (
+            <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+              <ProviderIcon provider={track.provider} size={16} />
+            </div>
+          )}
+        </AlbumArtContainer>
+
+        <TrackInfo>
+          <TrackName isSelected={isSelected}>
+            {track.name}
+          </TrackName>
+          <TrackArtist isSelected={isSelected}>
+            {track.artists}
+          </TrackArtist>
+        </TrackInfo>
+
+        <Duration isSelected={isSelected}>
+          {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
+        </Duration>
+      </PlaylistItemContainer>
+    );
+  }
+
+  return (
+    <SwipeableWrapper ref={swipeRef}>
+      {(offsetX < 0 || isRevealed) && (
+        <SwipeRemoveBackdrop>
+          <button
+            onClick={handleRemoveClick}
+            style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '8px 16px', font: 'inherit', fontWeight: 600 }}
+            aria-label={`Remove ${track.name}`}
+          >
+            Remove
+          </button>
+        </SwipeRemoveBackdrop>
+      )}
+      <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
+        <PlaylistItemContainer
+          ref={itemRef}
+          onClick={() => !isRevealed && onSelect(index)}
+          isSelected={isSelected}
+        >
+          <AlbumArtContainer>
+            <Avatar
+              src={track.image}
+              alt={track.album}
+              style={{ width: '3rem', height: '3rem' }}
+              fallback={
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                  <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 2a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7zm0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z" fill="currentColor"/>
+                </svg>
+              }
+            />
+            {showProviderIcon && track.provider && (
+              <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+                <ProviderIcon provider={track.provider} size={16} />
+              </div>
+            )}
+          </AlbumArtContainer>
+
+          <TrackInfo>
+            <TrackName isSelected={isSelected}>
+              {track.name}
+            </TrackName>
+            <TrackArtist isSelected={isSelected}>
+              {track.artists}
+            </TrackArtist>
+          </TrackInfo>
+
+          <Duration isSelected={isSelected}>
+            {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
+          </Duration>
+        </PlaylistItemContainer>
+      </SwipeableContent>
+    </SwipeableWrapper>
+  );
+});
+
+// Detect touch device via media query
+const useIsTouchDevice = () => {
+  const [isTouch, setIsTouch] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(pointer: coarse)');
+    setIsTouch(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsTouch(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isTouch;
+};
+
+const Playlist = memo<PlaylistProps>(({
+  tracks,
+  currentTrackIndex,
+  onTrackSelect,
+  onRemoveTrack,
+  onReorderTracks,
+  isOpen = false,
+  showProviderIcons = false,
+}) => {
   const currentTrackRef = useRef<HTMLDivElement>(null);
+  const isTouch = useIsTouchDevice();
+  const [isDragActive, setIsDragActive] = useState(false);
 
   // Auto-scroll to current track when playlist opens
   useEffect(() => {
@@ -229,33 +535,169 @@ const Playlist = memo<PlaylistProps>(({ tracks, currentTrackIndex, onTrackSelect
     }
   }, [isOpen, currentTrackIndex]);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
+    })
+  );
+
+  const sortableIds = tracks.map(t => `${t.name}-${t.id}`);
+
+  const handleDragStart = useCallback((_event: DragStartEvent) => {
+    setIsDragActive(true);
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setIsDragActive(false);
+    const { active, over } = event;
+    if (!over || active.id === over.id || !onReorderTracks) return;
+
+    const oldIndex = sortableIds.indexOf(String(active.id));
+    const newIndex = sortableIds.indexOf(String(over.id));
+    if (oldIndex !== -1 && newIndex !== -1) {
+      onReorderTracks(oldIndex, newIndex);
+    }
+  }, [sortableIds, onReorderTracks]);
+
+  const canManageQueue = !!(onRemoveTrack || onReorderTracks);
+
+  // On touch devices without reorder support, use swipeable items
+  if (isTouch && !onReorderTracks) {
+    return (
+      <PlaylistContainer>
+        <PlaylistCard>
+          <PlaylistHeader>
+            <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
+          </PlaylistHeader>
+          <PlaylistContentArea>
+            <PlaylistScrollArea>
+              <PlaylistItems>
+                {tracks.map((track, index) => (
+                  <SwipeablePlaylistItem
+                    key={`${track.name}-${track.id}`}
+                    track={track}
+                    index={index}
+                    isSelected={index === currentTrackIndex}
+                    onSelect={onTrackSelect}
+                    onRemove={onRemoveTrack}
+                    itemRef={index === currentTrackIndex ? currentTrackRef : undefined}
+                    showProviderIcon={showProviderIcons}
+                  />
+                ))}
+              </PlaylistItems>
+            </PlaylistScrollArea>
+          </PlaylistContentArea>
+        </PlaylistCard>
+      </PlaylistContainer>
+    );
+  }
+
+  // Desktop / with reorder: use DnD context
+  if (canManageQueue) {
+    return (
+      <PlaylistContainer>
+        <PlaylistCard>
+          <PlaylistHeader>
+            <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
+          </PlaylistHeader>
+          <PlaylistContentArea>
+            <PlaylistScrollArea>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                  <PlaylistItems>
+                    {tracks.map((track, index) => (
+                      <SortablePlaylistItem
+                        key={`${track.name}-${track.id}`}
+                        track={track}
+                        index={index}
+                        isSelected={index === currentTrackIndex}
+                        onSelect={onTrackSelect}
+                        onRemove={onRemoveTrack}
+                        itemRef={index === currentTrackIndex ? currentTrackRef : undefined}
+                        showProviderIcon={showProviderIcons}
+                        isDragActive={isDragActive}
+                      />
+                    ))}
+                  </PlaylistItems>
+                </SortableContext>
+              </DndContext>
+            </PlaylistScrollArea>
+          </PlaylistContentArea>
+        </PlaylistCard>
+      </PlaylistContainer>
+    );
+  }
+
+  // Fallback: no queue management (read-only)
   return (
     <PlaylistContainer>
       <PlaylistCard>
         <PlaylistHeader>
           <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
         </PlaylistHeader>
-
-        <PlaylistContent>
+        <PlaylistContentArea>
           <PlaylistScrollArea>
             <PlaylistItems>
               {tracks.map((track: Track, index: number) => (
-                <PlaylistItem
+                <PlaylistItemContainer
                   key={`${track.name}-${track.id}`}
-                  track={track}
-                  index={index}
+                  ref={index === currentTrackIndex ? currentTrackRef : undefined}
+                  onClick={() => onTrackSelect(index)}
                   isSelected={index === currentTrackIndex}
-                  onSelect={onTrackSelect}
-                  itemRef={index === currentTrackIndex ? currentTrackRef : undefined}
-                  showProviderIcon={showProviderIcons}
-                />
+                >
+                  <AlbumArtContainer>
+                    <Avatar
+                      src={track.image}
+                      alt={track.album}
+                      style={{ width: '3rem', height: '3rem' }}
+                      fallback={
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                          <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 2a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7zm0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z" fill="currentColor"/>
+                        </svg>
+                      }
+                    />
+                    {index === currentTrackIndex && (
+                      <PlayIcon>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M8 5v14l11-7z"/>
+                        </svg>
+                      </PlayIcon>
+                    )}
+                    {showProviderIcons && track.provider && (
+                      <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+                        <ProviderIcon provider={track.provider} size={16} />
+                      </div>
+                    )}
+                  </AlbumArtContainer>
+
+                  <TrackInfo>
+                    <TrackName isSelected={index === currentTrackIndex}>
+                      {track.name}
+                    </TrackName>
+                    <TrackArtist isSelected={index === currentTrackIndex}>
+                      {track.artists}
+                    </TrackArtist>
+                  </TrackInfo>
+
+                  <Duration isSelected={index === currentTrackIndex}>
+                    {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
+                  </Duration>
+                </PlaylistItemContainer>
               ))}
             </PlaylistItems>
           </PlaylistScrollArea>
-        </PlaylistContent>
+        </PlaylistContentArea>
       </PlaylistCard>
     </PlaylistContainer>
   );
 });
 
-export default Playlist; 
+export default Playlist;

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -113,6 +113,8 @@ interface QueueBottomSheetProps {
   tracks: Track[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
+  onRemoveTrack?: (index: number) => void;
+  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
   showProviderIcons?: boolean;
   radioActive?: boolean;
   radioSeedDescription?: string | null;
@@ -126,6 +128,8 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
   tracks,
   currentTrackIndex,
   onTrackSelect,
+  onRemoveTrack,
+  onReorderTracks,
   showProviderIcons,
   radioActive,
   radioSeedDescription,
@@ -204,6 +208,8 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
                   onTrackSelect(index);
                   onClose();
                 }}
+                onRemoveTrack={onRemoveTrack}
+                onReorderTracks={onReorderTracks}
                 isOpen={isOpen}
                 showProviderIcons={showProviderIcons}
               />

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -146,6 +146,8 @@ interface QueueDrawerProps {
   tracks: Track[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
+  onRemoveTrack?: (index: number) => void;
+  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
   showProviderIcons?: boolean;
   radioActive?: boolean;
   radioSeedDescription?: string | null;
@@ -194,6 +196,8 @@ const QueueDrawer = memo<QueueDrawerProps>(({
   tracks,
   currentTrackIndex,
   onTrackSelect,
+  onRemoveTrack,
+  onReorderTracks,
   showProviderIcons,
   radioActive,
   radioSeedDescription,
@@ -266,6 +270,8 @@ const QueueDrawer = memo<QueueDrawerProps>(({
                 onTrackSelect(index);
                 onClose();
               }}
+              onRemoveTrack={onRemoveTrack}
+              onReorderTracks={onReorderTracks}
               isOpen={isOpen}
               showProviderIcons={showProviderIcons}
             />

--- a/src/hooks/useHorizontalSwipeToRemove.ts
+++ b/src/hooks/useHorizontalSwipeToRemove.ts
@@ -1,0 +1,152 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+interface UseHorizontalSwipeToRemoveOptions {
+  onRemove: () => void;
+  enabled?: boolean;
+  threshold?: number;
+}
+
+interface UseHorizontalSwipeToRemoveReturn {
+  ref: React.RefObject<HTMLDivElement>;
+  offsetX: number;
+  isSwiping: boolean;
+  isRevealed: boolean;
+  reset: () => void;
+}
+
+const DIRECTION_LOCK_THRESHOLD = 10;
+const DEFAULT_THRESHOLD = 80;
+
+export function useHorizontalSwipeToRemove(
+  options: UseHorizontalSwipeToRemoveOptions
+): UseHorizontalSwipeToRemoveReturn {
+  const {
+    onRemove,
+    enabled = true,
+    threshold = DEFAULT_THRESHOLD,
+  } = options;
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [offsetX, setOffsetX] = useState(0);
+  const [isSwiping, setIsSwiping] = useState(false);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const directionLockedRef = useRef<'horizontal' | 'vertical' | null>(null);
+  const currentDeltaXRef = useRef(0);
+  const isRevealedRef = useRef(false);
+
+  const onRemoveRef = useRef(onRemove);
+  onRemoveRef.current = onRemove;
+
+  const reset = useCallback(() => {
+    setIsSwiping(false);
+    setOffsetX(0);
+    setIsRevealed(false);
+    isRevealedRef.current = false;
+    currentDeltaXRef.current = 0;
+    directionLockedRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || !enabled) return;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      startXRef.current = touch.clientX;
+      startYRef.current = touch.clientY;
+      currentDeltaXRef.current = 0;
+      directionLockedRef.current = null;
+
+      // If already revealed, start from revealed position
+      if (isRevealedRef.current) {
+        currentDeltaXRef.current = -threshold;
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (directionLockedRef.current === 'vertical') return;
+
+      const touch = e.touches[0];
+      const deltaX = touch.clientX - startXRef.current;
+      const deltaY = touch.clientY - startYRef.current;
+
+      if (directionLockedRef.current === null) {
+        const absDX = Math.abs(deltaX);
+        const absDY = Math.abs(deltaY);
+
+        if (absDX < DIRECTION_LOCK_THRESHOLD && absDY < DIRECTION_LOCK_THRESHOLD) {
+          return;
+        }
+
+        if (absDY > absDX) {
+          directionLockedRef.current = 'vertical';
+          return;
+        }
+
+        directionLockedRef.current = 'horizontal';
+        setIsSwiping(true);
+      }
+
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+
+      let newOffset: number;
+      if (isRevealedRef.current) {
+        // Already revealed: allow swiping right to close or further left
+        newOffset = -threshold + deltaX;
+      } else {
+        newOffset = deltaX;
+      }
+
+      // Clamp: only allow leftward (negative), max at -threshold * 1.2
+      newOffset = Math.min(0, Math.max(-threshold * 1.2, newOffset));
+      currentDeltaXRef.current = newOffset;
+      setOffsetX(newOffset);
+    };
+
+    const handleTouchEnd = () => {
+      if (directionLockedRef.current !== 'horizontal') {
+        directionLockedRef.current = null;
+        return;
+      }
+
+      const offset = currentDeltaXRef.current;
+
+      if (isRevealedRef.current) {
+        // If swiped back past half the threshold, close
+        if (offset > -threshold / 2) {
+          reset();
+        }
+        // Otherwise keep revealed
+      } else {
+        // If swiped past threshold, reveal
+        if (Math.abs(offset) >= threshold) {
+          setOffsetX(-threshold);
+          setIsRevealed(true);
+          isRevealedRef.current = true;
+        } else {
+          reset();
+        }
+      }
+
+      setIsSwiping(false);
+      directionLockedRef.current = null;
+    };
+
+    element.addEventListener('touchstart', handleTouchStart, { passive: true });
+    element.addEventListener('touchmove', handleTouchMove, { passive: false });
+    element.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+    return () => {
+      element.removeEventListener('touchstart', handleTouchStart);
+      element.removeEventListener('touchmove', handleTouchMove);
+      element.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [enabled, threshold, reset]);
+
+  return { ref, offsetX, isSwiping, isRevealed, reset };
+}

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -77,6 +77,7 @@ export function usePlayerLogic() {
   // In mixed queues these can differ, so playback controls should prefer the driving provider.
   const {
     tracks,
+    originalTracks,
     isLoading,
     error,
     shuffleEnabled,
@@ -605,6 +606,91 @@ export function usePlayerLogic() {
     setShowVisualEffects(false);
   }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowQueue, setShowVisualEffects]);
 
+  // ── Remove from queue ──────────────────────────────────────────────
+
+  const handleRemoveFromQueue = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= tracks.length) return;
+      // Cannot remove the currently playing track
+      if (index === currentTrackIndex) return;
+
+      const removedTrack = tracks[index];
+      console.log(`[Queue] handleRemoveFromQueue — removing index=${index}, track=${trkSummary(removedTrack)}, queueLen=${tracks.length}`);
+
+      // If this would empty the queue, go back to library
+      if (tracks.length <= 1) {
+        handleBackToLibrary();
+        return;
+      }
+
+      // Remove from mediaTracksRef by ID
+      mediaTracksRef.current = mediaTracksRef.current.filter(m => m.id !== removedTrack.id);
+
+      // Remove from originalTracks by ID (order-independent for shuffle)
+      setOriginalTracks(originalTracks.filter(t => t.id !== removedTrack.id));
+
+      // Adjust currentTrackIndex if removing before current
+      if (index < currentTrackIndex) {
+        setCurrentTrackIndex(prev => prev - 1);
+      }
+
+      // Remove from tracks by index
+      setTracks(prev => prev.filter((_, i) => i !== index));
+
+      console.log(`[Queue] handleRemoveFromQueue — done, new queueLen=${tracks.length - 1}`);
+    },
+    [tracks, originalTracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex]
+  );
+
+  // ── Reorder queue ─────────────────────────────────────────────────
+
+  const handleReorderQueue = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) return;
+      if (fromIndex < 0 || fromIndex >= tracks.length) return;
+      if (toIndex < 0 || toIndex >= tracks.length) return;
+
+      console.log(`[Queue] handleReorderQueue — from=${fromIndex} to=${toIndex}, queueLen=${tracks.length}`);
+
+      const currentTrackId = tracks[currentTrackIndex]?.id;
+
+      // Array move helper
+      const moveItem = <T,>(arr: T[], from: number, to: number): T[] => {
+        const result = [...arr];
+        const [item] = result.splice(from, 1);
+        result.splice(to, 0, item);
+        return result;
+      };
+
+      const newTracks = moveItem(tracks, fromIndex, toIndex);
+
+      // Update currentTrackIndex to follow the currently playing track
+      const newCurrentIndex = currentTrackId
+        ? newTracks.findIndex(t => t.id === currentTrackId)
+        : currentTrackIndex;
+
+      // Reorder mediaTracksRef to match
+      const idToMedia = new Map(mediaTracksRef.current.map(m => [m.id, m]));
+      const reorderedMedia = newTracks
+        .map(t => idToMedia.get(t.id))
+        .filter((m): m is MediaTrack => m !== undefined);
+      if (reorderedMedia.length === newTracks.length) {
+        mediaTracksRef.current = reorderedMedia;
+      }
+
+      // Only update originalTracks if shuffle is off
+      if (!shuffleEnabled) {
+        setOriginalTracks(newTracks);
+      }
+
+      setCurrentTrackIndex(newCurrentIndex >= 0 ? newCurrentIndex : 0);
+      setTracks(newTracks);
+
+      console.log(`[Queue] handleReorderQueue — done, currentIndex=${newCurrentIndex}`);
+    },
+    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex]
+  );
+
   /**
    * Start a radio session from the currently playing track.
    * Provider-agnostic: fetches catalog from the active provider, generates
@@ -717,6 +803,8 @@ export function usePlayerLogic() {
       handleCloseLibraryDrawer,
       handleBackToLibrary,
       handleStartRadio,
+      handleRemoveFromQueue,
+      handleReorderQueue,
     }),
     [
       handlePlaylistSelect,
@@ -730,6 +818,8 @@ export function usePlayerLogic() {
       handleCloseLibraryDrawer,
       handleBackToLibrary,
       handleStartRadio,
+      handleRemoveFromQueue,
+      handleReorderQueue,
     ]
   );
 


### PR DESCRIPTION
## Summary

- Add remove and reorder functionality for queue tracks
- Implement swipe-to-remove gesture on touch devices via `useHorizontalSwipeToRemove` hook
- Add drag-and-drop reordering on desktop via `@dnd-kit`
- Wire up `onRemoveTrack` and `onReorderTracks` handlers through `QueueDrawer` and `QueueBottomSheet`

## Changes

- **`Playlist.tsx`** — Three rendering modes: swipeable items (touch, no reorder), sortable drag-and-drop items (desktop with reorder), read-only fallback. Left-swipe past threshold reveals red "Remove" backdrop; X button appears on hover for desktop.
- **`useHorizontalSwipeToRemove.ts`** — New hook handling touch direction-locking, swipe threshold (80px), snap-back animation, and reveal state.
- **`usePlayerLogic.ts`** — `handleRemoveFromQueue` and `handleReorderQueue` implementations; guards against removing the currently playing track; keeps `tracks`, `mediaTracksRef`, and `originalTracks` in sync; adjusts current index on removal.
- **`QueueDrawer.tsx` / `QueueBottomSheet.tsx`** — Pass `onRemoveTrack` and `onReorderTracks` props down to `Playlist`.
- **`PlayerContent.tsx` / `AudioPlayer.tsx`** — Plumb the new handlers from `usePlayerLogic` to the queue components.

## Test plan

- [ ] On a touch device (or browser with `pointer: coarse` emulation), open the queue and swipe a non-playing track left — verify it's removed
- [ ] On desktop, open the queue and drag tracks to reorder — verify order updates correctly
- [ ] On desktop, hover a non-playing track and click X — verify removal
- [ ] Verify the currently playing track cannot be removed (no swipe, no X button)
- [ ] Verify removing the last track returns to the library
- [ ] Run `npm run test:run` — all 502 tests pass