### PR TITLE
fix: styled-components glow keyframes error and test renames

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useState, useCallback, useMemo } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import { breatheBorderGlow } from '../styles/animations';
 
@@ -103,7 +103,7 @@ const AlbumArtContainer = styled.div.withConfig({
       const glowA = 0.45 + t * 0.15;
       const glowB = 0.3 + t * 0.15;
       const glowC = 0.2 + t * 0.15;
-      return `
+      return css`
         box-shadow:
           inset 0 0 10px rgba(0, 0, 0, 0.25),
           0 0 0 1.5px rgba(255, 255, 255, ${edgeOpacity.toFixed(2)}),

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -242,7 +242,7 @@ describe('useCollectionLoader', () => {
     );
 
     await act(async () => {
-      await result.current.handlePlaylistSelect('playlist_123');
+      await result.current.loadCollection('playlist_123');
     });
 
     expect(mockStopRadioBase).toHaveBeenCalled();
@@ -272,7 +272,7 @@ describe('useCollectionLoader', () => {
     );
 
     await act(async () => {
-      await result.current.handlePlaylistSelect('playlist_123');
+      await result.current.loadCollection('playlist_123');
     });
 
     // setOriginalTracks gets the unshuffled list; setTracks gets whatever order
@@ -308,7 +308,7 @@ describe('useCollectionLoader', () => {
     );
 
     await act(async () => {
-      await result.current.handlePlaylistSelect('playlist_123', undefined, 'dropbox');
+      await result.current.loadCollection('playlist_123', 'dropbox');
     });
 
     expect(mockSetActiveProviderId).toHaveBeenCalledWith('dropbox');
@@ -337,7 +337,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect('playlist_123');
+      return result.current.loadCollection('playlist_123');
     });
 
     expect(mockSetError).toHaveBeenCalledWith('Network error');
@@ -371,7 +371,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect(LIKED_SONGS_ID);
+      return result.current.loadCollection(LIKED_SONGS_ID);
     });
 
     expect(mockSetError).toHaveBeenCalledWith('No liked tracks found.');
@@ -399,7 +399,7 @@ describe('useCollectionLoader', () => {
     );
 
     const trackCount = await act(async () => {
-      return result.current.handlePlaylistSelect('playlist_123');
+      return result.current.loadCollection('playlist_123');
     });
 
     expect(trackCount).toBe(0);


### PR DESCRIPTION
## Summary
- **AlbumArt.tsx**: Use `css` helper for the glow CSS block so styled-components can properly process the `breatheBorderGlow` keyframes interpolation (was inside a plain template literal, causing runtime injection error "LxeAx")
- **useCollectionLoader.test.ts**: Update tests from PR #407 to use `loadCollection` (renamed in #406) and fix call signature

## Test plan
- [x] `npm run test:run` — 576 tests pass
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Deploy to staging and verify glow animation works without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)