### PR TITLE
feat: add context menu to queue tracks

### DIFF
--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -1,4 +1,5 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { MediaTrack } from '@/types/domain';
 import { formatDuration } from '@/utils/formatDuration';
 import { Avatar } from '../components/styled';
@@ -6,6 +7,14 @@ import ProviderIcon from './ProviderIcon';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useHorizontalSwipeToRemove } from '@/hooks/useHorizontalSwipeToRemove';
+import { useLongPress } from '@/hooks/useLongPress';
+import { useLikeTrack } from '@/hooks/useLikeTrack';
+import TrackInfoPopover, {
+  PlayIcon as PopoverPlayIcon,
+  AddToLibraryIcon,
+  RemoveFromLibraryIcon,
+  TrashIcon,
+} from './controls/TrackInfoPopover';
 import {
   QueueListItem,
   AlbumArtContainer,
@@ -64,6 +73,114 @@ export interface QueueItemProps {
   isEditMode?: boolean;
 }
 
+interface ContextMenuState {
+  anchorRect: DOMRect;
+}
+
+function useQueueItemContextMenu(
+  track: MediaTrack,
+  index: number,
+  isSelected: boolean,
+  onSelect: (index: number) => void,
+  onRemove?: (index: number) => void,
+) {
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const { isLiked, isLikePending, handleLikeToggle, canSaveTrack } = useLikeTrack(
+    track.id,
+    track.provider,
+  );
+
+  const openContextMenu = useCallback((event: React.MouseEvent | React.TouchEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    let rect: DOMRect;
+    if ('touches' in event) {
+      const touch = event.touches[0] ?? event.changedTouches[0];
+      rect = new DOMRect(touch.clientX, touch.clientY, 0, 0);
+    } else {
+      rect = new DOMRect((event as React.MouseEvent).clientX, (event as React.MouseEvent).clientY, 0, 0);
+    }
+    setContextMenu({ anchorRect: rect });
+  }, []);
+
+  const closeContextMenu = useCallback(() => setContextMenu(null), []);
+
+  const buildOptions = useCallback(() => {
+    const options: Array<{ label: string; icon: React.ReactNode; onClick: () => void }> = [
+      {
+        label: 'Play now',
+        icon: React.createElement(PopoverPlayIcon),
+        onClick: () => onSelect(index),
+      },
+    ];
+
+    if (canSaveTrack) {
+      options.push({
+        label: isLiked ? 'Unlike' : 'Like',
+        icon: isLiked
+          ? React.createElement(RemoveFromLibraryIcon)
+          : React.createElement(AddToLibraryIcon),
+        onClick: handleLikeToggle,
+      });
+    }
+
+    if (onRemove && !isSelected) {
+      options.push({
+        label: 'Remove from queue',
+        icon: React.createElement(TrashIcon),
+        onClick: () => onRemove(index),
+      });
+    }
+
+    return options;
+  }, [index, isLiked, isLikePending, canSaveTrack, handleLikeToggle, onSelect, onRemove, isSelected]);
+
+  return { contextMenu, openContextMenu, closeContextMenu, buildOptions };
+}
+
+function TrackArtAndInfo({
+  track,
+  isSelected,
+  showProviderIcon,
+}: {
+  track: MediaTrack;
+  isSelected: boolean;
+  showProviderIcon?: boolean;
+}) {
+  return (
+    <>
+      <AlbumArtContainer>
+        <Avatar
+          src={track.image}
+          alt={track.album}
+          style={{ width: '3rem', height: '3rem' }}
+          fallback={<AlbumFallbackIcon />}
+        />
+        {isSelected && <PlayingIcon />}
+        {showProviderIcon && track.provider && (
+          <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+            <ProviderIcon provider={track.provider} size={16} />
+          </div>
+        )}
+      </AlbumArtContainer>
+
+      <TrackInfo>
+        <TrackName isSelected={isSelected}>
+          {track.name}
+        </TrackName>
+        <TrackArtist isSelected={isSelected}>
+          {track.artists}
+        </TrackArtist>
+      </TrackInfo>
+
+      <Duration isSelected={isSelected}>
+        {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
+      </Duration>
+    </>
+  );
+}
+
 export const SortableQueueItem = memo<QueueItemProps>(({
   track,
   index,
@@ -92,6 +209,12 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     position: 'relative' as const,
   };
 
+  const { contextMenu, openContextMenu, closeContextMenu, buildOptions } = useQueueItemContextMenu(
+    track, index, isSelected, onSelect, onRemove,
+  );
+
+  const { onTouchStart, onTouchEnd, onTouchMove } = useLongPress({ onLongPress: openContextMenu });
+
   const handleClick = useCallback(() => {
     if (!isDragActive && !isEditMode) {
       onSelect(index);
@@ -108,6 +231,10 @@ export const SortableQueueItem = memo<QueueItemProps>(({
       <QueueListItem
         ref={itemRef}
         onClick={handleClick}
+        onContextMenu={openContextMenu}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onTouchMove={onTouchMove}
         isSelected={isSelected}
       >
         {isEditMode && onRemove && (
@@ -116,33 +243,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
           </DragHandle>
         )}
 
-        <AlbumArtContainer>
-          <Avatar
-            src={track.image}
-            alt={track.album}
-            style={{ width: '3rem', height: '3rem' }}
-            fallback={<AlbumFallbackIcon />}
-          />
-          {isSelected && <PlayingIcon />}
-          {showProviderIcon && track.provider && (
-            <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
-              <ProviderIcon provider={track.provider} size={16} />
-            </div>
-          )}
-        </AlbumArtContainer>
-
-        <TrackInfo>
-          <TrackName isSelected={isSelected}>
-            {track.name}
-          </TrackName>
-          <TrackArtist isSelected={isSelected}>
-            {track.artists}
-          </TrackArtist>
-        </TrackInfo>
-
-        <Duration isSelected={isSelected}>
-          {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
-        </Duration>
+        <TrackArtAndInfo track={track} isSelected={isSelected} showProviderIcon={showProviderIcon} />
 
         {isEditMode && onRemove && !isSelected && (
           <RemoveButton onClick={handleRemoveClick} aria-label={`Remove ${track.name}`}>
@@ -150,6 +251,16 @@ export const SortableQueueItem = memo<QueueItemProps>(({
           </RemoveButton>
         )}
       </QueueListItem>
+
+      {contextMenu && createPortal(
+        <TrackInfoPopover
+          type="album"
+          anchorRect={contextMenu.anchorRect}
+          onClose={closeContextMenu}
+          options={buildOptions()}
+        />,
+        document.body,
+      )}
     </div>
   );
 });
@@ -180,93 +291,101 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index, reset]);
 
+  const { contextMenu, openContextMenu, closeContextMenu, buildOptions } = useQueueItemContextMenu(
+    track, index, isSelected, onSelect, onRemove,
+  );
+
+  const longPressHandlers = useLongPress({ onLongPress: openContextMenu });
+
   if (!canRemove) {
     return (
-      <QueueListItem
-        ref={itemRef}
-        onClick={() => {
-          if (!isEditMode) onSelect(index);
-        }}
-        isSelected={isSelected}
-      >
-        <AlbumArtContainer>
-          <Avatar
-            src={track.image}
-            alt={track.album}
-            style={{ width: '3rem', height: '3rem' }}
-            fallback={<AlbumFallbackIcon />}
-          />
-          {isSelected && <PlayingIcon />}
-          {showProviderIcon && track.provider && (
-            <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
-              <ProviderIcon provider={track.provider} size={16} />
-            </div>
-          )}
-        </AlbumArtContainer>
+      <>
+        <QueueListItem
+          ref={itemRef}
+          onClick={() => {
+            if (!isEditMode) onSelect(index);
+          }}
+          onContextMenu={openContextMenu}
+          {...longPressHandlers}
+          isSelected={isSelected}
+        >
+          <TrackArtAndInfo track={track} isSelected={isSelected} showProviderIcon={showProviderIcon} />
+        </QueueListItem>
 
-        <TrackInfo>
-          <TrackName isSelected={isSelected}>
-            {track.name}
-          </TrackName>
-          <TrackArtist isSelected={isSelected}>
-            {track.artists}
-          </TrackArtist>
-        </TrackInfo>
-
-        <Duration isSelected={isSelected}>
-          {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
-        </Duration>
-      </QueueListItem>
+        {contextMenu && createPortal(
+          <TrackInfoPopover
+            type="album"
+            anchorRect={contextMenu.anchorRect}
+            onClose={closeContextMenu}
+            options={buildOptions()}
+          />,
+          document.body,
+        )}
+      </>
     );
   }
 
   return (
-    <SwipeableWrapper ref={swipeRef}>
-      {(offsetX < 0 || isRevealed) && (
-        <SwipeRemoveBackdrop>
-          <button
-            onClick={handleRemoveClick}
-            style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '8px 16px', font: 'inherit', fontWeight: 600 }}
-            aria-label={`Remove ${track.name}`}
+    <>
+      <SwipeableWrapper ref={swipeRef}>
+        {(offsetX < 0 || isRevealed) && (
+          <SwipeRemoveBackdrop>
+            <button
+              onClick={handleRemoveClick}
+              style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '8px 16px', font: 'inherit', fontWeight: 600 }}
+              aria-label={`Remove ${track.name}`}
+            >
+              Remove
+            </button>
+          </SwipeRemoveBackdrop>
+        )}
+        <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
+          <QueueListItem
+            ref={itemRef}
+            onClick={() => !isRevealed && !isEditMode && onSelect(index)}
+            onContextMenu={openContextMenu}
+            {...longPressHandlers}
+            isSelected={isSelected}
           >
-            Remove
-          </button>
-        </SwipeRemoveBackdrop>
+            <AlbumArtContainer>
+              <Avatar
+                src={track.image}
+                alt={track.album}
+                style={{ width: '3rem', height: '3rem' }}
+                fallback={<AlbumFallbackIcon />}
+              />
+              {showProviderIcon && track.provider && (
+                <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+                  <ProviderIcon provider={track.provider} size={16} />
+                </div>
+              )}
+            </AlbumArtContainer>
+
+            <TrackInfo>
+              <TrackName isSelected={isSelected}>
+                {track.name}
+              </TrackName>
+              <TrackArtist isSelected={isSelected}>
+                {track.artists}
+              </TrackArtist>
+            </TrackInfo>
+
+            <Duration isSelected={isSelected}>
+              {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
+            </Duration>
+          </QueueListItem>
+        </SwipeableContent>
+      </SwipeableWrapper>
+
+      {contextMenu && createPortal(
+        <TrackInfoPopover
+          type="album"
+          anchorRect={contextMenu.anchorRect}
+          onClose={closeContextMenu}
+          options={buildOptions()}
+        />,
+        document.body,
       )}
-      <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
-        <QueueListItem
-          ref={itemRef}
-          onClick={() => !isRevealed && !isEditMode && onSelect(index)}
-          isSelected={isSelected}
-        >
-          <AlbumArtContainer>
-            <Avatar
-              src={track.image}
-              alt={track.album}
-              style={{ width: '3rem', height: '3rem' }}
-              fallback={<AlbumFallbackIcon />}
-            />
-            {showProviderIcon && track.provider && (
-              <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
-                <ProviderIcon provider={track.provider} size={16} />
-              </div>
-            )}
-          </AlbumArtContainer>
-
-          <TrackInfo>
-            <TrackName isSelected={isSelected}>
-              {track.name}
-            </TrackName>
-            <TrackArtist isSelected={isSelected}>
-              {track.artists}
-            </TrackArtist>
-          </TrackInfo>
-
-          <Duration isSelected={isSelected}>
-            {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
-          </Duration>
-        </QueueListItem>
-      </SwipeableContent>
-    </SwipeableWrapper>
+    </>
   );
 });

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,49 @@
+import { useRef, useCallback } from 'react';
+
+interface UseLongPressOptions {
+  onLongPress: (event: React.TouchEvent | React.MouseEvent) => void;
+  delay?: number;
+}
+
+interface LongPressHandlers {
+  onMouseDown: (event: React.MouseEvent) => void;
+  onMouseUp: () => void;
+  onMouseLeave: () => void;
+  onTouchStart: (event: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchMove: () => void;
+}
+
+export function useLongPress({ onLongPress, delay = 500 }: UseLongPressOptions): LongPressHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const eventRef = useRef<React.TouchEvent | React.MouseEvent | null>(null);
+
+  const start = useCallback(
+    (event: React.TouchEvent | React.MouseEvent) => {
+      eventRef.current = event;
+      timerRef.current = setTimeout(() => {
+        if (eventRef.current) {
+          onLongPress(eventRef.current);
+        }
+      }, delay);
+    },
+    [onLongPress, delay],
+  );
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    eventRef.current = null;
+  }, []);
+
+  return {
+    onMouseDown: start,
+    onMouseUp: cancel,
+    onMouseLeave: cancel,
+    onTouchStart: start,
+    onTouchEnd: cancel,
+    onTouchMove: cancel,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds right-click / long-press context menu to queue tracks
- Actions: Play now, Like/Unlike, Remove from queue
- Uses existing TrackInfoPopover for consistent UI
- Like shown only when provider supports hasSaveTrack
- Remove hidden for currently playing track

Closes #451

## Test plan
- [ ] Right-click on queue track shows context menu (desktop)
- [ ] Long-press on queue track shows context menu (mobile)
- [ ] Play now moves track to current and plays
- [ ] Like/Unlike toggles state
- [ ] Remove removes track from queue
- [ ] Menu dismisses on click outside or Escape