### PR TITLE
feat: add Wave background visualizer

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
+import type { VisualizerStyle } from '@/types/visualizer';
 import QuickEffectsRow from '@/components/controls/QuickEffectsRow';
 import { theme } from '@/styles/theme';
 
@@ -17,8 +18,8 @@ interface AlbumArtQuickSwapBackProps {
   onGlowRateChange: (v: number) => void;
   backgroundVisualizerEnabled: boolean;
   onBackgroundVisualizerToggle: () => void;
-  backgroundVisualizerStyle: 'fireflies' | 'comet';
-  onBackgroundVisualizerStyleChange: (style: 'fireflies' | 'comet') => void;
+  backgroundVisualizerStyle: VisualizerStyle;
+  onBackgroundVisualizerStyleChange: (style: VisualizerStyle) => void;
   backgroundVisualizerIntensity: number;
   onBackgroundVisualizerIntensityChange: (intensity: number) => void;
   translucenceEnabled: boolean;

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import type { VisualizerStyle } from '../types/visualizer';
 import { ParticleVisualizer } from './visualizers/ParticleVisualizer';
 import { TrailVisualizer } from './visualizers/TrailVisualizer';
+import { WaveVisualizer } from './visualizers/WaveVisualizer';
 
 interface AlbumArtBounds {
   left: number;
@@ -68,6 +69,8 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
         return ParticleVisualizer;
       case 'comet':
         return TrailVisualizer;
+      case 'wave':
+        return WaveVisualizer;
       default:
         return ParticleVisualizer;
     }

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -10,6 +10,7 @@ import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
 import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { VisualizerStyle } from '@/types/visualizer';
 import { FlipInner, ZenTrackInfo, ZenTrackName, ZenTrackArtist } from './styled';
 import { GestureLayer } from './GestureLayer';
 import { ZenClickZoneOverlay } from './ZenClickZoneOverlay';
@@ -241,7 +242,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     setBackgroundVisualizerEnabled(prev => !prev);
   }, [setBackgroundVisualizerEnabled]);
 
