### PR TITLE
fix(spotifyPlayer): eliminate per-skip transfer latency and stale seek on track switch

### DIFF
--- a/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
+++ b/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
@@ -92,6 +92,22 @@ describe('SpotifyPlaybackAdapter', () => {
     expect(spotifyPlayer.playTrack).not.toHaveBeenCalled();
   });
 
+  it('retries with force=true transfer on 403 error', async () => {
+    vi.useFakeTimers();
+    vi.mocked(spotifyPlayer.playTrack)
+      .mockRejectedValueOnce(new Error('Spotify API error: 403'))
+      .mockResolvedValue(undefined);
+
+    const playPromise = adapter.playTrack(makeSpotifyTrack());
+    await vi.runAllTimersAsync();
+    await playPromise;
+
+    // #given initial call + retry
+    const calls = vi.mocked(spotifyPlayer.transferPlaybackToDevice).mock.calls;
+    // #then the retry call must bypass the cache with force=true
+    expect(calls.some(c => c[0] === true)).toBe(true);
+  });
+
   it('ensures readiness before playing playlist context', async () => {
     const collection: CollectionRef = { provider: 'spotify', kind: 'playlist', id: 'playlist-1' };
 

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -115,7 +115,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         if (retryCount < MAX_PLAY_RETRIES) {
           const backoffMs = BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
           logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
-          await spotifyPlayer.transferPlaybackToDevice();
+          await spotifyPlayer.transferPlaybackToDevice(true);
           await new Promise(resolve => setTimeout(resolve, backoffMs));
           await spotifyPlayer.ensureDeviceIsActive(3, 1000);
           return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1);

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -184,7 +184,7 @@ export const useSpotifyPlaylistManager = ({
 
             if (retryCount < maxRetries) {
               const backoffMs = 2000 * Math.pow(2, retryCount);
-              await spotifyPlayer.transferPlaybackToDevice();
+              await spotifyPlayer.transferPlaybackToDevice(true);
               await new Promise(resolve => setTimeout(resolve, backoffMs));
               await spotifyPlayer.ensureDeviceIsActive(3, 1000);
 

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -37,6 +37,8 @@ class SpotifyPlayerService {
   lastPlayTrackTime = 0;
   /** Timestamp of last confirmed device-active check. */
   private lastDeviceActiveAt = 0;
+  /** Timestamp of last successful playback transfer. */
+  private lastTransferAt = 0;
 
   constructor() {
     // Restore state from HMR if available
@@ -179,13 +181,13 @@ class SpotifyPlayerService {
 
     const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${this.deviceId}`, {
       method: 'PUT',
-      body: JSON.stringify({ uris }),
+      body: JSON.stringify({ uris, position_ms: 0 }),
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
     });
-    
+
     logSpotify('Web API play track response status=%d ok=%s', response.status, response.ok);
     
     if (!response.ok) {
@@ -224,7 +226,7 @@ class SpotifyPlayerService {
 
     const token = await spotifyAuth.ensureValidToken();
 
-    const body: Record<string, unknown> = { context_uri: contextUri };
+    const body: Record<string, unknown> = { context_uri: contextUri, position_ms: 0 };
     if (offsetPosition !== undefined) {
       body.offset = { position: offsetPosition };
     }
@@ -269,13 +271,13 @@ class SpotifyPlayerService {
     
     const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${this.deviceId}`, {
       method: 'PUT',
-      body: JSON.stringify({ uris }),
+      body: JSON.stringify({ uris, position_ms: 0 }),
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
     });
-    
+
     logSpotify('Web API play URIs response status=%d ok=%s', response.status, response.ok);
     
     if (!response.ok) {
@@ -403,6 +405,7 @@ class SpotifyPlayerService {
       this.player = null;
       this.deviceId = null;
       this.isReady = false;
+      this.lastTransferAt = 0;
       this.saveState();
     }
   }
@@ -415,9 +418,14 @@ class SpotifyPlayerService {
     return this.isReady;
   }
 
-  async transferPlaybackToDevice(): Promise<void> {
+  async transferPlaybackToDevice(force = false): Promise<void> {
     if (!this.deviceId || !this.isReady) {
       throw new Error('Device not ready for playback transfer');
+    }
+
+    if (!force && Date.now() - this.lastTransferAt < SpotifyPlayerService.TRANSFER_TTL_MS) {
+      logSpotify('skipping transfer — device recently transferred');
+      return;
     }
 
     const token = await spotifyAuth.ensureValidToken();
@@ -437,6 +445,7 @@ class SpotifyPlayerService {
           console.warn('[spotifyPlayer] Transfer playback response:', response.status, errorText);
         } else {
           logSpotify('transferred playback to device');
+          this.lastTransferAt = Date.now();
         }
         return;
       } catch (error) {
@@ -453,6 +462,8 @@ class SpotifyPlayerService {
 
   /** How long a successful device-active check remains valid. */
   private static readonly DEVICE_ACTIVE_TTL_MS = 30_000;
+  /** How long a successful playback transfer remains valid. */
+  private static readonly TRANSFER_TTL_MS = 30_000;
 
   async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 800): Promise<boolean> {
     // Skip the API call if device was recently confirmed active


### PR DESCRIPTION
## Summary

- Add 30s TTL cache to `transferPlaybackToDevice()` so repeated skips don't pay an API round-trip cost when the device is already active. Retry paths (403 recovery) bypass the cache via `force=true`.
- Pass `position_ms: 0` explicitly in `playTrack`, `playContext`, and `playPlaylist` to prevent the preceding transfer's playback state from leaking into the new track's start position.
- Reset `lastTransferAt` in `disconnect()` so a reconnected device always triggers a fresh transfer.

Fixes #414

## Test plan
- [ ] `npm run test:run`
- [ ] On iPhone/Chrome with Spotify: skip several tracks in a row — verify each starts within ~500ms
- [ ] Skip mid-song — verify new track starts from 0:00, not from the previous track's offset
- [ ] Disconnect and reconnect Spotify — verify a fresh transfer is triggered on next play