### PR TITLE
feat: add context menu to queue tracks

### DIFF
--- a/src/components/QueueContextMenu.tsx
+++ b/src/components/QueueContextMenu.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+
+interface ContextMenuOption {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  destructive?: boolean;
+}
+
+interface QueueContextMenuProps {
+  x: number;
+  y: number;
+  options: ContextMenuOption[];
+  onClose: () => void;
+}
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: ${({ theme }) => theme.zIndex.modal};
+`;
+
+const MenuContainer = styled.div<{ $x: number; $y: number }>`
+  position: fixed;
+  left: ${({ $x }) => $x}px;
+  top: ${({ $y }) => $y}px;
+  z-index: ${({ theme }) => theme.zIndex.popover};
+  min-width: 180px;
+  background: ${({ theme }) => theme.colors.popover.background};
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
+  border-radius: ${({ theme }) => theme.borderRadius.xl};
+  box-shadow: ${({ theme }) => theme.shadows.popover};
+  padding: ${({ theme }) => theme.spacing.xs};
+  animation: contextMenuFadeIn ${({ theme }) => theme.transitions.fast} ease-out;
+
+  @keyframes contextMenuFadeIn {
+    from {
+      opacity: 0;
+      transform: scale(0.96) translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+`;
+
+const MenuItem = styled.button<{ $destructive?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.lg};
+  background: none;
+  border: none;
+  color: ${({ theme, $destructive }) =>
+    $destructive ? theme.colors.error : theme.colors.foreground};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  cursor: pointer;
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  transition: background ${({ theme }) => theme.transitions.fast} ease;
+  white-space: nowrap;
+  text-align: left;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.control.background};
+  }
+
+  &:active {
+    background: ${({ theme }) => theme.colors.control.backgroundHover};
+  }
+
+  svg {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    color: ${({ theme, $destructive }) =>
+      $destructive ? theme.colors.error : theme.colors.muted.foreground};
+  }
+`;
+
+function clampToViewport(x: number, y: number, menuWidth = 200, menuHeight = 120): { x: number; y: number } {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  return {
+    x: Math.min(x, vw - menuWidth - 8),
+    y: Math.min(y, vh - menuHeight - 8),
+  };
+}
+
+export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { x: cx, y: cy } = clampToViewport(x, y);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return createPortal(
+    <>
+      <Overlay onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
+      <MenuContainer ref={menuRef} $x={cx} $y={cy}>
+        {options.map((option, index) => (
+          <MenuItem
+            key={index}
+            $destructive={option.destructive}
+            onClick={() => {
+              option.onClick();
+              onClose();
+            }}
+          >
+            {option.icon}
+            {option.label}
+          </MenuItem>
+        ))}
+      </MenuContainer>
+    </>,
+    document.body
+  );
+}

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { formatDuration } from '@/utils/formatDuration';
 import { Avatar } from '../components/styled';
@@ -6,6 +6,9 @@ import ProviderIcon from './ProviderIcon';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useHorizontalSwipeToRemove } from '@/hooks/useHorizontalSwipeToRemove';
+import { useLongPress } from '@/hooks/useLongPress';
+import { useLikeTrack } from '@/hooks/useLikeTrack';
+import { QueueContextMenu } from './QueueContextMenu';
 import {
   QueueListItem,
   AlbumArtContainer,
@@ -52,6 +55,47 @@ const PlayingIcon = () => (
   </PlayIcon>
 );
 
+const ContextPlayIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+);
+
+const HeartIcon = ({ filled }: { filled: boolean }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill={filled ? 'currentColor' : 'none'}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    width="16"
+    height="16"
+  >
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
+const ContextTrashIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    width="16"
+    height="16"
+  >
+    <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+}
+
 export interface QueueItemProps {
   track: MediaTrack;
   index: number;
@@ -62,6 +106,55 @@ export interface QueueItemProps {
   showProviderIcon?: boolean;
   isDragActive?: boolean;
   isEditMode?: boolean;
+}
+
+function useQueueItemContextMenu(
+  track: MediaTrack,
+  index: number,
+  isSelected: boolean,
+  onSelect: (index: number) => void,
+  onRemove?: (index: number) => void,
+) {
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const { isLiked, handleLikeToggle, canSaveTrack } = useLikeTrack(track.id, track.provider);
+  const pointerPosRef = useRef({ x: 0, y: 0 });
+
+  const closeMenu = useCallback(() => setMenu(null), []);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  const onLongPress = useCallback(() => {
+    setMenu({ x: pointerPosRef.current.x, y: pointerPosRef.current.y });
+  }, []);
+
+  const baseLongPressHandlers = useLongPress({ onLongPress, enabled: true });
+
+  const longPressHandlers = {
+    ...baseLongPressHandlers,
+    onPointerDown: useCallback((e: React.PointerEvent) => {
+      pointerPosRef.current = { x: e.clientX, y: e.clientY };
+      baseLongPressHandlers.onPointerDown(e);
+    }, [baseLongPressHandlers]),
+  };
+
+  const options = [
+    {
+      label: 'Play now',
+      icon: <ContextPlayIcon />,
+      onClick: () => onSelect(index),
+    },
+    ...(canSaveTrack
+      ? [{ label: isLiked ? 'Unlike' : 'Like', icon: <HeartIcon filled={isLiked} />, onClick: handleLikeToggle }]
+      : []),
+    ...(!isSelected && onRemove
+      ? [{ label: 'Remove from queue', icon: <ContextTrashIcon />, onClick: () => onRemove(index), destructive: true }]
+      : []),
+  ];
+
+  return { menu, closeMenu, handleContextMenu, longPressHandlers, options };
 }
 
 export const SortableQueueItem = memo<QueueItemProps>(({
@@ -103,12 +196,18 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index]);
 
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+    track, index, isSelected, onSelect, onRemove
+  );
+
   return (
     <div ref={setNodeRef} style={style}>
       <QueueListItem
         ref={itemRef}
         onClick={handleClick}
+        onContextMenu={handleContextMenu}
         isSelected={isSelected}
+        {...longPressHandlers}
       >
         {isEditMode && onRemove && (
           <DragHandle {...attributes} {...listeners}>
@@ -150,6 +249,15 @@ export const SortableQueueItem = memo<QueueItemProps>(({
           </RemoveButton>
         )}
       </QueueListItem>
+
+      {menu && (
+        <QueueContextMenu
+          x={menu.x}
+          y={menu.y}
+          options={options}
+          onClose={closeMenu}
+        />
+      )}
     </div>
   );
 });
@@ -180,64 +288,21 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index, reset]);
 
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+    track, index, isSelected, onSelect, onRemove
+  );
+
   if (!canRemove) {
     return (
-      <QueueListItem
-        ref={itemRef}
-        onClick={() => {
-          if (!isEditMode) onSelect(index);
-        }}
-        isSelected={isSelected}
-      >
-        <AlbumArtContainer>
-          <Avatar
-            src={track.image}
-            alt={track.album}
-            style={{ width: '3rem', height: '3rem' }}
-            fallback={<AlbumFallbackIcon />}
-          />
-          {isSelected && <PlayingIcon />}
-          {showProviderIcon && track.provider && (
-            <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
-              <ProviderIcon provider={track.provider} size={16} />
-            </div>
-          )}
-        </AlbumArtContainer>
-
-        <TrackInfo>
-          <TrackName isSelected={isSelected}>
-            {track.name}
-          </TrackName>
-          <TrackArtist isSelected={isSelected}>
-            {track.artists}
-          </TrackArtist>
-        </TrackInfo>
-
-        <Duration isSelected={isSelected}>
-          {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
-        </Duration>
-      </QueueListItem>
-    );
-  }
-
-  return (
-    <SwipeableWrapper ref={swipeRef}>
-      {(offsetX < 0 || isRevealed) && (
-        <SwipeRemoveBackdrop>
-          <button
-            onClick={handleRemoveClick}
-            style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '8px 16px', font: 'inherit', fontWeight: 600 }}
-            aria-label={`Remove ${track.name}`}
-          >
-            Remove
-          </button>
-        </SwipeRemoveBackdrop>
-      )}
-      <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
+      <>
         <QueueListItem
           ref={itemRef}
