### PR TITLE
fix: auto-switch active provider when current provider is disabled

### DIFF
--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -219,6 +219,18 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     );
   }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId]);
 
+  // ── Auto-switch when active provider is disabled ──────────────────────
+  useEffect(() => {
+    if (storedProviderId === null) return;
+    if (enabledProviderIds.includes(storedProviderId)) return;
+
+    const fallback = enabledProviderIds.find(id => providerRegistry.has(id));
+    if (!fallback) return;
+
+    activeDescriptor?.playback.pause().catch(() => {});
+    setStoredProviderId(fallback);
+  }, [storedProviderId, enabledProviderIds, activeDescriptor, setStoredProviderId]);
+
   // Auto-dismiss fallthrough notification after 5 seconds
   useEffect(() => {
     if (!fallthroughNotification) return;


### PR DESCRIPTION
## Summary
- When the user disables the active provider (e.g. Spotify) via the library drawer toggle, `activeDescriptor` stayed pointed at the disabled provider
- This caused Liked Songs to show the wrong color (Spotify green instead of Dropbox) and load Spotify tracks instead of Dropbox tracks
- Adds an effect in `ProviderContext` that auto-switches to the first enabled provider when the current active provider is removed from `enabledProviderIds`

## Test plan
- [ ] Enable both Spotify and Dropbox providers
- [ ] Play a Spotify playlist
- [ ] Disable Spotify via the library drawer toggle
- [ ] Select "Liked Songs" — should show Dropbox color and load Dropbox tracks only
- [ ] Re-enable Spotify — active provider should not change unexpectedly
- [ ] Disable the non-active provider — active provider should remain unchanged