### PR TITLE
refactor: simplify library loading, caching, and sync underpinnings

### DIFF
--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -15,6 +15,16 @@ import { useProviderContext } from '../contexts/ProviderContext';
 import type { MediaCollection, ProviderId } from '../types/domain';
 import { LIKES_CHANGED_EVENT } from '../providers/dropbox/dropboxLikesCache';
 
+function splitCollections(collections: MediaCollection[]): { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[] } {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  for (const c of collections) {
+    if (c.kind === 'album') albums.push(collectionToAlbumInfo(c));
+    else playlists.push(collectionToPlaylistInfo(c));
+  }
+  return { playlists, albums };
+}
+
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
 
@@ -183,105 +193,40 @@ export function useLibrarySync(): UseLibrarySyncResult {
       const descriptor = getDescriptor(providerId);
       const catalog = descriptor?.catalog;
       const auth = descriptor?.auth;
-      if (!catalog || !auth) return;
-
-      if (!auth.isAuthenticated()) {
+      if (!catalog || !auth || !auth.isAuthenticated()) {
         nonSpotifyDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0 });
         return;
       }
 
       setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
 
-      // Fetch liked count (local IndexedDB, so fast)
-      let likedCount = 0;
-      if (catalog.getLikedCount && !cancelled) {
-        likedCount = await catalog.getLikedCount(controller.signal);
-      }
+      try {
+        // Run liked count and collection fetch concurrently (liked count is a fast local IDB read)
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(controller.signal),
+          catalog.getLikedCount ? catalog.getLikedCount(controller.signal) : Promise.resolve(0),
+        ]);
+        if (cancelled) return;
 
-      // Try cache first for this provider
-      let usedCache = false;
-      if (providerId === 'dropbox') {
-        try {
-          const { getCachedCatalog, putCatalogCache } = await import('@/providers/dropbox/dropboxCatalogCache');
-          const cached = await getCachedCatalog();
-
-          if (cached && !cancelled) {
-            const playlistItems: CachedPlaylistInfo[] = [];
-            const albumItems: AlbumInfo[] = [];
-            for (const c of cached.collections) {
-              if (c.kind === 'album') albumItems.push(collectionToAlbumInfo(c));
-              else playlistItems.push(collectionToPlaylistInfo(c));
-            }
-            nonSpotifyDataRef.current.set(providerId, { playlists: playlistItems, albums: albumItems, likedCount });
-            mergeAndSetData();
-
-            if (!cached.isStale) {
-              setSyncState(prev => ({
-                ...prev,
-                isInitialLoadComplete: true,
-                isSyncing: false,
-                lastSyncTimestamp: cached.cachedAt,
-              }));
-              usedCache = true;
-            }
-          }
-
-          if (!usedCache) {
-            const collections = await catalog.listCollections(controller.signal);
-            if (cancelled) return;
-
-            const playlistItems: CachedPlaylistInfo[] = [];
-            const albumItems: AlbumInfo[] = [];
-            for (const c of collections) {
-              if (c.kind === 'album') albumItems.push(collectionToAlbumInfo(c));
-              else playlistItems.push(collectionToPlaylistInfo(c));
-            }
-            nonSpotifyDataRef.current.set(providerId, { playlists: playlistItems, albums: albumItems, likedCount });
-            mergeAndSetData();
-            setSyncState(prev => ({
-              ...prev,
-              isInitialLoadComplete: true,
-              isSyncing: false,
-              lastSyncTimestamp: Date.now(),
-            }));
-            putCatalogCache(collections);
-          }
-        } catch (err) {
-          if (cancelled) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          console.error(`[useLibrarySync] Failed to load collections for ${providerId}:`, err);
-          setSyncState(prev => ({
-            ...prev,
-            isInitialLoadComplete: true,
-            isSyncing: false,
-            error: err instanceof Error ? err.message : 'Failed to load library',
-          }));
-        }
-      } else {
-        // Generic non-Spotify, non-Dropbox provider
-        try {
-          const collections = await catalog.listCollections(controller.signal);
-          if (cancelled) return;
-
-          const playlistItems: CachedPlaylistInfo[] = [];
-          const albumItems: AlbumInfo[] = [];
-          for (const c of collections) {
-            if (c.kind === 'album') albumItems.push(collectionToAlbumInfo(c));
-            else playlistItems.push(collectionToPlaylistInfo(c));
-          }
-          nonSpotifyDataRef.current.set(providerId, { playlists: playlistItems, albums: albumItems, likedCount });
-          mergeAndSetData();
-          setSyncState(prev => ({
-            ...prev,
-            isInitialLoadComplete: true,
-            isSyncing: false,
-            lastSyncTimestamp: Date.now(),
-          }));
-        } catch (err) {
-          if (cancelled) return;
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          console.error(`[useLibrarySync] Failed to load collections for ${providerId}:`, err);
-        }
+        const { playlists, albums } = splitCollections(collections);
+        nonSpotifyDataRef.current.set(providerId, { playlists, albums, likedCount });
+        mergeAndSetData();
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          lastSyncTimestamp: Date.now(),
+        }));
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.error(`[useLibrarySync] Failed to load collections for ${providerId}:`, err);
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          error: err instanceof Error ? err.message : 'Failed to load library',
+        }));
       }
     }
 
