### PR TITLE
fix: retry Spotify playback transfer on transient network error

### DIFF
--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -421,29 +421,33 @@ class SpotifyPlayerService {
     }
 
     const token = await spotifyAuth.ensureValidToken();
-    
-    try {
-      const response = await fetch('https://api.spotify.com/v1/me/player', {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          device_ids: [this.deviceId],
-          play: false
-        })
-      });
+    const body = JSON.stringify({ device_ids: [this.deviceId], play: false });
+    const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-      if (!response.ok && response.status !== 204) {
-        const errorText = await response.text();
-        console.warn('[spotifyPlayer] Transfer playback response:', response.status, errorText);
-      } else {
-        logSpotify('transferred playback to device');
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await fetch('https://api.spotify.com/v1/me/player', {
+          method: 'PUT',
+          headers,
+          body,
+        });
+
+        if (!response.ok && response.status !== 204) {
+          const errorText = await response.text();
+          console.warn('[spotifyPlayer] Transfer playback response:', response.status, errorText);
+        } else {
+          logSpotify('transferred playback to device');
+        }
+        return;
+      } catch (error) {
+        if (attempt === 0) {
+          console.warn('[spotifyPlayer] Transfer playback network error, retrying:', error);
+          await new Promise(resolve => setTimeout(resolve, 500));
+        } else {
+          console.error('[spotifyPlayer] Failed to transfer playback to device:', error);
+          throw error;
+        }
       }
-    } catch (error) {
-      console.error('[spotifyPlayer] Failed to transfer playback to device:', error);
-      throw error;
     }
   }
 


### PR DESCRIPTION
## What
- `transferPlaybackToDevice` now retries once (after 500ms) when the `PUT /v1/me/player` fetch throws a network-level error (`ERR_CONNECTION_CLOSED`, `Failed to fetch`)
- HTTP errors (4xx/5xx) are unaffected — only connection-level failures trigger the retry
- Second failure still re-throws so `ensurePlaybackReady` can propagate the error as before

## Why
Staging was logging `ERR_CONNECTION_CLOSED` on `PUT https://api.spotify.com/v1/me/player`, which caused `transferPlaybackToDevice` → `ensurePlaybackReady` → `playTrack` to fail entirely. The transfer endpoint is called to claim the Web Playback SDK device as active — a transient connection drop shouldn't abort playback when a single retry would succeed.

## Test plan
- [ ] Play a track via Spotify — playback starts normally
- [ ] Throttle the network (DevTools → Network → Slow 3G) and trigger a track play — should recover rather than show a play failure
- [ ] Confirm `[spotifyPlayer] Transfer playback network error, retrying:` appears in the console on a simulated connection drop, followed by successful playback