### PR TITLE
fix: respect iOS notch/safe-area in PWA mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ const AppContainer = styled.div`
   color: ${({ theme }) => theme.colors.foreground};
   min-height: 100vh;
   min-height: 100dvh;
+  box-sizing: border-box;
+  padding-top: env(safe-area-inset-top, 0px);
   ${flexCenter}
 `;
 


### PR DESCRIPTION
## Summary

- Adds `padding-top: env(safe-area-inset-top, 0px)` to `AppContainer` in `src/App.tsx`
- Adds `box-sizing: border-box` to ensure the padding doesn't affect `min-height: 100dvh`
- Keeps `viewport-fit=cover` intact so the background visuals still fill edge-to-edge

## Problem

When the app is added to the iPhone home screen as a PWA, the app renders in standalone/fullscreen mode. The existing `viewport-fit=cover` + `apple-mobile-web-app-status-bar-style: black-translucent` meta tags allow content to extend behind the notch and status area. The app had safe-area insets applied at the bottom (BottomBar) but not the top, so content was bleeding up through the notch.

## Solution

Applied `env(safe-area-inset-top)` padding to the outermost app container. On non-notch devices or regular browser tabs the env() variable resolves to 0, so there is no visual change on those surfaces.

## Test plan

- [ ] Add app to iPhone home screen
- [ ] Open from home screen (standalone mode)
- [ ] Verify content starts below the notch/status bar
- [ ] Verify background still fills full screen edge-to-edge
- [ ] Verify layout looks correct in regular Safari tab (no extra gap)

Made with [Cursor](https://cursor.com)