### PR TITLE
a11y: add aria-live region for track change announcements

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { flexCenter } from '@/styles/utils';
+import { flexCenter, srOnly } from '@/styles/utils';
 import PlayerStateRenderer from './PlayerStateRenderer';
 import PlayerContent from './PlayerContent';
 import BackgroundVisualizer from './BackgroundVisualizer';
@@ -29,6 +29,10 @@ const Container = styled.div`
   min-height: 100vh;
   min-height: 100dvh;
   ${flexCenter};
+`;
+
+const ScreenReaderAnnouncement = styled.div`
+  ${srOnly}
 `;
 
 const AudioPlayerComponent = () => {
@@ -184,6 +188,9 @@ const AudioPlayerComponent = () => {
     <PlayerSizingProvider>
     <ProfilingProvider>
       <Container>
+        <ScreenReaderAnnouncement aria-live="polite" aria-atomic="true">
+          {currentTrack ? `Now playing: ${currentTrack.name} by ${currentTrack.artists}` : ''}
+        </ScreenReaderAnnouncement>
         <DebugOverlay active={debugActive} />
         <ProfilingOverlay />
         {/* 5 rapid taps in top-left corner toggles debug overlay */}

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -83,6 +83,18 @@ export const cardBase = css`
   box-shadow: ${theme.shadows.sm};
 `;
 
+export const srOnly = css`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
 export const customScrollbar = css`
   &::-webkit-scrollbar {
     width: ${theme.spacing.sm};


### PR DESCRIPTION
## Summary

- Adds a `srOnly` CSS utility to `src/styles/utils.ts` for visually hiding elements while keeping them accessible to screen readers
- Adds a `ScreenReaderAnnouncement` styled-component in `AudioPlayer.tsx` rendered unconditionally in the DOM
- The element uses `aria-live="polite"` and `aria-atomic="true"` and announces `Now playing: {track name} by {artists}` whenever the current track changes; empty string when no track is active

## Test plan

- [ ] Load a playlist and verify a screen reader (VoiceOver/NVDA) announces the track name and artist on each track change
- [ ] Verify the announcement element is always present in the DOM (not conditionally rendered)
- [ ] Verify no visual change to the player UI
- [ ] `npx tsc -b --noEmit` passes cleanly
- [ ] `npm run test:run` — no new test failures introduced

Closes #444