### PR TITLE
fix: resolve stale closure in playTrack causing "no track at index" error

### DIFF
--- a/src/hooks/__tests__/useSpotifyPlayback.test.ts
+++ b/src/hooks/__tests__/useSpotifyPlayback.test.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
@@ -54,6 +55,7 @@ describe('useProviderPlayback', () => {
     makeMediaTrack({ id: 't3', name: 'Track 3', playbackRef: { provider: 'spotify' as ProviderId, ref: 'spotify:track:t3' } }),
   ];
   const setCurrentTrackIndex = vi.fn();
+  const mediaTracksRef = { current: mediaTracks };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -67,7 +69,7 @@ describe('useProviderPlayback', () => {
   it('returns early when no media track at index', async () => {
     // #given
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #when
@@ -82,7 +84,7 @@ describe('useProviderPlayback', () => {
   it('calls setCurrentTrackIndex on successful playback', async () => {
     // #given
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #when
@@ -101,7 +103,7 @@ describe('useProviderPlayback', () => {
     mockPlayTrack.mockRejectedValueOnce(new AuthExpiredError('spotify'));
 
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks, onAuthExpired })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, onAuthExpired })
     );
 
     // #when
@@ -119,7 +121,7 @@ describe('useProviderPlayback', () => {
     mockPlayTrack.mockRejectedValueOnce(new UnavailableTrackError('Track 1'));
 
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #when
@@ -140,7 +142,7 @@ describe('useProviderPlayback', () => {
     mockPlayTrack.mockRejectedValueOnce(new Error('Unknown failure'));
 
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #when
@@ -159,7 +161,7 @@ describe('useProviderPlayback', () => {
   it('prefetches the next track after successful playback', async () => {
     // #given
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #when
@@ -179,7 +181,7 @@ describe('useProviderPlayback', () => {
     ];
 
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks: mixedTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef: { current: mixedTracks } as React.MutableRefObject<MediaTrack[]> })
     );
 
     // #when — play dropbox track first
@@ -199,7 +201,7 @@ describe('useProviderPlayback', () => {
   it('resumes playback via current driving provider', async () => {
     // #given
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     await act(async () => {
@@ -220,7 +222,7 @@ describe('useProviderPlayback', () => {
   it('does not return activateDevice', () => {
     // #given
     const { result } = renderHook(() =>
-      useProviderPlayback({ setCurrentTrackIndex, mediaTracks })
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef })
     );
 
     // #then

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -96,7 +96,7 @@ export function usePlayerLogic() {
   const providerPlayback = useProviderPlayback({
     setCurrentTrackIndex,
     activeDescriptor,
-    mediaTracks: tracks,
+    mediaTracksRef,
     onAuthExpired: (providerId: ProviderId) => setAuthExpired(providerId),
   });
   const { playTrack } = providerPlayback;

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -8,14 +8,14 @@ import { logQueue } from '@/lib/debugLog';
 interface UseProviderPlaybackProps {
   setCurrentTrackIndex: (index: number) => void;
   activeDescriptor?: ProviderDescriptor | null;
-  mediaTracks: MediaTrack[];
+  mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
   onAuthExpired?: (providerId: ProviderId) => void;
 }
 
 export const useProviderPlayback = ({
   setCurrentTrackIndex,
   activeDescriptor,
-  mediaTracks,
+  mediaTracksRef,
   onAuthExpired,
 }: UseProviderPlaybackProps) => {
 
@@ -36,7 +36,8 @@ export const useProviderPlayback = ({
   }, []);
 
   const playTrack = useCallback(async (index: number, skipOnError = false) => {
-    const mediaTrack = mediaTracks[index];
+    const tracks = mediaTracksRef.current;
+    const mediaTrack = tracks[index];
     const trackProvider = resolveTrackProvider(mediaTrack);
 
     logQueue(
@@ -44,7 +45,7 @@ export const useProviderPlayback = ({
       index,
       trackProvider ?? 'NONE',
       mediaTrack ? `"${mediaTrack.name}" (${mediaTrack.id.slice(0, 8)})` : 'NO_MEDIA_TRACK',
-      mediaTracks.length,
+      tracks.length,
       String(skipOnError),
     );
 
@@ -54,8 +55,8 @@ export const useProviderPlayback = ({
     }
 
     if (!mediaTrack) {
-      if (mediaTracks.length > 0) {
-        console.warn(`[Playback] playTrack(${index}) — index out of bounds! mediaTracksRef has ${mediaTracks.length} items`);
+      if (tracks.length > 0) {
+        console.warn(`[Playback] playTrack(${index}) — index out of bounds! mediaTracksRef has ${tracks.length} items`);
       }
       console.error(`[Playback] playTrack(${index}) — no track at index`);
       return;
@@ -74,8 +75,8 @@ export const useProviderPlayback = ({
       await descriptor.playback.playTrack(mediaTrack);
       setCurrentTrackIndex(index);
 
-      const nextIndex = (index + 1) % mediaTracks.length;
-      const nextTrack = mediaTracks[nextIndex];
+      const nextIndex = (index + 1) % tracks.length;
+      const nextTrack = tracks[nextIndex];
       if (nextTrack && nextIndex !== index) {
         const nextDescriptor = providerRegistry.get(nextTrack.provider);
         nextDescriptor?.playback.prepareTrack?.(nextTrack);
@@ -88,18 +89,18 @@ export const useProviderPlayback = ({
 
       if (error instanceof UnavailableTrackError) {
         console.warn(`[${trackProvider}] ${error.message}`);
-        if (skipOnError && index < mediaTracks.length - 1) {
+        if (skipOnError && index < tracks.length - 1) {
           setTimeout(() => playTrack(index + 1, skipOnError), 500);
         }
         return;
       }
 
       console.error(`[${trackProvider}] Failed to play track:`, error);
-      if (skipOnError && index < mediaTracks.length - 1) {
+      if (skipOnError && index < tracks.length - 1) {
         setTimeout(() => playTrack(index + 1, skipOnError), 500);
       }
     }
-  }, [setCurrentTrackIndex, mediaTracks, pausePreviousProvider, resolveTrackProvider, onAuthExpired]);
+  }, [setCurrentTrackIndex, pausePreviousProvider, resolveTrackProvider, onAuthExpired]);
 
   const resumePlayback = useCallback(async () => {
     const currentProvider = currentPlaybackProviderRef.current;


### PR DESCRIPTION
## Summary
- `useProviderPlayback.playTrack` captured `mediaTracks` from the `useCallback` closure, which was stale when `loadCollection` called `setTracks()` then immediately `await playTrack(0)` before React re-rendered
- Switch to reading from `mediaTracksRef` (the shared mutable ref that `useCollectionLoader` updates synchronously) so `playTrack` always sees the latest tracks
- Remove the now-unnecessary `mediaTracks` prop from `useProviderPlayback` — it reads exclusively from the ref

## Test plan
- [x] `npm run test:run` — 555 tests pass
- [x] `npx tsc -b --noEmit` — clean
- [ ] Deploy to staging and verify clicking a playlist loads and plays tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)