### PR TITLE
Optimize Spotify playback with fast-path checks and longer TTLs

### DIFF
--- a/src/hooks/useAutoAdvance.ts
+++ b/src/hooks/useAutoAdvance.ts
@@ -97,7 +97,7 @@ export const useAutoAdvance = ({
           // The useEffect on currentTrackIndex resets hasEnded when the track
           // actually changes (after playTrack succeeds and calls setCurrentTrackIndex).
         }
-      }, 500);
+      }, 100);
     }
 
     function handleProviderStateChange(state: PlaybackState | null) {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -37,6 +37,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   private static readonly READY_POLL_MS = 200;
 
   private pendingUpcomingUris: string[] | null = null;
+  /** True after the first successful playTrack; lets subsequent plays skip heavy API checks. */
+  private playbackSessionActive = false;
 
   private async waitForPlayerReady(): Promise<void> {
     const start = Date.now();
@@ -55,17 +57,46 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     await spotifyPlayer.ensureDeviceIsActive();
   }
 
+  /**
+   * Fast path for consecutive plays: skip API calls when the player is locally
+   * known to be ready. Falls back to full ensurePlaybackReady() if local state
+   * indicates the device went away.
+   */
+  private async ensurePlaybackReadyFastPath(): Promise<void> {
+    if (!spotifyPlayer.getIsReady() || !spotifyPlayer.getDeviceId()) {
+      logSpotify('fast-path: device not ready locally, falling back to full check');
+      this.playbackSessionActive = false;
+      return this.ensurePlaybackReady();
+    }
+    logSpotify('fast-path: device locally ready, skipping transfer + active checks');
+  }
+
   async initialize(): Promise<void> {
     await spotifyPlayer.initialize();
   }
 
   async playTrack(track: MediaTrack): Promise<void> {
-    await this.ensurePlaybackReady();
-
     const uri = track.playbackRef.ref;
+
+    // If Spotify's SDK already natively advanced to this track, skip the API call entirely.
+    if (this.playbackSessionActive) {
+      const state = await spotifyPlayer.getCurrentState();
+      if (state?.track_window?.current_track?.uri === uri && !state.paused) {
+        logSpotify('Spotify already playing requested track natively, skipping API call');
+        return;
+      }
+    }
+
+    if (this.playbackSessionActive) {
+      await this.ensurePlaybackReadyFastPath();
+    } else {
+      await this.ensurePlaybackReady();
+    }
+
     const upcomingUris = this.pendingUpcomingUris ?? undefined;
 
     await this.playWithRetry(uri, track.name, upcomingUris);
+    this.playbackSessionActive = true;
 
     const activateDevice = async () => {
       try {
@@ -112,6 +143,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
           throw new UnavailableTrackError(trackName);
         }
 
+        this.playbackSessionActive = false;
         if (retryCount < MAX_PLAY_RETRIES) {
           const backoffMs = BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
           logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
@@ -194,6 +226,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
   getLastPlayTime(): number {
     return spotifyPlayer.lastPlayTrackTime;
+  }
+
+  prepareTrack(_track: MediaTrack): void {
+    // Pre-warm the auth token so no refresh delay hits the next transition.
+    spotifyAuth.ensureValidToken().catch(() => {});
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -223,8 +223,8 @@ class SpotifyPlayerService {
     return this.isReady;
   }
 
-  private static readonly DEVICE_ACTIVE_TTL_MS = 30_000;
-  private static readonly TRANSFER_TTL_MS = 30_000;
+  private static readonly DEVICE_ACTIVE_TTL_MS = 300_000;
+  private static readonly TRANSFER_TTL_MS = 300_000;
 
   async transferPlaybackToDevice(force = false): Promise<void> {
     if (!this.deviceId || !this.isReady) {
@@ -243,7 +243,7 @@ class SpotifyPlayerService {
     }
   }
 
-  async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 800): Promise<boolean> {
+  async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 300): Promise<boolean> {
     if (this.isReady && Date.now() - this.lastDeviceActiveAt < SpotifyPlayerService.DEVICE_ACTIVE_TTL_MS) {
       return true;
     }


### PR DESCRIPTION
## Summary
This PR optimizes Spotify playback performance by introducing a fast-path for consecutive track plays and extending device state cache TTLs to reduce unnecessary API calls.

## Key Changes

- **Fast-path playback optimization**: Added `playbackSessionActive` flag to track when playback is known to be active, allowing subsequent `playTrack()` calls to skip heavy API checks (`ensurePlaybackReady()`)
  - Implements `ensurePlaybackReadyFastPath()` that only falls back to full checks if local device state indicates the device is unavailable
  - Checks if Spotify's SDK has already natively advanced to the requested track, skipping the API call entirely if so
  - Resets the flag on 403 errors to force a full check on retry

- **Extended device state cache TTLs**: Increased `DEVICE_ACTIVE_TTL_MS` and `TRANSFER_TTL_MS` from 30 seconds to 300 seconds (5 minutes) to reduce redundant device status checks

- **Reduced initial delay for device active checks**: Lowered `initialDelayMs` from 800ms to 300ms in `ensureDeviceIsActive()` for faster device activation

- **Added track preparation hook**: Implemented `prepareTrack()` method to pre-warm auth tokens before track transitions, preventing refresh delays during playback

- **Faster auto-advance polling**: Reduced `useAutoAdvance` check interval from 500ms to 100ms for more responsive track ending detection

## Implementation Details

The fast-path optimization maintains backward compatibility by falling back to the full `ensurePlaybackReady()` check when needed. The `playbackSessionActive` flag is set after successful playback and reset on errors, ensuring the adapter gracefully handles device disconnections or playback failures.

https://claude.ai/code/session_01BRP6EXYBwpBjUGGBof9vdi