-          onClick={() => !isRevealed && !isEditMode && onSelect(index)}
+          onClick={() => {
+            if (!isEditMode) onSelect(index);
+          }}
+          onContextMenu={handleContextMenu}
           isSelected={isSelected}
+          {...longPressHandlers}
         >
           <AlbumArtContainer>
             <Avatar
@@ -246,6 +311,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
               style={{ width: '3rem', height: '3rem' }}
               fallback={<AlbumFallbackIcon />}
             />
+            {isSelected && <PlayingIcon />}
             {showProviderIcon && track.provider && (
               <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
                 <ProviderIcon provider={track.provider} size={16} />
@@ -266,7 +332,79 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
           </Duration>
         </QueueListItem>
-      </SwipeableContent>
-    </SwipeableWrapper>
+
+        {menu && (
+          <QueueContextMenu
+            x={menu.x}
+            y={menu.y}
+            options={options}
+            onClose={closeMenu}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SwipeableWrapper ref={swipeRef}>
+        {(offsetX < 0 || isRevealed) && (
+          <SwipeRemoveBackdrop>
+            <button
+              onClick={handleRemoveClick}
+              style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '8px 16px', font: 'inherit', fontWeight: 600 }}
+              aria-label={`Remove ${track.name}`}
+            >
+              Remove
+            </button>
+          </SwipeRemoveBackdrop>
+        )}
+        <SwipeableContent $offsetX={offsetX} $isSwiping={isSwiping}>
+          <QueueListItem
+            ref={itemRef}
+            onClick={() => !isRevealed && !isEditMode && onSelect(index)}
+            onContextMenu={handleContextMenu}
+            isSelected={isSelected}
+            {...longPressHandlers}
+          >
+            <AlbumArtContainer>
+              <Avatar
+                src={track.image}
+                alt={track.album}
+                style={{ width: '3rem', height: '3rem' }}
+                fallback={<AlbumFallbackIcon />}
+              />
+              {showProviderIcon && track.provider && (
+                <div style={{ position: 'absolute', bottom: -2, right: -2, zIndex: 2 }}>
+                  <ProviderIcon provider={track.provider} size={16} />
+                </div>
+              )}
+            </AlbumArtContainer>
+
+            <TrackInfo>
+              <TrackName isSelected={isSelected}>
+                {track.name}
+              </TrackName>
+              <TrackArtist isSelected={isSelected}>
+                {track.artists}
+              </TrackArtist>
+            </TrackInfo>
+
+            <Duration isSelected={isSelected}>
+              {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
+            </Duration>
+          </QueueListItem>
+        </SwipeableContent>
+      </SwipeableWrapper>
+
+      {menu && (
+        <QueueContextMenu
+          x={menu.x}
+          y={menu.y}
+          options={options}
+          onClose={closeMenu}
+        />
+      )}
+    </>
   );
 });


### PR DESCRIPTION
## Summary
- Adds `QueueContextMenu` component: portal-rendered, backdrop overlay, viewport clamping, Escape key support, fade-in animation
- Right-click triggers context menu on desktop queue tracks
- Long-press (500ms) triggers context menu on mobile, using existing `useLongPress` hook at `src/hooks/useLongPress.ts`
- Context menu actions:
  - **Play now** — select the track for immediate playback
  - **Like / Unlike** — toggle liked state (only shown when provider supports `hasSaveTrack`)
  - **Remove from queue** — removes track (hidden when track is currently playing)
- Styled with existing theme tokens (popover background, z-index, border radius, error color)

Closes #451

## Test plan
- [ ] Right-click on a queue track shows the context menu (desktop)
- [ ] Long-press on a queue track shows the context menu (mobile/touch)
- [ ] "Play now" plays the selected track
- [ ] "Like"/"Unlike" toggles liked state (only visible when provider supports it)
- [ ] "Remove from queue" removes the track (not shown for currently-playing track)
- [ ] Pressing Escape closes the menu
- [ ] Clicking outside the menu closes it
- [ ] Menu is clamped to viewport edges (doesn't overflow)
- [ ] No TypeScript errors: `npx tsc -b --noEmit` passes