### PR TITLE
feat: add provider context indicator to library drawer

### DIFF
--- a/src/components/PlaylistSelection/LibraryDrawerHeader.tsx
+++ b/src/components/PlaylistSelection/LibraryDrawerHeader.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { ProviderDescriptor } from '@/types/providers';
+
+const HeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${theme.spacing.md} ${theme.spacing.lg};
+  border-bottom: 1px solid ${theme.colors.popover.border};
+  flex-shrink: 0;
+`;
+
+const HeaderContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xs};
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.semibold};
+  color: ${theme.colors.foreground};
+  letter-spacing: 0.5px;
+`;
+
+const Subtitle = styled.p`
+  margin: 0;
+  font-size: ${theme.fontSize.xs};
+  color: ${theme.colors.muted.foreground};
+  opacity: 0.75;
+`;
+
+interface LibraryDrawerHeaderProps {
+  activeDescriptor: ProviderDescriptor | null;
+}
+
+const LibraryDrawerHeader = React.memo(function LibraryDrawerHeader({ activeDescriptor }: LibraryDrawerHeaderProps) {
+  const providerName = activeDescriptor?.name ?? 'Library';
+
+  return (
+    <HeaderContainer>
+      <HeaderContent>
+        <Title>{providerName} Library</Title>
+        <Subtitle>Browse and select</Subtitle>
+      </HeaderContent>
+    </HeaderContainer>
+  );
+});
+
+export default LibraryDrawerHeader;

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -26,6 +26,7 @@ import { useLibraryBrowsing } from './useLibraryBrowsing';
 import { useItemActions } from './useItemActions';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
+import LibraryDrawerHeader from './LibraryDrawerHeader';
 
 interface PlaylistSelectionProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -283,6 +284,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   if (inDrawer) {
     return (
       <DrawerContentWrapper>
+        <LibraryDrawerHeader activeDescriptor={activeDescriptor ?? null} />
         <LibraryStatusContent {...statusContentProps} />
         {showMainContent && <LibraryMainContent {...mainContentProps} />}
         {albumPopoverPortal}


### PR DESCRIPTION
## Summary
- Adds provider name indicator to library drawer header
- Shows which provider's library is currently being browsed (e.g., "Spotify Library", "Dropbox Library")
- Styled to match existing drawer theme using theme colors and spacing

Closes #452

## Test plan
- [ ] Library drawer shows "Spotify Library" when Spotify is active
- [ ] Library drawer shows "Dropbox Library" when Dropbox is active
- [ ] Updates when switching providers
- [ ] No layout shift or visual regression