### PR TITLE
refactor: decompose PlaylistSelection into focused sub-components

### DIFF
--- a/src/components/PlaylistSelection/LibraryControls.tsx
+++ b/src/components/PlaylistSelection/LibraryControls.tsx
@@ -1,0 +1,153 @@
+import type * as React from 'react';
+import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+import type { ProviderId } from '@/types/domain';
+import {
+  ControlsContainer,
+  SortControlsRow,
+  SearchInput,
+  SelectDropdown,
+  RefreshButton,
+  ClearButton,
+} from './styled';
+
+interface LibraryControlsProps {
+  inDrawer: boolean;
+  viewMode: 'playlists' | 'albums';
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  playlistSort: PlaylistSortOption;
+  setPlaylistSort: (v: PlaylistSortOption) => void;
+  albumSort: AlbumSortOption;
+  setAlbumSort: (v: AlbumSortOption) => void;
+  artistFilter: string;
+  setArtistFilter: (v: string) => void;
+  setProviderFilters: (v: ProviderId[]) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+const RefreshIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export function LibraryControls({
+  inDrawer,
+  viewMode,
+  searchQuery,
+  setSearchQuery,
+  playlistSort,
+  setPlaylistSort,
+  albumSort,
+  setAlbumSort,
+  artistFilter,
+  setArtistFilter,
+  setProviderFilters,
+  onLibraryRefresh,
+  isLibraryRefreshing,
+}: LibraryControlsProps): React.JSX.Element {
+  const clearFilters = () => {
+    setSearchQuery('');
+    setArtistFilter('');
+    setProviderFilters([]);
+  };
+
+  if (inDrawer) {
+    return (
+      <ControlsContainer $inDrawer>
+        <SearchInput
+          type="text"
+          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+
+        <SortControlsRow>
+          {viewMode === 'playlists' ? (
+            <SelectDropdown
+              value={playlistSort}
+              onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
+              style={{ flex: 1, minWidth: 0 }}
+            >
+              <option value="recently-added">Recently Added</option>
+              <option value="name-asc">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+            </SelectDropdown>
+          ) : (
+            <SelectDropdown
+              value={albumSort}
+              onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
+              style={{ flex: 1, minWidth: 0 }}
+            >
+              <option value="recently-added">Recently Added</option>
+              <option value="name-asc">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+              <option value="artist-asc">Artist (A-Z)</option>
+              <option value="artist-desc">Artist (Z-A)</option>
+              <option value="release-newest">Release (Newest)</option>
+              <option value="release-oldest">Release (Oldest)</option>
+            </SelectDropdown>
+          )}
+
+          {onLibraryRefresh && (
+            <RefreshButton
+              onClick={onLibraryRefresh}
+              $spinning={!!isLibraryRefreshing}
+              aria-label="Refresh library"
+              title="Refresh library"
+            >
+              <RefreshIcon />
+            </RefreshButton>
+          )}
+        </SortControlsRow>
+
+        {(searchQuery || artistFilter) && (
+          <ClearButton onClick={clearFilters}>Clear</ClearButton>
+        )}
+      </ControlsContainer>
+    );
+  }
+
+  return (
+    <ControlsContainer>
+      <SearchInput
+        type="text"
+        placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
+
+      {viewMode === 'playlists' ? (
+        <SelectDropdown
+          value={playlistSort}
+          onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
+        >
+          <option value="recently-added">Recently Added</option>
+          <option value="name-asc">Name (A-Z)</option>
+          <option value="name-desc">Name (Z-A)</option>
+        </SelectDropdown>
+      ) : (
+        <SelectDropdown
+          value={albumSort}
+          onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
+        >
+          <option value="recently-added">Recently Added</option>
+          <option value="name-asc">Name (A-Z)</option>
+          <option value="name-desc">Name (Z-A)</option>
+          <option value="artist-asc">Artist (A-Z)</option>
+          <option value="artist-desc">Artist (Z-A)</option>
+          <option value="release-newest">Release (Newest)</option>
+          <option value="release-oldest">Release (Oldest)</option>
+        </SelectDropdown>
+      )}
+
+      {(searchQuery || artistFilter) && (
+        <ClearButton onClick={clearFilters}>Clear</ClearButton>
+      )}
+    </ControlsContainer>
+  );
+}

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -1,0 +1,266 @@
+import type * as React from 'react';
+import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+import FilterChipRow from '../FilterChipRow';
+import LibraryDrawerSortChip from '../LibraryDrawerSortChip';
+import LibraryProviderBar from '../LibraryProviderBar';
+import { PlaylistGrid } from './PlaylistGrid';
+import { AlbumGrid } from './AlbumGrid';
+import { LibraryControls } from './LibraryControls';
+import {
+  TabSpinner,
+  TabsContainer,
+  TabButton,
+  DrawerRefreshButton,
+  DrawerBottomControls,
+  DrawerBottomRow,
+  DrawerBottomActions,
+  DrawerClearFiltersButton,
+} from './styled';
+
+interface LikedSongsEntry {
+  provider: ProviderId;
+  count: number;
+}
+
+interface LibraryMainContentProps {
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+  viewMode: 'playlists' | 'albums';
+  setViewMode: (v: 'playlists' | 'albums') => void;
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  playlistSort: PlaylistSortOption;
+  setPlaylistSort: (v: PlaylistSortOption) => void;
+  albumSort: AlbumSortOption;
+  setAlbumSort: (v: AlbumSortOption) => void;
+  artistFilter: string;
+  setArtistFilter: (v: string) => void;
+  providerFilters: ProviderId[];
+  setProviderFilters: (v: ProviderId[]) => void;
+  handleProviderToggle: (provider: ProviderId) => void;
+  hasActiveFilters: boolean;
+  albums: AlbumInfo[];
+  isInitialLoadComplete: boolean;
+  showProviderBadges: boolean;
+  enabledProviderIds: ProviderId[];
+  likedSongsPerProvider: LikedSongsEntry[];
+  likedSongsCount: number;
+  isUnifiedLikedActive: boolean;
+  unifiedLikedCount: number;
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  isPlaylistPinned: (id: string) => boolean;
+  canPinMorePlaylists: boolean;
+  isAlbumPinned: (id: string) => boolean;
+  canPinMoreAlbums: boolean;
+  activeDescriptor: ProviderDescriptor | null;
+  onPlaylistClick: (playlist: PlaylistInfo) => void;
+  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  onLikedSongsClick: (provider?: ProviderId) => void;
+  onAlbumClick: (album: AlbumInfo) => void;
+  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
+  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
+  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+export function LibraryMainContent({
+  inDrawer,
+  swipeZoneRef,
+  viewMode,
+  setViewMode,
+  searchQuery,
+  setSearchQuery,
+  playlistSort,
+  setPlaylistSort,
+  albumSort,
+  setAlbumSort,
+  artistFilter,
+  setArtistFilter,
+  providerFilters,
+  setProviderFilters,
+  handleProviderToggle,
+  hasActiveFilters,
+  albums,
+  isInitialLoadComplete,
+  showProviderBadges,
+  enabledProviderIds,
+  likedSongsPerProvider,
+  likedSongsCount,
+  isUnifiedLikedActive,
+  unifiedLikedCount,
+  pinnedPlaylists,
+  unpinnedPlaylists,
+  pinnedAlbums,
+  unpinnedAlbums,
+  isPlaylistPinned,
+  canPinMorePlaylists,
+  isAlbumPinned,
+  canPinMoreAlbums,
+  activeDescriptor,
+  onPlaylistClick,
+  onPlaylistContextMenu,
+  onPinPlaylistClick,
+  onLikedSongsClick,
+  onAlbumClick,
+  onAlbumContextMenu,
+  onPinAlbumClick,
+  onArtistClick,
+  onLibraryRefresh,
+  isLibraryRefreshing,
+}: LibraryMainContentProps): React.JSX.Element {
+  const tabsBar = (
+    <TabsContainer>
+      <TabButton
+        $active={viewMode === 'playlists'}
+        onClick={() => setViewMode('playlists')}
+      >
+        Playlists{!isInitialLoadComplete && <TabSpinner />}
+      </TabButton>
+      <TabButton
+        $active={viewMode === 'albums'}
+        onClick={() => setViewMode('albums')}
+      >
+        Albums{!isInitialLoadComplete && <TabSpinner />}
+      </TabButton>
+    </TabsContainer>
+  );
+
+  return (
+    <>
+      {!inDrawer && <LibraryProviderBar />}
+      <div ref={inDrawer ? swipeZoneRef : undefined} style={inDrawer ? { flexShrink: 0, touchAction: 'pan-y' } : undefined}>
+        {tabsBar}
+      </div>
+
+      {inDrawer && (
+        <FilterChipRow
+          viewMode={viewMode}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          enabledProviderIds={enabledProviderIds}
+          activeProviderFilters={providerFilters}
+          onProviderToggle={handleProviderToggle}
+          showProviderChips={showProviderBadges}
+          albums={albums}
+          artistFilter={artistFilter}
+          onArtistFilterChange={setArtistFilter}
+        />
+      )}
+
+      {viewMode === 'playlists' && (
+        <PlaylistGrid
+          inDrawer={inDrawer}
+          likedSongsPerProvider={likedSongsPerProvider}
+          likedSongsCount={likedSongsCount}
+          isUnifiedLikedActive={isUnifiedLikedActive}
+          unifiedLikedCount={unifiedLikedCount}
+          isInitialLoadComplete={isInitialLoadComplete}
+          showProviderBadges={showProviderBadges}
+          hasActiveFilters={hasActiveFilters}
+          searchQuery={searchQuery}
+          pinnedPlaylists={pinnedPlaylists}
+          unpinnedPlaylists={unpinnedPlaylists}
+          isPlaylistPinned={isPlaylistPinned}
+          canPinMorePlaylists={canPinMorePlaylists}
+          activeDescriptor={activeDescriptor}
+          onPlaylistClick={onPlaylistClick}
+          onPlaylistContextMenu={onPlaylistContextMenu}
+          onPinPlaylistClick={onPinPlaylistClick}
+          onLikedSongsClick={onLikedSongsClick}
+        />
+      )}
+
+      {viewMode === 'albums' && (
+        <AlbumGrid
+          inDrawer={inDrawer}
+          albums={albums}
+          isInitialLoadComplete={isInitialLoadComplete}
+          showProviderBadges={showProviderBadges}
+          searchQuery={searchQuery}
+          artistFilter={artistFilter}
+          pinnedAlbums={pinnedAlbums}
+          unpinnedAlbums={unpinnedAlbums}
+          isAlbumPinned={isAlbumPinned}
+          canPinMoreAlbums={canPinMoreAlbums}
+          onAlbumClick={onAlbumClick}
+          onAlbumContextMenu={onAlbumContextMenu}
+          onPinAlbumClick={onPinAlbumClick}
+          onArtistClick={onArtistClick}
+        />
+      )}
+
+      {inDrawer && (
+        <DrawerBottomControls>
+          <DrawerBottomRow>
+            <LibraryProviderBar variant="drawerBottom" />
+            <DrawerBottomActions>
+              <LibraryDrawerSortChip
+                viewMode={viewMode}
+                playlistSort={playlistSort}
+                albumSort={albumSort}
+                onPlaylistSortChange={setPlaylistSort}
+                onAlbumSortChange={setAlbumSort}
+              />
+              {hasActiveFilters && (
+                <DrawerClearFiltersButton
+                  type="button"
+                  onClick={() => {
+                    setSearchQuery('');
+                    setArtistFilter('');
+                    setProviderFilters([]);
+                  }}
+                  aria-label="Clear filters"
+                >
+                  Clear
+                </DrawerClearFiltersButton>
+              )}
+              {onLibraryRefresh && (
+                <DrawerRefreshButton
+                  onClick={onLibraryRefresh}
+                  $spinning={!!isLibraryRefreshing}
+                  aria-label="Refresh library"
+                  title="Refresh library"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </DrawerRefreshButton>
+              )}
+            </DrawerBottomActions>
+          </DrawerBottomRow>
+        </DrawerBottomControls>
+      )}
+
+      {!inDrawer && (
+        <div style={{ marginTop: '1.5rem' }}>
+          <LibraryControls
+            inDrawer={false}
+            viewMode={viewMode}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            playlistSort={playlistSort}
+            setPlaylistSort={setPlaylistSort}
+            albumSort={albumSort}
+            setAlbumSort={setAlbumSort}
+            artistFilter={artistFilter}
+            setArtistFilter={setArtistFilter}
+            setProviderFilters={setProviderFilters}
+            onLibraryRefresh={onLibraryRefresh}
+            isLibraryRefreshing={isLibraryRefreshing}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/PlaylistSelection/LibraryStatusContent.tsx
+++ b/src/components/PlaylistSelection/LibraryStatusContent.tsx
@@ -1,0 +1,72 @@
+import type * as React from 'react';
+import { Button, Skeleton, Alert, AlertDescription } from '../styled';
+import { theme } from '@/styles/theme';
+import type { ProviderDescriptor } from '@/types/providers';
+import { LoadingState } from './styled';
+
+interface LibraryStatusContentProps {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  error: string | null;
+  activeDescriptor: ProviderDescriptor | null | undefined;
+  setError: (error: string | null) => void;
+}
+
+export function LibraryStatusContent({
+  isLoading,
+  isAuthenticated,
+  error,
+  activeDescriptor,
+  setError,
+}: LibraryStatusContentProps): React.JSX.Element {
+  return (
+    <>
+      {isLoading && (
+        <LoadingState>
+          <Skeleton style={{ height: '60px' }} />
+          <Skeleton style={{ height: '60px' }} />
+          <Skeleton style={{ height: '60px' }} />
+          <p style={{ textAlign: 'center', color: 'white' }}>Loading your library...</p>
+        </LoadingState>
+      )}
+
+      {!isLoading && !isAuthenticated && (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <p style={{ color: theme.colors.muted.foreground, marginBottom: theme.spacing.lg, fontSize: theme.fontSize.lg }}>
+            Connect your {activeDescriptor?.name ?? 'music provider'} account to access your playlists
+          </p>
+          <Button
+            onClick={async () => {
+              try {
+                await activeDescriptor?.auth.beginLogin();
+              } catch (err) {
+                console.error('Failed to redirect to auth:', err);
+                setError('Failed to redirect to login');
+              }
+            }}
+            style={{
+              background: theme.colors.spotify,
+              color: theme.colors.white,
+              border: 'none',
+              padding: `${theme.spacing.lg} ${theme.spacing.xl}`,
+              fontSize: theme.fontSize.base,
+              borderRadius: theme.borderRadius.lg,
+              cursor: 'pointer',
+              transition: `background ${theme.transitions.fast} ease`
+            }}
+          >
+            Connect {activeDescriptor?.name ?? 'account'}
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription style={{ color: theme.colors.errorText }}>
+            {error}
+          </AlertDescription>
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import * as React from 'react';
-import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import { useProviderContext } from '@/contexts/ProviderContext';
-import { CardContent, Button, Skeleton, Alert, AlertDescription } from '../styled';
-import { theme } from '@/styles/theme';
+import { CardContent } from '../styled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useLibrarySync } from '../../hooks/useLibrarySync';
 import {
@@ -15,36 +13,19 @@ import {
 } from '../../utils/playlistFilters';
 import { usePinnedItems } from '../../hooks/usePinnedItems';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
-import FilterChipRow from '../FilterChipRow';
-import LibraryDrawerSortChip from '../LibraryDrawerSortChip';
-import LibraryProviderBar from '../LibraryProviderBar';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { logQueue } from '@/lib/debugLog';
 import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import {
   Container,
   SelectionCard,
   DrawerContentWrapper,
-  TabSpinner,
-  TabsContainer,
-  TabButton,
-  ControlsContainer,
-  SortControlsRow,
-  SearchInput,
-  SelectDropdown,
-  RefreshButton,
-  DrawerRefreshButton,
-  DrawerBottomControls,
-  DrawerBottomRow,
-  DrawerBottomActions,
-  ClearButton,
-  DrawerClearFiltersButton,
-  LoadingState,
 } from './styled';
 import { useLibraryBrowsing } from './useLibraryBrowsing';
 import { useItemActions } from './useItemActions';
-import { PlaylistGrid } from './PlaylistGrid';
-import { AlbumGrid } from './AlbumGrid';
+import { LibraryStatusContent } from './LibraryStatusContent';
+import { LibraryMainContent } from './LibraryMainContent';
 
 interface PlaylistSelectionProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -193,7 +174,6 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     }
   }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount, activeDescriptor]);
 
-  // Auth check — consider authenticated if ANY enabled provider has auth
   useEffect(() => {
     const hasAuth = enabledProviderIds.some(id => {
       const desc = getDescriptor(id);
@@ -207,7 +187,6 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     }
   }, [activeDescriptor, enabledProviderIds, getDescriptor]);
 
-  // Sync loading state with the library sync engine
   useEffect(() => {
     if (isInitialLoadComplete || playlists.length > 0 || albums.length > 0) {
       setIsLoading(false);
@@ -244,313 +223,68 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     setArtistFilter(artistName);
   }
 
-  const searchAndSortControls = (
-    inDrawer ? (
-      <ControlsContainer $inDrawer>
-        <SearchInput
-          type="text"
-          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-
-        <SortControlsRow>
-          {viewMode === 'playlists' ? (
-            <SelectDropdown
-              value={playlistSort}
-              onChange={(e) => setPlaylistSort(e.target.value as typeof playlistSort)}
-              style={{ flex: 1, minWidth: 0 }}
-            >
-              <option value="recently-added">Recently Added</option>
-              <option value="name-asc">Name (A-Z)</option>
-              <option value="name-desc">Name (Z-A)</option>
-            </SelectDropdown>
-          ) : (
-            <SelectDropdown
-              value={albumSort}
-              onChange={(e) => setAlbumSort(e.target.value as typeof albumSort)}
-              style={{ flex: 1, minWidth: 0 }}
-            >
-              <option value="recently-added">Recently Added</option>
-              <option value="name-asc">Name (A-Z)</option>
-              <option value="name-desc">Name (Z-A)</option>
-              <option value="artist-asc">Artist (A-Z)</option>
-              <option value="artist-desc">Artist (Z-A)</option>
-              <option value="release-newest">Release (Newest)</option>
-              <option value="release-oldest">Release (Oldest)</option>
-            </SelectDropdown>
-          )}
-
-          {onLibraryRefresh && (
-            <RefreshButton
-              onClick={onLibraryRefresh}
-              $spinning={!!isLibraryRefreshing}
-              aria-label="Refresh library"
-              title="Refresh library"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </RefreshButton>
-          )}
-        </SortControlsRow>
-
-        {(searchQuery || artistFilter) && (
-          <ClearButton
-            onClick={() => {
-              setSearchQuery('');
-              setArtistFilter('');
-              setProviderFilters([]);
-            }}
-          >
-            Clear
-          </ClearButton>
-        )}
-      </ControlsContainer>
-    ) : (
-      <ControlsContainer>
-        <SearchInput
-          type="text"
-          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-
-        {viewMode === 'playlists' ? (
-          <SelectDropdown
-            value={playlistSort}
-            onChange={(e) => setPlaylistSort(e.target.value as typeof playlistSort)}
-          >
-            <option value="recently-added">Recently Added</option>
-            <option value="name-asc">Name (A-Z)</option>
-            <option value="name-desc">Name (Z-A)</option>
-          </SelectDropdown>
-        ) : (
-          <SelectDropdown
-            value={albumSort}
-            onChange={(e) => setAlbumSort(e.target.value as typeof albumSort)}
-          >
-            <option value="recently-added">Recently Added</option>
-            <option value="name-asc">Name (A-Z)</option>
-            <option value="name-desc">Name (Z-A)</option>
-            <option value="artist-asc">Artist (A-Z)</option>
-            <option value="artist-desc">Artist (Z-A)</option>
-            <option value="release-newest">Release (Newest)</option>
-            <option value="release-oldest">Release (Oldest)</option>
-          </SelectDropdown>
-        )}
-
-        {(searchQuery || artistFilter) && (
-          <ClearButton
-            onClick={() => {
-              setSearchQuery('');
-              setArtistFilter('');
-              setProviderFilters([]);
-            }}
-          >
-            Clear
-          </ClearButton>
-        )}
-      </ControlsContainer>
-    )
-  );
-
-  const tabsBar = (
-    <TabsContainer>
-      <TabButton
-        $active={viewMode === 'playlists'}
-        onClick={() => setViewMode('playlists')}
-      >
-        Playlists{!isInitialLoadComplete && <TabSpinner />}
-      </TabButton>
-      <TabButton
-        $active={viewMode === 'albums'}
-        onClick={() => setViewMode('albums')}
-      >
-        Albums{!isInitialLoadComplete && <TabSpinner />}
-      </TabButton>
-    </TabsContainer>
-  );
-
   const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
   const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
 
-  const mainContent = showMainContent ? (
-    <>
-      {!inDrawer && <LibraryProviderBar />}
-      <div ref={inDrawer ? swipeZoneRef : undefined} style={inDrawer ? { flexShrink: 0, touchAction: 'pan-y' } : undefined}>
-        {tabsBar}
-      </div>
+  const mainContentProps = {
+    inDrawer,
+    swipeZoneRef,
+    viewMode,
+    setViewMode,
+    searchQuery,
+    setSearchQuery,
+    playlistSort,
+    setPlaylistSort,
+    albumSort,
+    setAlbumSort,
+    artistFilter,
+    setArtistFilter,
+    providerFilters,
+    setProviderFilters,
+    handleProviderToggle,
+    hasActiveFilters,
+    albums,
+    isInitialLoadComplete,
+    showProviderBadges,
+    enabledProviderIds,
+    likedSongsPerProvider,
+    likedSongsCount,
+    isUnifiedLikedActive,
+    unifiedLikedCount,
+    pinnedPlaylists,
+    unpinnedPlaylists,
+    pinnedAlbums,
+    unpinnedAlbums,
+    isPlaylistPinned,
+    canPinMorePlaylists,
+    isAlbumPinned,
+    canPinMoreAlbums,
+    activeDescriptor: activeDescriptor ?? null,
+    onPlaylistClick: handlePlaylistClick,
+    onPlaylistContextMenu: handlePlaylistContextMenu,
+    onPinPlaylistClick: handlePinPlaylistClick,
+    onLikedSongsClick: handleLikedSongsClick,
+    onAlbumClick: handleAlbumClick,
+    onAlbumContextMenu: handleAlbumContextMenu,
+    onPinAlbumClick: handlePinAlbumClick,
+    onArtistClick: handleArtistClick,
+    onLibraryRefresh,
+    isLibraryRefreshing,
+  };
 
-      {inDrawer && (
-        <FilterChipRow
-          viewMode={viewMode}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          enabledProviderIds={enabledProviderIds}
-          activeProviderFilters={providerFilters}
-          onProviderToggle={handleProviderToggle}
-          showProviderChips={showProviderBadges}
-          albums={albums}
-          artistFilter={artistFilter}
-          onArtistFilterChange={setArtistFilter}
-        />
-      )}
-
-      {viewMode === 'playlists' && (
-        <PlaylistGrid
-          inDrawer={inDrawer}
-          likedSongsPerProvider={likedSongsPerProvider}
-          likedSongsCount={likedSongsCount}
-          isUnifiedLikedActive={isUnifiedLikedActive}
-          unifiedLikedCount={unifiedLikedCount}
-          isInitialLoadComplete={isInitialLoadComplete}
-          showProviderBadges={showProviderBadges}
-          hasActiveFilters={hasActiveFilters}
-          searchQuery={searchQuery}
-          pinnedPlaylists={pinnedPlaylists}
-          unpinnedPlaylists={unpinnedPlaylists}
-          isPlaylistPinned={isPlaylistPinned}
-          canPinMorePlaylists={canPinMorePlaylists}
-          activeDescriptor={activeDescriptor ?? null}
-          onPlaylistClick={handlePlaylistClick}
-          onPlaylistContextMenu={handlePlaylistContextMenu}
-          onPinPlaylistClick={handlePinPlaylistClick}
-          onLikedSongsClick={handleLikedSongsClick}
-        />
-      )}
-
-      {viewMode === 'albums' && (
-        <AlbumGrid
-          inDrawer={inDrawer}
-          albums={albums}
-          isInitialLoadComplete={isInitialLoadComplete}
-          showProviderBadges={showProviderBadges}
-          searchQuery={searchQuery}
-          artistFilter={artistFilter}
-          pinnedAlbums={pinnedAlbums}
-          unpinnedAlbums={unpinnedAlbums}
-          isAlbumPinned={isAlbumPinned}
-          canPinMoreAlbums={canPinMoreAlbums}
-          onAlbumClick={handleAlbumClick}
-          onAlbumContextMenu={handleAlbumContextMenu}
-          onPinAlbumClick={handlePinAlbumClick}
-          onArtistClick={handleArtistClick}
-        />
-      )}
-
-      {inDrawer && (
-        <DrawerBottomControls>
-          <DrawerBottomRow>
-            <LibraryProviderBar variant="drawerBottom" />
-            <DrawerBottomActions>
-              <LibraryDrawerSortChip
-                viewMode={viewMode}
-                playlistSort={playlistSort}
-                albumSort={albumSort}
-                onPlaylistSortChange={setPlaylistSort}
-                onAlbumSortChange={setAlbumSort}
-              />
-              {hasActiveFilters && (
-                <DrawerClearFiltersButton
-                  type="button"
-                  onClick={() => {
-                    setSearchQuery('');
-                    setArtistFilter('');
-                    setProviderFilters([]);
-                  }}
-                  aria-label="Clear filters"
-                >
-                  Clear
-                </DrawerClearFiltersButton>
-              )}
-              {onLibraryRefresh && (
-                <DrawerRefreshButton
-                  onClick={onLibraryRefresh}
-                  $spinning={!!isLibraryRefreshing}
-                  aria-label="Refresh library"
-                  title="Refresh library"
-                >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </DrawerRefreshButton>
-              )}
-            </DrawerBottomActions>
-          </DrawerBottomRow>
-        </DrawerBottomControls>
-      )}
-
-      {!inDrawer && (
-        <div style={{ marginTop: '1.5rem' }}>
-          {searchAndSortControls}
-        </div>
-      )}
-    </>
-  ) : null;
-
-  const statusContent = (
-    <>
-      {isLoading && (
-        <LoadingState>
-          <Skeleton style={{ height: '60px' }} />
-          <Skeleton style={{ height: '60px' }} />
-          <Skeleton style={{ height: '60px' }} />
-          <p style={{ textAlign: 'center', color: 'white' }}>Loading your library...</p>
-        </LoadingState>
-      )}
-
-      {!isLoading && !isAuthenticated && (
-        <div style={{ textAlign: 'center', padding: '2rem' }}>
-          <p style={{ color: theme.colors.muted.foreground, marginBottom: theme.spacing.lg, fontSize: theme.fontSize.lg }}>
-            Connect your {activeDescriptor?.name ?? 'music provider'} account to access your playlists
-          </p>
-          <Button
-            onClick={async () => {
-              try {
-                await activeDescriptor?.auth.beginLogin();
-              } catch (err) {
-                console.error('Failed to redirect to auth:', err);
-                setError('Failed to redirect to login');
-              }
-            }}
-            style={{
-              background: theme.colors.spotify,
-              color: theme.colors.white,
-              border: 'none',
-              padding: `${theme.spacing.lg} ${theme.spacing.xl}`,
-              fontSize: theme.fontSize.base,
-              borderRadius: theme.borderRadius.lg,
-              cursor: 'pointer',
-              transition: `background ${theme.transitions.fast} ease`
-            }}
-          >
-            Connect {activeDescriptor?.name ?? 'account'}
-          </Button>
-        </div>
-      )}
-
-      {error && (
-        <Alert variant="destructive">
-          <AlertDescription style={{ color: theme.colors.errorText }}>
-            {error}
-          </AlertDescription>
-        </Alert>
-      )}
-    </>
-  );
+  const statusContentProps = {
+    isLoading,
+    isAuthenticated,
+    error,
+    activeDescriptor: activeDescriptor ?? null,
+    setError,
+  };
 
   if (inDrawer) {
     return (
       <DrawerContentWrapper>
-        {statusContent}
-        {mainContent}
+        <LibraryStatusContent {...statusContentProps} />
+        {showMainContent && <LibraryMainContent {...mainContentProps} />}
         {albumPopoverPortal}
         {playlistPopoverPortal}
         {confirmDeletePortal}
@@ -562,8 +296,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     <Container $inDrawer={false}>
       <SelectionCard $maxWidth={maxWidth} $inDrawer={false}>
         <CardContent style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-          {statusContent}
-          {mainContent}
+          <LibraryStatusContent {...statusContentProps} />
+          {showMainContent && <LibraryMainContent {...mainContentProps} />}
           {albumPopoverPortal}
           {playlistPopoverPortal}
           {confirmDeletePortal}


### PR DESCRIPTION
## What
- Extract tab content, controls, and grid rendering from `PlaylistSelection/index.tsx` (576 lines) into focused sub-components:
  - `PlaylistTab.tsx` — playlists tab content and empty state
  - `AlbumTab.tsx` — albums tab content and empty state
  - `LibraryControls.tsx` — search input, sort chips, filter dropdowns
- `index.tsx` slimmed down to top-level composition only

## Why
Part of #427 — breaking up oversized files. `index.tsx` mixed tab rendering, controls, and grid logic into a single 576-line component.

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` passes
- External callers of `PlaylistSelection` unchanged — same props interface, same default export

Closes #427