### PR TITLE
fix(layout): mobile safe-area without breaking vertical centering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,6 @@ const AppContainer = styled.div`
   min-height: 100vh;
   min-height: 100dvh;
   box-sizing: border-box;
-  padding-top: env(safe-area-inset-top, 0px);
   ${flexCenter}
 `;
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -182,7 +182,14 @@ const AudioPlayerComponent = () => {
         {/* 5 rapid taps in top-left corner toggles debug overlay */}
         <div
           onClick={handleActivatorTap}
-          style={{ position: 'fixed', top: 0, left: 0, width: 44, height: 44, zIndex: 999990 }}
+          style={{
+            position: 'fixed',
+            top: 'env(safe-area-inset-top, 0px)',
+            left: 0,
+            width: 44,
+            height: 44,
+            zIndex: 999990,
+          }}
         />
         <ProfiledComponent id="AccentColorBackground">
           <AccentColorBackground

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -72,7 +72,7 @@ const DrawerContainer = styled.div.withConfig({
 
 const DrawerHeader = styled.div`
   flex-shrink: 0;
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  padding: calc(${theme.spacing.sm} + env(safe-area-inset-top, 0px)) ${theme.spacing.md} ${theme.spacing.sm};
   min-height: 48px;
   display: flex;
   justify-content: space-between;

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -25,6 +25,7 @@ const QueueDrawerContainer = styled.div.withConfig({
   z-index: ${theme.zIndex.modal};
   overflow-y: auto;
   padding: ${theme.spacing.md};
+  padding-top: calc(${theme.spacing.md} + env(safe-area-inset-top, 0px));
   box-sizing: border-box;
   
   /* Enable container queries */

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -23,7 +23,7 @@ const slideOut = keyframes`
 
 const ToastContainer = styled.div<{ $exiting: boolean }>`
   position: fixed;
-  top: ${theme.spacing.lg};
+  top: calc(${theme.spacing.lg} + env(safe-area-inset-top, 0px));
   left: 50%;
   transform: translate(-50%, 0);
   z-index: ${theme.zIndex.modal + 10};

--- a/src/components/VisualEffectsMenu/styled.ts
+++ b/src/components/VisualEffectsMenu/styled.ts
@@ -64,7 +64,7 @@ export const DrawerHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: ${({ theme }) => theme.spacing.lg} ${theme.spacing.lg} ${theme.spacing.md};
+  padding: calc(${theme.spacing.lg} + env(safe-area-inset-top, 0px)) ${theme.spacing.lg} ${theme.spacing.md};
   border-bottom: 1px solid ${({ theme }) => theme.colors.popover.border};
   min-height: 60px;
   flex-shrink: 0; /* Prevent header from shrinking */


### PR DESCRIPTION
## Summary
Reverts the root `AppContainer` safe-area padding from #329-style behavior and applies `env(safe-area-inset-top)` only to fixed/overlay UI (toasts, drawers, effects menu header, debug tap target).

## Why
- Padding on the main flex container shifted Zen mode / album art below true vertical center.
- `min-height: 100dvh` on the player could exceed the padded parent and cause unwanted scroll.

## Test plan
- [ ] iPhone PWA / Safari: main player centered; toast and drawer close controls clear the notch
- [ ] Desktop unchanged (safe-area env resolves to 0)

Made with [Cursor](https://cursor.com)