### PR TITLE
fix: hydrate cached artwork for Dropbox liked songs

### DIFF
--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -380,14 +380,20 @@ export class DropboxCatalogAdapter implements CatalogProvider {
     if (collectionRef.provider !== 'dropbox') return [];
     if (collectionRef.kind === 'liked') {
       const tracks = await getLikedTracks();
-      await this.hydrateCachedDurations(tracks);
+      await Promise.all([
+        this.hydrateCachedDurations(tracks),
+        this.hydrateCachedArtwork(tracks),
+      ]);
       return tracks;
     }
 
     // Saved playlists: load from JSON file in Dropbox
     if (collectionRef.kind === 'playlist') {
       const tracks = await loadPlaylistTracks(this.auth, collectionRef.id);
-      await this.hydrateCachedDurations(tracks);
+      await Promise.all([
+        this.hydrateCachedDurations(tracks),
+        this.hydrateCachedArtwork(tracks),
+      ]);
       return tracks;
     }
 
@@ -465,6 +471,25 @@ export class DropboxCatalogAdapter implements CatalogProvider {
       for (const t of needDuration) {
         const cached = durationsMap.get(t.id);
         if (cached !== undefined) t.durationMs = cached;
+      }
+    }
+  }
+
+  private async hydrateCachedArtwork(tracks: MediaTrack[]): Promise<void> {
+    const needArt = tracks.filter((t) => !t.image && t.albumId);
+    if (needArt.length === 0) return;
+    const albumIds = [...new Set(needArt.map((t) => t.albumId!))];
+    const artMap = new Map<string, string>();
+    await Promise.all(
+      albumIds.map(async (albumId) => {
+        const cached = await getAlbumArt(albumId);
+        if (cached) artMap.set(albumId, cached);
+      }),
+    );
+    if (artMap.size > 0) {
+      for (const t of needArt) {
+        const art = artMap.get(t.albumId!);
+        if (art) t.image = art;
       }
     }
   }


### PR DESCRIPTION
## Summary

- Liked songs and saved playlists loaded via `listTracks()` were not hydrating artwork from the IndexedDB art cache, causing tracks to arrive in the queue with missing thumbnails
- Regular folder listings already resolve artwork at load time via `resolveAlbumArtByDir`, but the liked/playlist paths skipped this
- Regression introduced in `40e2d69` which removed the two-phase thumbnail loader that previously compensated for this gap
- Adds `hydrateCachedArtwork()` that batch-reads the art cache for all tracks missing images, called alongside `hydrateCachedDurations()` for liked and playlist collections

## Test plan

- [ ] Load Dropbox liked songs — thumbnails should appear immediately for previously cached albums
- [ ] Load a saved Dropbox playlist — same behavior
- [ ] Like a track from a browsed album, reload, load liked songs — artwork should be present
- [ ] Verify Spotify queue tracks are unaffected
- [ ] Run `npm run test:run` — all 519 tests pass