### PR TITLE
a11y: add :focus-visible styles for keyboard navigation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -116,3 +116,20 @@ input[type="range"]::-moz-range-track {
     -moz-osx-font-smoothing: grayscale;
   }
 }
+
+/* WCAG 2.4.7 Focus Visible — keyboard navigation only */
+:focus-visible {
+  outline: 2px solid #646cff;
+  outline-offset: 2px;
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid #646cff;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

- Add explicit `:focus-visible` styles for all interactive elements (`button`, `input`, `[role="button"]`, `a`, `select`, `textarea`, `[tabindex]`)
- WCAG 2.4.7 Focus Visible (Level AA) compliance
- Uses the theme's primary color (`#646cff`) for consistent visual style
- Focus rings only appear on keyboard navigation — not on mouse click

## Test plan

- [ ] Tab through the player — all controls show a visible focus ring
- [ ] Focus ring does not appear on mouse click (`:focus-visible` only)
- [ ] No TypeScript or build errors

Closes #446