### PR TITLE
Reassign keyboard shortcuts: S for visual effects menu

### DIFF
--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -115,7 +115,7 @@ const shortcuts = [
   { key: 'M', description: 'Mute / Unmute' },
   { key: 'G', description: 'Toggle glow effect' },
   { key: 'V', description: 'Toggle background visualizations' },
-  { key: 'O', description: 'Open visual effects menu' },
+  { key: 'S', description: 'Open settings' },
   { key: 'Z', description: 'Toggle zen mode' },
   { key: 'Esc', description: 'Close menus' },
   { key: '/', description: 'Show this help' },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -7,9 +7,8 @@
   * - ArrowRight: Next track
   * - ArrowLeft: Previous track
   * - V: Toggle background visualizations
-  * - O: Toggle visual effects menu
+  * - S: Toggle visual effects menu
   * - G: Toggle glow effect
-  * - S: Toggle shuffle
   * - ?: Show keyboard shortcuts help
   * - Escape: Close menus (queue drawer and visual effects)
   * - M: Mute
@@ -140,8 +139,8 @@ export const useKeyboardShortcuts = (
           }
           break;
 
-        case 'KeyO':
-          // O toggles visual effects menu
+        case 'KeyS':
+          // S toggles visual effects menu
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleVisualEffectsMenu?.();
@@ -199,14 +198,6 @@ export const useKeyboardShortcuts = (
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleLike?.();
-          }
-          break;
-
-        case 'KeyS':
-          // S toggles shuffle
-          if (!event.ctrlKey && !event.metaKey) {
-            event.preventDefault();
-            onToggleShuffle?.();
           }
           break;
 


### PR DESCRIPTION
## Summary
Reassigned keyboard shortcuts to improve the user experience. The 'S' key now toggles the visual effects menu (previously 'O'), and the shuffle toggle functionality has been removed from the 'S' key binding.

## Key Changes
- Changed visual effects menu toggle from 'O' key to 'S' key in `useKeyboardShortcuts.ts`
- Removed the shuffle toggle functionality that was previously bound to the 'S' key
- Updated keyboard shortcuts help documentation in `KeyboardShortcutsHelp.tsx` to reflect the new 'S' key binding for opening settings/visual effects menu
- Updated JSDoc comments to document the new keyboard shortcut mapping

## Implementation Details
- The 'S' key handler now calls `onToggleVisualEffectsMenu?.()` instead of `onToggleShuffle?.()`
- The shuffle toggle case statement has been completely removed from the keyboard event handler
- Help text updated from "Open visual effects menu" to "Open settings" for clarity

https://claude.ai/code/session_01RWRZDDF9C3ZZTDYUPvHfg2