### PR TITLE
feat(queue): add add-to-queue toast with inline queue action (#347)

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -12,12 +12,17 @@ import {
 } from './styled';
 import PlaylistSelection from './PlaylistSelection';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
+import type { AddToQueueResult, ProviderId } from '@/types/domain';
 
 interface LibraryDrawerProps {
   isOpen: boolean;
   onClose: () => void;
-  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: import('@/types/domain').ProviderId) => void;
-  onAddToQueue?: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
   initialSearchQuery?: string;
   initialViewMode?: 'playlists' | 'albums';
 }
@@ -122,7 +127,7 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
   const selectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handlePlaylistSelectWrapper = useCallback(
-    (playlistId: string, playlistName: string, provider?: import('@/types/domain').ProviderId) => {
+    (playlistId: string, playlistName: string, provider?: ProviderId) => {
       onClose();
       if (selectTimeoutRef.current) clearTimeout(selectTimeoutRef.current);
       selectTimeoutRef.current = setTimeout(() => {

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -27,9 +27,10 @@ import { useProfilingContext } from '@/contexts/ProfilingContext';
 import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import LibraryDrawer from './LibraryDrawer';
 import AlbumArtQuickSwapBack from './AlbumArtQuickSwapBack';
-import type { ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
 import Toast from './Toast';
+import type { RadioState } from '@/hooks/useRadio';
 
 const SaveQueueDialog = lazy(() => import('./SaveQueueDialog'));
 
@@ -46,8 +47,12 @@ interface PlaybackHandlers {
   onTrackSelect: (index: number) => void;
   onOpenLibraryDrawer: () => void;
   onCloseLibraryDrawer: () => void;
-  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: import('@/types/domain').ProviderId) => void;
-  onAddToQueue?: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
   onAlbumPlay: (albumId: string, albumName: string) => void;
   onBackToLibrary: () => void;
   onStartRadio?: () => void;
@@ -67,11 +72,11 @@ interface PlayerContentProps {
   showLibraryDrawer: boolean;
   onAlbumArtBoundsChange?: (bounds: AlbumArtBounds | null) => void;
   handlers: PlaybackHandlers;
-  currentTrackProvider?: import('@/types/domain').ProviderId;
-  radioState?: import('@/hooks/useRadio').RadioState;
+  currentTrackProvider?: ProviderId;
+  radioState?: RadioState;
   isRadioAvailable?: boolean;
   radioActive?: boolean;
-  mediaTracksRef?: React.RefObject<import('@/types/domain').MediaTrack[]>;
+  mediaTracksRef?: React.RefObject<MediaTrack[]>;
 }
 
 const ContentWrapper = styled.div.withConfig({
@@ -349,7 +354,11 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   // --- Save queue as playlist ---
   const { connectedProviderIds } = useProviderContext();
   const [showSaveQueueDialog, setShowSaveQueueDialog] = useState(false);
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    actionLabel?: string;
+    onAction?: () => void;
+  } | null>(null);
   const saveProviders = useMemo(
     () => connectedProviderIds.filter((id): id is 'dropbox' | 'spotify' => id === 'dropbox' || id === 'spotify'),
     [connectedProviderIds],
@@ -378,7 +387,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
         if (!result) return false;
 
         setShowSaveQueueDialog(false);
-        setToastMessage(`Saved "${name}" to Dropbox`);
+        setToast({ message: `Saved "${name}" to Dropbox` });
         window.dispatchEvent(new Event(LIBRARY_REFRESH_EVENT));
         return true;
       }
@@ -399,7 +408,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
         await addTracksToPlaylist(playlist.id, uris);
 
         setShowSaveQueueDialog(false);
-        setToastMessage(`Saved "${name}" to Spotify`);
+        setToast({ message: `Saved "${name}" to Spotify` });
         return true;
       }
 
@@ -410,14 +419,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     }
   }, [mediaTracksRef, tracks]);
 
-  const handleDismissToast = useCallback(() => setToastMessage(null), []);
-
-  // Auto-dismiss toast
-  useEffect(() => {
-    if (!toastMessage) return;
-    const timer = setTimeout(() => setToastMessage(null), 5000);
-    return () => clearTimeout(timer);
-  }, [toastMessage]);
+  const handleDismissToast = useCallback(() => setToast(null), []);
 
   // --- Local UI state ---
   const [showHelp, setShowHelp] = useState(false);
@@ -510,6 +512,32 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
     setShowQueue(prev => !prev);
   }, [setShowQueue, handlers, setShowVisualEffects]);
   const handleCloseQueue = useCallback(() => setShowQueue(false), [setShowQueue]);
+
+  const handleOpenQueueFromToast = useCallback(() => {
+    handlers.onCloseLibraryDrawer();
+    setShowVisualEffects(false);
+    setShowQueue(true);
+  }, [handlers, setShowVisualEffects, setShowQueue]);
+
+  const handleAddToQueueWithToast = useCallback(
+    async (playlistId: string, playlistName?: string, provider?: ProviderId) => {
+      if (!handlers.onAddToQueue) return null;
+      const result = await handlers.onAddToQueue(playlistId, playlistName, provider);
+      if (!result || result.added <= 0) return null;
+      const name = result.collectionName?.trim();
+      const title = name && name.length > 0 ? `"${name}"` : 'this collection';
+      setToast({
+        message: `Added ${result.added} ${result.added === 1 ? 'track' : 'tracks'} from ${title} to your`,
+        actionLabel: 'queue',
+        onAction: () => {
+          handleOpenQueueFromToast();
+          setToast(null);
+        },
+      });
+      return result;
+    },
+    [handlers, handleOpenQueueFromToast],
+  );
 
   // --- App settings handlers ---
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
@@ -934,7 +962,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
           isOpen={showLibraryDrawer}
           onClose={handleCloseLibraryDrawer}
           onPlaylistSelect={handlers.onPlaylistSelect}
-          onAddToQueue={handlers.onAddToQueue}
+          onAddToQueue={handleAddToQueueWithToast}
           initialSearchQuery={librarySearchQuery}
           initialViewMode={libraryViewMode}
         />
@@ -950,7 +978,14 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
           />
         </Suspense>
       )}
