### PR TITLE
feat: enable flip menu via long-press in zen mode

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -275,6 +275,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
             onSwipeDown={onSwipeDown}
             isTouchDevice={isTouchDevice}
             onClick={handleClick}
+            onLongPress={zenModeEnabled ? toggleFlip : undefined}
             albumArtContainerRef={albumArtContainerRef}
             onZoneHover={setHoveredZone}
             zenModeEnabled={zenModeEnabled}

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useSwipeGesture } from '@/hooks/useSwipeGesture';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
+import { useLongPress } from '@/hooks/useLongPress';
 import { ClickableAlbumArtContainer } from './styled';
 
 type Zone = 'left' | 'center' | 'right';
@@ -12,6 +13,7 @@ interface GestureLayerProps {
   onSwipeDown: () => void;
   isTouchDevice: boolean;
   onClick: (e: React.MouseEvent) => void;
+  onLongPress?: () => void;
   albumArtContainerRef: React.MutableRefObject<HTMLDivElement | null>;
   children: React.ReactNode;
   onZoneHover?: (zone: Zone | null) => void;
@@ -26,6 +28,7 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
   onSwipeDown,
   isTouchDevice,
   onClick,
+  onLongPress,
   albumArtContainerRef,
   children,
   onZoneHover,
@@ -42,6 +45,11 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
     onSwipeDown,
     threshold: 80,
     enabled: isTouchDevice,
+  });
+
+  const longPressHandlers = useLongPress({
+    onLongPress: onLongPress ?? (() => {}),
+    enabled: zenModeEnabled === true && onLongPress !== undefined,
   });
 
   const handleRef = useCallback((el: HTMLDivElement | null) => {
@@ -81,6 +89,15 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
     ? { onMouseMove: handleMouseMove, onMouseLeave: handleMouseLeave }
     : {};
 
+  const zenLongPressHandlers = zenModeEnabled && onLongPress
+    ? {
+        onPointerDown: longPressHandlers.onPointerDown,
+        onPointerUp: longPressHandlers.onPointerUp,
+        onPointerCancel: longPressHandlers.onPointerCancel,
+        onPointerMove: longPressHandlers.onPointerMove,
+      }
+    : {};
+
   return (
     <ClickableAlbumArtContainer
       ref={handleRef}
@@ -88,6 +105,7 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
       $bothGestures={isTouchDevice}
       {...(isTouchDevice ? gestureHandlers : {})}
       {...zoneHoverHandlers}
+      {...zenLongPressHandlers}
       onClick={handleClick}
       style={{
         transform: `translateX(${offsetX}px)`,

--- a/src/hooks/__tests__/useLongPress.test.ts
+++ b/src/hooks/__tests__/useLongPress.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPress } from '../useLongPress';
+
+const createPointerEvent = (x: number, y: number): React.PointerEvent => ({
+  clientX: x,
+  clientY: y,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+} as unknown as React.PointerEvent);
+
+describe('useLongPress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires onLongPress after 500ms', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // #then
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onLongPress if pointer is released before 500ms', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+      result.current.onPointerUp(createPointerEvent(100, 100));
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('calls onShortPress on short tap', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onShortPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onShortPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerUp(createPointerEvent(100, 100));
+    });
+
+    // #then
+    expect(onShortPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels long-press when pointer moves beyond threshold', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      result.current.onPointerMove(createPointerEvent(115, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel long-press on small pointer movement within threshold', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      result.current.onPointerMove(createPointerEvent(105, 102));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // #then
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels long-press on pointer cancel', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      result.current.onPointerCancel(createPointerEvent(100, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when enabled is false', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onShortPress = vi.fn();
+    const { result } = renderHook(() =>
+      useLongPress({ onLongPress, onShortPress, enabled: false })
+    );
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100));
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+      result.current.onPointerUp(createPointerEvent(100, 100));
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onShortPress).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,74 @@
+import { useRef, useCallback } from 'react';
+
+const LONG_PRESS_DURATION_MS = 500;
+const MOVE_CANCEL_THRESHOLD = 10;
+
+interface UseLongPressOptions {
+  onLongPress: () => void;
+  onShortPress?: () => void;
+  enabled?: boolean;
+}
+
+interface UseLongPressReturn {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+}
+
+export function useLongPress({
+  onLongPress,
+  onShortPress,
+  enabled = true,
+}: UseLongPressOptions): UseLongPressReturn {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const firedRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (!enabled) return;
+    firedRef.current = false;
+    startXRef.current = e.clientX;
+    startYRef.current = e.clientY;
+
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      timerRef.current = null;
+      onLongPress();
+    }, LONG_PRESS_DURATION_MS);
+  }, [enabled, onLongPress]);
+
+  const onPointerUp = useCallback((_e: React.PointerEvent) => {
+    if (!enabled) return;
+    const wasPending = timerRef.current !== null;
+    cancel();
+    if (wasPending && !firedRef.current) {
+      onShortPress?.();
+    }
+    firedRef.current = false;
+  }, [enabled, cancel, onShortPress]);
+
+  const onPointerCancel = useCallback((_e: React.PointerEvent) => {
+    cancel();
+    firedRef.current = false;
+  }, [cancel]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!enabled) return;
+    const dx = Math.abs(e.clientX - startXRef.current);
+    const dy = Math.abs(e.clientY - startYRef.current);
+    if (dx > MOVE_CANCEL_THRESHOLD || dy > MOVE_CANCEL_THRESHOLD) {
+      cancel();
+    }
+  }, [enabled, cancel]);
+
+  return { onPointerDown, onPointerUp, onPointerCancel, onPointerMove };
+}


### PR DESCRIPTION
## Summary
- Adds `useLongPress` hook with 500ms threshold and move-cancel support
- Long-press on album art in zen mode opens flip menu
- Short tap retains positional playback controls (prev/play/next zones)
- Cancels on pointer move >10px to avoid conflicting with swipe gestures
- 7 new tests for the hook

Closes #459

## Test plan
- [ ] In zen mode, short tap works as before (prev/play/next zones)
- [ ] In zen mode, long-press (~500ms) flips to back menu
- [ ] Swipe gestures still work (long-press cancels on move)
- [ ] Non-zen mode unaffected
- [ ] Works on both touch and mouse