### PR TITLE
Refactor zen mode track info layout with separate name and artist

### DIFF
--- a/src/components/PlayerContent.tsx
+++ b/src/components/PlayerContent.tsx
@@ -283,29 +283,49 @@ const ZenControlsInner = styled.div`
 
 // Zen mode track info — non-interactive song + artist label below album art
 const ZenTrackInfo = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$zenMode', '$isMobile', '$isTablet'].includes(prop),
-})<{ $zenMode: boolean; $isMobile: boolean; $isTablet: boolean }>`
+  shouldForwardProp: (prop) => !['$zenMode'].includes(prop),
+})<{ $zenMode: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   pointer-events: none;
-  color: ${({ theme }) => theme.colors.white};
+  margin-top: ${({ theme }) => theme.spacing.sm};
+  padding: 0 ${({ theme }) => theme.spacing.md};
+  overflow: hidden;
+  opacity: ${({ $zenMode }) => $zenMode ? 1 : 0};
+  max-height: ${({ $zenMode }) => $zenMode ? '5rem' : '0'};
+  transition: ${({ $zenMode }) => $zenMode
+    ? 'opacity 600ms ease 800ms, max-height 300ms ease 300ms'
+    : 'opacity 200ms ease, max-height 200ms ease'
+  };
+`;
+
+const ZenTrackName = styled.div.withConfig({
+  shouldForwardProp: (prop) => !['$isMobile', '$isTablet'].includes(prop),
+})<{ $isMobile: boolean; $isTablet: boolean }>`
   font-weight: ${({ theme }) => theme.fontWeight.semibold};
   font-size: ${({ $isMobile, $isTablet, theme }) => {
     if ($isMobile) return theme.fontSize.lg;
     if ($isTablet) return theme.fontSize.xl;
     return theme.fontSize['2xl'];
   }};
+  color: ${({ theme }) => theme.colors.white};
   text-shadow: ${({ theme }) => theme.shadows.textMd};
-  margin-top: ${({ theme }) => theme.spacing.sm};
-  padding: 0 ${({ theme }) => theme.spacing.md};
-  opacity: ${({ $zenMode }) => $zenMode ? 1 : 0};
-  max-height: ${({ $zenMode }) => $zenMode ? '3rem' : '0'};
-  transition: ${({ $zenMode }) => $zenMode
-    ? 'opacity 600ms ease 800ms, max-height 300ms ease 300ms'
-    : 'opacity 200ms ease, max-height 200ms ease'
-  };
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+`;
+
+const ZenTrackArtist = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.base};
+  line-height: 1.4;
+  color: ${({ theme }) => theme.colors.gray[300]};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 `;
 
 // Album art container with click handler
@@ -869,8 +889,13 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({ isPlaying, sho
               </ClickableAlbumArtContainer>
             </div>
           </CardContent>
-          <ZenTrackInfo $zenMode={zenModeEnabled} $isMobile={isMobile} $isTablet={isTablet}>
-            {currentTrack?.name}{currentTrack?.artists ? ` \u2014 ${currentTrack.artists}` : ''}
+          <ZenTrackInfo $zenMode={zenModeEnabled}>
+            <ZenTrackName $isMobile={isMobile} $isTablet={isTablet}>
+              {currentTrack?.name}
+            </ZenTrackName>
+            {currentTrack?.artists && (
+              <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
+            )}
           </ZenTrackInfo>
           <ZenControlsWrapper $zenMode={zenModeEnabled}>
             <ZenControlsInner ref={controlsRef}>


### PR DESCRIPTION
## Summary
Refactored the zen mode track information display to use a more flexible layout structure with separate styled components for track name and artist, improving maintainability and visual hierarchy.

## Key Changes
- **Simplified `ZenTrackInfo` component**: Removed `$isMobile` and `$isTablet` props and related responsive font sizing logic. Changed to a flex column layout with centered alignment
- **Created `ZenTrackName` component**: New styled component that handles track name display with responsive font sizing (lg on mobile, xl on tablet, 2xl on desktop) and text truncation
- **Created `ZenTrackArtist` component**: New styled component for artist display with smaller base font size and gray color, supporting text truncation
- **Updated JSX structure**: Split the concatenated track name and artist string into separate elements with conditional rendering for the artist section
- **Adjusted max-height**: Increased `ZenTrackInfo` max-height from `3rem` to `5rem` to accommodate the two-line layout

## Implementation Details
- The refactoring maintains the same visual behavior while improving code organization and separation of concerns
- Each styled component now has a single responsibility: the container handles layout and animation, the name handles responsive sizing, and the artist handles styling
- The artist section now only renders when artist data is available, replacing the previous inline conditional string concatenation
- All responsive behavior is preserved through the `$isMobile` and `$isTablet` props passed to `ZenTrackName`

https://claude.ai/code/session_01CiNJAm9MzpCdU22VTHkK1C