### PR TITLE
Refactor terminology and components related to queue and playlist (#345)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ src/
 ```
 
 ### Performance Considerations
-- Lazy load heavy components (VisualEffectsMenu, PlaylistDrawer)
+- Lazy load heavy components (VisualEffectsMenu, QueueDrawer, QueueBottomSheet)
 - Cache color extraction with LRU cache in colorExtractor.ts
 - Use Web Workers for image processing (imageProcessor.worker.ts)
 - Debounce rapid state updates (150ms standard)
@@ -91,9 +91,10 @@ src/
   - TimelineControls (bottom)
 
 Related UI:
-- **PlaylistDrawer** - Sliding drawer with tracks
+- **QueueDrawer** / **QueueBottomSheet** - Queue (up-next tracks) on desktop/tablet vs mobile
+- **QueueTrackList** - Track list inside queue surfaces (lazy-loaded); reorder/remove/edit modes
 - **VisualEffectsMenu** - Visual effects controls
-- **PlaylistSelection** - Playlist picker with Liked Songs support
+- **PlaylistSelection** - Library playlist/album picker with Liked Songs support
 
 ## Spotify Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,11 @@ npm run deploy:preview # Deploy preview
 
 ## Architecture
 
+### Queue vs playlist (terminology)
+
+- **Queue** — tracks scheduled to play next (reorder/remove in `QueueDrawer` / `QueueBottomSheet`; list UI in `QueueTrackList.tsx`).
+- **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `PlaylistSelection` and loaded through `usePlaylistManager` / catalog APIs.
+
 ### Source Layout
 
 ```
@@ -86,7 +91,7 @@ AppContainer (flexCenter, min-height: 100dvh)
 - **`overflow: visible` is required on ContentWrapper** — `container-type: inline-size` creates containment that clips absolutely-positioned children
 - **`100dvh`** throughout to handle iOS address bar changes
 - **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
-- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle playlist (up) and library (down) drawers
+- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle **queue** (up) and **library** (down) drawers (`QueueDrawer` / `QueueBottomSheet` vs `LibraryDrawer`)
 - **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout
 
 ### Multi-Provider Architecture

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ A visually immersive music player built with React and TypeScript, featuring cus
 
 - **Multi-Provider Support** — Stream from Spotify or your personal Dropbox music library
 - **Unified Cross-Provider Playback** — Keep playback controls consistent across mixed Spotify + Dropbox queues
-- **Playlists & Albums** — Browse, search, sort, filter, and pin your collections
+- **Queue** — See and edit what plays next (reorder, remove tracks) in the queue drawer or mobile sheet
+- **Playlists & Albums** — Browse, search, sort, filter, and pin your **library** collections (not the same as the playback queue)
 - **Unified Liked Songs** — Merge liked tracks from connected providers into one queue
 - **Track Radio** — Generate a one-shot radio playlist from the current track (Last.fm-powered matching)
 - **Visual Effects** — Dynamic glow, configurable album art filters, accent color backgrounds
 - **Background Visualizers** — Animated particle and geometric visualizer backgrounds
 - **Album Art Flip Menu** — Tap album art to reveal quick-access visual controls
-- **Swipe Gestures** — Swipe to change tracks, open playlists, or browse the library
+- **Swipe Gestures** — Swipe to change tracks, open the queue, or browse the library
 - **Keyboard Shortcuts** — Context-aware controls with device-specific behavior
 - **Responsive Design** — Fluid layout from mobile phones to ultra-wide desktops
 - **Instant Startup** — IndexedDB-based library cache with background sync

--- a/docs/analysis/ANALYSIS.md
+++ b/docs/analysis/ANALYSIS.md
@@ -26,7 +26,7 @@ Vorbis Player is a React-based Spotify music player with visual effects and albu
    - Type definitions for major interfaces
 
 3. **Performance Optimizations**
-   - Lazy loading of heavy components (VisualEffectsMenu, PlaylistDrawer)
+   - Lazy loading of heavy components (VisualEffectsMenu, QueueDrawer, QueueBottomSheet)
    - Color extraction caching with LRU cache
    - Web Workers for image processing
    - React.memo on heavy components
@@ -34,7 +34,7 @@ Vorbis Player is a React-based Spotify music player with visual effects and albu
 4. **Feature-Rich**
    - Multiple visualizers (particles, geometric, gradient flow, waveform)
    - Advanced visual effects (glow, filters, accent colors)
-   - Playlist management with shuffle support
+   - Library collections and playback queue, with shuffle support
    - Keyboard shortcuts and UI controls
 
 ---
@@ -193,7 +193,7 @@ export default React.memo(AlbumArt);
 
 // MISSING for components with:
 - VisualEffectsMenu
-- PlaylistDrawer
+- QueueDrawer
 - PlayerContent (has many props)
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,13 +46,14 @@ src/
 ├── components/              # React components (~42 files)
 │   ├── AudioPlayer.tsx      # Main orchestrator with centralized state
 │   ├── PlayerContent.tsx    # Main player layout (centering, responsive sizing)
-│   ├── PlayerStateRenderer.tsx  # Loading/error/playlist selection states
+│   ├── PlayerStateRenderer.tsx  # Loading/error and library collection selection states
 │   ├── AlbumArt.tsx         # Album artwork with filters & glow effects
 │   ├── PlaylistSelection.tsx    # Playlist/album browser with search/sort/filter/pin
 │   ├── SpotifyPlayerControls.tsx # Player control interface
 │   ├── LibraryDrawer.tsx    # Full-screen library browser drawer
-│   ├── PlaylistDrawer.tsx   # Sliding track list drawer (desktop/tablet)
-│   ├── PlaylistBottomSheet.tsx  # Mobile playlist bottom sheet
+│   ├── QueueDrawer.tsx      # Queue (up-next) side drawer (desktop/tablet)
+│   ├── QueueBottomSheet.tsx # Queue bottom sheet (mobile)
+│   ├── QueueTrackList.tsx   # Queue track list (reorder/remove); lazy-loaded by queue surfaces
 │   ├── ColorPickerPopover.tsx   # Per-album color picker
 │   ├── AlbumArtBackside.tsx     # Flip menu back face
 │   ├── BottomBar/               # Bottom bar components

--- a/docs/development/ai-agent-wip.md
+++ b/docs/development/ai-agent-wip.md
@@ -71,12 +71,12 @@
 
 ### Phase 2: Core Sizing Implementation
 - [x] **Task 1**: Replace ContentWrapper - *Replaced hardcoded ContentWrapper with responsive wrapper using usePlayerSizing hook*
-- [x] **Task 2**: Implement Fluid Dimensions - *Replaced all hardcoded dimensions with fluid calculations across VisualEffectsMenu, PlaylistDrawer, VisualEffectsPerformanceMonitor, PlaylistSelection, TimelineSlider, and AlbumArt components*
+- [x] **Task 2**: Implement Fluid Dimensions - *Replaced all hardcoded dimensions with fluid calculations across VisualEffectsMenu, QueueDrawer, VisualEffectsPerformanceMonitor, PlaylistSelection, TimelineSlider, and AlbumArt components*
 - [x] **Task 3**: Add Aspect Ratio Support - *Handle different screen orientations and ratios*
 - [x] **Task 4**: Create Responsive Components - *Updated SpotifyPlayerControls component with responsive sizing using usePlayerSizing hook*
 
 ### Phase 3: Advanced Responsive Features
-- [x] **Task 1**: Implement Container Queries - *Added component-level responsive behavior with container queries for PlayerContent, PlaylistDrawer, VisualEffectsMenu, and SpotifyPlayerControls components*
+- [x] **Task 1**: Implement Container Queries - *Added component-level responsive behavior with container queries for PlayerContent, QueueDrawer, VisualEffectsMenu, and SpotifyPlayerControls components*
 - [x] **Task 2**: Add Smooth Transitions - *Implemented smooth size changes between breakpoints with CSS transitions and usePlayerSizing hook integration*
 - [x] **Task 3**: Optimize Viewport Handling - *Improved mobile viewport meta tag and scaling with enhanced mobile breakpoints, touch optimizations, and visual viewport API support*
 - [x] **Task 4**: Add Progressive Enhancement - *Ensured graceful degradation for older browsers with comprehensive fallbacks for container queries, backdrop-filter, visual viewport API, CSS custom properties, and modern CSS features*

--- a/docs/implementation-plans/mobile-bottom-menu.md
+++ b/docs/implementation-plans/mobile-bottom-menu.md
@@ -54,7 +54,7 @@ zIndex: {
 }
 ```
 
-This places the bottom menu **above** background overlays but **below** modals (playlist drawer, VFX menu), so the menu handle stays accessible while drawers are open, but doesn't block drawer interactions.
+This places the bottom menu **above** background overlays but **below** modals (queue drawer, VFX menu), so the menu handle stays accessible while drawers are open, but doesn't block drawer interactions.
 
 ---
 
@@ -147,7 +147,7 @@ Extracted sub-component containing the button grid. Same buttons as the current 
 
 1. **Glow toggle** — `ControlButton` with `isActive={glowEnabled}`, `GlowIcon`
 2. **Background Visualizer toggle** — conditional on `onBackgroundVisualizerToggle` prop, `BackgroundVisualizerIcon`
-3. **Playlist** — opens playlist drawer, `PlaylistIcon`
+3. **Queue** — opens the queue drawer (`onShowPlaylist` prop / `PlaylistIcon` in code)
 4. **Visual Effects** — opens VFX menu, `VisualEffectsIcon`
 5. **Color Picker** — `ColorPickerPopover` (renders via portal, so positioning works from bottom)
 6. **Back to Library** — conditional on `onBackToLibrary` prop, `BackToLibraryIcon`
@@ -157,7 +157,7 @@ All icons imported from `src/components/icons/QuickActionIcons.tsx`.
 
 Uses `useCustomAccentColors` hook for color picker integration (same as current drawer).
 
-**Auto-collapse behavior:** When the user taps Playlist or Visual Effects (actions that open full-screen drawers), the menu auto-collapses. Glow/Visualizer toggles do NOT auto-collapse (quick toggle).
+**Auto-collapse behavior:** When the user taps Queue or Visual Effects (actions that open full-screen drawers), the menu auto-collapses. Glow/Visualizer toggles do NOT auto-collapse (quick toggle).
 
 ---
 
@@ -190,7 +190,7 @@ const getTransform = () => {
 - Tap handle -> toggle
 - The `ref` from `useSwipeGesture` attaches to the `HandleArea`
 
-**Auto-collapse on drawer open:** Wrap `onShowPlaylist`/`onShowVisualEffects` callbacks to call `collapse()` then the original handler.
+**Auto-collapse on drawer open:** Wrap `onShowPlaylist` (queue) / `onShowVisualEffects` callbacks to call `collapse()` then the original handler.
 
 **Props interface:** Same as current `MobileQuickActionsDrawerProps` minus `isExpanded` and `onToggleExpand` (state is internal), plus `transitionDuration` and `transitionEasing` from `usePlayerSizing`.
 
@@ -254,7 +254,7 @@ Remove `src/components/MobileQuickActionsDrawer.tsx` entirely.
 - **Safe area insets**: `viewport-fit=cover` is already set in `index.html`. The `MenuWrapper` uses `padding-bottom: env(safe-area-inset-bottom, 0px)` to respect iPhone home indicators.
 - **Landscape mode**: Buttons use `flex-wrap: wrap` — on narrow landscape heights, the menu stays compact. The handle remains at 32px.
 - **ColorPickerPopover positioning**: The popover uses `createPortal` to `document.body` and positions above the trigger button via `getBoundingClientRect()`. Since the button is near the bottom, the popover's existing upward positioning (`transform: translate(-50%, -100%)`) should work. Verify on small screens.
-- **Menu + drawer overlap**: The menu (z-index 1350) sits below drawer overlays (1300) and modals (1400). When playlist/VFX drawers open, the menu auto-collapses. The handle remains tappable above background content.
+- **Menu + drawer overlap**: The menu (z-index 1350) sits below drawer overlays (1300) and modals (1400). When queue/VFX drawers open, the menu auto-collapses. The handle remains tappable above background content.
 - **Rapid taps**: CSS `transform` transitions naturally interpolate from current position — no jitter on rapid toggles.
 
 ---
@@ -268,8 +268,8 @@ Remove `src/components/MobileQuickActionsDrawer.tsx` entirely.
 5. **Test tap to collapse**: Tap handle again -> menu slides down
 6. **Test swipe up**: Swipe up on handle -> expands
 7. **Test swipe down**: Swipe down on handle -> collapses
-8. **Test buttons**: Each button (glow, visualizer, playlist, VFX, color picker, back to library) functions correctly
-9. **Test auto-collapse**: Tapping Playlist or Visual Effects collapses the menu and opens the respective drawer
+8. **Test buttons**: Each button (glow, visualizer, queue, VFX, color picker, back to library) functions correctly
+9. **Test auto-collapse**: Tapping Queue or Visual Effects collapses the menu and opens the respective drawer
 10. **Test desktop unchanged**: On desktop viewport, side panels appear as before, no bottom menu
 11. **Test controls hidden**: Tap album art to hide controls -> bottom menu handle still visible and functional
 12. **Test safe area**: On iPhone (or simulator), verify the menu respects the home indicator area

--- a/docs/implementation-plans/mobile-library-drawer.md
+++ b/docs/implementation-plans/mobile-library-drawer.md
@@ -95,7 +95,7 @@ const [showLibraryDrawer, setShowLibraryDrawer] = useState(false);
 ```typescript
 const handleOpenLibraryDrawer = useCallback(() => {
   setShowLibraryDrawer(true);
-  setShowPlaylist(false);      // Close playlist drawer if open
+  setShowPlaylist(false);      // Close queue drawer if open
   setShowVisualEffects(false); // Close VFX menu if open
 }, [setShowPlaylist, setShowVisualEffects]);
 
@@ -272,7 +272,7 @@ One potential issue: PlaylistSelection's `Container` centers content with `displ
 ## Edge Cases
 
 - **Escape key**: Should close the library drawer. Add to the `handleEscapeClose` handler in PlayerContent.
-- **Drawer + other overlays**: Opening library drawer auto-closes playlist drawer and VFX menu (handled in `handleOpenLibraryDrawer`).
+- **Drawer + other overlays**: Opening library drawer auto-closes the queue drawer and VFX menu (handled in `handleOpenLibraryDrawer`).
 - **Data freshness**: PlaylistSelection fetches fresh data every time it mounts. Since we conditionally render `{isOpen && <PlaylistSelection />}`, each open gets fresh data.
 - **Rapid open/close**: The 320ms delay in playlist selection could cause issues if user opens drawer, selects quickly, then opens again. Use `clearTimeout` pattern or ignore if drawer is already closed.
 - **Scroll position reset**: Since PlaylistSelection unmounts on close, scroll position resets each time. This is acceptable since the drawer is a fresh browsing session.

--- a/docs/implementation-plans/perf-album-switch.md
+++ b/docs/implementation-plans/perf-album-switch.md
@@ -56,7 +56,7 @@ img.onload → extractDominantColor() → worker result → startTransition(setA
 
 ### 4. `usePlayerSizing` instantiated 7 times independently
 
-**What happens:** `usePlayerSizing` is called directly in 7 components: `PlayerContent`, `SpotifyPlayerControls`, `PlaylistDrawer`, `BottomBar`, `AlbumArt`, `VisualEffectsMenu`, `TimelineSlider`, and `PlaylistSelection`. Each instance sets up its own resize listener and maintains its own `viewport`/`dimensions` state. On resize, all 7 fire state updates independently.
+**What happens:** `usePlayerSizing` is called directly in 7 components: `PlayerContent`, `SpotifyPlayerControls`, `QueueDrawer`, `BottomBar`, `AlbumArt`, `VisualEffectsMenu`, `TimelineSlider`, and `PlaylistSelection`. Each instance sets up its own resize listener and maintains its own `viewport`/`dimensions` state. On resize, all 7 fire state updates independently.
 
 During album switch this is less critical (viewport doesn't change), but it means 7 hook instances doing redundant work on every resize, and it contributes to render breadth generally.
 
@@ -125,7 +125,7 @@ Implement in this order for maximum incremental gain with safe rollback:
 | `src/contexts/PlayerSizingContext.tsx` | New file |
 | `src/components/PlayerContent.tsx` | Use context instead of hook directly |
 | `src/components/SpotifyPlayerControls.tsx` | Same |
-| `src/components/PlaylistDrawer.tsx` | Same |
+| `src/components/QueueDrawer.tsx` | Same |
 | `src/components/BottomBar/index.tsx` | Same |
 | `src/components/AlbumArt.tsx` | Same |
 | `src/components/VisualEffectsMenu/index.tsx` | Same |

--- a/docs/implementation-plans/spotify-adapter-migration.md
+++ b/docs/implementation-plans/spotify-adapter-migration.md
@@ -23,7 +23,7 @@ Migrate the app from direct Spotify coupling to a provider-based architecture. S
 | **Services**  | `services/spotify.ts` (auth + API + types), `services/spotifyPlayer.ts` (SDK), `services/cache/librarySyncEngine.ts`, `libraryCache.ts`, `cacheTypes.ts` |
 | **Hooks**     | `usePlaylistManager`, `useSpotifyPlayback`, `useSpotifyControls`, `usePlayerLogic`, `useAutoAdvance`, `useVolume`, `useLibrarySync`, `useLikeTrack` |
 | **Contexts**  | `TrackContext` (uses `Track` from spotify) |
-| **Components**| `PlayerStateRenderer`, `PlaylistSelection`, `SpotifyPlayerControls`, `TrackInfo`, `Playlist`, `AlbumArt`, etc. |
+| **Components**| `PlayerStateRenderer`, `PlaylistSelection`, `SpotifyPlayerControls`, `TrackInfo`, `QueueTrackList`, `AlbumArt`, etc. |
 
 ## Migration Order (Incremental, No Big Bang)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -23,7 +23,7 @@ Fixed at the bottom of the screen:
 - Shuffle toggle
 - Visual effects menu (gear icon for full controls)
 - Back to library
-- Playlist drawer toggle
+- Queue drawer toggle
 - Zen mode toggle (desktop/tablet)
 
 ### Playback Controls

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -14,7 +14,7 @@ import {
 } from './styled';
 import type { Track } from '../services/spotify';
 
-const Playlist = React.lazy(() => import('./Playlist'));
+const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
 
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
@@ -201,7 +201,7 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
                 </DrawerFallback>
               }
             >
-              <Playlist
+              <QueueTrackList
                 tracks={tracks}
                 currentTrackIndex={currentTrackIndex}
                 onTrackSelect={(index) => {

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -6,7 +6,7 @@ import { theme } from '../styles/theme';
 import { DrawerFallback, DrawerFallbackCard } from './styled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
-const Playlist = React.lazy(() => import('./Playlist'));
+const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
 
 const QueueDrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['isOpen', 'width', 'transitionDuration', 'transitionEasing'].includes(prop),
@@ -278,7 +278,7 @@ const QueueDrawer = memo<QueueDrawerProps>(({
               </DrawerFallbackCard>
             </DrawerFallback>
           }>
-            <Playlist
+            <QueueTrackList
               tracks={tracks}
               currentTrackIndex={currentTrackIndex}
               onTrackSelect={(index) => {

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -23,7 +23,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useHorizontalSwipeToRemove } from '@/hooks/useHorizontalSwipeToRemove';
 
 // Styled components
-const PlaylistContainer = styled.div`
+const QueueListRoot = styled.div`
   width: 100%;
   flex: 1;
   min-height: 0;
@@ -31,7 +31,7 @@ const PlaylistContainer = styled.div`
   flex-direction: column;
 `;
 
-const PlaylistCard = styled(Card)`
+const QueueListCard = styled(Card)`
   background: ${({ theme }) => theme.colors.muted.background};
   backdrop-filter: blur(12px);
   border: 1px solid ${({ theme }) => theme.colors.control.border};
@@ -44,12 +44,12 @@ const PlaylistCard = styled(Card)`
   min-height: 0;
 `;
 
-const PlaylistHeader = styled(CardHeader)`
+const QueueListCardHeader = styled(CardHeader)`
   padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.sm};
   flex-shrink: 0;
 `;
 
-const PlaylistHeaderRow = styled.div`
+const QueueListCardHeaderRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -72,13 +72,13 @@ const EditButton = styled.button`
   }
 `;
 
-const PlaylistDescription = styled(CardDescription)`
+const QueueListMeta = styled(CardDescription)`
   font-size: ${({ theme }) => theme.fontSize.sm};
   color: ${({ theme }) => theme.colors.gray[400]};
   margin: 0;
 `;
 
-const PlaylistContentArea = styled(CardContent)`
+const QueueListContent = styled(CardContent)`
   padding: 0;
   overflow: hidden;
   flex: 1;
@@ -87,19 +87,19 @@ const PlaylistContentArea = styled(CardContent)`
   flex-direction: column;
 `;
 
-const PlaylistScrollArea = styled(ScrollArea)`
+const QueueListScroll = styled(ScrollArea)`
   flex: 1;
   min-height: 0;
 `;
 
-const PlaylistItems = styled.div`
+const QueueListItems = styled.div`
   padding: 1rem ${({ theme }) => theme.spacing.md};
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing.sm};
 `;
 
-const PlaylistItemContainer = styled.div.withConfig({
+const QueueListItem = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== 'isSelected',
 })<{ isSelected: boolean }>`
   display: flex;
@@ -206,7 +206,7 @@ const RemoveButton = styled.button`
   opacity: 0;
   transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
 
-  ${PlaylistItemContainer}:hover & {
+  ${QueueListItem}:hover & {
     opacity: 1;
   }
 
@@ -266,7 +266,7 @@ const RemoveIcon = () => (
   </svg>
 );
 
-interface PlaylistProps {
+interface QueueTrackListProps {
   tracks: Track[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
@@ -277,7 +277,7 @@ interface PlaylistProps {
   canEdit?: boolean;
 }
 
-interface PlaylistItemProps {
+interface QueueItemProps {
   track: Track;
   index: number;
   isSelected: boolean;
@@ -289,8 +289,8 @@ interface PlaylistItemProps {
   isEditMode?: boolean;
 }
 
-// Desktop playlist item with sortable + hover remove
-const SortablePlaylistItem = memo<PlaylistItemProps>(({
+// Desktop queue item with sortable + hover remove
+const SortableQueueItem = memo<QueueItemProps>(({
   track,
   index,
   isSelected,
@@ -331,7 +331,7 @@ const SortablePlaylistItem = memo<PlaylistItemProps>(({
 
   return (
     <div ref={setNodeRef} style={style}>
-      <PlaylistItemContainer
+      <QueueListItem
         ref={itemRef}
         onClick={handleClick}
         isSelected={isSelected}
@@ -385,13 +385,13 @@ const SortablePlaylistItem = memo<PlaylistItemProps>(({
             <RemoveIcon />
           </RemoveButton>
         )}
-      </PlaylistItemContainer>
+      </QueueListItem>
     </div>
   );
 });
 
-// Mobile playlist item with swipe-to-remove
-const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
+// Mobile queue item with swipe-to-remove
+const SwipeableQueueItem = memo<QueueItemProps>(({
   track,
   index,
   isSelected,
@@ -420,7 +420,7 @@ const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
   if (!canRemove) {
     // No swipe for current track — render without swipe wrapper
     return (
-      <PlaylistItemContainer
+      <QueueListItem
         ref={itemRef}
         onClick={() => onSelect(index)}
         isSelected={isSelected}
@@ -462,7 +462,7 @@ const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
         <Duration isSelected={isSelected}>
           {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
         </Duration>
-      </PlaylistItemContainer>
+      </QueueListItem>
     );
   }
 
@@ -480,7 +480,7 @@ const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
         </SwipeRemoveBackdrop>
       )}
       <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
-        <PlaylistItemContainer
+        <QueueListItem
           ref={itemRef}
           onClick={() => !isRevealed && onSelect(index)}
           isSelected={isSelected}
@@ -515,7 +515,7 @@ const SwipeablePlaylistItem = memo<PlaylistItemProps>(({
           <Duration isSelected={isSelected}>
             {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
           </Duration>
-        </PlaylistItemContainer>
+        </QueueListItem>
       </SwipeableContent>
     </SwipeableWrapper>
   );
@@ -534,7 +534,7 @@ const useIsTouchDevice = () => {
   return isTouch;
 };
 
-const Playlist = memo<PlaylistProps>(({
+const QueueTrackList = memo<QueueTrackListProps>(({
   tracks,
   currentTrackIndex,
   onTrackSelect,
@@ -549,7 +549,7 @@ const Playlist = memo<PlaylistProps>(({
   const [isDragActive, setIsDragActive] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
 
-  // Auto-scroll to current track when playlist opens
+  // Auto-scroll to current track when queue opens
   useEffect(() => {
     if (isOpen && currentTrackRef.current && currentTrackIndex >= 0) {
       const timeoutId = setTimeout(() => {
@@ -607,19 +607,19 @@ const Playlist = memo<PlaylistProps>(({
   // On touch devices without reorder support, use swipeable items
   if (isTouch && !onReorderTracks) {
     return (
-      <PlaylistContainer>
-        <PlaylistCard>
-          <PlaylistHeader>
-            <PlaylistHeaderRow>
-              <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
+      <QueueListRoot>
+        <QueueListCard>
+          <QueueListCardHeader>
+            <QueueListCardHeaderRow>
+              <QueueListMeta>{tracks.length} tracks</QueueListMeta>
               {editButton}
-            </PlaylistHeaderRow>
-          </PlaylistHeader>
-          <PlaylistContentArea>
-            <PlaylistScrollArea>
-              <PlaylistItems>
+            </QueueListCardHeaderRow>
+          </QueueListCardHeader>
+          <QueueListContent>
+            <QueueListScroll>
+              <QueueListItems>
                 {tracks.map((track, index) => (
-                  <SwipeablePlaylistItem
+                  <SwipeableQueueItem
                     key={`${track.name}-${track.id}`}
                     track={track}
                     index={index}
@@ -631,27 +631,27 @@ const Playlist = memo<PlaylistProps>(({
                     isEditMode={isEditMode}
                   />
                 ))}
-              </PlaylistItems>
-            </PlaylistScrollArea>
-          </PlaylistContentArea>
-        </PlaylistCard>
-      </PlaylistContainer>
+              </QueueListItems>
+            </QueueListScroll>
+          </QueueListContent>
+        </QueueListCard>
+      </QueueListRoot>
     );
   }
 
   // Desktop / with reorder: use DnD context
   if (canManageQueue) {
     return (
-      <PlaylistContainer>
-        <PlaylistCard>
-          <PlaylistHeader>
-            <PlaylistHeaderRow>
-              <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
+      <QueueListRoot>
+        <QueueListCard>
+          <QueueListCardHeader>
+            <QueueListCardHeaderRow>
+              <QueueListMeta>{tracks.length} tracks</QueueListMeta>
               {editButton}
-            </PlaylistHeaderRow>
-          </PlaylistHeader>
-          <PlaylistContentArea>
-            <PlaylistScrollArea>
+            </QueueListCardHeaderRow>
+          </QueueListCardHeader>
+          <QueueListContent>
+            <QueueListScroll>
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -659,9 +659,9 @@ const Playlist = memo<PlaylistProps>(({
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                  <PlaylistItems>
+                  <QueueListItems>
                     {tracks.map((track, index) => (
-                      <SortablePlaylistItem
+                      <SortableQueueItem
                         key={`${track.name}-${track.id}`}
                         track={track}
                         index={index}
@@ -674,28 +674,28 @@ const Playlist = memo<PlaylistProps>(({
                         isEditMode={isEditMode}
                       />
                     ))}
-                  </PlaylistItems>
+                  </QueueListItems>
                 </SortableContext>
               </DndContext>
-            </PlaylistScrollArea>
-          </PlaylistContentArea>
-        </PlaylistCard>
-      </PlaylistContainer>
+            </QueueListScroll>
+          </QueueListContent>
+        </QueueListCard>
+      </QueueListRoot>
     );
   }
 
   // Fallback: no queue management (read-only)
   return (
-    <PlaylistContainer>
-      <PlaylistCard>
-        <PlaylistHeader>
-          <PlaylistDescription>{tracks.length} tracks</PlaylistDescription>
-        </PlaylistHeader>
-        <PlaylistContentArea>
-          <PlaylistScrollArea>
-            <PlaylistItems>
+    <QueueListRoot>
+      <QueueListCard>
+        <QueueListCardHeader>
+          <QueueListMeta>{tracks.length} tracks</QueueListMeta>
+        </QueueListCardHeader>
+        <QueueListContent>
+          <QueueListScroll>
+            <QueueListItems>
               {tracks.map((track: Track, index: number) => (
-                <PlaylistItemContainer
+                <QueueListItem
                   key={`${track.name}-${track.id}`}
                   ref={index === currentTrackIndex ? currentTrackRef : undefined}
                   onClick={() => onTrackSelect(index)}
@@ -738,14 +738,14 @@ const Playlist = memo<PlaylistProps>(({
                   <Duration isSelected={index === currentTrackIndex}>
                     {track.duration_ms ? `${Math.floor(track.duration_ms / 60000)}:${Math.floor((track.duration_ms % 60000) / 1000).toString().padStart(2, '0')}` : '--:--'}
                   </Duration>
-                </PlaylistItemContainer>
+                </QueueListItem>
               ))}
-            </PlaylistItems>
-          </PlaylistScrollArea>
-        </PlaylistContentArea>
-      </PlaylistCard>
-    </PlaylistContainer>
+            </QueueListItems>
+          </QueueListScroll>
+        </QueueListContent>
+      </QueueListCard>
+    </QueueListRoot>
   );
 });
 
-export default Playlist;
+export default QueueTrackList;

--- a/tasks/0001-prd-unified-liked-tracks.md
+++ b/tasks/0001-prd-unified-liked-tracks.md
@@ -53,7 +53,7 @@ When multiple music providers (Spotify, Dropbox) are enabled simultaneously, eac
 - **Performance**: Fetching liked tracks from multiple providers should happen in parallel. Consider caching the merged result with invalidation on any provider's change event.
 - **useLibrarySync**: Currently returns `likedSongsPerProvider: PerProviderLikedCount[]`. This can be extended to also return a `totalLikedCount` when multiple providers are active.
 - **PlaylistSelection**: Currently renders one card per provider when `likedSongsPerProvider.length >= 1`. Needs to render a single unified card when 2+ providers are present.
-- **Track list rendering**: The track list component (used by `PlaylistDrawer`) needs to support an optional provider icon column/badge.
+- **Track list rendering**: `QueueTrackList` (used by `QueueDrawer` / `QueueBottomSheet`) needs to support an optional provider icon column/badge.
 
 ## Success Metrics
 

--- a/tasks/tasks-0001-prd-unified-liked-tracks.md
+++ b/tasks/tasks-0001-prd-unified-liked-tracks.md
@@ -9,9 +9,9 @@
 - `src/providers/spotify/spotifyCatalogAdapter.ts` - Maps `added_at` to `addedAt` on `MediaTrack`
 - `src/providers/dropbox/dropboxLikesCache.ts` - Returns `likedAt` as `addedAt` on liked tracks
 - `src/components/PlaylistSelection.tsx` - Shows single unified liked card with blended gradient when 2+ providers active
-- `src/components/Playlist.tsx` - Added provider icon badges on track items (unified context only)
-- `src/components/PlaylistDrawer.tsx` - Passes `showProviderIcons` prop through to Playlist
-- `src/components/PlaylistBottomSheet.tsx` - Passes `showProviderIcons` prop through to Playlist
+- `src/components/QueueTrackList.tsx` - Added provider icon badges on track items (unified context only)
+- `src/components/QueueDrawer.tsx` - Passes `showProviderIcons` prop through to QueueTrackList
+- `src/components/QueueBottomSheet.tsx` - Passes `showProviderIcons` prop through to QueueTrackList
 - `src/components/PlayerContent.tsx` - Determines when to show provider icons based on unified state
 - `src/components/ProviderIcon.tsx` - Existing provider icon badge component (reused as-is)
 - `src/hooks/usePlayerLogic.ts` - Handles unified liked playlist selection (parallel fetch + merge)
@@ -36,7 +36,7 @@
   - [x] 2.3 Display the total liked count (sum across providers) on the unified card.
   - [x] 2.4 Ensure the pinning feature works with the unified liked card (same `LIKED_SONGS_ID` key).
 - [x] 3.0 Update track list rendering to display provider icons
-  - [x] 3.1 Modify `Playlist.tsx` track item rendering to accept and display an optional provider icon badge using the existing `ProviderIcon` component. Positioned on the album art thumbnail.
+  - [x] 3.1 Modify `QueueTrackList.tsx` track item rendering to accept and display an optional provider icon badge using the existing `ProviderIcon` component. Positioned on the album art thumbnail.
   - [x] 3.2 Pass the `provider` field from each `Track` to the track item when the current playlist is the unified liked playlist. Only show provider icons in the unified context (not for regular single-provider playlists).
 - [x] 4.0 Wire up like/unlike actions and track loading in the unified context
   - [x] 4.1 Modify `usePlayerLogic.ts` `handlePlaylistSelect`: when `LIKED_SONGS_ID` is selected without a specific provider (unified mode), fetch liked tracks from all providers in parallel, merge and sort by recency, and set as the current playlist.


### PR DESCRIPTION
- Updated references from "Playlist" to "Queue" in various documentation files to clarify the distinction between playback queue and library collections.
- Renamed components and adjusted comments to reflect the new terminology, including changes in `QueueDrawer`, `QueueBottomSheet`, and `QueueTrackList`.
- Removed the `Playlist` component and replaced its functionality with `QueueTrackList` to streamline the codebase and improve maintainability.
- Enhanced user guide and implementation plans to align with the updated queue management features.