### PR TITLE
feat(library): pinned sort, drawer bottom controls, read-only provider bar

### DIFF
--- a/src/components/FilterChipRow.tsx
+++ b/src/components/FilterChipRow.tsx
@@ -8,17 +8,13 @@ import {
   SearchChipWrapper,
   SearchChipIcon,
   SearchChipInput,
-  ClearChip,
   SortChipWrapper,
-  SortDropdown,
-  SortOption,
   ArtistListPopover,
   ArtistOption,
   ArtistCount,
 } from './styled/FilterChips';
 import ProviderIcon from './ProviderIcon';
 import type { ProviderId } from '@/types/domain';
-import type { AlbumSortOption, PlaylistSortOption } from '@/utils/playlistFilters';
 import type { AlbumInfo } from '@/services/spotify';
 
 // ── Icons ────────────────────────────────────────────────────
@@ -37,38 +33,6 @@ const CloseIcon = () => (
   </svg>
 );
 
-const SortIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <line x1="4" y1="6" x2="20" y2="6" />
-    <line x1="4" y1="12" x2="14" y2="12" />
-    <line x1="4" y1="18" x2="8" y2="18" />
-  </svg>
-);
-
-const ChevronDownIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="6 9 12 15 18 9" />
-  </svg>
-);
-
-// ── Sort labels ──────────────────────────────────────────────
-
-const PLAYLIST_SORT_LABELS: Record<PlaylistSortOption, string> = {
-  'recently-added': 'Recently Added',
-  'name-asc': 'Name (A-Z)',
-  'name-desc': 'Name (Z-A)',
-};
-
-const ALBUM_SORT_LABELS: Record<AlbumSortOption, string> = {
-  'recently-added': 'Recently Added',
-  'name-asc': 'Name (A-Z)',
-  'name-desc': 'Name (Z-A)',
-  'artist-asc': 'Artist (A-Z)',
-  'artist-desc': 'Artist (Z-A)',
-  'release-newest': 'Release (Newest)',
-  'release-oldest': 'Release (Oldest)',
-};
-
 // ── Component ────────────────────────────────────────────────
 
 interface FilterChipRowProps {
@@ -76,11 +40,6 @@ interface FilterChipRowProps {
   // Search
   searchQuery: string;
   onSearchChange: (query: string) => void;
-  // Sort
-  playlistSort: PlaylistSortOption;
-  albumSort: AlbumSortOption;
-  onPlaylistSortChange: (sort: PlaylistSortOption) => void;
-  onAlbumSortChange: (sort: AlbumSortOption) => void;
   // Providers
   enabledProviderIds: ProviderId[];
   activeProviderFilters: ProviderId[];
@@ -90,19 +49,12 @@ interface FilterChipRowProps {
   albums: AlbumInfo[];
   artistFilter: string;
   onArtistFilterChange: (artist: string) => void;
-  // Active filters indicator
-  hasActiveFilters: boolean;
-  onClearFilters: () => void;
 }
 
 const FilterChipRow = React.memo(function FilterChipRow({
   viewMode,
   searchQuery,
   onSearchChange,
-  playlistSort,
-  albumSort,
-  onPlaylistSortChange,
-  onAlbumSortChange,
   enabledProviderIds,
   activeProviderFilters,
   onProviderToggle,
@@ -110,44 +62,15 @@ const FilterChipRow = React.memo(function FilterChipRow({
   albums,
   artistFilter,
   onArtistFilterChange,
-  hasActiveFilters,
-  onClearFilters,
 }: FilterChipRowProps): JSX.Element {
   const [searchExpanded, setSearchExpanded] = useState(false);
-  const [sortOpen, setSortOpen] = useState(false);
   const [artistListOpen, setArtistListOpen] = useState(false);
-  const [sortMenuPos, setSortMenuPos] = useState<{ top: number; left: number } | null>(null);
   const [artistMenuPos, setArtistMenuPos] = useState<{ top: number; left: number } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const sortRef = useRef<HTMLDivElement>(null);
-  const sortDropdownRef = useRef<HTMLDivElement>(null);
   const artistRef = useRef<HTMLDivElement>(null);
   const artistDropdownRef = useRef<HTMLDivElement>(null);
 
   const MENU_GAP_PX = 4;
-
-  // ChipRow uses overflow-x: auto, which clips overflow-y — portaled menus avoid that.
-  useLayoutEffect(() => {
-    if (!sortOpen) {
-      setSortMenuPos(null);
-      return;
-    }
-    const update = () => {
-      const el = sortRef.current;
-      if (!el) return;
-      const rect = el.getBoundingClientRect();
-      const minW = 180;
-      const left = Math.max(8, Math.min(rect.left, window.innerWidth - minW - 8));
-      setSortMenuPos({ top: rect.bottom + MENU_GAP_PX, left });
-    };
-    update();
-    window.addEventListener('scroll', update, true);
-    window.addEventListener('resize', update);
-    return () => {
-      window.removeEventListener('scroll', update, true);
-      window.removeEventListener('resize', update);
-    };
-  }, [sortOpen]);
 
   useLayoutEffect(() => {
     if (!artistListOpen) {
@@ -171,15 +94,9 @@ const FilterChipRow = React.memo(function FilterChipRow({
     };
   }, [artistListOpen]);
 
-  // Close dropdowns when clicking outside (menus are portaled, so check both anchors + panels)
   useEffect(() => {
     function handleClick(e: MouseEvent) {
       const t = e.target as Node;
-      if (sortOpen) {
-        const inSort =
-          !!(sortRef.current?.contains(t) || sortDropdownRef.current?.contains(t));
-        if (!inSort) setSortOpen(false);
-      }
       if (artistListOpen) {
         const inArtist =
           !!(artistRef.current?.contains(t) || artistDropdownRef.current?.contains(t));
@@ -188,30 +105,26 @@ const FilterChipRow = React.memo(function FilterChipRow({
     }
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [sortOpen, artistListOpen]);
+  }, [artistListOpen]);
 
   useEffect(() => {
-    if (!sortOpen && !artistListOpen) return;
+    if (!artistListOpen) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        setSortOpen(false);
         setArtistListOpen(false);
       }
     }
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [sortOpen, artistListOpen]);
+  }, [artistListOpen]);
 
-  // Auto-focus search input when expanded
   useEffect(() => {
     if (searchExpanded) {
-      // Small delay for animation
       const timer = setTimeout(() => searchInputRef.current?.focus(), 50);
       return () => clearTimeout(timer);
     }
   }, [searchExpanded]);
 
-  // Expand search if there's a non-empty query (e.g. set externally)
   useEffect(() => {
     if (searchQuery && !searchExpanded) setSearchExpanded(true);
   }, [searchQuery, searchExpanded]);
@@ -225,7 +138,6 @@ const FilterChipRow = React.memo(function FilterChipRow({
     }
   }, [searchExpanded, onSearchChange]);
 
-  // Top artists by album count
   const topArtists = useMemo(() => {
     if (viewMode !== 'albums') return [];
     const counts = new Map<string, number>();
@@ -242,13 +154,8 @@ const FilterChipRow = React.memo(function FilterChipRow({
   const visibleArtists = topArtists.slice(0, 5);
   const hasMoreArtists = topArtists.length > 5;
 
-  const currentSort = viewMode === 'playlists' ? playlistSort : albumSort;
-  const sortLabels = viewMode === 'playlists' ? PLAYLIST_SORT_LABELS : ALBUM_SORT_LABELS;
-  const currentSortLabel = sortLabels[currentSort as keyof typeof sortLabels] ?? 'Sort';
-
   return (
     <ChipRow>
-      {/* Search chip */}
       <SearchChipWrapper $expanded={searchExpanded}>
         <SearchChipIcon onClick={handleSearchToggle} aria-label={searchExpanded ? 'Close search' : 'Search'}>
           {searchExpanded ? <CloseIcon /> : <SearchIcon />}
@@ -264,52 +171,6 @@ const FilterChipRow = React.memo(function FilterChipRow({
         )}
       </SearchChipWrapper>
 
-      {/* Sort chip */}
-      <SortChipWrapper ref={sortRef}>
-        <Chip $active={sortOpen} onClick={() => setSortOpen(!sortOpen)} aria-expanded={sortOpen} aria-haspopup="listbox">
-          <SortIcon />
-          {currentSortLabel}
-          <ChevronDownIcon />
-        </Chip>
-        {sortOpen &&
-          sortMenuPos &&
-          createPortal(
-            <SortDropdown
-              ref={sortDropdownRef}
-              role="listbox"
-              aria-label="Sort by"
-              style={{
-                position: 'fixed',
-                top: sortMenuPos.top,
-                left: sortMenuPos.left,
-                zIndex: theme.zIndex.popover,
-                margin: 0,
-              }}
-            >
-              {Object.entries(sortLabels).map(([value, label]) => (
-                <SortOption
-                  key={value}
-                  $active={currentSort === value}
-                  role="option"
-                  aria-selected={currentSort === value}
-                  onClick={() => {
-                    if (viewMode === 'playlists') {
-                      onPlaylistSortChange(value as PlaylistSortOption);
-                    } else {
-                      onAlbumSortChange(value as AlbumSortOption);
-                    }
-                    setSortOpen(false);
-                  }}
-                >
-                  {label}
-                </SortOption>
-              ))}
-            </SortDropdown>,
-            document.body
-          )}
-      </SortChipWrapper>
-
-      {/* Provider chips */}
       {showProviderChips && enabledProviderIds.map((provider) => (
         <Chip
           key={provider}
@@ -321,7 +182,6 @@ const FilterChipRow = React.memo(function FilterChipRow({
         </Chip>
       ))}
 
-      {/* Artist chips (albums tab only) */}
       {viewMode === 'albums' && visibleArtists.map(([artist]) => (
         <Chip
           key={artist}
@@ -332,7 +192,6 @@ const FilterChipRow = React.memo(function FilterChipRow({
         </Chip>
       ))}
 
-      {/* More artists chip */}
       {viewMode === 'albums' && hasMoreArtists && (
         <SortChipWrapper ref={artistRef} style={{ position: 'relative' }}>
           <Chip $active={artistListOpen || (!!artistFilter && !visibleArtists.some(([a]) => a === artistFilter))} onClick={() => setArtistListOpen(!artistListOpen)}>
@@ -369,14 +228,6 @@ const FilterChipRow = React.memo(function FilterChipRow({
               document.body
             )}
         </SortChipWrapper>
-      )}
-
-      {/* Clear filters chip */}
-      {hasActiveFilters && (
-        <ClearChip onClick={onClearFilters}>
-          <CloseIcon />
-          Clear
-        </ClearChip>
       )}
     </ChipRow>
   );

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -70,55 +70,13 @@ const DrawerContainer = styled.div.withConfig({
   }
 `;
 
-const DrawerHeader = styled.div`
-  flex-shrink: 0;
-  padding: calc(${theme.spacing.sm} + env(safe-area-inset-top, 0px)) ${theme.spacing.md} ${theme.spacing.sm};
-  min-height: 48px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  position: relative;
-  touch-action: none;
-`;
-
-const CloseButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: none;
-  background: none;
-  color: ${({ theme }) => theme.colors.foreground};
-  font-size: ${({ theme }) => theme.fontSize.xl};
-  cursor: pointer;
-  border-radius: 50%;
-  transition: background ${({ theme }) => theme.transitions.fast} ease;
-  padding: 0;
-
-  &:active {
-    background: ${({ theme }) => theme.colors.control.background};
-  }
-`;
-
-const DrawerTitle = styled.h3`
-  color: ${theme.colors.white};
-  margin: 0;
-  font-size: ${theme.fontSize.xl};
-  font-weight: ${theme.fontWeight.semibold};
-  text-align: center;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  pointer-events: none;
-`;
-
 const DrawerContent = styled.div`
   flex: 1;
   min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  padding-top: env(safe-area-inset-top, 0px);
 `;
 
 const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode }: LibraryDrawerProps) {
@@ -178,14 +136,6 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
       >
         {isOpen && (
           <>
-            <DrawerHeader>
-              <CloseButton onClick={onClose} aria-label="Close library">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-                  <path d="M4 7L10 13L16 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </CloseButton>
-              <DrawerTitle>Library</DrawerTitle>
-            </DrawerHeader>
             <DrawerContent>
               <PlaylistSelection
                 onPlaylistSelect={handlePlaylistSelectWrapper}

--- a/src/components/LibraryDrawerSortChip.tsx
+++ b/src/components/LibraryDrawerSortChip.tsx
@@ -1,0 +1,154 @@
+import { useState, useRef, useEffect, useLayoutEffect } from 'react';
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { theme } from '@/styles/theme';
+import { Chip, SortChipWrapper, SortDropdown, SortOption } from './styled/FilterChips';
+import type { AlbumSortOption, PlaylistSortOption } from '@/utils/playlistFilters';
+
+const SortIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="4" y1="6" x2="20" y2="6" />
+    <line x1="4" y1="12" x2="14" y2="12" />
+    <line x1="4" y1="18" x2="8" y2="18" />
+  </svg>
+);
+
+const ChevronDownIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+const PLAYLIST_SORT_LABELS: Record<PlaylistSortOption, string> = {
+  'recently-added': 'Recently Added',
+  'name-asc': 'Name (A-Z)',
+  'name-desc': 'Name (Z-A)',
+};
+
+const ALBUM_SORT_LABELS: Record<AlbumSortOption, string> = {
+  'recently-added': 'Recently Added',
+  'name-asc': 'Name (A-Z)',
+  'name-desc': 'Name (Z-A)',
+  'artist-asc': 'Artist (A-Z)',
+  'artist-desc': 'Artist (Z-A)',
+  'release-newest': 'Release (Newest)',
+  'release-oldest': 'Release (Oldest)',
+};
+
+export interface LibraryDrawerSortChipProps {
+  viewMode: 'playlists' | 'albums';
+  playlistSort: PlaylistSortOption;
+  albumSort: AlbumSortOption;
+  onPlaylistSortChange: (sort: PlaylistSortOption) => void;
+  onAlbumSortChange: (sort: AlbumSortOption) => void;
+}
+
+const LibraryDrawerSortChip = React.memo(function LibraryDrawerSortChip({
+  viewMode,
+  playlistSort,
+  albumSort,
+  onPlaylistSortChange,
+  onAlbumSortChange,
+}: LibraryDrawerSortChipProps): JSX.Element {
+  const [sortOpen, setSortOpen] = useState(false);
+  const [sortMenuPos, setSortMenuPos] = useState<{ top: number; left: number } | null>(null);
+  const sortRef = useRef<HTMLDivElement>(null);
+  const sortDropdownRef = useRef<HTMLDivElement>(null);
+
+  const MENU_GAP_PX = 4;
+
+  useLayoutEffect(() => {
+    if (!sortOpen) {
+      setSortMenuPos(null);
+      return;
+    }
+    const update = () => {
+      const el = sortRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const minW = 180;
+      const left = Math.max(8, Math.min(rect.left, window.innerWidth - minW - 8));
+      setSortMenuPos({ top: rect.bottom + MENU_GAP_PX, left });
+    };
+    update();
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [sortOpen]);
+
+  useEffect(() => {
+    if (!sortOpen) return;
+    function handleClick(e: MouseEvent) {
+      const t = e.target as Node;
+      const inSort =
+        !!(sortRef.current?.contains(t) || sortDropdownRef.current?.contains(t));
+      if (!inSort) setSortOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [sortOpen]);
+
+  useEffect(() => {
+    if (!sortOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setSortOpen(false);
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [sortOpen]);
+
+  const currentSort = viewMode === 'playlists' ? playlistSort : albumSort;
+  const sortLabels = viewMode === 'playlists' ? PLAYLIST_SORT_LABELS : ALBUM_SORT_LABELS;
+  const currentSortLabel = sortLabels[currentSort as keyof typeof sortLabels] ?? 'Sort';
+
+  return (
+    <SortChipWrapper ref={sortRef}>
+      <Chip $active={sortOpen} onClick={() => setSortOpen(!sortOpen)} aria-expanded={sortOpen} aria-haspopup="listbox">
+        <SortIcon />
+        {currentSortLabel}
+        <ChevronDownIcon />
+      </Chip>
+      {sortOpen &&
+        sortMenuPos &&
+        createPortal(
+          <SortDropdown
+            ref={sortDropdownRef}
+            role="listbox"
+            aria-label="Sort by"
+            style={{
+              position: 'fixed',
+              top: sortMenuPos.top,
+              left: sortMenuPos.left,
+              zIndex: theme.zIndex.popover,
+              margin: 0,
+            }}
+          >
+            {Object.entries(sortLabels).map(([value, label]) => (
+              <SortOption
+                key={value}
+                $active={currentSort === value}
+                role="option"
+                aria-selected={currentSort === value}
+                onClick={() => {
+                  if (viewMode === 'playlists') {
+                    onPlaylistSortChange(value as PlaylistSortOption);
+                  } else {
+                    onAlbumSortChange(value as AlbumSortOption);
+                  }
+                  setSortOpen(false);
+                }}
+              >
+                {label}
+              </SortOption>
+            ))}
+          </SortDropdown>,
+          document.body
+        )}
+    </SortChipWrapper>
+  );
+});
+
+export default LibraryDrawerSortChip;

--- a/src/components/LibraryProviderBar.tsx
+++ b/src/components/LibraryProviderBar.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import Switch from '@/components/controls/Switch';
 
-
 const TOGGLE_ON_COLOR = '#4ade80';
 const TOGGLE_OFF_COLOR = 'rgba(255, 255, 255, 0.25)';
 
@@ -69,6 +68,13 @@ const ConnectButton = styled.button`
   }
 `;
 
+const DrawerOffBadge = styled.span`
+  font-size: 0.65rem;
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  color: ${({ theme }) => theme.colors.muted.foreground};
+  opacity: 0.85;
+`;
+
 interface LibraryProviderBarProps {
   variant?: 'default' | 'drawerBottom';
 }
@@ -78,6 +84,8 @@ const LibraryProviderBar = React.memo(function LibraryProviderBar({ variant = 'd
   const providers = useMemo(() => registry.getAll(), [registry]);
 
   if (providers.length < 2) return null;
+
+  const drawerBottom = variant === 'drawerBottom';
 
   return (
     <Bar $variant={variant}>
@@ -91,6 +99,7 @@ const LibraryProviderBar = React.memo(function LibraryProviderBar({ variant = 'd
           <ProviderRow key={descriptor.id}>
             <StatusDot $color={dotColor} />
             <ProviderName $dimmed={!isEnabled}>{descriptor.name}</ProviderName>
+            {drawerBottom && !isEnabled && <DrawerOffBadge>Off</DrawerOffBadge>}
             {isEnabled && isConnected && (
               <ProviderStatusBadge $status="connected">Connected</ProviderStatusBadge>
             )}
@@ -104,13 +113,15 @@ const LibraryProviderBar = React.memo(function LibraryProviderBar({ variant = 'd
                 </ConnectButton>
               </>
             )}
-            <Switch
-              on={isEnabled}
-              onToggle={() => toggleProvider(descriptor.id)}
-              ariaLabel={`${isEnabled ? 'Disable' : 'Enable'} ${descriptor.name}`}
-              disabled={isLastEnabled}
-              variant="neutral"
-            />
+            {!drawerBottom && (
+              <Switch
+                on={isEnabled}
+                onToggle={() => toggleProvider(descriptor.id)}
+                ariaLabel={`${isEnabled ? 'Disable' : 'Enable'} ${descriptor.name}`}
+                disabled={isLastEnabled}
+                variant="neutral"
+              />
+            )}
           </ProviderRow>
         );
       })}

--- a/src/components/PlaylistSelection.tsx
+++ b/src/components/PlaylistSelection.tsx
@@ -14,15 +14,18 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useLibrarySync } from '../hooks/useLibrarySync';
 import {
-  filterAndSortPlaylists,
-  filterAndSortAlbums,
-  partitionByPinned,
+  filterPlaylistsOnly,
+  sortPlaylistSubgroup,
+  filterAlbumsOnly,
+  sortAlbumSubgroup,
+  buildLibraryViewWithPins,
   type PlaylistSortOption,
   type AlbumSortOption
 } from '../utils/playlistFilters';
 import { usePinnedItems } from '../hooks/usePinnedItems';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId, isAlbumId } from '../constants/playlist';
 import FilterChipRow from './FilterChipRow';
+import LibraryDrawerSortChip from './LibraryDrawerSortChip';
 import LibraryProviderBar from './LibraryProviderBar';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
@@ -506,6 +509,10 @@ const RefreshButton = styled.button<{ $spinning: boolean }>`
   }
 `;
 
+const DrawerRefreshButton = styled(RefreshButton)`
+  flex-shrink: 0;
+`;
+
 const DrawerBottomControls = styled.div`
   flex-shrink: 0;
   padding: ${theme.spacing.sm} 0 0;
@@ -525,9 +532,12 @@ const DrawerBottomRow = styled.div`
   flex-wrap: wrap;
 `;
 
-const DrawerRefreshButton = styled(RefreshButton)`
-  margin-left: auto;
+const DrawerBottomActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
   flex-shrink: 0;
+  margin-left: auto;
 `;
 
 const ClearButton = styled.button`
@@ -544,6 +554,11 @@ const ClearButton = styled.button`
     background: ${({ theme }) => theme.colors.control.backgroundHover};
     color: ${({ theme }) => theme.colors.white};
   }
+`;
+
+const DrawerClearFiltersButton = styled(ClearButton)`
+  padding: ${({ theme }) => `${theme.spacing.xs} ${theme.spacing.md}`};
+  font-size: ${({ theme }) => theme.fontSize.xs};
 `;
 
 const EmptyState = styled.div<{ $fullWidth?: boolean }>`
@@ -866,37 +881,43 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     });
   }, []);
 
-  const filteredPlaylists = useMemo(() => {
+  const playlistLibraryView = useMemo(() => {
     let items = playlists;
     if (providerFilters.length > 0) {
       items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
     }
-    return filterAndSortPlaylists(items, searchQuery, playlistSort);
-  }, [playlists, searchQuery, playlistSort, providerFilters]);
+    const filtered = filterPlaylistsOnly(items, searchQuery);
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedPlaylistIds,
+      (p) => p.id,
+      (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
+    );
+  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds]);
 
-  const filteredAlbums = useMemo(() => {
+  const filteredPlaylists = playlistLibraryView.flat;
+  const pinnedPlaylists = playlistLibraryView.pinned;
+  const unpinnedPlaylists = playlistLibraryView.unpinned;
+
+  const albumLibraryView = useMemo(() => {
     let items = albums;
     if (providerFilters.length > 0) {
       items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
     }
-    return filterAndSortAlbums(items, searchQuery, albumSort, 'all', artistFilter);
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters]);
+    const filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter);
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedAlbumIds,
+      (a) => a.id,
+      (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
+    );
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds]);
+
+  const filteredAlbums = albumLibraryView.flat;
+  const pinnedAlbums = albumLibraryView.pinned;
+  const unpinnedAlbums = albumLibraryView.unpinned;
 
   const hasActiveFilters = searchQuery !== '' || artistFilter !== '' || providerFilters.length > 0;
-
-  const { pinned: pinnedPlaylists, unpinned: unpinnedPlaylists } = useMemo(() => {
-    if (hasActiveFilters || pinnedPlaylistIds.length === 0) {
-      return { pinned: [] as PlaylistInfo[], unpinned: filteredPlaylists };
-    }
-    return partitionByPinned(filteredPlaylists, pinnedPlaylistIds, (p) => p.id);
-  }, [filteredPlaylists, pinnedPlaylistIds, hasActiveFilters]);
-
-  const { pinned: pinnedAlbums, unpinned: unpinnedAlbums } = useMemo(() => {
-    if (pinnedAlbumIds.length === 0) {
-      return { pinned: [] as AlbumInfo[], unpinned: filteredAlbums };
-    }
-    return partitionByPinned(filteredAlbums, pinnedAlbumIds, (a) => a.id);
-  }, [filteredAlbums, pinnedAlbumIds]);
 
   useEffect(() => {
     if (viewMode === 'playlists') {
@@ -1321,10 +1342,6 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
           viewMode={viewMode}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          playlistSort={playlistSort}
-          albumSort={albumSort}
-          onPlaylistSortChange={setPlaylistSort}
-          onAlbumSortChange={setAlbumSort}
           enabledProviderIds={enabledProviderIds}
           activeProviderFilters={providerFilters}
           onProviderToggle={handleProviderToggle}
@@ -1332,8 +1349,6 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
           albums={albums}
           artistFilter={artistFilter}
           onArtistFilterChange={setArtistFilter}
-          hasActiveFilters={hasActiveFilters}
-          onClearFilters={() => { setSearchQuery(''); setArtistFilter(''); setProviderFilters([]); }}
         />
       )}
 
@@ -1635,23 +1650,47 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
         );
       })()}
 
-      {inDrawer && onLibraryRefresh && (
+      {inDrawer && (
         <DrawerBottomControls>
           <DrawerBottomRow>
             <LibraryProviderBar variant="drawerBottom" />
-            <DrawerRefreshButton
-              onClick={onLibraryRefresh}
-              $spinning={!!isLibraryRefreshing}
-              aria-label="Refresh library"
-              title="Refresh library"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </DrawerRefreshButton>
+            <DrawerBottomActions>
+              <LibraryDrawerSortChip
+                viewMode={viewMode}
+                playlistSort={playlistSort}
+                albumSort={albumSort}
+                onPlaylistSortChange={setPlaylistSort}
+                onAlbumSortChange={setAlbumSort}
+              />
+              {hasActiveFilters && (
+                <DrawerClearFiltersButton
+                  type="button"
+                  onClick={() => {
+                    setSearchQuery('');
+                    setArtistFilter('');
+                    setProviderFilters([]);
+                  }}
+                  aria-label="Clear filters"
+                >
+                  Clear
+                </DrawerClearFiltersButton>
+              )}
+              {onLibraryRefresh && (
+                <DrawerRefreshButton
+                  onClick={onLibraryRefresh}
+                  $spinning={!!isLibraryRefreshing}
+                  aria-label="Refresh library"
+                  title="Refresh library"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </DrawerRefreshButton>
+              )}
+            </DrawerBottomActions>
           </DrawerBottomRow>
         </DrawerBottomControls>
       )}

--- a/src/components/styled/FilterChips.tsx
+++ b/src/components/styled/FilterChips.tsx
@@ -104,17 +104,6 @@ export const SearchChipInput = styled.input`
   }
 `;
 
-export const ClearChip = styled(Chip)`
-  border-color: ${theme.colors.control.borderHover};
-  color: ${theme.colors.muted.foreground};
-  background: none;
-
-  &:hover {
-    color: ${theme.colors.white};
-    background: ${theme.colors.control.backgroundHover};
-  }
-`;
-
 /** Sort chip with dropdown arrow. */
 export const SortChipWrapper = styled.div`
   position: relative;

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -7,6 +7,12 @@ export const LIKED_SONGS_ID = 'liked-songs';
 /** Display name for the Liked Songs collection */
 export const LIKED_SONGS_NAME = 'Liked Songs';
 
+/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row, Dropbox "All Music" uses id ''). */
+export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, '']);
+
+/** Album IDs that stay in catalog order and are not reordered by library sort (Dropbox aggregate uses id ''). */
+export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set(['']);
+
 /** Check whether a playlist selection ID represents an album */
 export function isAlbumId(playlistId: string): boolean {
   return playlistId.startsWith(ALBUM_ID_PREFIX);

--- a/src/utils/__tests__/playlistFilters.test.ts
+++ b/src/utils/__tests__/playlistFilters.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   filterAndSortPlaylists,
+  filterPlaylistsOnly,
+  sortPlaylistSubgroup,
+  filterAlbumsOnly,
+  sortAlbumSubgroup,
   filterAndSortAlbums,
   getAvailableDecades,
   partitionByPinned,
@@ -127,6 +131,46 @@ describe('filterAndSortPlaylists', () => {
       expect(result[0].name).toBe('Workout Mix'); // 2025-01-01
       expect(result[1].name).toBe('Road Trip');   // 2024-12-01
       expect(result[2].name).toBe('Chill Vibes'); // 2024-06-15
+    });
+
+    it('keeps anchor playlists before sorted remainder (All Music id "", liked-songs)', () => {
+      const allMusic: PlaylistInfo = {
+        id: '',
+        name: 'All Music',
+        description: null,
+        images: [],
+        tracks: { total: 100 },
+        owner: null,
+        added_at: '2020-01-01T10:00:00Z',
+      };
+      const likedInList: PlaylistInfo = {
+        id: 'liked-songs',
+        name: 'Liked Songs',
+        description: null,
+        images: [],
+        tracks: { total: 5 },
+        owner: null,
+        added_at: '2021-01-01T10:00:00Z',
+      };
+      const mixed = [mockPlaylists[2], allMusic, mockPlaylists[0], likedInList];
+      const result = filterAndSortPlaylists(mixed, '', 'name-asc');
+      expect(result.map(p => p.name)).toEqual([
+        'All Music',
+        'Liked Songs',
+        'Chill Vibes',
+        'Road Trip',
+      ]);
+    });
+  });
+
+  describe('sortPlaylistSubgroup with partition (pinned + sort)', () => {
+    it('sorts within pinned and unpinned groups independently', () => {
+      const filtered = filterPlaylistsOnly(mockPlaylists, '');
+      const { pinned, unpinned } = partitionByPinned(filtered, ['3', '1'], (p) => p.id);
+      const pinnedSorted = sortPlaylistSubgroup(pinned, 'name-asc');
+      const unpinnedSorted = sortPlaylistSubgroup(unpinned, 'name-asc');
+      expect(pinnedSorted.map(p => p.name)).toEqual(['Chill Vibes', 'Road Trip']);
+      expect(unpinnedSorted.map(p => p.name)).toEqual(['Workout Mix']);
     });
   });
 });
@@ -312,6 +356,37 @@ describe('filterAndSortAlbums', () => {
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe('Abbey Road');
       expect(result[1].name).toBe('Let It Be');
+    });
+
+    it('keeps anchor album (id "") before sorted remainder', () => {
+      const allMusic: AlbumInfo = {
+        id: '',
+        name: 'All Music',
+        artists: 'Various',
+        images: [],
+        release_date: '',
+        total_tracks: 999,
+        uri: '',
+        added_at: '2010-01-01T10:00:00Z',
+      };
+      const mixed = [mockAlbums[2], allMusic, mockAlbums[0]];
+      const result = filterAndSortAlbums(mixed, '', 'name-asc');
+      expect(result.map(a => a.name)).toEqual([
+        'All Music',
+        'Abbey Road',
+        'Random Access Memories',
+      ]);
+    });
+  });
+
+  describe('sortAlbumSubgroup with partition (pinned + sort)', () => {
+    it('sorts within pinned and unpinned groups independently', () => {
+      const filtered = filterAlbumsOnly(mockAlbums, '', 'all', '');
+      const { pinned, unpinned } = partitionByPinned(filtered, ['3', '1'], (a) => a.id);
+      const pinnedSorted = sortAlbumSubgroup(pinned, 'name-asc');
+      const unpinnedSorted = sortAlbumSubgroup(unpinned, 'name-asc');
+      expect(pinnedSorted.map(a => a.name)).toEqual(['Abbey Road', 'Random Access Memories']);
+      expect(unpinnedSorted.map(a => a.name)).toEqual(['Thriller']);
     });
   });
 });

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -1,4 +1,5 @@
 import type { PlaylistInfo, AlbumInfo } from '../services/spotify';
+import { LIBRARY_ALBUM_SORT_ANCHOR_IDS, LIBRARY_PLAYLIST_SORT_ANCHOR_IDS } from '../constants/playlist';
 
 // ============================================================
 // TYPE DEFINITIONS
@@ -15,7 +16,7 @@ export type AlbumSortOption =
   | 'release-oldest'
   | 'recently-added';
 
-type YearFilterOption =
+export type YearFilterOption =
   | 'all'
   | '2020s'
   | '2010s'
@@ -112,6 +113,50 @@ function matchesYearFilter(year: number | null, filter: YearFilterOption): boole
 // MAIN FILTER/SORT FUNCTIONS
 // ============================================================
 
+function sortPlaylistArrayInPlace(playlists: PlaylistInfo[], sortOption: PlaylistSortOption): void {
+  switch (sortOption) {
+    case 'name-asc':
+      playlists.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case 'name-desc':
+      playlists.sort((a, b) => b.name.localeCompare(a.name));
+      break;
+    case 'recently-added':
+    default:
+      playlists.sort((a, b) => {
+        const dateA = parseAddedAt(a.added_at);
+        const dateB = parseAddedAt(b.added_at);
+        return dateB - dateA; // Most recent first
+      });
+      break;
+  }
+}
+
+/**
+ * Filter playlists by search query (no sorting).
+ */
+export function filterPlaylistsOnly(playlists: PlaylistInfo[], searchQuery: string): PlaylistInfo[] {
+  return playlists.filter(p => matchesSearch(p, searchQuery));
+}
+
+/**
+ * Sort playlists for the library UI: anchor collections keep catalog order, remaining items follow the sort option.
+ */
+export function sortPlaylistSubgroup(
+  items: PlaylistInfo[],
+  sortOption: PlaylistSortOption,
+  anchorIds: ReadonlySet<string> = LIBRARY_PLAYLIST_SORT_ANCHOR_IDS
+): PlaylistInfo[] {
+  const anchors: PlaylistInfo[] = [];
+  const rest: PlaylistInfo[] = [];
+  for (const p of items) {
+    if (anchorIds.has(p.id)) anchors.push(p);
+    else rest.push(p);
+  }
+  sortPlaylistArrayInPlace(rest, sortOption);
+  return [...anchors, ...rest];
+}
+
 /**
  * Filter and sort playlists based on search query and sort option
  */
@@ -120,28 +165,97 @@ export function filterAndSortPlaylists(
   searchQuery: string,
   sortOption: PlaylistSortOption
 ): PlaylistInfo[] {
-  // Step 1: Filter by search query
-  const result = playlists.filter(p => matchesSearch(p, searchQuery));
+  const filtered = filterPlaylistsOnly(playlists, searchQuery);
+  return sortPlaylistSubgroup(filtered, sortOption);
+}
 
-  // Step 2: Sort
-  switch (sortOption) {
-    case 'name-asc':
-      result.sort((a, b) => a.name.localeCompare(b.name));
-      break;
-    case 'name-desc':
-      result.sort((a, b) => b.name.localeCompare(a.name));
-      break;
-    case 'recently-added':
-    default:
-      result.sort((a, b) => {
-        const dateA = parseAddedAt(a.added_at);
-        const dateB = parseAddedAt(b.added_at);
-        return dateB - dateA; // Most recent first
-      });
-      break;
+/**
+ * Filter albums by search, decade, and artist (no sorting).
+ */
+export function filterAlbumsOnly(
+  albums: AlbumInfo[],
+  searchQuery: string,
+  yearFilter: YearFilterOption = 'all',
+  artistFilter: string = ''
+): AlbumInfo[] {
+  let result = albums.filter(a => matchesSearch(a, searchQuery));
+
+  if (yearFilter !== 'all') {
+    result = result.filter(a => {
+      const year = extractYear(a.release_date);
+      return matchesYearFilter(year, yearFilter);
+    });
+  }
+
+  if (artistFilter) {
+    const normalizedArtistFilter = normalizeText(artistFilter);
+    result = result.filter(a => normalizeText(a.artists).includes(normalizedArtistFilter));
   }
 
   return result;
+}
+
+function sortAlbumArrayInPlace(albums: AlbumInfo[], sortOption: AlbumSortOption): void {
+  switch (sortOption) {
+    case 'name-asc':
+      albums.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case 'name-desc':
+      albums.sort((a, b) => b.name.localeCompare(a.name));
+      break;
+    case 'artist-asc':
+      albums.sort((a, b) => a.artists.localeCompare(b.artists));
+      break;
+    case 'artist-desc':
+      albums.sort((a, b) => b.artists.localeCompare(a.artists));
+      break;
+    case 'release-newest':
+      albums.sort((a, b) => {
+        const yearA = extractYear(a.release_date);
+        const yearB = extractYear(b.release_date);
+        if (yearA === null && yearB === null) return 0;
+        if (yearA === null) return 1;
+        if (yearB === null) return -1;
+        return yearB - yearA;
+      });
+      break;
+    case 'release-oldest':
+      albums.sort((a, b) => {
+        const yearA = extractYear(a.release_date);
+        const yearB = extractYear(b.release_date);
+        if (yearA === null && yearB === null) return 0;
+        if (yearA === null) return 1;
+        if (yearB === null) return -1;
+        return yearA - yearB;
+      });
+      break;
+    case 'recently-added':
+    default:
+      albums.sort((a, b) => {
+        const dateA = parseAddedAt(a.added_at);
+        const dateB = parseAddedAt(b.added_at);
+        return dateB - dateA;
+      });
+      break;
+  }
+}
+
+/**
+ * Sort albums for the library UI: anchor items keep catalog order, remaining items follow the sort option.
+ */
+export function sortAlbumSubgroup(
+  items: AlbumInfo[],
+  sortOption: AlbumSortOption,
+  anchorIds: ReadonlySet<string> = LIBRARY_ALBUM_SORT_ANCHOR_IDS
+): AlbumInfo[] {
+  const anchors: AlbumInfo[] = [];
+  const rest: AlbumInfo[] = [];
+  for (const a of items) {
+    if (anchorIds.has(a.id)) anchors.push(a);
+    else rest.push(a);
+  }
+  sortAlbumArrayInPlace(rest, sortOption);
+  return [...anchors, ...rest];
 }
 
 /**
@@ -154,68 +268,8 @@ export function filterAndSortAlbums(
   yearFilter: YearFilterOption = 'all',
   artistFilter: string = ''
 ): AlbumInfo[] {
-  // Step 1: Filter by search query
-  let result = albums.filter(a => matchesSearch(a, searchQuery));
-
-  // Step 2: Filter by year/decade
-  if (yearFilter !== 'all') {
-    result = result.filter(a => {
-      const year = extractYear(a.release_date);
-      return matchesYearFilter(year, yearFilter);
-    });
-  }
-
-  // Step 3: Filter by artist
-  if (artistFilter) {
-    const normalizedArtistFilter = normalizeText(artistFilter);
-    result = result.filter(a => normalizeText(a.artists).includes(normalizedArtistFilter));
-  }
-
-  // Step 4: Sort
-  switch (sortOption) {
-    case 'name-asc':
-      result.sort((a, b) => a.name.localeCompare(b.name));
-      break;
-    case 'name-desc':
-      result.sort((a, b) => b.name.localeCompare(a.name));
-      break;
-    case 'artist-asc':
-      result.sort((a, b) => a.artists.localeCompare(b.artists));
-      break;
-    case 'artist-desc':
-      result.sort((a, b) => b.artists.localeCompare(a.artists));
-      break;
-    case 'release-newest':
-      result.sort((a, b) => {
-        const yearA = extractYear(a.release_date);
-        const yearB = extractYear(b.release_date);
-        if (yearA === null && yearB === null) return 0;
-        if (yearA === null) return 1;
-        if (yearB === null) return -1;
-        return yearB - yearA;
-      });
-      break;
-    case 'release-oldest':
-      result.sort((a, b) => {
-        const yearA = extractYear(a.release_date);
-        const yearB = extractYear(b.release_date);
-        if (yearA === null && yearB === null) return 0;
-        if (yearA === null) return 1;
-        if (yearB === null) return -1;
-        return yearA - yearB;
-      });
-      break;
-    case 'recently-added':
-    default:
-      result.sort((a, b) => {
-        const dateA = parseAddedAt(a.added_at);
-        const dateB = parseAddedAt(b.added_at);
-        return dateB - dateA; // Most recent first
-      });
-      break;
-  }
-
-  return result;
+  const filtered = filterAlbumsOnly(albums, searchQuery, yearFilter, artistFilter);
+  return sortAlbumSubgroup(filtered, sortOption);
 }
 
 /**
@@ -277,4 +331,29 @@ export function partitionByPinned<T>(
   }
 
   return { pinned, unpinned };
+}
+
+/**
+ * From filtered library items, produce flat / pinned / unpinned lists.
+ * With no pin ids, sorts the full list once; otherwise partitions by pins then sorts each subgroup
+ * (same pattern as sortPlaylistSubgroup / sortAlbumSubgroup per subgroup).
+ */
+export function buildLibraryViewWithPins<T>(
+  filtered: T[],
+  pinnedIds: string[],
+  getId: (item: T) => string,
+  sortSubgroup: (items: T[]) => T[]
+): { flat: T[]; pinned: T[]; unpinned: T[] } {
+  if (pinnedIds.length === 0) {
+    const sorted = sortSubgroup(filtered);
+    return { flat: sorted, pinned: [], unpinned: sorted };
+  }
+  const { pinned, unpinned } = partitionByPinned(filtered, pinnedIds, getId);
+  const pinnedSorted = sortSubgroup(pinned);
+  const unpinnedSorted = sortSubgroup(unpinned);
+  return {
+    flat: [...pinnedSorted, ...unpinnedSorted],
+    pinned: pinnedSorted,
+    unpinned: unpinnedSorted,
+  };
 }


### PR DESCRIPTION
## Summary
- **Pinned library sort:** Playlist and album sort options apply within pinned and unpinned groups. Special entries (Liked Songs id, Dropbox All Music `''`) stay anchored and are not reordered by sort.
- **Helpers:** `filterAlbumsOnly`, `sortAlbumSubgroup`, `buildLibraryViewWithPins`; extended `playlistFilters` tests.
- **Drawer UI:** Sort chip and Clear live on the **bottom row** next to refresh (no Clear at the end of the chip scroller). Removed the **Library** title/header row; safe-area padding on drawer content.
- **Provider bar (drawer):** No enable/disable toggles—shows Connected, Expired + Connect, or **Off** when a provider is disabled. Default library bar unchanged (still has toggles).
- **FilterChipRow:** Search, provider filter chips, artist chips only; sort moved to `LibraryDrawerSortChip`.

## Testing
`npm run test:run` (540 tests) passed locally.

Made with [Cursor](https://cursor.com)