### PR TITLE
feat: add pulse animation to like/heart button

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useState, useEffect, useRef } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import { theme } from '../styles/theme';
 
@@ -22,6 +22,7 @@ const heartBeat = keyframes`
 
 const StyledLikeButton = styled.button<{
   $isLiked: boolean;
+  $isPulsing: boolean;
   $isMobile: boolean;
   $isTablet: boolean;
 }>`
@@ -43,7 +44,8 @@ const StyledLikeButton = styled.button<{
   }};
   position: relative;
 
-  svg {
+  .heart-icon-wrapper {
+    position: relative;
     width: ${({ $isMobile, $isTablet }) => {
     if ($isMobile) return '1.25rem';
     if ($isTablet) return '1.375rem';
@@ -54,9 +56,30 @@ const StyledLikeButton = styled.button<{
     if ($isTablet) return '1.375rem';
     return '1.5rem';
   }};
-    fill: currentColor;
-    transition: all 0.2s ease;
   }
+
+  svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+    transition: opacity 0.3s ease;
+  }
+
+  .heart-filled {
+    opacity: ${({ $isLiked }) => $isLiked ? 1 : 0};
+  }
+
+  .heart-outline {
+    opacity: ${({ $isLiked }) => $isLiked ? 0 : 1};
+  }
+
+  ${({ $isPulsing }) => $isPulsing && css`
+    .heart-icon-wrapper {
+      animation: ${heartBeat} 0.6s ease-in-out;
+    }
+  `}
 
   ${({ $isLiked }) => $isLiked ? css`
     background: var(--accent-color);
@@ -66,10 +89,6 @@ const StyledLikeButton = styled.button<{
       background: color-mix(in srgb, var(--accent-color) 87%, transparent);
       color: var(--accent-contrast-color);
       transform: translateY(-1px);
-    }
-
-    svg {
-      animation: ${heartBeat} 0.6s ease-in-out;
     }
   ` : css`
     background: color-mix(in srgb, var(--accent-color) 20%, transparent);
@@ -94,14 +113,18 @@ const StyledLikeButton = styled.button<{
   }
 `;
 
-const HeartIcon = memo<{ filled: boolean }>(({ filled }) => (
-  <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-    {filled ? (
-      <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-    ) : (
-      <path d="M16.5 3c-1.74 0-3.41.81-4.5 2.09C10.91 3.81 9.24 3 7.5 3 4.42 3 2 5.42 2 8.5c0 3.78 3.4 6.86 8.55 11.54L12 21.35l1.45-1.32C18.6 15.36 22 12.28 22 8.5 22 5.42 19.58 3 16.5 3zm-4.4 15.55l-.1.1-.1-.1C7.14 14.24 4 11.39 4 8.5 4 6.5 5.5 5 7.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5c2 0 3.5 1.5 3.5 3.5 0 2.89-3.14 5.74-7.9 10.05z" />
-    )}
-  </svg>
+const FILLED_PATH = 'M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z';
+const OUTLINE_PATH = 'M16.5 3c-1.74 0-3.41.81-4.5 2.09C10.91 3.81 9.24 3 7.5 3 4.42 3 2 5.42 2 8.5c0 3.78 3.4 6.86 8.55 11.54L12 21.35l1.45-1.32C18.6 15.36 22 12.28 22 8.5 22 5.42 19.58 3 16.5 3zm-4.4 15.55l-.1.1-.1-.1C7.14 14.24 4 11.39 4 8.5 4 6.5 5.5 5 7.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5c2 0 3.5 1.5 3.5 3.5 0 2.89-3.14 5.74-7.9 10.05z';
+
+const HeartIcon = memo(() => (
+  <span className="heart-icon-wrapper">
+    <svg className="heart-outline" viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path d={OUTLINE_PATH} />
+    </svg>
+    <svg className="heart-filled" viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path d={FILLED_PATH} />
+    </svg>
+  </span>
 ));
 
 HeartIcon.displayName = 'HeartIcon';
@@ -120,6 +143,8 @@ const areLikeButtonPropsEqual = (
   );
 };
 
+const PULSE_DURATION_MS = 600;
+
 const LikeButton = memo<LikeButtonProps>(({
   trackId,
   isLiked,
@@ -129,8 +154,25 @@ const LikeButton = memo<LikeButtonProps>(({
   $isMobile = false,
   $isTablet = false
 }) => {
+  const [isPulsing, setIsPulsing] = useState(false);
+  const pulseTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+    };
+  }, []);
+
   const handleClick = useCallback(() => {
     if (isLoading || !trackId) return;
+
+    setIsPulsing(false);
+    requestAnimationFrame(() => {
+      setIsPulsing(true);
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+      pulseTimerRef.current = setTimeout(() => setIsPulsing(false), PULSE_DURATION_MS);
+    });
+
     onToggleLike();
   }, [isLoading, trackId, onToggleLike]);
 
@@ -146,6 +188,7 @@ const LikeButton = memo<LikeButtonProps>(({
   return (
     <StyledLikeButton
       $isLiked={isLiked}
+      $isPulsing={isPulsing}
       $isMobile={$isMobile}
       $isTablet={$isTablet}
       disabled={isLoading || !trackId}
@@ -157,7 +200,7 @@ const LikeButton = memo<LikeButtonProps>(({
       role="button"
       tabIndex={0}
     >
-      <HeartIcon filled={isLiked} />
+      <HeartIcon />
     </StyledLikeButton>
   );
 }, areLikeButtonPropsEqual);

--- a/src/components/__tests__/LikeButton.test.tsx
+++ b/src/components/__tests__/LikeButton.test.tsx
@@ -17,20 +17,13 @@ function renderLikeButton(overrides?: Partial<typeof defaultProps>) {
 }
 
 describe('LikeButton', () => {
-  it('renders outlined heart icon when isLiked is false', () => {
+  it('renders both outline and filled heart SVGs for cross-fade', () => {
     renderLikeButton({ isLiked: false });
-    const svg = screen.getByRole('button').querySelector('svg');
-    expect(svg).toBeTruthy();
-    const path = svg!.querySelector('path');
-    expect(path!.getAttribute('d')).toContain('16.5 3c-1.74');
-  });
-
-  it('renders filled heart icon when isLiked is true', () => {
-    renderLikeButton({ isLiked: true });
-    const svg = screen.getByRole('button').querySelector('svg');
-    expect(svg).toBeTruthy();
-    const path = svg!.querySelector('path');
-    expect(path!.getAttribute('d')).toContain('12 21.35l-1.45');
+    const button = screen.getByRole('button');
+    const svgs = button.querySelectorAll('svg');
+    expect(svgs).toHaveLength(2);
+    expect(svgs[0]).toHaveClass('heart-outline');
+    expect(svgs[1]).toHaveClass('heart-filled');
   });
 
   it('is disabled and shows heart icon when isLoading is true', () => {


### PR DESCRIPTION
## Summary
- Adds pulse keyframe animation to like/heart button on click
- Smooth opacity cross-fade transition instead of instant toggle
- Uses styled-components keyframes, hardware-accelerated

Closes #447

## Test plan
- [ ] Click like button — verify pulse animation plays
- [ ] Verify smooth fill transition (not instant)
- [ ] Works on both desktop and mobile