### PR TITLE
fix(library): align refresh button with mobile filter controls

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
 import { theme } from '@/styles/theme';
 import {
@@ -70,7 +70,7 @@ const DrawerHeader = styled.div`
   padding: ${theme.spacing.sm} ${theme.spacing.md};
   min-height: 48px;
   display: grid;
-  grid-template-columns: 40px 1fr 40px;
+  grid-template-columns: 40px 1fr;
   align-items: center;
   touch-action: none;
 `;
@@ -101,35 +101,6 @@ const DrawerTitle = styled.h3`
   font-size: ${theme.fontSize.xl};
   font-weight: ${theme.fontWeight.semibold};
   text-align: center;
-`;
-
-const spin = keyframes`
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-`;
-
-const RefreshButton = styled.button<{ $spinning: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: none;
-  background: none;
-  color: ${({ theme }) => theme.colors.foreground};
-  cursor: pointer;
-  border-radius: 50%;
-  transition: background ${({ theme }) => theme.transitions.fast} ease;
-  padding: 0;
-  justify-self: end;
-
-  &:active {
-    background: ${({ theme }) => theme.colors.control.background};
-  }
-
-  & > svg {
-    animation: ${({ $spinning }) => ($spinning ? spin : 'none')} 0.8s linear infinite;
-  }
 `;
 
 const DrawerContent = styled.div`
@@ -204,19 +175,6 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
                 </svg>
               </CloseButton>
               <DrawerTitle>Library</DrawerTitle>
-              <RefreshButton
-                onClick={handleRefresh}
-                $spinning={isRefreshing}
-                aria-label="Refresh library"
-                title="Refresh library"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                  <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </RefreshButton>
             </DrawerHeader>
             <DrawerContent>
               <PlaylistSelection
@@ -225,6 +183,8 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
                 inDrawer
                 initialSearchQuery={initialSearchQuery}
                 initialViewMode={initialViewMode}
+                onLibraryRefresh={handleRefresh}
+                isLibraryRefreshing={isRefreshing}
               />
             </DrawerContent>
             <SwipeHandle

--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -48,6 +48,10 @@ interface PlaylistSelectionProps {
   initialSearchQuery?: string;
   /** Set the active tab when the drawer opens */
   initialViewMode?: 'playlists' | 'albums';
+  /** Drawer-only: show refresh button near the sort dropdown */
+  onLibraryRefresh?: () => void;
+  /** Drawer-only: controls the refresh spinner */
+  isLibraryRefreshing?: boolean;
 }
 
 type AlbumPopoverState = {
@@ -382,12 +386,28 @@ const TabButton = styled.button<{ $active: boolean }>`
   }
 `;
 
-const ControlsContainer = styled.div`
+const ControlsContainer = styled.div<{ $inDrawer?: boolean }>`
   display: flex;
   gap: 0.75rem;
   align-items: center;
   margin-bottom: 1rem;
   flex-wrap: wrap;
+  ${({ $inDrawer }) =>
+    $inDrawer
+      ? `
+    flex-direction: column;
+    align-items: stretch;
+    flex-wrap: nowrap;
+  `
+      : ''}
+`;
+
+const SortControlsRow = styled.div`
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
 `;
 
 const SearchInput = styled.input`
@@ -434,6 +454,30 @@ const SelectDropdown = styled.select`
   option {
     background: ${({ theme }) => theme.colors.popover.background};
     color: ${({ theme }) => theme.colors.white};
+  }
+`;
+
+const RefreshButton = styled.button<{ $spinning: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: none;
+  color: ${({ theme }) => theme.colors.foreground};
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background ${({ theme }) => theme.transitions.fast} ease;
+  padding: 0;
+  flex-shrink: 0;
+
+  &:active {
+    background: ${({ theme }) => theme.colors.control.background};
+  }
+
+  & > svg {
+    animation: ${({ $spinning }) => ($spinning ? 'vorbis-spinner-spin 0.8s linear infinite' : 'none')};
   }
 `;
 
@@ -655,7 +699,16 @@ const GridCardImageComponent: React.FC<LazyImageProps> = React.memo(function Gri
   );
 });
 
-const PlaylistSelection = React.memo(function PlaylistSelection({ onPlaylistSelect, onAddToQueue, inDrawer = false, swipeZoneRef, initialSearchQuery, initialViewMode }: PlaylistSelectionProps): JSX.Element {
+const PlaylistSelection = React.memo(function PlaylistSelection({
+  onPlaylistSelect,
+  onAddToQueue,
+  inDrawer = false,
+  swipeZoneRef,
+  initialSearchQuery,
+  initialViewMode,
+  onLibraryRefresh,
+  isLibraryRefreshing
+}: PlaylistSelectionProps): JSX.Element {
   const { activeDescriptor, hasMultipleProviders, enabledProviderIds, getDescriptor } = useProviderContext();
   const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
   const showProviderBadges = hasMultipleProviders && enabledProviderIds.length > 1;
@@ -1014,50 +1067,116 @@ const PlaylistSelection = React.memo(function PlaylistSelection({ onPlaylistSele
   const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !libraryFullyLoaded));
 
   const searchAndSortControls = (
-    <ControlsContainer>
-      <SearchInput
-        type="text"
-        placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-      />
+    inDrawer ? (
+      <ControlsContainer $inDrawer>
+        <SearchInput
+          type="text"
+          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
 
-      {viewMode === 'playlists' ? (
-        <SelectDropdown
-          value={playlistSort}
-          onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
-        >
-          <option value="recently-added">Recently Added</option>
-          <option value="name-asc">Name (A-Z)</option>
-          <option value="name-desc">Name (Z-A)</option>
-        </SelectDropdown>
-      ) : (
-        <SelectDropdown
-          value={albumSort}
-          onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
-        >
-          <option value="recently-added">Recently Added</option>
-          <option value="name-asc">Name (A-Z)</option>
-          <option value="name-desc">Name (Z-A)</option>
-          <option value="artist-asc">Artist (A-Z)</option>
-          <option value="artist-desc">Artist (Z-A)</option>
-          <option value="release-newest">Release (Newest)</option>
-          <option value="release-oldest">Release (Oldest)</option>
-        </SelectDropdown>
-      )}
+        <SortControlsRow>
+          {viewMode === 'playlists' ? (
+            <SelectDropdown
+              value={playlistSort}
+              onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
+              style={{ flex: 1, minWidth: 0 }}
+            >
+              <option value="recently-added">Recently Added</option>
+              <option value="name-asc">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+            </SelectDropdown>
+          ) : (
+            <SelectDropdown
+              value={albumSort}
+              onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
+              style={{ flex: 1, minWidth: 0 }}
+            >
+              <option value="recently-added">Recently Added</option>
+              <option value="name-asc">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+              <option value="artist-asc">Artist (A-Z)</option>
+              <option value="artist-desc">Artist (Z-A)</option>
+              <option value="release-newest">Release (Newest)</option>
+              <option value="release-oldest">Release (Oldest)</option>
+            </SelectDropdown>
+          )}
+
+          {onLibraryRefresh && (
+            <RefreshButton
+              onClick={onLibraryRefresh}
+              $spinning={!!isLibraryRefreshing}
+              aria-label="Refresh library"
+              title="Refresh library"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </RefreshButton>
+          )}
+        </SortControlsRow>
+
+        {(searchQuery || artistFilter) && (
+          <ClearButton
+            onClick={() => {
+              setSearchQuery('');
+              setArtistFilter('');
+            }}
+          >
+            Clear
+          </ClearButton>
+        )}
+      </ControlsContainer>
+    ) : (
+      <ControlsContainer>
+        <SearchInput
+          type="text"
+          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+
+        {viewMode === 'playlists' ? (
+          <SelectDropdown
+            value={playlistSort}
+            onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
+          >
+            <option value="recently-added">Recently Added</option>
+            <option value="name-asc">Name (A-Z)</option>
+            <option value="name-desc">Name (Z-A)</option>
+          </SelectDropdown>
+        ) : (
+          <SelectDropdown
+            value={albumSort}
+            onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
+          >
+            <option value="recently-added">Recently Added</option>
+            <option value="name-asc">Name (A-Z)</option>
+            <option value="name-desc">Name (Z-A)</option>
+            <option value="artist-asc">Artist (A-Z)</option>
+            <option value="artist-desc">Artist (Z-A)</option>
+            <option value="release-newest">Release (Newest)</option>
+            <option value="release-oldest">Release (Oldest)</option>
+          </SelectDropdown>
+        )}
 
 
-      {(searchQuery || artistFilter) && (
-        <ClearButton
-          onClick={() => {
-            setSearchQuery('');
-            setArtistFilter('');
-          }}
-        >
-          Clear
-        </ClearButton>
-      )}
-    </ControlsContainer>
+        {(searchQuery || artistFilter) && (
+          <ClearButton
+            onClick={() => {
+              setSearchQuery('');
+              setArtistFilter('');
+            }}
+          >
+            Clear
+          </ClearButton>
+        )}
+      </ControlsContainer>
+    )
   );
 
   const tabsBar = (


### PR DESCRIPTION
## Summary
- move the library refresh action out of the top-right header slot in the drawer
- place refresh inline with the bottom search/sort controls on mobile so it is easier to reach
- preserve the existing refresh behavior and spinner state by passing refresh props from `LibraryDrawer` into `PlaylistSelection`

## Test plan
- [x] Open library drawer on mobile-sized viewport and verify refresh appears next to the sort dropdown
- [x] Verify no extra dedicated footer row is added for refresh
- [x] Tap refresh and confirm spinner animates and library refresh event still fires
- [x] Confirm no linter errors in modified files

Made with [Cursor](https://cursor.com)