### PR TITLE
fix(library): move provider toggles to drawer bottom row with refresh (2/2)

### DIFF
--- a/src/components/LibraryProviderBar.tsx
+++ b/src/components/LibraryProviderBar.tsx
@@ -7,15 +7,22 @@ import Switch from '@/components/controls/Switch';
 const TOGGLE_ON_COLOR = '#4ade80';
 const TOGGLE_OFF_COLOR = 'rgba(255, 255, 255, 0.25)';
 
-const Bar = styled.div`
+const Bar = styled.div<{ $variant?: 'default' | 'drawerBottom' }>`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: ${({ $variant }) => ($variant === 'drawerBottom' ? 'flex-start' : 'center')};
   flex-wrap: wrap;
   gap: ${({ theme }) => theme.spacing.md};
   row-gap: ${({ theme }) => theme.spacing.xs};
-  padding: ${({ theme }) => theme.spacing.xs} 0;
-  flex-shrink: 0;
+  padding: ${({ theme, $variant }) => ($variant === 'drawerBottom' ? '0' : `${theme.spacing.xs} 0`)};
+  flex-shrink: ${({ $variant }) => ($variant === 'drawerBottom' ? 1 : 0)};
+  ${({ $variant }) =>
+    $variant === 'drawerBottom'
+      ? `
+    flex: 1 1 auto;
+    min-width: 0;
+  `
+      : ''}
 `;
 
 const ProviderRow = styled.div`
@@ -62,14 +69,18 @@ const ConnectButton = styled.button`
   }
 `;
 
-const LibraryProviderBar = React.memo(function LibraryProviderBar() {
+interface LibraryProviderBarProps {
+  variant?: 'default' | 'drawerBottom';
+}
+
+const LibraryProviderBar = React.memo(function LibraryProviderBar({ variant = 'default' }: LibraryProviderBarProps) {
   const { registry, enabledProviderIds, toggleProvider } = useProviderContext();
   const providers = useMemo(() => registry.getAll(), [registry]);
 
   if (providers.length < 2) return null;
 
   return (
-    <Bar>
+    <Bar $variant={variant}>
       {providers.map((descriptor) => {
         const isEnabled = enabledProviderIds.includes(descriptor.id);
         const isConnected = descriptor.auth.isAuthenticated();

--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -516,6 +516,20 @@ const DrawerBottomControls = styled.div`
   }
 `;
 
+const DrawerBottomRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  width: 100%;
+  min-width: 0;
+  flex-wrap: wrap;
+`;
+
+const DrawerRefreshButton = styled(RefreshButton)`
+  margin-left: auto;
+  flex-shrink: 0;
+`;
+
 const ClearButton = styled.button`
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: ${({ theme }) => theme.colors.control.background};
@@ -1297,7 +1311,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
 
   const mainContent = showMainContent ? (
     <>
-      <LibraryProviderBar />
+      {!inDrawer && <LibraryProviderBar />}
       <div ref={inDrawer ? swipeZoneRef : undefined} style={inDrawer ? { flexShrink: 0, touchAction: 'pan-y' } : undefined}>
         {tabsBar}
       </div>
@@ -1623,8 +1637,9 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
 
       {inDrawer && onLibraryRefresh && (
         <DrawerBottomControls>
-          <SortControlsRow style={{ justifyContent: 'flex-end' }}>
-            <RefreshButton
+          <DrawerBottomRow>
+            <LibraryProviderBar variant="drawerBottom" />
+            <DrawerRefreshButton
               onClick={onLibraryRefresh}
               $spinning={!!isLibraryRefreshing}
               aria-label="Refresh library"
@@ -1636,8 +1651,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
                 <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                 <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
-            </RefreshButton>
-          </SortControlsRow>
+            </DrawerRefreshButton>
+          </DrawerBottomRow>
         </DrawerBottomControls>
       )}
 


### PR DESCRIPTION
## Stack
**PR 2 of 2.** Base branch: `fix/library-sort-menu-and-added-at` (#379). After #379 merges to `develop`, retarget this PR to `develop` (or merge #379 first and rebase).

---

## Summary
Moves the multi-provider **LibraryProviderBar** (status dots, labels, Connected/Expired, enable toggles) from the row above Playlists/Albums tabs to the **bottom strip of the library drawer**, on the same row as the **Refresh library** control. Desktop library (non-drawer) layout is unchanged: the bar stays above tabs.

### Implementation
- `LibraryProviderBar`: optional `variant="drawerBottom"` for a compact, left-aligned bar that can share a row with the refresh button.
- `PlaylistSelection`: `DrawerBottomRow` + `DrawerRefreshButton` (`margin-left: auto`) so refresh stays right-aligned when the provider bar is hidden (single provider).

## Test plan
- [ ] Library drawer with Spotify + Dropbox: provider row appears at bottom next to refresh; toggles still work.
- [ ] Single-provider setup: bottom row shows refresh only (right-aligned).
- [ ] Desktop library: provider bar still above tabs.

Made with [Cursor](https://cursor.com)