### PR TITLE
feat(visualizer): intensity controls particle count

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -318,20 +318,20 @@ function QuickEffectsRow({
               <SubLabel>Intensity</SubLabel>
               <OptionButtonGroup>
                 <OptionButton
-                  $isActive={backgroundVisualizerIntensity === 30}
-                  onClick={() => onBackgroundVisualizerIntensityChange(30)}
+                  $isActive={backgroundVisualizerIntensity === 20}
+                  onClick={() => onBackgroundVisualizerIntensityChange(20)}
                 >
                   Less
                 </OptionButton>
                 <OptionButton
-                  $isActive={backgroundVisualizerIntensity === 60}
-                  onClick={() => onBackgroundVisualizerIntensityChange(60)}
+                  $isActive={backgroundVisualizerIntensity === 40}
+                  onClick={() => onBackgroundVisualizerIntensityChange(40)}
                 >
                   Normal
                 </OptionButton>
                 <OptionButton
-                  $isActive={backgroundVisualizerIntensity === 90}
-                  onClick={() => onBackgroundVisualizerIntensityChange(90)}
+                  $isActive={backgroundVisualizerIntensity === 60}
+                  onClick={() => onBackgroundVisualizerIntensityChange(60)}
                 >
                   More
                 </OptionButton>

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -41,13 +41,14 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
   const config = useVisualizerDebugConfig();
   const p = config.particle;
 
-  const getParticleCount = useCallback((width: number, height: number): number => {
+  const getParticleCount = useCallback((width: number, height: number, intensityValue: number): number => {
     const pixelCount = width * height;
     const isMobile = width < 768;
+    const scale = Math.max(0.1, intensityValue / 60);
     if (isMobile) {
-      return Math.min(Math.round(p.countBaseMobile), Math.floor(pixelCount / p.countPixelDivisorMobile));
+      return Math.round(Math.min(p.countBaseMobile, Math.floor(pixelCount / p.countPixelDivisorMobile)) * scale);
     }
-    return Math.min(Math.round(p.countBaseDesktop), Math.floor(pixelCount / p.countPixelDivisor));
+    return Math.round(Math.min(p.countBaseDesktop, Math.floor(pixelCount / p.countPixelDivisor)) * scale);
   }, [p]);
 
   const initializeParticles = useCallback((
@@ -104,13 +105,13 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     particles: Particle[],
     width: number,
     height: number,
-    intensityValue: number
+    _intensityValue: number
   ): void => {
     ctx.clearRect(0, 0, width, height);
 
     particles.forEach(particle => {
       ctx.save();
-      ctx.globalAlpha = particle.opacity * (intensityValue / 100);
+      ctx.globalAlpha = particle.opacity;
       ctx.fillStyle = particle.color;
       ctx.beginPath();
       ctx.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -73,13 +73,14 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     inited: false,
   });
 
-  const getParticleCount = useCallback((width: number, height: number): number => {
+  const getParticleCount = useCallback((width: number, height: number, intensityValue: number): number => {
     const pixelCount = width * height;
     const isMobile = width < 768;
+    const scale = Math.max(0.1, intensityValue / 60);
     if (isMobile) {
-      return Math.min(Math.round(t.countBaseMobile), Math.floor(pixelCount / t.countPixelDivisorMobile));
+      return Math.round(Math.min(t.countBaseMobile, Math.floor(pixelCount / t.countPixelDivisorMobile)) * scale);
     }
-    return Math.min(Math.round(t.countBaseDesktop), Math.floor(pixelCount / t.countPixelDivisor));
+    return Math.round(Math.min(t.countBaseDesktop, Math.floor(pixelCount / t.countPixelDivisor)) * scale);
   }, [t]);
 
   const initializeParticles = useCallback((
@@ -191,16 +192,15 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     particles: TrailParticle[],
     width: number,
     height: number,
-    intensityValue: number
+    _intensityValue: number
   ): void => {
     ctx.clearRect(0, 0, width, height);
 
     const ship = shipRef.current;
-    const intensityFactor = intensityValue / 100;
 
     particles.forEach(particle => {
       if (particle.life <= 0) return;
-      const alpha = Math.max(0, particle.life) * intensityFactor;
+      const alpha = Math.max(0, particle.life);
       const r = Math.max(t.minVisibleRadius, particle.radius * particle.life);
 
       ctx.save();
@@ -212,9 +212,9 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
       ctx.restore();
     });
 
-    if (ship.inited && intensityFactor > 0 && t.glowRadius > 0) {
+    if (ship.inited && t.glowRadius > 0) {
       const glow = ctx.createRadialGradient(ship.x, ship.y, 0, ship.x, ship.y, t.glowRadius);
-      glow.addColorStop(0, `rgba(255,255,255,${0.5 * intensityFactor})`);
+      glow.addColorStop(0, 'rgba(255,255,255,0.5)');
       glow.addColorStop(1, 'rgba(255,255,255,0)');
       ctx.save();
       ctx.globalAlpha = 1;

--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -36,7 +36,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   const [perAlbumGlow, setPerAlbumGlow] = useLocalStorage<Record<string, { intensity: number; rate: number }>>('vorbis-player-per-album-glow', {});
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>('vorbis-player-background-visualizer-enabled', true);
   const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>('vorbis-player-background-visualizer-style', 'fireflies');
-  const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>('vorbis-player-background-visualizer-intensity', 60);
+  const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>('vorbis-player-background-visualizer-intensity', 40);
   const [accentColorBackgroundPreferred, setAccentColorBackgroundPreferred] = useLocalStorage<boolean>('vorbis-player-accent-color-background-preferred', false);
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
   const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>('vorbis-player-translucence-enabled', false);

--- a/src/hooks/useCanvasVisualizer.ts
+++ b/src/hooks/useCanvasVisualizer.ts
@@ -8,7 +8,7 @@ interface UseCanvasVisualizerProps<T> {
   /**
    * Calculate how many items to spawn based on canvas dimensions
    */
-  getItemCount: (width: number, height: number) => number;
+  getItemCount: (width: number, height: number, intensity: number) => number;
   /**
    * Create the initial array of items
    */
@@ -57,17 +57,17 @@ export const useCanvasVisualizer = <T>({
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
 
-      const count = getItemCount(canvas.width, canvas.height);
+      const count = getItemCount(canvas.width, canvas.height, intensity);
       itemsRef.current = initializeItems(count, canvas.width, canvas.height, accentColor);
     };
 
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
-    
+
     return () => {
       window.removeEventListener('resize', resizeCanvas);
     };
-  }, [accentColor, getItemCount, initializeItems]);
+  }, [accentColor, intensity, getItemCount, initializeItems]);
 
   // Handle color changes for existing items
   useEffect(() => {

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -167,7 +167,7 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
   const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>(
     'vorbis-player-background-visualizer-intensity',
-    60
+    40
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Visualizer intensity setting now controls **particle count** instead of opacity/alpha
- Opacity is fixed to natural values (particle pulse opacity for fireflies, life-based alpha for comet trail)
- Intensity levels shifted to Less (20), Normal (40), More (60) — "More" produces the same particle count as the previous default
- Particles re-initialize when intensity changes via updated `useCanvasVisualizer` hook

## Test plan
- [ ] Toggle intensity between Less/Normal/More on fireflies visualizer — particle density should visibly change
- [ ] Toggle intensity on comet visualizer — trail density should change
- [ ] Verify particle brightness/opacity stays consistent across intensity levels
- [ ] Check mobile and desktop particle counts scale appropriately
- [ ] Verify default (Normal) looks less dense than previous default


🤖 Generated with [Claude Code](https://claude.com/claude-code)