### PR TITLE
Add retry button for missing album artwork

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -49,6 +49,7 @@ interface AlbumArtProps {
   zenMode?: boolean;
   translucenceEnabled?: boolean;
   translucenceOpacity?: number;
+  onRetryAlbumArt?: () => void;
 }
 
 
@@ -163,10 +164,13 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
       prevProps.translucenceOpacity !== nextProps.translucenceOpacity) {
     return false;
   }
+  if (prevProps.onRetryAlbumArt !== nextProps.onRetryAlbumArt) {
+    return false;
+  }
   return true;
 };
 
-const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentColor, glowIntensity, glowRate, glowEnabled, zenMode, translucenceEnabled, translucenceOpacity }) => {
+const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentColor, glowIntensity, glowRate, glowEnabled, zenMode, translucenceEnabled, translucenceOpacity, onRetryAlbumArt }) => {
   const [canvasUrl, setCanvasUrl] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const { processImage } = useImageProcessingWorker();
@@ -292,14 +296,40 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
         ) : (
           <div style={{
             width: '100%',
+            height: '100%',
             backgroundColor: theme.colors.gray[900],
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
+            gap: '12px',
             color: theme.colors.gray[500],
             borderRadius: theme.borderRadius['3xl']
           }}>
-            <p>No image</p>
+            <p style={{ margin: 0 }}>No image</p>
+            {onRetryAlbumArt && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onRetryAlbumArt(); }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '6px 14px',
+                  background: 'rgba(255, 255, 255, 0.1)',
+                  color: 'rgba(255, 255, 255, 0.7)',
+                  border: '1px solid rgba(255, 255, 255, 0.15)',
+                  borderRadius: '8px',
+                  fontSize: '13px',
+                  cursor: 'pointer',
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="23 4 23 10 17 10" />
+                  <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                </svg>
+                Retry
+              </button>
+            )}
           </div>
         )}
         {isProcessing && <ProcessingSpinner size={spinnerDimensions.size} innerSize={spinnerDimensions.innerSize} />}

--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -26,6 +26,7 @@ interface AlbumArtQuickSwapBackProps {
   isMobile: boolean;
   isTablet: boolean;
   onClose: () => void;
+  onRetryAlbumArt?: () => void;
 }
 
 const BacksideRoot = styled.div`
@@ -75,6 +76,29 @@ const Title = styled.div`
   margin-bottom: ${theme.spacing.md};
 `;
 
+const RetryButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  margin-top: ${theme.spacing.md};
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: ${theme.borderRadius.lg};
+  font-size: ${theme.fontSize.xs};
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  &:active {
+    background: rgba(255, 255, 255, 0.25);
+  }
+`;
+
 function AlbumArtQuickSwapBack({
   currentTrack,
   accentColor,
@@ -98,6 +122,7 @@ function AlbumArtQuickSwapBack({
   isMobile,
   isTablet,
   onClose,
+  onRetryAlbumArt,
 }: AlbumArtQuickSwapBackProps) {
   return (
     <BacksideRoot>
@@ -131,6 +156,15 @@ function AlbumArtQuickSwapBack({
           isTablet={isTablet}
         />
         </div>
+        {onRetryAlbumArt && !currentTrack?.image && (
+          <RetryButton onClick={(e) => { e.stopPropagation(); onRetryAlbumArt(); }}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+            Retry Artwork
+          </RetryButton>
+        )}
       </Content>
     </BacksideRoot>
   );

--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -432,6 +432,14 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
   const [isFlipped, setIsFlipped] = useState(false);
   const toggleFlip = useCallback(() => setIsFlipped(f => !f), []);
   const flipContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleRetryAlbumArt = useCallback(async () => {
+    const providerId = currentTrackProvider ?? currentTrack?.provider;
+    if (!providerId) return;
+    const { providerRegistry } = await import('@/providers/registry');
+    const descriptor = providerRegistry.get(providerId);
+    descriptor?.playback.refreshCurrentTrackArt?.();
+  }, [currentTrackProvider, currentTrack?.provider]);
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Report album art bounds for trail visualizer (head stays inside art)
@@ -817,6 +825,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                       translucenceEnabled={translucenceEnabled}
                       translucenceOpacity={translucenceOpacity}
                       zenMode={zenModeEnabled}
+                      onRetryAlbumArt={handleRetryAlbumArt}
                     />
                   </ProfiledComponent>
                   <AlbumArtQuickSwapBack
@@ -842,6 +851,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
                     isMobile={isMobile}
                     isTablet={isTablet}
                     onClose={() => setIsFlipped(false)}
+                    onRetryAlbumArt={handleRetryAlbumArt}
                   />
                 </FlipInner>
               </ClickableAlbumArtContainer>

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -178,6 +178,33 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.catalog.prefetchTemporaryLink(track.playbackRef.ref);
   }
 
+  refreshCurrentTrackArt(): void {
+    const track = this.currentTrack;
+    if (!track || track.image) return;
+
+    // Try album art from Dropbox folder (cover.jpg etc.)
+    if (track.albumId) {
+      this.catalog.resolveAlbumArt(track.albumId).then((imageUrl) => {
+        if (!imageUrl) return;
+        if (this.currentTrack?.id !== track.id) return;
+        if (this.currentTrack.image) return;
+
+        this.currentTrack = { ...this.currentTrack, image: imageUrl };
+        this.pendingMetadataUpdate = {
+          ...(this.pendingMetadataUpdate ?? {}),
+          image: imageUrl,
+        };
+        this.notifyListeners();
+      }).catch(() => {});
+    }
+
+    // Also re-attempt ID3 tag extraction for embedded cover art
+    const dropboxPath = track.playbackRef.ref;
+    this.catalog.getTemporaryLink(dropboxPath).then((streamUrl) => {
+      this.enrichMetadataInBackground(track, streamUrl);
+    }).catch(() => {});
+  }
+
   async playCollection(
     _collectionRef: CollectionRef,
     _options?: { offset?: number },

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -64,6 +64,8 @@ export interface PlaybackProvider {
   subscribe(listener: (state: PlaybackState | null) => void): () => void;
   /** Optional: pre-warm resources for an upcoming track (e.g. fetch temporary links). */
   prepareTrack?(track: MediaTrack): void;
+  /** Optional: re-fetch album art for the currently playing track. */
+  refreshCurrentTrackArt?(): void;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a retry button that appears when album artwork fails to load or is missing, allowing users to re-fetch artwork without restarting playback
- Retry button appears both on the main album art placeholder and on the quick-swap backside card
- Implements `refreshCurrentTrackArt()` on the Dropbox playback adapter, which re-resolves album art from folder images (cover.jpg, etc.) and updates the playing track
- Adds `refreshCurrentTrackArt` as an optional method on the `PlaybackProvider` interface for any provider to implement

## Test plan

- [ ] Play a Dropbox track with missing album art — verify retry button appears on the placeholder
- [ ] Click retry — verify it attempts to re-fetch and updates artwork if available
- [ ] Flip to quick-swap back — verify retry button also appears there when art is missing
- [ ] Play a track with existing artwork — verify no retry button is shown
- [ ] Verify Spotify playback is unaffected (method is optional on the interface)