-      {toastMessage && <Toast message={toastMessage} onDismiss={handleDismissToast} />}
+      {toast && (
+        <Toast
+          message={toast.message}
+          onDismiss={handleDismissToast}
+          actionLabel={toast.actionLabel}
+          onAction={toast.onAction}
+        />
+      )}
     </ContentWrapper>
   );
 });

--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -35,12 +35,17 @@ import TrackInfoPopover, {
   AddToQueueIcon,
   ICON_MAP,
 } from './controls/TrackInfoPopover';
+import type { AddToQueueResult, ProviderId } from '@/types/domain';
 
 type ViewMode = 'playlists' | 'albums';
 
 interface PlaylistSelectionProps {
-  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: import('@/types/domain').ProviderId) => void;
-  onAddToQueue?: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
   /** When true, uses compact layout for drawer context (no centering, fills available space) */
   inDrawer?: boolean;
   /** Ref for swipe-to-close gesture zone (search/filters area only, not the scrollable list) */
@@ -898,7 +903,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     });
   }
 
-  function handleLikedSongsClick(provider?: import('@/types/domain').ProviderId): void {
+  function handleLikedSongsClick(provider?: ProviderId): void {
     const resolvedProvider = provider ?? (likedSongsPerProvider.length === 1 ? likedSongsPerProvider[0].provider : undefined);
     onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
   }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -6,25 +6,28 @@ import { theme } from '@/styles/theme';
 interface ToastProps {
   message: string;
   onDismiss: () => void;
+  /** Optional text button (e.g. “View queue”) — does not dismiss on its own unless `onAction` does. */
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 const slideIn = keyframes`
-  from { transform: translateY(-100%); opacity: 0; }
-  to   { transform: translateY(0); opacity: 1; }
+  from { transform: translate(-50%, -100%); opacity: 0; }
+  to   { transform: translate(-50%, 0); opacity: 1; }
 `;
 
 const slideOut = keyframes`
-  from { transform: translateY(0); opacity: 1; }
-  to   { transform: translateY(-100%); opacity: 0; }
+  from { transform: translate(-50%, 0); opacity: 1; }
+  to   { transform: translate(-50%, -100%); opacity: 0; }
 `;
 
 const ToastContainer = styled.div<{ $exiting: boolean }>`
   position: fixed;
   top: ${theme.spacing.lg};
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, 0);
   z-index: ${theme.zIndex.modal + 10};
-  max-width: min(420px, 90vw);
+  max-width: min(460px, calc(100vw - ${theme.spacing.lg} * 2));
   padding: ${theme.spacing.sm} ${theme.spacing.lg};
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(12px);
@@ -35,35 +38,110 @@ const ToastContainer = styled.div<{ $exiting: boolean }>`
   line-height: 1.4;
   display: flex;
   align-items: center;
-  gap: ${theme.spacing.sm};
+  justify-content: space-between;
+  gap: ${theme.spacing.md};
   animation: ${({ $exiting }) => ($exiting ? slideOut : slideIn)} 0.3s ease forwards;
+  cursor: default;
+
+  @media (max-width: ${theme.breakpoints.md}) {
+    padding: ${theme.spacing.sm} ${theme.spacing.md};
+    gap: ${theme.spacing.sm};
+  }
+`;
+
+const MessageText = styled.span`
+  flex: 1;
+  min-width: 0;
   cursor: pointer;
 `;
 
-const DismissIcon = styled.span`
+const ActionsRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
   flex-shrink: 0;
-  opacity: 0.5;
-  font-size: 0.75rem;
 `;
 
-export default function Toast({ message, onDismiss }: ToastProps) {
+const ActionButton = styled.button`
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: ${theme.colors.primary};
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.15);
+  }
+`;
+
+const DismissIcon = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  opacity: 0.5;
+  font-size: 0.75rem;
+  cursor: pointer;
+  line-height: 1;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
+export default function Toast({ message, onDismiss, actionLabel, onAction }: ToastProps) {
   const [exiting, setExiting] = useState(false);
 
   useEffect(() => {
-    // Start exit animation 300ms before the parent auto-dismisses
-    const timer = setTimeout(() => setExiting(true), 4700);
-    return () => clearTimeout(timer);
-  }, []);
+    const displayDurationMs = 5000;
+    const exitDurationMs = 300;
+    const exitTimer = setTimeout(() => setExiting(true), displayDurationMs - exitDurationMs);
+    const dismissTimer = setTimeout(onDismiss, displayDurationMs);
+    return () => {
+      clearTimeout(exitTimer);
+      clearTimeout(dismissTimer);
+    };
+  }, [onDismiss]);
 
-  const handleClick = () => {
+  const handleDismiss = () => {
     setExiting(true);
     setTimeout(onDismiss, 300);
   };
 
+  const handleAction = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onAction?.();
+  };
+
   return createPortal(
-    <ToastContainer $exiting={exiting} onClick={handleClick}>
-      <span>{message}</span>
-      <DismissIcon>✕</DismissIcon>
+    <ToastContainer $exiting={exiting} role="status">
+      <MessageText onClick={handleDismiss} title="Dismiss">
+        {message}
+        {actionLabel && onAction ? (
+          <>
+            {' '}
+            <ActionButton type="button" onClick={handleAction}>
+              {actionLabel}
+            </ActionButton>
+          </>
+        ) : null}
+      </MessageText>
+      <ActionsRow>
+        <DismissIcon type="button" onClick={handleDismiss} aria-label="Dismiss">
+          ✕
+        </DismissIcon>
+      </ActionsRow>
     </ToastContainer>,
     document.body,
   );

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -12,7 +12,7 @@ import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { useRadio } from '@/hooks/useRadio';
 import { useSpotifyQueueSync } from '@/hooks/useSpotifyQueueSync';
 import type { Track } from '@/services/spotify';
-import type { PlaybackState, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, PlaybackState, ProviderId } from '@/types/domain';
 import type { MediaTrack } from '@/types/domain';
 import type { RadioSeed } from '@/types/radio';
 import { isAlbumId, extractAlbumId, LIKED_SONGS_ID, resolvePlaylistRef } from '@/constants/playlist';
@@ -175,7 +175,7 @@ export function usePlayerLogic() {
   });
 
   const handlePlaylistSelect = useCallback(
-    async (playlistId: string, _playlistName?: string, provider?: import('@/types/domain').ProviderId) => {
+    async (playlistId: string, _playlistName?: string, provider?: import('@/types/domain').ProviderId): Promise<number> => {
       logQueue('handlePlaylistSelect called — playlistId=%s provider=%s', playlistId, provider ?? 'active');
 
       // Unified liked songs: fetch from all connected providers, merge by timestamp
@@ -204,7 +204,7 @@ export function usePlayerLogic() {
             setOriginalTracks([]);
             setCurrentTrackIndex(0);
             setIsLoading(false);
-            return;
+            return 0;
           }
 
           const trackList = merged.map(mediaTrackToTrack);
@@ -231,14 +231,15 @@ export function usePlayerLogic() {
             // Route initial playback through shared playTrack() so Spotify queue sync runs immediately.
             await playTrack(0);
           }
+          return merged.length;
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to load liked tracks.');
           setTracks([]);
           setOriginalTracks([]);
           setCurrentTrackIndex(0);
           setIsLoading(false);
+          return 0;
         }
-        return;
       }
 
       // Determine which provider descriptor to use for this collection
@@ -274,7 +275,7 @@ export function usePlayerLogic() {
             setOriginalTracks([]);
             setCurrentTrackIndex(0);
             setIsLoading(false);
-            return;
+            return 0;
           }
           const trackList = list.map(mediaTrackToTrack);
           setOriginalTracks(trackList);
@@ -295,14 +296,15 @@ export function usePlayerLogic() {
           drivingProviderRef.current = providerId;
           queueSnapshot(`Non-Spotify (${providerId}) playlist loaded`, trackList, mediaTracksRef.current.length, 0);
           await playTrack(0);
+          return list.length;
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to load collection.');
           setTracks([]);
           setOriginalTracks([]);
           setCurrentTrackIndex(0);
           setIsLoading(false);
+          return 0;
         }
-        return;
       }
       // Pause any non-Spotify provider before handing off to the Spotify playlist manager
       // (which plays via the SDK directly, bypassing the cross-provider pause in playTrack).
@@ -320,6 +322,7 @@ export function usePlayerLogic() {
       } else {
         logQueue('Spotify playlist returned 0 tracks');
       }
+      return spotifyTracks.length;
     },
     [
       activeDescriptor,
@@ -540,7 +543,7 @@ export function usePlayerLogic() {
    * starts playback of the first added track.
    */
   const handleAddToQueue = useCallback(
-    async (playlistId: string, _playlistName?: string, provider?: import('@/types/domain').ProviderId) => {
+    async (playlistId: string, _playlistName?: string, provider?: import('@/types/domain').ProviderId): Promise<AddToQueueResult | null> => {
       const isQueueEmpty = tracks.length === 0;
       logQueue(
         'handleAddToQueue — playlistId=%s, provider=%s, currentQueueLen=%d, mediaLen=%d',
@@ -553,13 +556,17 @@ export function usePlayerLogic() {
       // If nothing is playing, just load normally
       if (isQueueEmpty) {
         logQueue('handleAddToQueue — queue empty, delegating to handlePlaylistSelect');
-        return handlePlaylistSelect(playlistId, _playlistName, provider);
+        const loaded = await handlePlaylistSelect(playlistId, _playlistName, provider);
+        if (loaded > 0) {
+          return { added: loaded, collectionName: _playlistName };
+        }
+        return null;
       }
 
       const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
       const targetProviderId = provider ?? activeDescriptor?.id;
 
-      if (!targetDescriptor || !targetProviderId) return;
+      if (!targetDescriptor || !targetProviderId) return null;
 
       try {
         let newMediaTracks: MediaTrack[];
@@ -586,7 +593,7 @@ export function usePlayerLogic() {
           newMediaTracks = await catalog.listTracks(collectionRef);
         }
 
-        if (newMediaTracks.length === 0) return;
+        if (newMediaTracks.length === 0) return null;
 
         const newTracks = newMediaTracks.map(mediaTrackToTrack);
 
@@ -605,8 +612,10 @@ export function usePlayerLogic() {
           mediaTracksRef.current.length,
           newTracks.map(t => trkSummary(t)).join(', '),
         );
+        return { added: newMediaTracks.length, collectionName: _playlistName };
       } catch (err) {
         console.error('[Queue] Failed to add to queue:', err);
+        return null;
       }
     },
     [tracks.length, handlePlaylistSelect, activeDescriptor, getDescriptor, setTracks, setOriginalTracks]

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -94,6 +94,13 @@ export function collectionRefToKey(ref: CollectionRef): string {
   return `${ref.provider}:${ref.kind}:${ref.id}`;
 }
 
+/** Result of appending a collection to the queue; used for confirmation UI. */
+export interface AddToQueueResult {
+  added: number;
+  /** Display name from the library (album or playlist title). */
+  collectionName?: string;
+}
+
 /** Parse a stored key back into CollectionRef if possible. */
 export function keyToCollectionRef(key: string): CollectionRef | null {
   const parts = key.split(':');


### PR DESCRIPTION
Return structured add-to-queue results and surface a centered toast with an inline queue link so users get immediate, compact feedback without excessive mobile wrapping.

Made-with: Cursor