### PR TITLE
refactor: import VisualizerStyle type in QuickEffectsRow

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
+import type { VisualizerStyle } from '@/types/visualizer';
 import { extractTopVibrantColors } from '@/utils/colorExtractor';
 import type { ExtractedColor } from '@/utils/colorExtractor';
 import { OptionButton, OptionButtonGroup } from '@/components/VisualEffectsMenu/styled';
@@ -23,8 +24,8 @@ interface QuickEffectsRowProps {
   onGlowRateChange?: (v: number) => void;
   backgroundVisualizerEnabled: boolean;
   onBackgroundVisualizerToggle: () => void;
-  backgroundVisualizerStyle: 'fireflies' | 'comet';
-  onBackgroundVisualizerStyleChange: (style: 'fireflies' | 'comet') => void;
+  backgroundVisualizerStyle: VisualizerStyle;
+  onBackgroundVisualizerStyleChange: (style: VisualizerStyle) => void;
   backgroundVisualizerIntensity?: number;
   onBackgroundVisualizerIntensityChange?: (intensity: number) => void;
   translucenceEnabled: boolean;


### PR DESCRIPTION
## Summary
- Replaces inline type literal with imported VisualizerStyle type
- Ensures QuickEffectsRow stays in sync when new visualizer styles are added

Closes #468

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes