### PR TITLE
chore: add close-issues and clean-branches Claude skills

### DIFF
--- a/.claude/skills/clean-branches/SKILL.md
+++ b/.claude/skills/clean-branches/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: clean-branches
+description: Bulk-delete orphaned local branches and remote branches whose PRs have been merged or closed. Run after a merge cycle to keep the branch list clean.
+---
+
+# Clean Branches
+
+Remove stale local branches and remote branches that have had their PRs merged or closed.
+
+## Usage
+
+```
+/clean-branches
+```
+
+## Steps
+
+### 1. Fetch and prune remote tracking refs
+
+```bash
+git fetch --prune
+```
+
+This removes remote-tracking refs for branches deleted on the remote.
+
+### 2. Find orphaned local branches
+
+Local branches with no remote tracking ref are orphaned:
+
+```bash
+git branch -vv | grep -v 'origin/'
+```
+
+Also check for branches merged into main (safe to delete):
+
+```bash
+git branch --merged main | grep -v '^\* main$'
+```
+
+### 3. Delete orphaned local branches
+
+Use `-d` for merged branches, `-D` for unmerged ones (backup/* branches, old feature branches with no remote):
+
+```bash
+git branch -D <branch1> <branch2> ...
+```
+
+For branch names with spaces (common in backup/* branches), use a loop:
+
+```bash
+git branch | grep 'backup/' | while IFS= read -r branch; do
+  branch="${branch#  }"
+  git branch -D "$branch"
+done
+```
+
+### 4. Find remote branches with merged/closed PRs
+
+Get all merged PR branch names:
+
+```bash
+gh pr list --state merged --limit 100 --json headRefName --jq '.[].headRefName'
+```
+
+Get all current remote branches (excluding protected):
+
+```bash
+gh api repos/{owner}/{repo}/branches --paginate --jq '.[].name' | grep -vE '^(main|staging)$'
+```
+
+Cross-reference: delete remote branches that appear in the merged PR list.
+
+### 5. Delete merged remote branches
+
+```bash
+git push origin --delete <branch1> <branch2> ...
+```
+
+Or in a loop for many branches:
+
+```bash
+for branch in branch1 branch2; do
+  git push origin --delete "$branch" && echo "deleted: $branch" || echo "failed: $branch"
+done
+```
+
+### 6. Report what was skipped
+
+List any remote branches with **no PR at all** — these may be long-lived feature branches or abandoned work. Present them to the user and ask before deleting.
+
+## Notes
+
+- Never delete `main`, `staging`, or any branch the user is actively working on.
+- Branches without PRs (e.g. `apple-music-integration`, `feature/vorbis-mode`) should be flagged to the user rather than auto-deleted.
+- `backup/*` branches are created automatically by Claude Code worktree scripts — safe to force-delete.

--- a/.claude/skills/close-issues/SKILL.md
+++ b/.claude/skills/close-issues/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: close-issues
+description: Close GitHub issues that were addressed by recently merged PRs. Because PRs target `staging` (not `main`), GitHub never auto-closes issues. Use after merging PRs into staging or after cutting a staging → main release.
+---
+
+# Close Issues
+
+Find GitHub issues referenced in recently merged PRs and close any that are still open.
+
+## Usage
+
+```
+/close-issues
+```
+
+## Steps
+
+1. Get merged PRs from the last batch (recent staging merges or today's work):
+
+```bash
+gh pr list --state merged --limit 20 --json number,title,mergedAt,body
+```
+
+2. Extract issue references from PR bodies — look for patterns like `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive).
+
+3. For each referenced issue number, check if it's still open:
+
+```bash
+gh issue view <N> --json number,title,state
+```
+
+4. Close any that are still open, with a comment referencing the PR that addressed it:
+
+```bash
+gh issue close <N> --comment "Resolved in #<PR> (merged to staging)."
+```
+
+5. Report to the user which issues were closed and which were already closed.
+
+## Notes
+
+- PRs in this repo target `staging`, not `main` — GitHub's auto-close only fires when merging to the default branch, so issues stay open even after the fix lands.
+- If running after a staging → main release (cut-staging), you can scan the full staging diff: `git log main..origin/staging --oneline` before the merge to catch all referenced issues.


### PR DESCRIPTION
## What
- Add `/close-issues` skill — scans recent merged PR bodies for `Closes/Fixes/Resolves #N` references and closes any still-open issues with a comment. Necessary because PRs target `staging`, so GitHub's auto-close never fires.
- Add `/clean-branches` skill — full local + remote branch cleanup: prunes stale tracking refs, deletes orphaned locals (including space-in-name `backup/*` branches), cross-references remote branches against merged PRs, and flags no-PR branches for user review before deleting.

## Why
Both steps were performed manually multiple times this session with no existing skill to automate them. Codifying the exact steps (including edge cases like space-in-name branches and the staging PR base) prevents drift in future sessions.

## Test plan
- [ ] Run `/close-issues` after merging a PR that references an issue — verify the issue gets closed with a comment
- [ ] Run `/clean-branches` after a merge cycle — verify orphaned locals and merged remote branches are removed, and no-PR branches are flagged rather than auto-deleted