### PR TITLE
test: add component tests for QueueDrawer, VisualEffectsMenu, ProviderSetupScreen

### DIFF
--- a/src/components/__tests__/ProviderSetupScreen.test.tsx
+++ b/src/components/__tests__/ProviderSetupScreen.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import { makeProviderDescriptor } from '@/test/fixtures';
+import type { ProviderDescriptor } from '@/types/providers';
+
+const mockSetActiveProviderId = vi.fn();
+const mockToggleProvider = vi.fn();
+let mockProviderContextValue: Record<string, unknown>;
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => mockProviderContextValue),
+}));
+
+import ProviderSetupScreen from '../ProviderSetupScreen';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+function buildProviderContext(overrides: Record<string, unknown> = {}) {
+  const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+  const dropboxDesc = makeProviderDescriptor({
+    id: 'dropbox' as 'spotify',
+    name: 'Dropbox',
+    capabilities: { hasSaveTrack: true, hasExternalLink: false, hasLikedCollection: true },
+  });
+
+  return {
+    chosenProviderId: null,
+    activeDescriptor: spotifyDesc,
+    setActiveProviderId: mockSetActiveProviderId,
+    registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+    enabledProviderIds: ['spotify', 'dropbox'],
+    toggleProvider: mockToggleProvider,
+    ...overrides,
+  };
+}
+
+describe('ProviderSetupScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProviderContextValue = buildProviderContext();
+  });
+
+  describe('first visit (chosenProviderId is null)', () => {
+    it('renders welcome title', () => {
+      // #given
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Welcome to Vorbis Player')).toBeInTheDocument();
+    });
+
+    it('renders all registered providers', () => {
+      // #given
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Spotify')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox')).toBeInTheDocument();
+    });
+
+    it('shows Connect buttons for unauthenticated providers', () => {
+      // #given
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      const connectButtons = screen.getAllByText('Connect');
+      expect(connectButtons).toHaveLength(2);
+    });
+
+    it('shows Connected badge for authenticated providers', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      vi.mocked(spotifyDesc.auth.isAuthenticated).mockReturnValue(true);
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+      expect(screen.getAllByText('Connect')).toHaveLength(1);
+    });
+
+    it('shows Continue button when at least one provider is authenticated', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      vi.mocked(spotifyDesc.auth.isAuthenticated).mockReturnValue(true);
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Continue')).toBeInTheDocument();
+    });
+
+    it('does not show Continue button when no providers are authenticated', () => {
+      // #given
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.queryByText('Continue')).not.toBeInTheDocument();
+    });
+
+    it('shows simplified subtitle for single provider', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc] },
+        enabledProviderIds: ['spotify'],
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Connect your music provider to get started')).toBeInTheDocument();
+    });
+
+    it('does not render provider toggle switches for a single provider', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc] },
+        enabledProviderIds: ['spotify'],
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    });
+
+    it('renders provider toggle switches for multiple providers', () => {
+      // #given
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      const switches = screen.getAllByRole('switch');
+      expect(switches).toHaveLength(2);
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls beginLogin when Connect is clicked', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getAllByText('Connect')[0]);
+
+      // #then
+      expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
+    });
+
+    it('calls setActiveProviderId when Continue is clicked', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      vi.mocked(spotifyDesc.auth.isAuthenticated).mockReturnValue(true);
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc] },
+        enabledProviderIds: ['spotify'],
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByText('Continue'));
+
+      // #then
+      expect(mockSetActiveProviderId).toHaveBeenCalledWith('spotify');
+    });
+
+    it('renders settings gear button when onOpenSettings is provided', () => {
+      // #given
+      const onOpenSettings = vi.fn();
+      render(<Wrapper><ProviderSetupScreen onOpenSettings={onOpenSettings} /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Open settings'));
+
+      // #then
+      expect(onOpenSettings).toHaveBeenCalled();
+    });
+
+    it('renders Browse Library link when authenticated and onOpenLibrary is provided', () => {
+      // #given
+      const onOpenLibrary = vi.fn();
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      vi.mocked(spotifyDesc.auth.isAuthenticated).mockReturnValue(true);
+      mockProviderContextValue = buildProviderContext({
+        registry: { getAll: () => [spotifyDesc] },
+        enabledProviderIds: ['spotify'],
+      });
+
+      render(<Wrapper><ProviderSetupScreen onOpenLibrary={onOpenLibrary} /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByText('Browse Library'));
+
+      // #then
+      expect(onOpenLibrary).toHaveBeenCalled();
+    });
+  });
+
+  describe('expired session (chosenProviderId is set)', () => {
+    it('renders Session Expired title', () => {
+      // #given
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    });
+
+    it('shows Expired badge and Reconnect button for expired providers', () => {
+      // #given
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getAllByText('Expired')).toHaveLength(2);
+      expect(screen.getAllByText('Reconnect')).toHaveLength(2);
+    });
+
+    it('shows Connected badge for still-authenticated providers in expired view', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      vi.mocked(spotifyDesc.auth.isAuthenticated).mockReturnValue(true);
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+      expect(screen.getAllByText('Reconnect')).toHaveLength(1);
+    });
+
+    it('calls beginLogin when Reconnect is clicked on expired view', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getAllByText('Reconnect')[0]);
+
+      // #then
+      expect(mockSetActiveProviderId).toHaveBeenCalled();
+      expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
+    });
+
+    it('shows singular subtitle for single expired provider', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+        activeDescriptor: spotifyDesc,
+        registry: { getAll: () => [spotifyDesc] },
+        enabledProviderIds: ['spotify'],
+      });
+
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then
+      expect(
+        screen.getByText(/Your Spotify session has expired/)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/QueueDrawer.test.tsx
+++ b/src/components/__tests__/QueueDrawer.test.tsx
@@ -1,0 +1,207 @@
+import React, { Suspense } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: vi.fn(() => ({
+    viewport: { width: 1200, height: 800 },
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    transitionDuration: 300,
+    transitionEasing: 'ease',
+  })),
+}));
+
+vi.mock('@/components/QueueTrackList', () => ({
+  default: ({ tracks, currentTrackIndex, onTrackSelect, onRemoveTrack }: {
+    tracks: { id: string; name: string }[];
+    currentTrackIndex: number;
+    onTrackSelect: (i: number) => void;
+    onRemoveTrack?: (i: number) => void;
+  }) => (
+    <div data-testid="queue-track-list">
+      {tracks.map((t, i) => (
+        <div key={t.id} data-testid={`track-${i}`}>
+          <span>{t.name}</span>
+          <button onClick={() => onTrackSelect(i)}>select</button>
+          {onRemoveTrack && <button onClick={() => onRemoveTrack(i)}>remove</button>}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import QueueDrawer from '../QueueDrawer';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <Suspense fallback={<div>Loading...</div>}>
+      {children}
+    </Suspense>
+  </ThemeProvider>
+);
+
+describe('QueueDrawer', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    tracks: [
+      makeMediaTrack({ id: 'a', name: 'Track A' }),
+      makeMediaTrack({ id: 'b', name: 'Track B' }),
+    ],
+    currentTrackIndex: 0,
+    onTrackSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the drawer with a "Queue" title when not in radio mode', () => {
+      // #given
+      render(<Wrapper><QueueDrawer {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Queue')).toBeInTheDocument();
+    });
+
+    it('renders "Radio" title when radioActive is true', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} radioActive radioSeedDescription="Based on Song X" />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByText('Radio')).toBeInTheDocument();
+      expect(screen.getByText('Based on Song X')).toBeInTheDocument();
+    });
+
+    it('renders the track list with provided tracks', () => {
+      // #given
+      render(<Wrapper><QueueDrawer {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByTestId('queue-track-list')).toBeInTheDocument();
+      expect(screen.getByText('Track A')).toBeInTheDocument();
+      expect(screen.getByText('Track B')).toBeInTheDocument();
+    });
+
+    it('renders empty track list when no tracks are provided', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} tracks={[]} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByTestId('queue-track-list')).toBeInTheDocument();
+    });
+
+    it('renders save button when canSaveQueue is true', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} canSaveQueue onSaveQueue={vi.fn()} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByLabelText('Save queue as playlist')).toBeInTheDocument();
+    });
+
+    it('does not render save button when canSaveQueue is false', () => {
+      // #given
+      render(<Wrapper><QueueDrawer {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.queryByLabelText('Save queue as playlist')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClose when overlay is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      const { container } = render(
+        <Wrapper><QueueDrawer {...defaultProps} onClose={onClose} /></Wrapper>
+      );
+
+      // #when — the overlay is the first child rendered by the portal
+      const overlay = container.ownerDocument.body.querySelector('[class]');
+      if (overlay) fireEvent.click(overlay);
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when close button is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(<Wrapper><QueueDrawer {...defaultProps} onClose={onClose} /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByText('×'));
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onTrackSelect and onClose when a track is selected', () => {
+      // #given
+      const onTrackSelect = vi.fn();
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} onTrackSelect={onTrackSelect} onClose={onClose} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getAllByText('select')[1]);
+
+      // #then
+      expect(onTrackSelect).toHaveBeenCalledWith(1);
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onSaveQueue when save button is clicked', () => {
+      // #given
+      const onSaveQueue = vi.fn();
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} canSaveQueue onSaveQueue={onSaveQueue} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Save queue as playlist'));
+
+      // #then
+      expect(onSaveQueue).toHaveBeenCalled();
+    });
+
+    it('calls onRemoveTrack when a track is removed', () => {
+      // #given
+      const onRemoveTrack = vi.fn();
+      render(
+        <Wrapper>
+          <QueueDrawer {...defaultProps} onRemoveTrack={onRemoveTrack} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getAllByText('remove')[0]);
+
+      // #then
+      expect(onRemoveTrack).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/src/components/__tests__/VisualEffectsMenu.test.tsx
+++ b/src/components/__tests__/VisualEffectsMenu.test.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import { makeProviderDescriptor } from '@/test/fixtures';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: vi.fn(() => ({
+    viewport: { width: 1200, height: 800 },
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    transitionDuration: 300,
+    transitionEasing: 'ease',
+  })),
+}));
+
+const mockToggleProvider = vi.fn();
+const mockRegistry = {
+  getAll: vi.fn(() => []),
+  get: vi.fn(),
+};
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    registry: mockRegistry,
+    enabledProviderIds: ['spotify'],
+    connectedProviderIds: ['spotify'],
+    toggleProvider: mockToggleProvider,
+  })),
+}));
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  useProfilingContext: vi.fn(() => ({
+    enabled: false,
+    collector: null,
+  })),
+}));
+
+vi.mock('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: vi.fn((key: string, defaultValue: unknown) => {
+    const state = { value: defaultValue };
+    return [state.value, vi.fn((v: unknown) => { state.value = v; })];
+  }),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: vi.fn(() => ({
+    collections: [],
+    isLoading: false,
+    error: null,
+  })),
+  LIBRARY_REFRESH_EVENT: 'vorbis-library-refresh',
+  ART_REFRESHED_EVENT: 'vorbis-art-refreshed',
+}));
+
+import { useProviderContext } from '@/contexts/ProviderContext';
+import AppSettingsMenu from '../VisualEffectsMenu/index';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('AppSettingsMenu', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onClearCache: vi.fn().mockResolvedValue(undefined),
+    profilerEnabled: false,
+    onProfilerToggle: vi.fn(),
+    visualizerDebugEnabled: false,
+    onVisualizerDebugToggle: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistry.getAll.mockReturnValue([]);
+  });
+
+  describe('rendering', () => {
+    it('renders with the Settings title', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
+    it('renders close button with accessible label', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByLabelText('Close settings drawer')).toBeInTheDocument();
+    });
+
+    it('renders Advanced collapsible section', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Advanced')).toBeInTheDocument();
+    });
+  });
+
+  describe('close behavior', () => {
+    it('calls onClose when close button is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(<Wrapper><AppSettingsMenu {...defaultProps} onClose={onClose} /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Close settings drawer'));
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('music sources section', () => {
+    it('renders provider toggles when multiple providers exist', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Music Sources')).toBeInTheDocument();
+      expect(screen.getByText('Spotify')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox')).toBeInTheDocument();
+    });
+
+    it('does not render Music Sources section with a single provider', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      mockRegistry.getAll.mockReturnValue([spotifyDesc]);
+
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.queryByText('Music Sources')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('advanced section', () => {
+    it('shows cache and profiler options when Advanced is expanded', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByText('Advanced'));
+
+      // #then
+      expect(screen.getByText('Clear Library Cache')).toBeInTheDocument();
+      expect(screen.getByText('Performance Profiler')).toBeInTheDocument();
+      expect(screen.getByText('Visualizer Debug')).toBeInTheDocument();
+    });
+
+    it('calls onProfilerToggle when profiler button is clicked', () => {
+      // #given
+      const onProfilerToggle = vi.fn();
+      render(
+        <Wrapper>
+          <AppSettingsMenu {...defaultProps} onProfilerToggle={onProfilerToggle} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getByText('Advanced'));
+      const onButtons = screen.getAllByText('On');
+      fireEvent.click(onButtons[0]);
+
+      // #then
+      expect(onProfilerToggle).toHaveBeenCalled();
+    });
+
+    it('calls onVisualizerDebugToggle when debug button is clicked', () => {
+      // #given
+      const onVisualizerDebugToggle = vi.fn();
+      render(
+        <Wrapper>
+          <AppSettingsMenu {...defaultProps} onVisualizerDebugToggle={onVisualizerDebugToggle} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getByText('Advanced'));
+      const onButtons = screen.getAllByText('On');
+      fireEvent.click(onButtons[1]);
+
+      // #then
+      expect(onVisualizerDebugToggle).toHaveBeenCalled();
+    });
+  });
+
+  describe('cache clearing', () => {
+    it('shows confirmation options when Clear Cache is clicked', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+      fireEvent.click(screen.getByText('Advanced'));
+
+      // #when
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #then
+      expect(screen.getByText('Confirm Clear')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('returns to initial state when cancel is clicked', () => {
+      // #given
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+      fireEvent.click(screen.getByText('Advanced'));
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(screen.getByText('Clear Cache')).toBeInTheDocument();
+      expect(screen.queryByText('Confirm Clear')).not.toBeInTheDocument();
+    });
+
+    it('calls onClearCache when confirmed', async () => {
+      // #given
+      const onClearCache = vi.fn().mockResolvedValue(undefined);
+      render(
+        <Wrapper>
+          <AppSettingsMenu {...defaultProps} onClearCache={onClearCache} />
+        </Wrapper>
+      );
+      fireEvent.click(screen.getByText('Advanced'));
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #when
+      fireEvent.click(screen.getByText('Confirm Clear'));
+
+      // #then
+      await waitFor(() => {
+        expect(onClearCache).toHaveBeenCalledWith({
+          clearLikes: false,
+          clearPins: false,
+          clearAccentColors: false,
+        });
+      });
+    });
+  });
+
+  describe('provider data sections', () => {
+    it('renders provider data section for providers with clearArtCache', () => {
+      // #given
+      const descriptor = makeProviderDescriptor({
+        id: 'dropbox' as 'spotify',
+        name: 'Dropbox',
+      });
+      (descriptor.catalog as Record<string, unknown>).clearArtCache = vi.fn();
+      mockRegistry.getAll.mockReturnValue([descriptor]);
+
+      vi.mocked(useProviderContext).mockReturnValue({
+        registry: mockRegistry,
+        enabledProviderIds: ['dropbox'],
+        connectedProviderIds: ['dropbox'],
+        toggleProvider: mockToggleProvider,
+      } as unknown as ReturnType<typeof useProviderContext>);
+
+      render(<Wrapper><AppSettingsMenu {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Dropbox Data')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 41 tests across 3 new test files for previously untested components
- `QueueDrawer.test.tsx` (11 tests) — rendering, interactions, track selection
- `VisualEffectsMenu.test.tsx` (13 tests) — settings sections, provider toggles, cache clearing flow
- `ProviderSetupScreen.test.tsx` (17 tests) — first visit, expired session, provider cards, interactions

All 619 tests pass across 52 test files.

## Test plan

- [x] `npm run test:run` passes (619 tests, 52 files)
- [x] TypeScript compiles cleanly

Closes #424