### PR TITLE
fix: preserve queue order when saving to Spotify playlist

### DIFF
--- a/src/hooks/useSaveQueueAsPlaylist.ts
+++ b/src/hooks/useSaveQueueAsPlaylist.ts
@@ -42,27 +42,26 @@ const MAX_CONCURRENT_RESOLVE = 3;
  */
 async function resolveTrackUris(tracks: Track[]): Promise<{ uris: string[]; skipped: number }> {
   const resolveEnabled = spotifyQueueSync.isResolveEnabled();
-  const uris: string[] = [];
-  let skipped = 0;
 
-  // Split into Spotify and non-Spotify
-  const toResolve: Track[] = [];
-  for (const track of tracks) {
+  // Build a slot per track to preserve original queue order
+  const slots: (string | null)[] = new Array(tracks.length).fill(null);
+  const toResolve: { index: number; track: Track }[] = [];
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
     if (track.provider === 'spotify' || !track.provider) {
-      if (track.uri) uris.push(track.uri);
-      else skipped++;
+      slots[i] = track.uri ?? null;
     } else if (resolveEnabled) {
-      toResolve.push(track);
-    } else {
-      skipped++;
+      toResolve.push({ index: i, track });
     }
+    // else: slot stays null → skipped
   }
 
-  // Resolve non-Spotify tracks
+  // Resolve non-Spotify tracks in batches, writing results back into slots
   for (let i = 0; i < toResolve.length; i += MAX_CONCURRENT_RESOLVE) {
     const chunk = toResolve.slice(i, i + MAX_CONCURRENT_RESOLVE);
     const results = await Promise.all(
-      chunk.map(async (track) => {
+      chunk.map(async ({ track }) => {
         // Check queue sync cache first
         const cached = spotifyQueueSync.getResolvedUri(track.id);
         if (cached) return cached;
@@ -78,10 +77,17 @@ async function resolveTrackUris(tracks: Track[]): Promise<{ uris: string[]; skip
       }),
     );
 
-    for (const uri of results) {
-      if (uri) uris.push(uri);
-      else skipped++;
+    for (let j = 0; j < chunk.length; j++) {
+      slots[chunk[j].index] = results[j];
     }
+  }
+
+  // Collect results in original order
+  const uris: string[] = [];
+  let skipped = 0;
+  for (const uri of slots) {
+    if (uri) uris.push(uri);
+    else skipped++;
   }
 
   return { uris, skipped };


### PR DESCRIPTION
## Summary

- When saving a mixed Dropbox+Spotify queue as a Spotify playlist, non-Spotify tracks were all appended after the Spotify tracks instead of appearing at their correct positions
- Root cause: `resolveTrackUris` pushed Spotify URIs into the output array eagerly during the initial split loop, then appended resolved non-Spotify URIs afterward — losing interleaving

## Fix

Replaced the two-pass approach with slot-based indexing:
1. Pre-allocate a `slots` array with one entry per track (preserving original indices)
2. Fill Spotify URIs directly into their indexed slots
3. Resolve non-Spotify tracks in batches and write results back into their original slot positions
4. Collect `slots` in order to produce the final URI array

## Test plan

- [ ] Play a Dropbox album, generate radio from first track, save queue as Spotify playlist — verify Dropbox tracks appear interspersed at their correct positions, not all at the end
- [ ] Save a Spotify-only queue — behavior unchanged
- [ ] Save a queue with unresolvable tracks — skipped count still correct
- [ ] All 502 existing tests pass (`npm run test:run`)