### PR TITLE
refactor: rename handlePlaylistSelect to loadCollection

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -61,12 +61,16 @@ const AudioPlayerComponent = () => {
   }, [resolveDisplayProvider]);
 
   const handleAlbumPlay = useCallback((albumId: string) => {
-    handlers.handlePlaylistSelect(
+    handlers.loadCollection(
       toAlbumPlaylistId(albumId),
-      undefined,
       currentTrack?.provider,
     );
   }, [handlers, currentTrack?.provider]);
+
+  const handlePlaylistSelect = useCallback(
+    (id: string, _name?: string, provider?: import('@/types/domain').ProviderId) => handlers.loadCollection(id, provider),
+    [handlers]
+  );
 
   const playbackHandlers = useMemo(() => ({
     onPlay: handlers.handlePlay,
@@ -76,14 +80,14 @@ const AudioPlayerComponent = () => {
     onTrackSelect: handlers.playTrack,
     onOpenLibraryDrawer: handlers.handleOpenLibraryDrawer,
     onCloseLibraryDrawer: handlers.handleCloseLibraryDrawer,
-    onPlaylistSelect: handlers.handlePlaylistSelect,
+    onPlaylistSelect: handlePlaylistSelect,
     onAddToQueue: handlers.handleAddToQueue,
     onAlbumPlay: handleAlbumPlay,
     onBackToLibrary: handlers.handleBackToLibrary,
     onStartRadio: handlers.handleStartRadio,
     onRemoveFromQueue: handlers.handleRemoveFromQueue,
     onReorderQueue: handlers.handleReorderQueue,
-  }), [handlers, handleAlbumPlay]);
+  }), [handlers, handleAlbumPlay, handlePlaylistSelect]);
 
   const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification } = useProviderContext();
   // Setup is needed when no provider has been chosen yet and none are connected,
@@ -101,7 +105,7 @@ const AudioPlayerComponent = () => {
     if (!playlistParam) return;
     autoSelectFired.current = true;
     window.history.replaceState({}, '', '/');
-    handlers.handlePlaylistSelect(playlistParam);
+    handlers.loadCollection(playlistParam);
   }, [needsSetup, selectedPlaylistId, handlers]);
 
   const isMainPlayerActive = !state.isLoading && !state.error && selectedPlaylistId !== null && tracks.length > 0;
@@ -151,7 +155,7 @@ const AudioPlayerComponent = () => {
             error={state.error}
             selectedPlaylistId={selectedPlaylistId}
             tracks={tracks}
-            onPlaylistSelect={handlers.handlePlaylistSelect}
+            onPlaylistSelect={handlePlaylistSelect}
           />
         </ProfiledComponent>
       );
@@ -231,7 +235,7 @@ const AudioPlayerComponent = () => {
               <LibraryDrawer
                 isOpen={state.showLibraryDrawer}
                 onClose={handlers.handleCloseLibraryDrawer}
-                onPlaylistSelect={handlers.handlePlaylistSelect}
+                onPlaylistSelect={handlePlaylistSelect}
                 onAddToQueue={handlers.handleAddToQueue}
               />
             </Suspense>

--- a/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
@@ -86,7 +86,7 @@ describe('Keyboard Shortcuts Integration', () => {
     expect(result.current.handlers).toHaveProperty('handlePause');
     expect(result.current.handlers).toHaveProperty('handleNext');
     expect(result.current.handlers).toHaveProperty('handlePrevious');
-    expect(result.current.handlers).toHaveProperty('handlePlaylistSelect');
+    expect(result.current.handlers).toHaveProperty('loadCollection');
     expect(result.current.handlers).toHaveProperty('handleOpenLibraryDrawer');
     expect(result.current.handlers).toHaveProperty('handleBackToLibrary');
     expect(typeof result.current.handlers.handlePlay).toBe('function');

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -85,7 +85,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect('playlist_123', 'My Playlist');
+      return result.current.loadCollection('playlist_123');
     });
 
     expect(mockSetIsLoading).toHaveBeenCalledWith(true);
@@ -141,7 +141,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect(LIKED_SONGS_ID);
+      return result.current.loadCollection(LIKED_SONGS_ID);
     });
 
     // Should merge and sort by addedAt (newest first): track 3 (1500), track 1 (1000), track 2 (500)
