### PR TITLE
feat: show provider indicator on album art in zen mode

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -1,14 +1,25 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import styled from 'styled-components';
 import { CardContent } from '@/components/styled';
 import AlbumArt from '@/components/AlbumArt';
 import AlbumArtQuickSwapBack from '@/components/AlbumArtQuickSwapBack';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
+import { ProviderBadge } from '@/components/ProviderBadge';
 import { useColorContext } from '@/contexts/ColorContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
+import { useProviderContext } from '@/contexts/ProviderContext';
 import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { FlipInner, ZenTrackInfo, ZenTrackName, ZenTrackArtist } from './styled';
 import { GestureLayer } from './GestureLayer';
+
+const ZenProviderBadgeOverlay = styled.div`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.sm};
+  right: ${({ theme }) => theme.spacing.sm};
+  z-index: 10;
+  pointer-events: none;
+`;
 
 interface AlbumArtBounds {
   left: number;
@@ -44,6 +55,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   onSwipeDown,
   onAlbumArtBoundsChange,
 }) => {
+  const { connectedProviderIds } = useProviderContext();
+
   const {
     accentColor,
     customAccentColors,
@@ -190,6 +203,11 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
         alignItems: 'center',
         paddingTop: zenModeEnabled ? '0' : (isMobile ? '0.25rem' : '0.5rem')
       }}>
+        {zenModeEnabled && connectedProviderIds.length > 1 && currentTrackProvider != null && (
+          <ZenProviderBadgeOverlay>
+            <ProviderBadge providerId={currentTrackProvider} />
+          </ZenProviderBadgeOverlay>
+        )}
         <div ref={flipContainerRef} style={{ width: '100%' }}>
           <GestureLayer
             onSwipeLeft={onSwipeLeft}

--- a/src/components/ProviderBadge.tsx
+++ b/src/components/ProviderBadge.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { ProviderId } from '@/types/domain';
+import { providerRegistry } from '@/providers/registry';
+
+const BadgeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.xs};
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  padding: 3px 8px 3px 4px;
+  pointer-events: none;
+  user-select: none;
+`;
+
+const IconWrapper = styled.div<{ $size: number }>`
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const ProviderName = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+  line-height: 1;
+`;
+
+interface ProviderBadgeProps {
+  providerId: ProviderId;
+  iconSize?: number;
+  className?: string;
+}
+
+export const ProviderBadge: React.FC<ProviderBadgeProps> = React.memo(({ providerId, iconSize = 16, className }) => {
+  const descriptor = providerRegistry.get(providerId);
+  if (!descriptor) return null;
+
+  const IconComponent = descriptor.icon;
+
+  return (
+    <BadgeContainer className={className}>
+      <IconWrapper $size={iconSize}>
+        {IconComponent ? <IconComponent size={iconSize} /> : null}
+      </IconWrapper>
+      <ProviderName>{descriptor.name}</ProviderName>
+    </BadgeContainer>
+  );
+});
+
+ProviderBadge.displayName = 'ProviderBadge';


### PR DESCRIPTION
## Summary

- Adds a `ProviderBadge` component (pill with provider icon + name) rendered in the top-right corner of the album art
- Only visible when **Zen mode is active** and **2+ providers are connected** — hidden in standard view (provider already shown in controls panel)
- `pointer-events: none` — does not interfere with album art gestures
- Uses theme tokens throughout; provider name read from descriptor (no hardcoded strings)

## Test plan

- [ ] Connect Spotify + Dropbox, enter Zen mode, play a mixed queue — badge should appear and update as driving provider changes
- [ ] Exit Zen mode — badge should disappear
- [ ] Single provider only — badge should not appear even in Zen mode
- [ ] Verify no layout shifts or gesture interference on album art

Closes #456