-  const handleBackgroundVisualizerStyleChange = useCallback((style: 'fireflies' | 'comet') => {
+  const handleBackgroundVisualizerStyleChange = useCallback((style: VisualizerStyle) => {
     setBackgroundVisualizerStyle(style);
   }, [setBackgroundVisualizerStyle]);
 
@@ -308,7 +309,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
                 onGlowRateChange={handleGlowRateChange}
                 backgroundVisualizerEnabled={backgroundVisualizerEnabled}
                 onBackgroundVisualizerToggle={handleBackgroundVisualizerToggle}
-                backgroundVisualizerStyle={backgroundVisualizerStyle as 'fireflies' | 'comet'}
+                backgroundVisualizerStyle={backgroundVisualizerStyle}
                 onBackgroundVisualizerStyleChange={handleBackgroundVisualizerStyleChange}
                 backgroundVisualizerIntensity={backgroundVisualizerIntensity}
                 onBackgroundVisualizerIntensityChange={handleBackgroundVisualizerIntensityChange}

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -312,6 +312,12 @@ function QuickEffectsRow({
               >
                 Comet
               </OptionButton>
+              <OptionButton
+                $isActive={backgroundVisualizerStyle === 'wave'}
+                onClick={() => onBackgroundVisualizerStyleChange('wave')}
+              >
+                Wave
+              </OptionButton>
             </OptionButtonGroup>
           </SubSettingRow>
           {hasVizIntensity && (

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -1,0 +1,138 @@
+import React, { useCallback } from 'react';
+import { generateColorVariant } from '../../utils/visualizerUtils';
+import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
+
+interface WaveVisualizerProps {
+  intensity: number;
+  accentColor: string;
+  isPlaying: boolean;
+  playbackPosition?: number;
+  zenMode?: boolean;
+}
+
+interface Wave {
+  phase: number;
+  phaseSpeed: number;
+  amplitude: number;
+  frequency: number;
+  yBase: number;
+  opacity: number;
+  color: string;
+}
+
+const WAVE_COUNT = 4;
+const PAUSED_SPEED_MULT = 0.3;
+
+/**
+ * WaveVisualizer Component
+ *
+ * Renders layered sine waves rising from the bottom of the canvas, each filling
+ * the area below with a semi-transparent color derived from the accent color.
+ *
+ * Pausing slows phase advancement to ~30% of normal speed.
+ *
+ * @component
+ */
+export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
+  intensity,
+  accentColor,
+  isPlaying,
+}) => {
+  const getItemCount = useCallback(
+    (_width: number, _height: number, _intensity: number): number => WAVE_COUNT,
+    []
+  );
+
+  const initializeItems = useCallback(
+    (count: number, _width: number, height: number, baseColor: string): Wave[] => {
+      return Array.from({ length: count }, (_, i) => {
+        const layerRatio = i / count;
+        return {
+          phase: Math.random() * Math.PI * 2,
+          phaseSpeed: 0.004 + Math.random() * 0.003,
+          amplitude: height * (0.06 + layerRatio * 0.05),
+          frequency: 0.003 + Math.random() * 0.002,
+          yBase: height * (0.55 + layerRatio * 0.12),
+          opacity: 0.12 + layerRatio * 0.1,
+          color: generateColorVariant(baseColor, 0.4 + layerRatio * 0.4),
+        };
+      });
+    },
+    []
+  );
+
+  const updateItems = useCallback(
+    (waves: Wave[], deltaTime: number, playing: boolean, _width: number, height: number): void => {
+      const speedMult = playing ? 1.0 : PAUSED_SPEED_MULT;
+      const dt = deltaTime / 16;
+      waves.forEach((wave, i) => {
+        wave.phase += wave.phaseSpeed * speedMult * dt;
+        if (wave.phase > Math.PI * 2) wave.phase -= Math.PI * 2;
+        wave.yBase = height * (0.55 + (i / WAVE_COUNT) * 0.12);
+        wave.amplitude = height * (0.06 + (i / WAVE_COUNT) * 0.05);
+      });
+    },
+    []
+  );
+
+  const renderItems = useCallback(
+    (
+      ctx: CanvasRenderingContext2D,
+      waves: Wave[],
+      width: number,
+      height: number,
+      intensityValue: number
+    ): void => {
+      ctx.clearRect(0, 0, width, height);
+      const intensityScale = Math.max(0.3, intensityValue / 60);
+
+      waves.forEach(wave => {
+        ctx.save();
+        ctx.globalAlpha = wave.opacity * intensityScale;
+        ctx.fillStyle = wave.color;
+
+        ctx.beginPath();
+        ctx.moveTo(0, height);
+
+        for (let x = 0; x <= width; x += 4) {
+          const y = wave.yBase + Math.sin(x * wave.frequency + wave.phase) * wave.amplitude;
+          ctx.lineTo(x, y);
+        }
+
+        ctx.lineTo(width, height);
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+      });
+    },
+    []
+  );
+
+  const handleColorChange = useCallback((waves: Wave[], color: string): void => {
+    waves.forEach((wave, i) => {
+      wave.color = generateColorVariant(color, 0.4 + (i / WAVE_COUNT) * 0.4);
+    });
+  }, []);
+
+  const canvasRef = useCanvasVisualizer<Wave>({
+    accentColor,
+    isPlaying,
+    intensity,
+    getItemCount,
+    initializeItems,
+    updateItems,
+    renderItems,
+    onColorChange: handleColorChange,
+  });
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'block',
+      }}
+    />
+  );
+};

--- a/src/constants/visualizerDebugConfig.ts
+++ b/src/constants/visualizerDebugConfig.ts
@@ -54,15 +54,32 @@ export interface TrailVisualizerConfig {
   countPixelDivisorMobile: number;
 }
 
+export interface WaveVisualizerConfig {
+  waveCount: number;
+  phaseSpeedMin: number;
+  phaseSpeedSpread: number;
+  amplitudeBase: number;
+  amplitudeLayerScale: number;
+  frequencyMin: number;
+  frequencySpread: number;
+  yBaseStart: number;
+  yBaseLayerScale: number;
+  opacityBase: number;
+  opacityLayerScale: number;
+  pausedSpeedMult: number;
+}
+
 export interface VisualizerDebugConfig {
   particle: ParticleVisualizerConfig;
   trail: TrailVisualizerConfig;
+  wave: WaveVisualizerConfig;
 }
 
 /** Partial overrides for debug panel; nested keys are optional. */
 export interface VisualizerDebugOverrides {
   particle?: Partial<ParticleVisualizerConfig>;
   trail?: Partial<TrailVisualizerConfig>;
+  wave?: Partial<WaveVisualizerConfig>;
 }
 
 const DEFAULT_PARTICLE: ParticleVisualizerConfig = {
@@ -109,9 +126,25 @@ const DEFAULT_TRAIL: TrailVisualizerConfig = {
 
 
 
+const DEFAULT_WAVE: WaveVisualizerConfig = {
+  waveCount: 4,
+  phaseSpeedMin: 0.004,
+  phaseSpeedSpread: 0.003,
+  amplitudeBase: 0.06,
+  amplitudeLayerScale: 0.05,
+  frequencyMin: 0.003,
+  frequencySpread: 0.002,
+  yBaseStart: 0.55,
+  yBaseLayerScale: 0.12,
+  opacityBase: 0.12,
+  opacityLayerScale: 0.1,
+  pausedSpeedMult: 0.3,
+};
+
 export const DEFAULT_VISUALIZER_DEBUG_CONFIG: VisualizerDebugConfig = {
   particle: { ...DEFAULT_PARTICLE },
   trail: { ...DEFAULT_TRAIL },
+  wave: { ...DEFAULT_WAVE },
 };
 
 /** Deep merge: overrides only replace provided keys; nested objects are merged. */
@@ -127,5 +160,9 @@ export function mergeVisualizerConfig(
     ...base.trail,
     ...(overrides?.trail ?? {}),
   };
-  return { particle, trail };
+  const wave = {
+    ...base.wave,
+    ...(overrides?.wave ?? {}),
+  };
+  return { particle, trail, wave };
 }

--- a/src/types/visualizer.d.ts
+++ b/src/types/visualizer.d.ts
@@ -7,7 +7,8 @@
 
 export type VisualizerStyle =
   | 'fireflies'
-  | 'comet';
+  | 'comet'
+  | 'wave';
 
 interface VisualizerConfig {
   particleCount?: number;


### PR DESCRIPTION
## Summary
- Adds new Wave (waveform fill) background visualizer
- 3-5 layered sine waves rising from canvas bottom with area fill
- Phase animation slows on pause, colors derived from accent color
- Wired into visualizer style selector in QuickEffectsRow

Closes #466

## Test plan
- [ ] Select Wave style in effects row — waves appear
- [ ] Waves animate smoothly, slow on pause
- [ ] Colors match accent color
- [ ] Other visualizer styles still work