### PR TITLE
a11y: add aria-label attributes to icon-only buttons

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -139,6 +139,7 @@ const BottomBar = React.memo(function BottomBar({
               isActive={shuffleEnabled}
               onClick={onShuffleToggle}
               title={`Shuffle ${shuffleEnabled ? 'ON' : 'OFF'}`}
+              aria-label="Shuffle"
               aria-pressed={shuffleEnabled}
             >
               <ShuffleIcon />
@@ -165,6 +166,7 @@ const BottomBar = React.memo(function BottomBar({
             $compact
             onClick={onShowVisualEffects}
             title="App settings"
+            aria-label="App settings"
           >
             <VisualEffectsIcon />
           </ControlButton>
@@ -176,6 +178,7 @@ const BottomBar = React.memo(function BottomBar({
               $compact
               onClick={onBackToLibrary}
               title="Back to Library"
+              aria-label="Back to Library"
             >
               <BackToLibraryIcon />
             </ControlButton>
@@ -187,6 +190,7 @@ const BottomBar = React.memo(function BottomBar({
             $compact
             onClick={onShowQueue}
             title="Show Queue"
+            aria-label="Show Queue"
           >
             <QueueIcon />
           </ControlButton>
@@ -199,6 +203,7 @@ const BottomBar = React.memo(function BottomBar({
               isActive={zenModeEnabled}
               onClick={onZenModeToggle}
               title={`Zen Mode ${zenModeEnabled ? 'ON' : 'OFF'}`}
+              aria-label="Zen Mode"
               aria-pressed={zenModeEnabled}
             >
               <ZenModeIcon />

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -261,7 +261,7 @@ const QueueDrawer = memo<QueueDrawerProps>(({
                 </svg>
               </SaveButton>
             )}
-            <CloseButton onClick={onClose}>×</CloseButton>
+            <CloseButton onClick={onClose} aria-label="Close queue drawer">×</CloseButton>
           </HeaderActions>
         </QueueHeader>
 

--- a/src/components/controls/PlaybackControls.tsx
+++ b/src/components/controls/PlaybackControls.tsx
@@ -33,12 +33,12 @@ const PlaybackControls = memo<PlaybackControlsProps>(({
 }) => {
     return (
         <>
-            <ControlButton $isMobile={isMobile} $isTablet={isTablet} onClick={onPrevious}>
+            <ControlButton $isMobile={isMobile} $isTablet={isTablet} onClick={onPrevious} aria-label="Previous track">
                 <svg viewBox="0 0 24 24">
                     <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
                 </svg>
             </ControlButton>
-            <ControlButton $isMobile={isMobile} $isTablet={isTablet} isActive={isPlaying} onClick={isPlaying ? onPause : onPlay}>
+            <ControlButton $isMobile={isMobile} $isTablet={isTablet} isActive={isPlaying} onClick={isPlaying ? onPause : onPlay} aria-label={isPlaying ? 'Pause' : 'Play'} aria-pressed={isPlaying}>
                 {isPlaying ? (
                     <svg viewBox="0 0 24 24">
                         <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
@@ -49,7 +49,7 @@ const PlaybackControls = memo<PlaybackControlsProps>(({
                     </svg>
                 )}
             </ControlButton>
-            <ControlButton $isMobile={isMobile} $isTablet={isTablet} onClick={onNext}>
+            <ControlButton $isMobile={isMobile} $isTablet={isTablet} onClick={onNext} aria-label="Next track">
                 <svg viewBox="0 0 24 24">
                     <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
                 </svg>

--- a/src/components/controls/VolumeControl.tsx
+++ b/src/components/controls/VolumeControl.tsx
@@ -243,6 +243,8 @@ const VolumeControl = memo<VolumeControlProps>(({
                 isActive={isOpen}
                 onClick={togglePopover}
                 title="Volume"
+                aria-label="Volume"
+                aria-pressed={isOpen}
             >
                 <VolumeIcon isMuted={isMuted} volume={volume} />
             </ControlButton>
@@ -271,6 +273,8 @@ const VolumeControl = memo<VolumeControlProps>(({
                         $isMuted={isMuted}
                         onClick={onClick}
                         title={isMuted ? 'Unmute' : 'Mute'}
+                        aria-label={isMuted ? 'Unmute' : 'Mute'}
+                        aria-pressed={isMuted}
                     >
                         {isMuted ? <UnmuteIcon /> : <MuteIcon />}
                     </MuteButton>


### PR DESCRIPTION
## Summary
- Audits all icon-only buttons across the player
- Adds missing aria-label attributes for screen reader accessibility
- Adds aria-pressed for toggle buttons where appropriate

Closes #445

## Test plan
- [ ] Screen reader can identify all buttons by their labels
- [ ] aria-pressed reflects toggle state correctly (shuffle, zen mode, volume)
- [ ] No visual or functional changes to the UI