### PR TITLE
feat: enable full-item drag in queue edit mode

### DIFF
--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -208,9 +208,11 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         onContextMenu={handleContextMenu}
         isSelected={isSelected}
         {...longPressHandlers}
+        {...(isEditMode && onRemove ? { ...attributes, ...listeners } : {})}
+        style={isEditMode && onRemove ? { cursor: isDragging ? 'grabbing' : 'grab', touchAction: 'none' } : undefined}
       >
         {isEditMode && onRemove && (
-          <DragHandle {...attributes} {...listeners}>
+          <DragHandle>
             <GripIcon />
           </DragHandle>
         )}


### PR DESCRIPTION
## Summary
- Makes entire queue track item draggable in edit mode
- Grip icon remains as visual affordance
- Normal (non-edit) mode unaffected

Closes #478

## Test plan
- [ ] In edit mode, drag from any part of track item to reorder
- [ ] Grip icon still visible
- [ ] Normal mode: clicking tracks still selects/plays them
- [ ] Drag-and-drop reorder still works correctly