### PR TITLE
feat(dropbox): implement album art caching for improved performance

### DIFF
--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -8,6 +8,7 @@ const DB_NAME = 'vorbis-dropbox-art';
 const DB_VERSION = 6;
 const STORE = 'art';
 const ART_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const ALBUM_ART_KEY_PREFIX = 'album:';
 
 interface CachedArt {
   path: string;
@@ -92,6 +93,20 @@ export async function putArt(path: string, dataUrl: string): Promise<void> {
       resolve();
     }
   });
+}
+
+function albumArtCacheKey(albumPath: string): string {
+  return `${ALBUM_ART_KEY_PREFIX}${albumPath}`;
+}
+
+export async function getAlbumArt(albumPath: string): Promise<string | null> {
+  if (!albumPath) return null;
+  return getArt(albumArtCacheKey(albumPath));
+}
+
+export async function putAlbumArt(albumPath: string, dataUrl: string): Promise<void> {
+  if (!albumPath || !dataUrl) return;
+  await putArt(albumArtCacheKey(albumPath), dataUrl);
 }
 
 export async function clearArt(): Promise<void> {

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -17,7 +17,15 @@
 import type { CatalogProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, MediaCollection, CollectionRef } from '@/types/domain';
 import { DropboxAuthAdapter } from './dropboxAuthAdapter';
-import { getArt, putArt, clearArt, getDurationsMap, getTagsMap } from './dropboxArtCache';
+import {
+  getArt,
+  putArt,
+  clearArt,
+  getDurationsMap,
+  getTagsMap,
+  getAlbumArt,
+  putAlbumArt,
+} from './dropboxArtCache';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import {
   getLikedTracks,
@@ -35,7 +43,6 @@ import { getLikesSync } from './dropboxLikesSync';
 const AUDIO_EXTENSIONS = ['.mp3', '.flac', '.ogg', '.m4a', '.wav', '.aac', '.wma', '.opus'];
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
 const ALBUM_ART_NAMES = ['cover', 'album', 'folder', 'front', 'album cover', 'album_cover', 'artwork'];
-const THUMBNAIL_ART_NAMES = ['thumb', 'thumbnail'];
 
 interface DropboxFileEntry {
   '.tag': 'file' | 'folder';
@@ -77,11 +84,6 @@ function findArtByNames(entries: DropboxFileEntry[], names: string[]): string | 
 function pickAlbumArtPath(entries: DropboxFileEntry[]): string | null {
   if (entries.length === 0) return null;
   return findArtByNames(entries, ALBUM_ART_NAMES) ?? entries[0].path_lower;
-}
-
-function pickThumbnailArtPath(entries: DropboxFileEntry[]): string | null {
-  if (entries.length === 0) return null;
-  return findArtByNames(entries, THUMBNAIL_ART_NAMES) ?? pickAlbumArtPath(entries);
 }
 
 function parentDir(path: string): string {
@@ -161,6 +163,49 @@ export class DropboxCatalogAdapter implements CatalogProvider {
   /** Clears all cached album art, forcing a fresh download on next library load. */
   async clearArtCache(): Promise<void> {
     await clearArt();
+  }
+
+  async getAlbumArtForAlbum(albumPath: string): Promise<string | null> {
+    return getAlbumArt(albumPath);
+  }
+
+  async cacheAlbumArtForAlbum(albumPath: string, dataUrl: string): Promise<void> {
+    await putAlbumArt(albumPath, dataUrl);
+  }
+
+  /**
+   * Resolve artwork once per album directory, with fallback to album-level cached art.
+   * This keeps track/collection artwork consistent and avoids redundant network fetches.
+   */
+  private async resolveAlbumArtByDir(
+    imagesByDir: Map<string, DropboxFileEntry[]>,
+    albumDirs: Iterable<string>,
+  ): Promise<Map<string, string>> {
+    const dirToImageUrl = new Map<string, string>();
+    const uniqueDirs = Array.from(new Set(albumDirs));
+
+    await Promise.all(
+      uniqueDirs.map(async (dir) => {
+        const entries = imagesByDir.get(dir) ?? [];
+        const imagePath = pickAlbumArtPath(entries);
+        if (imagePath) {
+          const imageUrl = await this.fetchArtDataUrl(imagePath);
+          if (imageUrl) {
+            dirToImageUrl.set(dir, imageUrl);
+            // Keep an album-keyed alias so tracks from this album can hydrate instantly.
+            await putAlbumArt(dir, imageUrl);
+            return;
+          }
+        }
+
+        const cachedAlbumArt = await getAlbumArt(dir);
+        if (cachedAlbumArt) {
+          dirToImageUrl.set(dir, cachedAlbumArt);
+        }
+      }),
+    );
+
+    return dirToImageUrl;
   }
 
   private async dropboxApi<T>(
@@ -255,21 +300,7 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         processBatch(result.entries);
       }
 
-      // Fetch and cache art data URLs for each album directory in parallel
-      const dirImagePaths = new Map<string, string>();
-      for (const dirPath of audioCount.keys()) {
-        const entries = imagesByDir.get(dirPath) ?? [];
-        const path = pickThumbnailArtPath(entries);
-        if (path) dirImagePaths.set(dirPath, path);
-      }
-
-      const dirToImageUrl = new Map<string, string>();
-      await Promise.all(
-        Array.from(dirImagePaths.entries()).map(async ([dir, path]) => {
-          const url = await this.fetchArtDataUrl(path);
-          if (url) dirToImageUrl.set(dir, url);
-        }),
-      );
+      const dirToImageUrl = await this.resolveAlbumArtByDir(imagesByDir, audioCount.keys());
 
       let totalTracks = 0;
       const albums: MediaCollection[] = [];
@@ -350,19 +381,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         processBatch(result.entries);
       }
 
-      const dirToImagePath = new Map<string, string>();
-      for (const [dir, entries] of imagesByDir) {
-        const path = pickAlbumArtPath(entries);
-        if (path) dirToImagePath.set(dir, path);
-      }
-
-      const dirToImageUrl = new Map<string, string>();
-      await Promise.all(
-        Array.from(dirToImagePath.entries()).map(async ([dir, path]) => {
-          const url = await this.fetchArtDataUrl(path);
-          if (url) dirToImageUrl.set(dir, url);
-        }),
-      );
+      const albumDirs = audioEntries.map((entry) => parentDir(entry.path_lower));
+      const dirToImageUrl = await this.resolveAlbumArtByDir(imagesByDir, albumDirs);
 
       const tracks: MediaTrack[] = audioEntries.map((entry) => {
         const dir = parentDir(entry.path_lower);

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -63,6 +63,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     const streamUrl = await this.catalog.getTemporaryLink(dropboxPath);
 
     this.currentTrack = track;
+    this.hydrateAlbumArtFromCache(track);
     this.pendingMetadataUpdate = null;
     this.pendingDurationMs = null;
     this.audio!.src = streamUrl;
@@ -70,6 +71,26 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
     this.startUpdateInterval();
     this.enrichMetadataInBackground(track, streamUrl);
+  }
+
+  private hydrateAlbumArtFromCache(track: MediaTrack): void {
+    if (track.image || !track.albumId) return;
+    this.catalog.getAlbumArtForAlbum(track.albumId)
+      .then((cachedImage) => {
+        if (!cachedImage) return;
+        if (this.currentTrack?.id !== track.id) return;
+        if (this.currentTrack.image) return;
+
+        this.currentTrack = { ...this.currentTrack, image: cachedImage };
+        this.pendingMetadataUpdate = {
+          ...(this.pendingMetadataUpdate ?? {}),
+          image: cachedImage,
+        };
+        this.notifyListeners();
+      })
+      .catch(() => {
+        // Best-effort cache hydration.
+      });
   }
 
   private enrichMetadataInBackground(track: MediaTrack, streamUrl: string): void {
@@ -118,8 +139,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       if (title && title !== track.name) update.name = title;
       if (artist && artist !== track.artists) update.artists = artist;
       if (album && album !== track.album) update.album = album;
-      if (coverArt && !track.image) {
+      if (coverArt && !this.currentTrack?.image) {
         update.image = bytesToDataUrl(coverArt.data, coverArt.mimeType);
+        if (track.albumId) {
+          this.catalog.cacheAlbumArtForAlbum(track.albumId, update.image).catch(() => {});
+        }
       }
 
       if (title || artist || album) {
@@ -137,7 +161,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       if (isrc) mbUpdate.isrc = isrc;
 
       if (Object.keys(update).length > 0 || Object.keys(mbUpdate).length > 0) {
-        this.currentTrack = { ...track, ...update, ...mbUpdate };
+        this.currentTrack = { ...(this.currentTrack ?? track), ...update, ...mbUpdate };
         if (Object.keys(update).length > 0) {
           this.pendingMetadataUpdate = update;
         }


### PR DESCRIPTION
- Added functions to cache and retrieve album art in the dropboxArtCache module.
- Integrated album art caching into the DropboxCatalogAdapter for efficient artwork resolution.
- Enhanced DropboxPlaybackAdapter to hydrate album art from cache when playing tracks.

This update optimizes album art handling, reducing redundant network requests and improving user experience.