@@ -292,7 +237,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       cancelled = true;
       controller.abort();
     };
-  }, [nonSpotifyEnabledIds.join(','), getDescriptor, mergeAndSetData]);
+  }, [[...nonSpotifyEnabledIds].sort().join(','), getDescriptor, mergeAndSetData]);
 
   // ── Listen for likes-changed events to update count in real-time ──────
   useEffect(() => {
@@ -317,7 +262,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       handlers.push(() => window.removeEventListener(LIKES_CHANGED_EVENT, handleLikesChanged));
     }
     return () => handlers.forEach(cleanup => cleanup());
-  }, [nonSpotifyEnabledIds.join(','), getDescriptor, mergeAndSetData]);
+  }, [[...nonSpotifyEnabledIds].sort().join(','), getDescriptor, mergeAndSetData]);
 
   const refreshNow = useCallback(async () => {
     // Refresh Spotify — force full re-fetch to catch changes that
@@ -334,18 +279,12 @@ export function useLibrarySync(): UseLibrarySyncResult {
 
       setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
       try {
-        const collections = await catalog.listCollections();
-        const playlistItems: CachedPlaylistInfo[] = [];
-        const albumItems: AlbumInfo[] = [];
-        for (const c of collections) {
-          if (c.kind === 'album') albumItems.push(collectionToAlbumInfo(c));
-          else playlistItems.push(collectionToPlaylistInfo(c));
-        }
-        let likedCount = 0;
-        if (catalog.getLikedCount) {
-          likedCount = await catalog.getLikedCount();
-        }
-        nonSpotifyDataRef.current.set(providerId, { playlists: playlistItems, albums: albumItems, likedCount });
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(undefined, { forceRefresh: true }),
+          catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
+        ]);
+        const { playlists, albums } = splitCollections(collections);
+        nonSpotifyDataRef.current.set(providerId, { playlists, albums, likedCount });
         mergeAndSetData();
         setSyncState(prev => ({
           ...prev,
@@ -353,9 +292,6 @@ export function useLibrarySync(): UseLibrarySyncResult {
           isSyncing: false,
           lastSyncTimestamp: Date.now(),
         }));
-        if (providerId === 'dropbox') {
-          import('@/providers/dropbox/dropboxCatalogCache').then(m => m.putCatalogCache(collections));
-        }
       } catch (err) {
         setSyncState(prev => ({
           ...prev,

--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -153,21 +153,16 @@ export async function putTagMetadata(trackId: string, tags: Omit<CachedTagMetada
   }
 }
 
-export async function getTagsMap(trackIds: string[]): Promise<Map<string, CachedTagMetadata>> {
-  const result = new Map<string, CachedTagMetadata>();
-  if (trackIds.length === 0) return result;
-  const database = await getDb();
-  if (!database) return result;
+function batchGetFromStore<T>(database: IDBDatabase, storeName: string, ids: string[]): Promise<Map<string, T>> {
   return new Promise((resolve) => {
+    const result = new Map<string, T>();
     try {
-      const tx = database.transaction('tags', 'readonly');
-      const store = tx.objectStore('tags');
-      let pending = trackIds.length;
-      for (const id of trackIds) {
+      const store = database.transaction(storeName, 'readonly').objectStore(storeName);
+      let pending = ids.length;
+      for (const id of ids) {
         const req = store.get(id);
         req.onsuccess = () => {
-          const entry = req.result as CachedTagMetadata | undefined;
-          if (entry) result.set(id, entry);
+          if (req.result) result.set(id, req.result as T);
           if (--pending === 0) resolve(result);
         };
         req.onerror = () => {
@@ -180,29 +175,21 @@ export async function getTagsMap(trackIds: string[]): Promise<Map<string, Cached
   });
 }
 
-export async function getDurationsMap(trackIds: string[]): Promise<Map<string, number>> {
-  const result = new Map<string, number>();
-  if (trackIds.length === 0) return result;
+export async function getTagsMap(trackIds: string[]): Promise<Map<string, CachedTagMetadata>> {
+  if (trackIds.length === 0) return new Map();
   const database = await getDb();
-  if (!database) return result;
-  return new Promise((resolve) => {
-    try {
-      const tx = database.transaction('durations', 'readonly');
-      const store = tx.objectStore('durations');
-      let pending = trackIds.length;
-      for (const id of trackIds) {
-        const req = store.get(id);
-        req.onsuccess = () => {
-          const entry = req.result as { trackId: string; durationMs: number } | undefined;
-          if (entry && entry.durationMs > 0) result.set(id, entry.durationMs);
-          if (--pending === 0) resolve(result);
-        };
-        req.onerror = () => {
-          if (--pending === 0) resolve(result);
-        };
-      }
-    } catch {
-      resolve(result);
-    }
-  });
+  if (!database) return new Map();
+  return batchGetFromStore<CachedTagMetadata>(database, 'tags', trackIds);
+}
+
+export async function getDurationsMap(trackIds: string[]): Promise<Map<string, number>> {
+  if (trackIds.length === 0) return new Map();
+  const database = await getDb();
+  if (!database) return new Map();
+  const raw = await batchGetFromStore<{ trackId: string; durationMs: number }>(database, 'durations', trackIds);
+  const result = new Map<string, number>();
+  for (const [id, entry] of raw) {
+    if (entry.durationMs > 0) result.set(id, entry.durationMs);
+  }
+  return result;
 }

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -26,6 +26,7 @@ import {
   getAlbumArt,
   putAlbumArt,
 } from './dropboxArtCache';
+import { getCachedCatalog, putCatalogCache } from './dropboxCatalogCache';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import {
   getLikedTracks,
@@ -216,29 +217,23 @@ export class DropboxCatalogAdapter implements CatalogProvider {
     let token = await this.auth.ensureValidToken();
     if (!token) throw new Error('Not authenticated with Dropbox');
 
-    let response = await fetch(`https://api.dropboxapi.com/2${endpoint}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-      signal,
-    });
-
-    if (response.status === 401) {
-      token = await this.auth.refreshAccessToken();
-      if (!token) throw new Error('Dropbox authentication expired');
-
-      response = await fetch(`https://api.dropboxapi.com/2${endpoint}`, {
+    const makeRequest = (accessToken: string) =>
+      fetch(`https://api.dropboxapi.com/2${endpoint}`, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(body),
         signal,
       });
+
+    let response = await makeRequest(token);
+
+    if (response.status === 401) {
+      token = await this.auth.refreshAccessToken();
+      if (!token) throw new Error('Dropbox authentication expired');
+      response = await makeRequest(token);
     }
 
     if (!response.ok) {
@@ -249,19 +244,44 @@ export class DropboxCatalogAdapter implements CatalogProvider {
     return response.json();
   }
 
+  private async paginateFolder(
+    path: string,
+    callback: (entries: DropboxFileEntry[]) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    let result = await this.dropboxApi<DropboxListFolderResult>(
+      '/files/list_folder',
+      { path, recursive: true },
+      signal,
+    );
+    callback(result.entries);
+    while (result.has_more) {
+      if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
+      result = await this.dropboxApi<DropboxListFolderResult>(
+        '/files/list_folder/continue',
+        { cursor: result.cursor },
+        signal,
+      );
+      callback(result.entries);
+    }
+  }
+
   /**
    * Recursively scans the app root to discover albums (folders containing audio files).
    * Each such folder becomes an album collection; its parent folder name is the artist.
    * Also returns a single "All Music" playlist with the total track count.
+   *
+   * Results are cached in IndexedDB for 1 hour. Pass `{ forceRefresh: true }` to bypass the cache.
    */
-  async listCollections(signal?: AbortSignal): Promise<MediaCollection[]> {
-    try {
-      let result = await this.dropboxApi<DropboxListFolderResult>(
-        '/files/list_folder',
-        { path: '', recursive: true },
-        signal,
-      );
+  async listCollections(signal?: AbortSignal, options?: { forceRefresh?: boolean }): Promise<MediaCollection[]> {
+    if (!options?.forceRefresh) {
+      const cached = await getCachedCatalog();
+      if (cached && !cached.isStale) {
+        return cached.collections;
+      }
+    }
 
+    try {
       // path_lower → display name / parent path
       const dirDisplayName = new Map<string, string>();
       const dirParent = new Map<string, string>();
@@ -270,12 +290,11 @@ export class DropboxCatalogAdapter implements CatalogProvider {
       // path_lower → image file entries
       const imagesByDir = new Map<string, DropboxFileEntry[]>();
 
-      const processBatch = (entries: DropboxFileEntry[]) => {
+      await this.paginateFolder('', (entries) => {
         for (const entry of entries) {
           if (entry['.tag'] === 'folder') {
             dirDisplayName.set(entry.path_lower, entry.name);
-            const parent = parentDir(entry.path_lower);
-            dirParent.set(entry.path_lower, parent);
+            dirParent.set(entry.path_lower, parentDir(entry.path_lower));
           } else if (entry['.tag'] === 'file') {
             const dir = parentDir(entry.path_lower);
             if (isAudioFile(entry.name)) {
@@ -287,18 +306,7 @@ export class DropboxCatalogAdapter implements CatalogProvider {
             }
           }
         }
-      };
-
-      processBatch(result.entries);
-      while (result.has_more) {
-        if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
-        result = await this.dropboxApi<DropboxListFolderResult>(
-          '/files/list_folder/continue',
-          { cursor: result.cursor },
-          signal,
-        );
-        processBatch(result.entries);
-      }
+      }, signal);
 
       const dirToImageUrl = await this.resolveAlbumArtByDir(imagesByDir, audioCount.keys());
 
@@ -333,7 +341,9 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         trackCount: totalTracks,
       };
 
-      return [allMusic, ...albums];
+      const collections = [allMusic, ...albums];
+      putCatalogCache(collections);
+      return collections;
     } catch (error) {
       console.error('[DropboxCatalog] Failed to list collections:', error);
       throw error;
@@ -347,16 +357,10 @@ export class DropboxCatalogAdapter implements CatalogProvider {
     const folderPath = collectionRef.id;
 
     try {
-      let result = await this.dropboxApi<DropboxListFolderResult>(
-        '/files/list_folder',
-        { path: folderPath, recursive: true },
-        signal,
-      );
-
       const audioEntries: DropboxFileEntry[] = [];
       const imagesByDir = new Map<string, DropboxFileEntry[]>();
 
-      const processBatch = (entries: DropboxFileEntry[]) => {
+      await this.paginateFolder(folderPath, (entries) => {
         for (const entry of entries) {
           if (entry['.tag'] !== 'file') continue;
           if (isAudioFile(entry.name)) {
@@ -368,18 +372,7 @@ export class DropboxCatalogAdapter implements CatalogProvider {
             imagesByDir.set(dir, list);
           }
         }
-      };
-
-      processBatch(result.entries);
-      while (result.has_more) {
-        if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
-        result = await this.dropboxApi<DropboxListFolderResult>(
-          '/files/list_folder/continue',
-          { cursor: result.cursor },
-          signal,
-        );
-        processBatch(result.entries);
-      }
+      }, signal);
 
       const albumDirs = audioEntries.map((entry) => parentDir(entry.path_lower));
       const dirToImageUrl = await this.resolveAlbumArtByDir(imagesByDir, albumDirs);

--- a/src/services/cache/libraryCache.ts
+++ b/src/services/cache/libraryCache.ts
@@ -192,6 +192,21 @@ function idbPutAll<T>(storeName: string, items: T[]): Promise<void> {
   });
 }
 
+/** Atomically replace all records in a store: clear + putAll in a single transaction. */
+function idbReplaceAll<T>(storeName: string, items: T[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('DB not initialized')); return; }
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    store.clear();
+    for (const item of items) {
+      store.put(item);
+    }
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 // =============================================================================
 // Playlist Operations
 // =============================================================================
@@ -216,10 +231,8 @@ export async function putAllPlaylists(playlists: CachedPlaylistInfo[]): Promise<
     return;
   }
   try {
-    await idbClear(STORE_PLAYLISTS);
-    await idbPutAll(STORE_PLAYLISTS, playlists);
+    await idbReplaceAll(STORE_PLAYLISTS, playlists);
   } catch {
-    // Fall through to memory
     for (const p of playlists) fallbackStores.playlists.set(p.id, p);
   }
 }
@@ -274,8 +287,7 @@ export async function putAllAlbums(albums: AlbumInfo[]): Promise<void> {
     return;
   }
   try {
-    await idbClear(STORE_ALBUMS);
-    await idbPutAll(STORE_ALBUMS, albums);
+    await idbReplaceAll(STORE_ALBUMS, albums);
   } catch {
     for (const a of albums) fallbackStores.albums.set(a.id, a);
   }

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -412,24 +412,27 @@ export class LibrarySyncEngine {
     const fetchedIds = new Set(allFetched.map(p => p.id));
     const snapshotIds: Record<string, string> = { ...(meta?.snapshotIds ?? {}) };
 
+    const removals: Promise<void>[] = [];
     for (const cached of cachedPlaylists) {
       if (!fetchedIds.has(cached.id)) {
-        await cache.removePlaylist(cached.id);
-        await cache.removeTrackList(`playlist:${cached.id}`);
+        removals.push(cache.removePlaylist(cached.id), cache.removeTrackList(`playlist:${cached.id}`));
         delete snapshotIds[cached.id];
       }
     }
+    await Promise.all(removals);
 
+    const writes: Promise<void>[] = [];
     for (const fetched of allFetched) {
       const cached = cachedMap.get(fetched.id);
       if (cached && fetched.snapshot_id && fetched.snapshot_id !== cached.snapshot_id) {
-        await cache.removeTrackList(`playlist:${fetched.id}`);
+        writes.push(cache.removeTrackList(`playlist:${fetched.id}`));
       }
-      await cache.putPlaylist(fetched);
+      writes.push(cache.putPlaylist(fetched));
       if (fetched.snapshot_id) {
         snapshotIds[fetched.id] = fetched.snapshot_id;
       }
     }
+    await Promise.all(writes);
 
     await cache.putMeta('playlists', {
       lastValidated: Date.now(),
@@ -451,31 +454,40 @@ export class LibrarySyncEngine {
 
     const fetchedIds = new Set(allFetched.map(a => a.id));
 
+    const ops: Promise<void>[] = [];
     for (const cached of cachedAlbums) {
       if (!fetchedIds.has(cached.id) && !this.pendingAdditions.has(cached.id)) {
-        await cache.removeAlbum(cached.id);
-        await cache.removeTrackList(`album:${cached.id}`);
+        ops.push(cache.removeAlbum(cached.id), cache.removeTrackList(`album:${cached.id}`));
       }
     }
-
     for (const fetched of allFetched) {
       if (!this.pendingRemovals.has(fetched.id)) {
-        await cache.putAlbum(fetched);
+        ops.push(cache.putAlbum(fetched));
       }
     }
+    await Promise.all(ops);
 
-    const finalAlbums = await cache.getAllAlbums();
-    const latestAddedAt = finalAlbums.reduce(
+    // Compute the final album list from what we already have in memory
+    // Compute the final album list from in-memory state
+    const finalAlbums: AlbumInfo[] = [
+      ...allFetched.filter(f => !this.pendingRemovals.has(f.id)),
+      // Locally-added albums not yet reflected in the API response
+      ...cachedAlbums.filter(a => this.pendingAdditions.has(a.id) && !fetchedIds.has(a.id)),
+    ];
+    const seen = new Set<string>();
+    const deduped = finalAlbums.filter(a => seen.has(a.id) ? false : (seen.add(a.id), true));
+
+    const latestAddedAt = deduped.reduce(
       (latest, a) => (a.added_at && a.added_at > latest ? a.added_at : latest),
       '',
     );
     await cache.putMeta('albums', {
       lastValidated: Date.now(),
-      totalCount: finalAlbums.length,
+      totalCount: deduped.length,
       latestAddedAt: latestAddedAt || undefined,
     });
 
-    return finalAlbums;
+    return deduped;
   }
 
   // =========================================================================

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -27,7 +27,7 @@ export interface AuthProvider {
 export interface CatalogProvider {
   readonly providerId: ProviderId;
   /** List collections (playlists, albums, folders) for library browser. */
-  listCollections(signal?: AbortSignal): Promise<MediaCollection[]>;
+  listCollections(signal?: AbortSignal, options?: { forceRefresh?: boolean }): Promise<MediaCollection[]>;
   /** List tracks for a collection. */
   listTracks(collectionRef: CollectionRef, signal?: AbortSignal): Promise<MediaTrack[]>;
   /** Optional: total count for "Liked" or similar (Spotify). */


### PR DESCRIPTION
## Summary

- **Move Dropbox catalog cache into the adapter** — `useLibrarySync` no longer has a `if (providerId === 'dropbox')` branch that imports Dropbox-specific cache modules. The adapter handles its own 1-hour cache in `listCollections()` and bypasses it on `forceRefresh: true`. Added optional `options?: { forceRefresh?: boolean }` to the `CatalogProvider` interface (backward-compatible).
- **Extract `splitCollections()` helper** — eliminates 3 identical loops in `useLibrarySync` that split `MediaCollection[]` into playlists/albums arrays
- **Extract `paginateFolder()` in `DropboxCatalogAdapter`** — eliminates the duplicate `while (has_more)` Dropbox pagination loop shared by `listCollections` and `listTracks`
- **Extract `batchGetFromStore()` in `dropboxArtCache`** — eliminates the duplicate pending-counter IDB batch-fetch pattern in `getTagsMap` / `getDurationsMap`
- **Fix `dropboxApi()` 401 retry** — the entire `fetch(...)` call was duplicated for the retry; now uses a `makeRequest` closure
- **Parallelize N+1 IDB writes** in `syncPlaylists` / `syncAlbums` — sequential `await` per item replaced with `Promise.all`
- **Eliminate redundant `getAllAlbums()` read** in `syncAlbums()` — final list computed from in-memory state instead of re-reading the store after writes
- **Parallelize `listCollections` + `getLikedCount`** in both load and refresh paths
- **Atomic `putAllPlaylists` / `putAllAlbums`** — replaced two-transaction `idbClear` + `idbPutAll` (crash window between them) with a new `idbReplaceAll` that clears and writes in one transaction
- **Sort provider IDs before joining** as React dep string — prevents spurious effect re-runs if provider order changes

## Test plan

- [ ] Spotify-only: library loads normally on cold start and warm start; background sync still runs every 90s
- [ ] Dropbox-only: library loads from cache on second open (within 1h TTL); pull-to-refresh fetches fresh data
- [ ] Both providers: library shows both Spotify and Dropbox collections merged correctly
- [ ] Liked songs count updates in real-time after toggling a like
- [ ] Album save/remove applies optimistically and survives the next background sync
- [ ] All 502 tests pass (`npm run test:run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)