### PR TITLE
fix(library): center drawer header and provider connection row

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -24,7 +24,7 @@ interface LibraryDrawerProps {
 
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
-})<{
+}) <{
   $isOpen: boolean;
   $isDragging: boolean;
   $dragOffset: number;
@@ -69,9 +69,10 @@ const DrawerHeader = styled.div`
   flex-shrink: 0;
   padding: ${theme.spacing.sm} ${theme.spacing.md};
   min-height: 48px;
-  display: grid;
-  grid-template-columns: 40px 1fr;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
+  position: relative;
   touch-action: none;
 `;
 
@@ -101,6 +102,10 @@ const DrawerTitle = styled.h3`
   font-size: ${theme.fontSize.xl};
   font-weight: ${theme.fontWeight.semibold};
   text-align: center;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
 `;
 
 const DrawerContent = styled.div`

--- a/src/components/LibraryProviderBar.tsx
+++ b/src/components/LibraryProviderBar.tsx
@@ -10,8 +10,11 @@ const TOGGLE_OFF_COLOR = 'rgba(255, 255, 255, 0.25)';
 const Bar = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: ${({ theme }) => theme.spacing.md};
-  padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.md};
+  row-gap: ${({ theme }) => theme.spacing.xs};
+  padding: ${({ theme }) => theme.spacing.xs} 0;
   flex-shrink: 0;
 `;
 


### PR DESCRIPTION
## Summary
- center the `Library` drawer title using absolute centering so side controls no longer visually shift it
- center and wrap provider connection rows to remove left-heavy alignment in the provider status bar
- reduce extra horizontal inset in the provider bar to better align top sections with the tab area

## Test plan
- [x] Open Library drawer on mobile-sized viewport and verify `Library` title is visually centered
- [x] Verify provider connection row appears centered and wraps cleanly when space is constrained
- [ ] Run full automated test suite

Made with [Cursor](https://cursor.com)