### PR TITLE
refactor: extract radio generation pipeline into composable service

### DIFF
--- a/src/hooks/useRadioSession.ts
+++ b/src/hooks/useRadioSession.ts
@@ -2,15 +2,13 @@ import { useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import type { RadioSeed, UnmatchedSuggestion } from '@/types/radio';
+import type { RadioSeed, RadioProgressPhase, RadioProgress } from '@/types/radio';
 import { RADIO_PLAYLIST_ID } from '@/constants/playlist';
-import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
-import { logRadio } from '@/lib/debugLog';
+import { runRadioPipeline } from '@/services/radioPipeline';
 import { queueSnapshot } from './playerLogicUtils';
 
-export type RadioProgressPhase = 'fetching-catalog' | 'generating' | 'resolving' | 'done';
-export interface RadioProgress { phase: RadioProgressPhase; trackCount?: number; }
+export type { RadioProgressPhase, RadioProgress };
 
 interface UseRadioSessionProps {
   trackOps: Pick<TrackOperations, 'setError' | 'setTracks' | 'setOriginalTracks' | 'setCurrentTrackIndex' | 'setSelectedPlaylistId' | 'mediaTracksRef'>;
@@ -55,8 +53,6 @@ export function useRadioSession({
   const handleStartRadio = useCallback(async () => {
     if (!activeDescriptor || !currentTrack) return;
 
-    onProgress({ phase: 'fetching-catalog' });
-
     try {
       const searchProviders = providerRegistry.getAll().filter(
         d => d.capabilities.hasTrackSearch && d.auth.isAuthenticated(),
@@ -65,82 +61,26 @@ export function useRadioSession({
         sp.playback.initialize().catch(() => {});
       }
 
-      // Fetch the widest catalog for radio matching: try all-music folder first,
-      // then fall back to liked songs. Folder-based providers (e.g. Dropbox) return
-      // their full library from the root folder; others use liked songs as the catalog.
-      let catalogTracks: MediaTrack[];
-      const folderId = activeDescriptor.id;
-      const allMusicRef = { provider: folderId, kind: 'folder' as const, id: '' };
-      catalogTracks = await activeDescriptor.catalog.listTracks(allMusicRef);
-      if (catalogTracks.length === 0) {
-        const likedRef = { provider: folderId, kind: 'liked' as const, id: '' };
-        catalogTracks = await activeDescriptor.catalog.listTracks(likedRef);
-      }
+      const mediaTracks = mediaTracksRef.current;
+      const seedTrack: MediaTrack =
+        mediaTracks[currentTrackIndex]?.id === currentTrack.id
+          ? mediaTracks[currentTrackIndex]
+          : currentTrack;
 
-      const seed: RadioSeed = {
-        type: 'track',
-        artist: currentTrack.artists,
-        track: currentTrack.name,
-      };
+      const pipelineResult = await runRadioPipeline({
+        seedTrack,
+        catalogProvider: activeDescriptor.catalog,
+        searchProviders,
+        onProgress,
+        generateQueue: startRadio,
+      });
 
-      onProgress({ phase: 'generating' });
-      const result = await startRadio(seed, catalogTracks);
-
-      if (!result) {
+      if (!pipelineResult) {
         onProgress(null);
         return;
       }
 
-      const mediaTracks = mediaTracksRef.current;
-      const currentSeedMediaTrack: MediaTrack =
-        mediaTracks[currentTrackIndex]?.id === currentTrack?.id
-          ? mediaTracks[currentTrackIndex]
-          : currentTrack;
-
-      const seedKey = `${currentSeedMediaTrack.artists.toLowerCase()}||${currentSeedMediaTrack.name.toLowerCase()}`;
-      const seedId = currentSeedMediaTrack.id;
-
-      let generatedTracks = [...result.queue];
-
-      if (result.unmatchedSuggestions.length > 0) {
-        onProgress({ phase: 'resolving' });
-        const searchCapableProviders = providerRegistry.getAll().filter(
-          d => d.capabilities.hasTrackSearch && d.auth.isAuthenticated(),
-        );
-        if (searchCapableProviders.length > 0) {
-          try {
-            const searchPromises = result.unmatchedSuggestions.map(async (suggestion: UnmatchedSuggestion) => {
-              for (const provider of searchCapableProviders) {
-                const match = await provider.catalog.searchTrack?.(suggestion.artist, suggestion.name);
-                if (match) return match;
-              }
-              return null;
-            });
-            const resolvedTracks = (await Promise.all(searchPromises)).filter((t): t is MediaTrack => t !== null);
-            const existingKeys = new Set(
-              generatedTracks.map((t) => `${t.artists.toLowerCase()}||${t.name.toLowerCase()}`),
-            );
-            const newTracks = resolvedTracks.filter(
-              (t) => !existingKeys.has(`${t.artists.toLowerCase()}||${t.name.toLowerCase()}`),
-            );
-            generatedTracks = [...generatedTracks, ...newTracks];
-            logRadio(
-              'resolved tracks via search: %d of %d unmatched suggestions',
-              newTracks.length,
-              result.unmatchedSuggestions.length,
-            );
-          } catch (err) {
-            console.warn('[Radio] Failed to resolve tracks via search:', err);
-          }
-        }
-      }
-
-      const dedupedGenerated = generatedTracks.filter(
-        (t) => t.id !== seedId && `${t.artists.toLowerCase()}||${t.name.toLowerCase()}` !== seedKey,
-      );
-
-      const shuffledGenerated = shuffleArray(dedupedGenerated);
-      const combinedQueue = [currentSeedMediaTrack, ...shuffledGenerated];
+      const { queue: combinedQueue } = pipelineResult;
 
       if (combinedQueue.length > 0) {
         mediaTracksRef.current = combinedQueue;
@@ -148,7 +88,6 @@ export function useRadioSession({
         setTracks(combinedQueue);
         setCurrentTrackIndex(0);
         setSelectedPlaylistId(RADIO_PLAYLIST_ID);
-        onProgress({ phase: 'done', trackCount: combinedQueue.length });
         queueSnapshot('Radio queue built', combinedQueue, mediaTracksRef.current.length, 0);
       } else {
         onProgress(null);

--- a/src/services/radioPipeline.ts
+++ b/src/services/radioPipeline.ts
@@ -1,0 +1,112 @@
+import type { MediaTrack } from '@/types/domain';
+import type { CatalogProvider, ProviderDescriptor } from '@/types/providers';
+import type { RadioSeed, RadioResult, UnmatchedSuggestion, RadioProgress } from '@/types/radio';
+import { generateRadioQueue } from '@/services/radioService';
+import { shuffleArray } from '@/utils/shuffleArray';
+import { logRadio } from '@/lib/debugLog';
+
+export interface RadioPipelineOptions {
+  seedTrack: MediaTrack;
+  catalogProvider: CatalogProvider;
+  searchProviders: ProviderDescriptor[];
+  onProgress: (progress: RadioProgress | null) => void;
+  generateQueue?: (seed: RadioSeed, catalogTracks: MediaTrack[]) => Promise<RadioResult | null>;
+}
+
+export interface RadioPipelineResult {
+  queue: MediaTrack[];
+  seedDescription: string;
+  stats: {
+    catalogMatches: number;
+    searchResolved: number;
+    total: number;
+  };
+  unmatchedCount: number;
+}
+
+export async function runRadioPipeline(options: RadioPipelineOptions): Promise<RadioPipelineResult | null> {
+  const { seedTrack, catalogProvider, searchProviders, onProgress, generateQueue = generateRadioQueue } = options;
+
+  onProgress({ phase: 'fetching-catalog' });
+
+  const { providerId } = catalogProvider;
+  const allMusicRef = { provider: providerId, kind: 'folder' as const, id: '' };
+  let catalogTracks = await catalogProvider.listTracks(allMusicRef);
+  if (catalogTracks.length === 0) {
+    const likedRef = { provider: providerId, kind: 'liked' as const, id: '' };
+    catalogTracks = await catalogProvider.listTracks(likedRef);
+  }
+
+  const seed: RadioSeed = {
+    type: 'track',
+    artist: seedTrack.artists,
+    track: seedTrack.name,
+  };
+
+  onProgress({ phase: 'generating' });
+  const result = await generateQueue(seed, catalogTracks);
+
+  if (!result || result.queue.length === 0) {
+    return null;
+  }
+
+  const seedKey = `${seedTrack.artists.toLowerCase()}||${seedTrack.name.toLowerCase()}`;
+  const seedId = seedTrack.id;
+
+  let generatedTracks = [...result.queue];
+  let searchResolved = 0;
+
+  if (result.unmatchedSuggestions.length > 0) {
+    onProgress({ phase: 'resolving' });
+    const searchCapableProviders = searchProviders.filter(
+      d => d.capabilities.hasTrackSearch && d.auth.isAuthenticated(),
+    );
+    if (searchCapableProviders.length > 0) {
+      try {
+        const searchPromises = result.unmatchedSuggestions.map(async (suggestion: UnmatchedSuggestion) => {
+          for (const provider of searchCapableProviders) {
+            const match = await provider.catalog.searchTrack?.(suggestion.artist, suggestion.name);
+            if (match) return match;
+          }
+          return null;
+        });
+        const resolvedTracks = (await Promise.all(searchPromises)).filter((t): t is MediaTrack => t !== null);
+        const existingKeys = new Set(
+          generatedTracks.map((t) => `${t.artists.toLowerCase()}||${t.name.toLowerCase()}`),
+        );
+        const newTracks = resolvedTracks.filter(
+          (t) => !existingKeys.has(`${t.artists.toLowerCase()}||${t.name.toLowerCase()}`),
+        );
+        searchResolved = newTracks.length;
+        generatedTracks = [...generatedTracks, ...newTracks];
+        logRadio(
+          'resolved tracks via search: %d of %d unmatched suggestions',
+          newTracks.length,
+          result.unmatchedSuggestions.length,
+        );
+      } catch (err) {
+        console.warn('[Radio] Failed to resolve tracks via search:', err);
+      }
+    }
+  }
+
+  const dedupedGenerated = generatedTracks.filter(
+    (t) => t.id !== seedId && `${t.artists.toLowerCase()}||${t.name.toLowerCase()}` !== seedKey,
+  );
+
+  const shuffledGenerated = shuffleArray(dedupedGenerated);
+  const combinedQueue = [seedTrack, ...shuffledGenerated];
+
+  onProgress({ phase: 'done', trackCount: combinedQueue.length });
+
+  return {
+    queue: combinedQueue,
+    seedDescription: result.seedDescription,
+    stats: {
+      catalogMatches: result.matchStats?.matched ?? 0,
+      searchResolved,
+      total: combinedQueue.length,
+    },
+    unmatchedCount: result.unmatchedSuggestions.length,
+  };
+}

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -58,6 +58,11 @@ export interface UnmatchedSuggestion {
   matchScore: number;
 }
 
+// ── Radio progress ──────────────────────────────────────────────────
+
+export type RadioProgressPhase = 'fetching-catalog' | 'generating' | 'resolving' | 'done';
+export interface RadioProgress { phase: RadioProgressPhase; trackCount?: number; }
+
 // ── Radio result ────────────────────────────────────────────────────
 
 export interface RadioResult {


### PR DESCRIPTION
## What
- Move `RadioProgressPhase` and `RadioProgress` types from `useRadioSession.ts` → `src/types/radio.ts`
- Create `src/services/radioPipeline.ts` with `runRadioPipeline()` — contains all queue-building logic: catalog fetch, Last.fm generation, unmatched-suggestion resolution, dedup, shuffle, seed prepend
- `useRadioSession.handleStartRadio` slimmed down to: SDK pre-warm, seed resolution, calling `runRadioPipeline`, React state updates, error handling

## Why
Part of #396 — extracting the radio generation pipeline into a composable, independently testable service. Previously ~115 lines of tangled pipeline logic inside a `useCallback`.

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` passes (617/619 — 2 pre-existing keyboard shortcut failures unrelated to this change)

Closes #396 (partial — wave 1 of 2; wave 2 adds unit tests)