### PR TITLE
fix(scripts): fall back to .env for new worktree env copy

### DIFF
--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -26,8 +26,11 @@ echo "Copying environment file..."
 if [ -f "${REPO_ROOT}/.env.local" ]; then
   cp "${REPO_ROOT}/.env.local" "${WORKTREE_PATH}/.env.local"
   echo "  .env.local copied."
+elif [ -f "${REPO_ROOT}/.env" ]; then
+  cp "${REPO_ROOT}/.env" "${WORKTREE_PATH}/.env.local"
+  echo "  .env copied as .env.local."
 else
-  echo "  WARNING: No .env.local found in main repo — copy it manually."
+  echo "  WARNING: No .env.local or .env found in main repo — copy it manually."
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Updates `scripts/new-worktree.sh` so when creating a worktree, if the main repo has no `.env.local` but has `.env`, it copies `.env` to the worktree as `.env.local`.

## Why
Worktrees need `.env.local` for Spotify/tests per project docs; some setups only keep `.env` in the main tree.

## Test plan
- [ ] Run `./scripts/new-worktree.sh <name>` with only `.env` present and confirm `.env.local` appears in the new worktree.

Made with [Cursor](https://cursor.com)