### PR TITLE
feat: add provider identity badge for mixed-queue playback

### DIFF
--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import styled from 'styled-components';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
+import { useProviderContext } from '@/contexts/ProviderContext';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState } from '@/hooks/useRadio';
 import type { RadioProgress } from '@/hooks/usePlayerLogic';
@@ -9,6 +11,15 @@ import { ContentWrapper, PlayerContainer, PlayerStack } from './styled';
 import { AlbumArtSection } from './AlbumArtSection';
 import { PlayerControlsSection } from './PlayerControlsSection';
 import { DrawerOrchestrator } from './DrawerOrchestrator';
+import { ProviderBadge } from '@/components/ProviderBadge';
+
+const BadgeOverlay = styled.div`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.sm};
+  right: ${({ theme }) => theme.spacing.sm};
+  z-index: 10;
+  pointer-events: none;
+`;
 
 export interface PlaybackHandlers {
   onPlay: () => void;
@@ -67,6 +78,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
 }) => {
   const { currentTrack, showQueue, setShowQueue } = useCurrentTrackContext();
   const { zenModeEnabled, setZenModeEnabled, setShowVisualEffects } = useVisualEffectsContext();
+  const { connectedProviderIds } = useProviderContext();
+  const showProviderBadge = connectedProviderIds.length > 1 && currentTrackProvider != null;
   const { dimensions, useFluidSizing, padding, transitionDuration, transitionEasing, isMobile, isTablet, hasPointerInput, isTouchDevice } = usePlayerSizingContext();
 
   const [librarySearchQuery, setLibrarySearchQuery] = useState<string | undefined>(undefined);
@@ -171,6 +184,11 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
       onClick={handleZenExitClick}
     >
       <PlayerContainer>
+        {showProviderBadge && (
+          <BadgeOverlay>
+            <ProviderBadge providerId={currentTrackProvider!} />
+          </BadgeOverlay>
+        )}
         <PlayerStack $zenMode={zenModeEnabled}>
           <AlbumArtSection
             currentTrack={currentTrack}

--- a/src/components/ProviderBadge.tsx
+++ b/src/components/ProviderBadge.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { ProviderId } from '@/types/domain';
+import { providerRegistry } from '@/providers/registry';
+
+const BadgeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.xs};
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  padding: 3px 8px 3px 4px;
+  pointer-events: none;
+  user-select: none;
+`;
+
+const IconWrapper = styled.div<{ $size: number }>`
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const ProviderName = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+  line-height: 1;
+`;
+
+interface ProviderBadgeProps {
+  providerId: ProviderId;
+  iconSize?: number;
+  className?: string;
+}
+
+export const ProviderBadge: React.FC<ProviderBadgeProps> = React.memo(({ providerId, iconSize = 16, className }) => {
+  const descriptor = providerRegistry.get(providerId);
+  if (!descriptor) return null;
+
+  const IconComponent = descriptor.icon;
+
+  return (
+    <BadgeContainer className={className}>
+      <IconWrapper $size={iconSize}>
+        {IconComponent ? <IconComponent size={iconSize} /> : null}
+      </IconWrapper>
+      <ProviderName>{descriptor.name}</ProviderName>
+    </BadgeContainer>
+  );
+});
+
+ProviderBadge.displayName = 'ProviderBadge';


### PR DESCRIPTION
## Summary

- Adds a `ProviderBadge` component that shows the current driving provider (name + icon) as a small pill overlay on the player card
- Badge only appears when 2+ providers are connected — hidden in single-provider setups
- Reads provider metadata from the registry (no hardcoded strings); styled with themed frosted-glass effect using existing theme tokens
- `pointer-events: none` on the overlay so it doesn't interfere with album art gestures

## Test plan

- [ ] Connect both Spotify and Dropbox, play a mixed queue — badge should appear and update as tracks switch providers
- [ ] Connect only one provider — badge should not appear
- [ ] Verify no layout shifts; badge floats over album art without affecting player centering

Closes #448

🤖 Generated with [Claude Code](https://claude.ai/claude-code)