### PR TITLE
fix: exclude playwright and fsevents from Vite dep optimization

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,9 @@ styled: ['styled-components']
     },
     dedupe: ['react', 'react-dom', 'styled-components'],
   },
+  optimizeDeps: {
+    exclude: ['playwright-core', '@playwright/test', 'fsevents']
+  },
   server: {
     host: '127.0.0.1',
     port: 3000


### PR DESCRIPTION
## Summary
- Excludes `playwright-core`, `@playwright/test`, and `fsevents` from Vite's dependency pre-bundling
- Fixes `chromium-bidi` resolution errors and `.node` file loader failures during dev server HMR

## Test plan
- [ ] Run `rm -rf node_modules/.vite && npm run dev` and confirm no chromium-bidi or fsevents errors in console
- [ ] Verify HMR still works correctly
- [ ] Run `npm run build` to confirm production build is unaffected