@@ -174,7 +174,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect('playlist_123', 'Empty Playlist');
+      return result.current.loadCollection('playlist_123');
     });
 
     expect(mockSetError).toHaveBeenCalledWith('No tracks found in this collection.');
@@ -209,7 +209,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect('playlist_123');
+      return result.current.loadCollection('playlist_123');
     });
 
     // Should delegate to spotifyHandlePlaylistSelect

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -45,7 +45,7 @@ describe('useQueueManagement', () => {
         currentTrackIndex: 1,
         shuffleEnabled: false,
         trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
-        handlePlaylistSelect: mockHandlePlaylistSelect,
+        loadCollection: mockHandlePlaylistSelect,
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
@@ -70,7 +70,7 @@ describe('useQueueManagement', () => {
         currentTrackIndex: 2,
         shuffleEnabled: false,
         trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
-        handlePlaylistSelect: mockHandlePlaylistSelect,
+        loadCollection: mockHandlePlaylistSelect,
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
@@ -96,7 +96,7 @@ describe('useQueueManagement', () => {
         currentTrackIndex: 0,
         shuffleEnabled: false,
         trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
-        handlePlaylistSelect: mockHandlePlaylistSelect,
+        loadCollection: mockHandlePlaylistSelect,
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
@@ -112,7 +112,7 @@ describe('useQueueManagement', () => {
     expect(mockSetTracks).toHaveBeenCalled();
   });
 
-  it('handleAddToQueue delegates to handlePlaylistSelect when queue is empty', async () => {
+  it('handleAddToQueue delegates to loadCollection when queue is empty', async () => {
     mockHandlePlaylistSelect.mockResolvedValue(3);
 
     const { result } = renderHook(() =>
@@ -121,7 +121,7 @@ describe('useQueueManagement', () => {
         currentTrackIndex: 0,
         shuffleEnabled: false,
         trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
-        handlePlaylistSelect: mockHandlePlaylistSelect,
+        loadCollection: mockHandlePlaylistSelect,
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
@@ -132,7 +132,7 @@ describe('useQueueManagement', () => {
       return result.current.handleAddToQueue('playlist_id', 'My Playlist');
     });
 
-    expect(mockHandlePlaylistSelect).toHaveBeenCalledWith('playlist_id', 'My Playlist', undefined);
+    expect(mockHandlePlaylistSelect).toHaveBeenCalledWith('playlist_id', undefined);
     expect(response).toEqual({ added: 3, collectionName: 'My Playlist' });
   });
 
@@ -152,7 +152,7 @@ describe('useQueueManagement', () => {
         currentTrackIndex: 0,
         shuffleEnabled: false,
         trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
-        handlePlaylistSelect: mockHandlePlaylistSelect,
+        loadCollection: mockHandlePlaylistSelect,
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -24,7 +24,7 @@ interface UseCollectionLoaderProps {
 }
 
 interface UseCollectionLoaderReturn {
-  handlePlaylistSelect: (playlistId: string, _playlistName?: string, provider?: ProviderId) => Promise<number>;
+  loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
 }
 
 export function useCollectionLoader({
@@ -176,9 +176,9 @@ export function useCollectionLoader({
     applyTracks, loadContextPlayback, drivingProviderRef, mediaTracksRef, playTrack,
   ]);
 
-  const handlePlaylistSelect = useCallback(
-    async (playlistId: string, _playlistName?: string, provider?: ProviderId): Promise<number> => {
-      logQueue('handlePlaylistSelect called — playlistId=%s provider=%s', playlistId, provider ?? 'active');
+  const loadCollection = useCallback(
+    async (playlistId: string, provider?: ProviderId): Promise<number> => {
+      logQueue('loadCollection called — playlistId=%s provider=%s', playlistId, provider ?? 'active');
 
       if (radioStateIsActive) stopRadioBase();
 
@@ -207,6 +207,6 @@ export function useCollectionLoader({
   );
 
   return {
-    handlePlaylistSelect,
+    loadCollection,
   };
 }

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -120,7 +120,7 @@ export function usePlayerLogic() {
   });
 
   // Initialize collection loader
-  const { handlePlaylistSelect } = useCollectionLoader({
+  const { loadCollection } = useCollectionLoader({
     trackOps,
     activeDescriptor,
     getDescriptor,
@@ -279,7 +279,7 @@ export function usePlayerLogic() {
     tracks,
     currentTrackIndex,
     shuffleEnabled,
-    handlePlaylistSelect,
+    loadCollection,
     handleBackToLibrary,
     activeDescriptor,
     getDescriptor,
@@ -289,7 +289,7 @@ export function usePlayerLogic() {
 
   const handlers = useMemo(
     () => ({
-      handlePlaylistSelect,
+      loadCollection,
       handleAddToQueue,
       handlePlay,
       handlePause,
@@ -304,7 +304,7 @@ export function usePlayerLogic() {
       handleReorderQueue,
     }),
     [
-      handlePlaylistSelect,
+      loadCollection,
       handleAddToQueue,
       handlePlay,
       handlePause,

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -17,14 +17,14 @@ interface UseQueueManagementProps {
   tracks: MediaTrack[];
   currentTrackIndex: number;
   shuffleEnabled: boolean;
-  handlePlaylistSelect: (playlistId: string, _playlistName?: string, provider?: ProviderId) => Promise<number>;
+  loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
   handleBackToLibrary: () => void;
   activeDescriptor: ProviderDescriptor | undefined;
   getDescriptor: (providerId: ProviderId) => ProviderDescriptor | undefined;
 }
 
 interface UseQueueManagementReturn {
-  handleAddToQueue: (playlistId: string, _playlistName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  handleAddToQueue: (playlistId: string, collectionName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
   handleRemoveFromQueue: (index: number) => void;
   handleReorderQueue: (fromIndex: number, toIndex: number) => void;
 }
@@ -34,7 +34,7 @@ export function useQueueManagement({
   tracks,
   currentTrackIndex,
   shuffleEnabled,
-  handlePlaylistSelect,
+  loadCollection,
   handleBackToLibrary,
   activeDescriptor,
   getDescriptor,
@@ -49,7 +49,7 @@ export function useQueueManagement({
    * starts playback of the first added track.
    */
   const handleAddToQueue = useCallback(
-    async (playlistId: string, _playlistName?: string, provider?: ProviderId): Promise<AddToQueueResult | null> => {
+    async (playlistId: string, collectionName?: string, provider?: ProviderId): Promise<AddToQueueResult | null> => {
       const isQueueEmpty = tracks.length === 0;
       logQueue(
         'handleAddToQueue — playlistId=%s, provider=%s, currentQueueLen=%d, mediaLen=%d',
@@ -60,10 +60,10 @@ export function useQueueManagement({
       );
 
       if (isQueueEmpty) {
-        logQueue('handleAddToQueue — queue empty, delegating to handlePlaylistSelect');
-        const loaded = await handlePlaylistSelect(playlistId, _playlistName, provider);
+        logQueue('handleAddToQueue — queue empty, delegating to loadCollection');
+        const loaded = await loadCollection(playlistId, provider);
         if (loaded > 0) {
-          return { added: loaded, collectionName: _playlistName };
+          return { added: loaded, collectionName };
         }
         return null;
       }
@@ -96,13 +96,13 @@ export function useQueueManagement({
           mediaTracksRef.current.length,
           newMediaTracks.map((t: MediaTrack) => trkSummary(t)).join(', '),
         );
-        return { added: newMediaTracks.length, collectionName: _playlistName };
+        return { added: newMediaTracks.length, collectionName };
       } catch (err) {
         console.error('[Queue] Failed to add to queue:', err);
         return null;
       }
     },
-    [tracks.length, handlePlaylistSelect, activeDescriptor, getDescriptor, setTracks, setOriginalTracks]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks]
   );
 
   const handleRemoveFromQueue = useCallback(


### PR DESCRIPTION
## Summary
- Rename `handlePlaylistSelect` to `loadCollection` across hooks and tests — the function loads tracks and starts playback, not just "selects a playlist"
- Remove unused `_playlistName` parameter from the signature
- Updates all call sites in `usePlayerLogic`, `useQueueManagement`, and tests

## Test plan
- [ ] Run `npm run test:run`
- [ ] Run `npx tsc -b --noEmit`
- [ ] Verify playlist/album/liked songs loading still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)