### PR TITLE
Add progressive thumbnail loading for Dropbox tracks in queue

### DIFF
--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -21,6 +21,7 @@ import { providerRegistry } from '@/providers/registry';
 import { resolveViaSpotify } from '@/services/spotifyResolver';
 import { logQueue, logRadio } from '@/lib/debugLog';
 import { useMediaTracksMirror } from '@/hooks/useMediaTracksMirror';
+import { useQueueThumbnailLoader } from '@/hooks/useQueueThumbnailLoader';
 import {
   appendMediaTracks,
   moveItemInArray,
@@ -349,6 +350,9 @@ export function usePlayerLogic() {
 
   // Background-resolve non-Spotify tracks to Spotify URIs for queue sync
   useSpotifyQueueSync({ tracks });
+
+  // Progressively load missing thumbnails for Dropbox tracks in the queue
+  useQueueThumbnailLoader(tracks, mediaTracksRef, setTracks);
 
   // Auto-extract accent color from album artwork; respects overrides in ColorContext
   useAccentColor(currentTrack, accentColorOverrides, setAccentColor, setAccentColorOverrides);

--- a/src/hooks/useQueueThumbnailLoader.ts
+++ b/src/hooks/useQueueThumbnailLoader.ts
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useCallback } from 'react';
+import type { Track } from '@/services/spotify';
+import type { MediaTrack } from '@/types/domain';
+import { getAlbumArt } from '@/providers/dropbox/dropboxArtCache';
+import { providerRegistry } from '@/providers/registry';
+import type { DropboxCatalogAdapter } from '@/providers/dropbox/dropboxCatalogAdapter';
+import { logQueue } from '@/lib/debugLog';
+
+/** Maximum number of concurrent Dropbox API art fetches. */
+const FETCH_CONCURRENCY = 3;
+
+/**
+ * Progressively loads missing thumbnails for Dropbox tracks in the queue.
+ *
+ * Phase 1: Hydrates from the IndexedDB album art cache (fast, no network).
+ * Phase 2: For albums still missing art, scans their Dropbox directories
+ *          for cover images and fetches them.
+ *
+ * Updates are batched so the queue UI re-renders efficiently.
+ */
+export function useQueueThumbnailLoader(
+  tracks: readonly Track[],
+  mediaTracksRef: React.MutableRefObject<MediaTrack[]>,
+  setTracks: React.Dispatch<React.SetStateAction<Track[]>>,
+) {
+  // Track which album IDs we've already attempted to resolve (avoid re-fetching)
+  const attemptedAlbumIds = useRef(new Set<string>());
+
+  // Abort controller for in-flight operations when tracks change
+  const abortRef = useRef<AbortController | null>(null);
+
+  const applyImageUpdates = useCallback(
+    (updates: Map<string, string>) => {
+      if (updates.size === 0) return;
+      logQueue('thumbnailLoader — applying %d image updates', updates.size);
+
+      // Update mediaTracksRef
+      for (const mt of mediaTracksRef.current) {
+        if (mt.provider === 'dropbox' && !mt.image && mt.albumId) {
+          const img = updates.get(mt.albumId);
+          if (img) mt.image = img;
+        }
+      }
+
+      // Update UI tracks
+      setTracks((prev) =>
+        prev.map((t) => {
+          if (t.provider === 'dropbox' && !t.image && t.album_id) {
+            const img = updates.get(t.album_id);
+            if (img) return { ...t, image: img };
+          }
+          return t;
+        }),
+      );
+    },
+    [mediaTracksRef, setTracks],
+  );
+
+  useEffect(() => {
+    // Find Dropbox tracks without images
+    const missing = tracks.filter(
+      (t) => t.provider === 'dropbox' && !t.image && t.album_id,
+    );
+    if (missing.length === 0) return;
+
+    // Dedupe by album ID (multiple tracks share the same album art)
+    const albumIds = [...new Set(missing.map((t) => t.album_id!))];
+    // Filter out already-attempted album IDs
+    const toResolve = albumIds.filter((id) => !attemptedAlbumIds.current.has(id));
+    if (toResolve.length === 0) return;
+
+    // Mark as attempted immediately so we don't re-trigger
+    for (const id of toResolve) attemptedAlbumIds.current.add(id);
+
+    // Cancel any previous in-flight operation
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    logQueue('thumbnailLoader — resolving art for %d albums', toResolve.length);
+
+    const run = async () => {
+      // ── Phase 1: IndexedDB cache lookup ──
+      const cacheResults = new Map<string, string>();
+      const uncached: string[] = [];
+
+      await Promise.all(
+        toResolve.map(async (albumId) => {
+          const cached = await getAlbumArt(albumId);
+          if (cached) {
+            cacheResults.set(albumId, cached);
+          } else {
+            uncached.push(albumId);
+          }
+        }),
+      );
+
+      if (controller.signal.aborted) return;
+
+      // Apply cache hits immediately
+      if (cacheResults.size > 0) {
+        applyImageUpdates(cacheResults);
+        logQueue(
+          'thumbnailLoader — phase 1 (cache): resolved %d, remaining %d',
+          cacheResults.size,
+          uncached.length,
+        );
+      }
+
+      // ── Phase 2: Fetch from Dropbox API for uncached albums ──
+      if (uncached.length === 0) return;
+
+      const dropbox = providerRegistry.get('dropbox');
+      if (!dropbox) return;
+
+      const catalog = dropbox.catalog as DropboxCatalogAdapter;
+      if (typeof catalog.resolveAlbumArt !== 'function') return;
+
+      // Process in batches to limit concurrency
+      const fetchResults = new Map<string, string>();
+
+      for (let i = 0; i < uncached.length; i += FETCH_CONCURRENCY) {
+        if (controller.signal.aborted) return;
+        const batch = uncached.slice(i, i + FETCH_CONCURRENCY);
+
+        const results = await Promise.all(
+          batch.map(async (albumId) => {
+            try {
+              const art = await catalog.resolveAlbumArt(albumId, controller.signal);
+              return art ? ([albumId, art] as const) : null;
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        for (const result of results) {
+          if (result) fetchResults.set(result[0], result[1]);
+        }
+
+        // Apply each batch as it completes for progressive loading
+        if (fetchResults.size > 0 && !controller.signal.aborted) {
+          applyImageUpdates(fetchResults);
+          logQueue('thumbnailLoader — phase 2 (fetch): resolved %d so far', fetchResults.size);
+          fetchResults.clear();
+        }
+      }
+    };
+
+    run().catch(() => {});
+
+    return () => controller.abort();
+  }, [tracks, applyImageUpdates]);
+
+  // Reset attempted set when queue is cleared
+  useEffect(() => {
+    if (tracks.length === 0) {
+      attemptedAlbumIds.current.clear();
+    }
+  }, [tracks.length]);
+}

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -453,6 +453,42 @@ export class DropboxCatalogAdapter implements CatalogProvider {
     };
   }
 
+  /**
+   * Resolve album art for a single album directory.
+   * Checks IndexedDB cache first, then scans the Dropbox directory for image files.
+   * Returns a data URL or null.
+   */
+  async resolveAlbumArt(albumDir: string, signal?: AbortSignal): Promise<string | null> {
+    if (!albumDir) return null;
+
+    // Check cache first
+    const cached = await getAlbumArt(albumDir);
+    if (cached) return cached;
+
+    // Scan the directory for image files
+    try {
+      const result = await this.dropboxApi<{ entries: DropboxFileEntry[] }>(
+        '/files/list_folder',
+        { path: albumDir, recursive: false },
+        signal,
+      );
+
+      const images = result.entries.filter(
+        (e) => e['.tag'] === 'file' && isImageFile(e.name),
+      );
+      const imagePath = pickAlbumArtPath(images);
+      if (!imagePath) return null;
+
+      const imageUrl = await this.fetchArtDataUrl(imagePath);
+      if (imageUrl) {
+        await putAlbumArt(albumDir, imageUrl);
+      }
+      return imageUrl;
+    } catch {
+      return null;
+    }
+  }
+
   async getTemporaryLink(path: string): Promise<string> {
     const cached = this.tempLinkCache.get(path);
     if (cached && Date.now() < cached.expiresAt) {


### PR DESCRIPTION
## Summary
Implements progressive loading of missing album artwork for Dropbox tracks in the playback queue. The system uses a two-phase approach: first hydrating from an IndexedDB cache, then fetching from Dropbox directories for uncached albums with controlled concurrency.

## Key Changes
- **New hook `useQueueThumbnailLoader`**: Manages the progressive loading lifecycle for queue thumbnails
  - Phase 1: Fast cache lookup from IndexedDB (no network)
  - Phase 2: Scans Dropbox directories for cover images with batched API requests (max 3 concurrent)
  - Deduplicates by album ID to avoid redundant work
  - Tracks attempted album IDs to prevent re-fetching
  - Cancels in-flight operations when tracks change via AbortController

- **New method `resolveAlbumArt` in `DropboxCatalogAdapter`**: 
  - Resolves album art for a single album directory
  - Checks cache first, then scans directory for image files
  - Returns data URL or null
  - Respects AbortSignal for cancellation

- **Integration in `usePlayerLogic`**: 
  - Wires up the thumbnail loader hook to run alongside other queue management logic
  - Passes tracks, mediaTracksRef, and setTracks for bidirectional updates

## Implementation Details
- Updates are batched and applied progressively as each batch completes, enabling smooth UI updates without blocking
- The hook maintains an `attemptedAlbumIds` Set to avoid re-triggering resolution for albums already processed
- Errors during Dropbox API calls are silently caught to prevent queue disruption
- Queue clearing resets the attempted set to allow fresh resolution on next load

https://claude.ai/code/session_01Q5ms6qqWyujydPsL9NL41z