### PR TITLE
fix(queue): no tap-to-play while queue is in edit mode

### DIFF
--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -319,10 +319,10 @@ const SortableQueueItem = memo<QueueItemProps>(({
   };
 
   const handleClick = useCallback(() => {
-    if (!isDragActive) {
+    if (!isDragActive && !isEditMode) {
       onSelect(index);
     }
-  }, [onSelect, index, isDragActive]);
+  }, [onSelect, index, isDragActive, isEditMode]);
 
   const handleRemoveClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -422,7 +422,9 @@ const SwipeableQueueItem = memo<QueueItemProps>(({
     return (
       <QueueListItem
         ref={itemRef}
-        onClick={() => onSelect(index)}
+        onClick={() => {
+          if (!isEditMode) onSelect(index);
+        }}
         isSelected={isSelected}
       >
         <AlbumArtContainer>
@@ -482,7 +484,7 @@ const SwipeableQueueItem = memo<QueueItemProps>(({
       <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
         <QueueListItem
           ref={itemRef}
-          onClick={() => !isRevealed && onSelect(index)}
+          onClick={() => !isRevealed && !isEditMode && onSelect(index)}
           isSelected={isSelected}
         >
           <AlbumArtContainer>


### PR DESCRIPTION
## Summary
When the queue is in **Edit** mode, tapping a row no longer jumps playback to that track. Tap-to-play only applies when **Edit** is off, so reordering, dragging, and removing are less likely to accidentally start the wrong track.

## Changes
- `SortableQueueItem`: skip `onSelect` when `isEditMode` (desktop / DnD)
- `SwipeableQueueItem`: same for touch swipe-remove rows and for the now-playing row (no swipe) in edit mode

## Testing
- `npx tsc --noEmit`
- `npm run test:run`

Made with [Cursor](https://cursor.com)