### PR TITLE
cleanup: standardize hook file structure

### DIFF
--- a/src/hooks/__tests__/useRadioSession.test.ts
+++ b/src/hooks/__tests__/useRadioSession.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useRadioSession } from '../useRadioSession';
-import type { RadioProgress } from '../useRadioSession';
+import type { RadioProgress } from '@/types/radio';
 import { makeMediaTrack, makeProviderDescriptor } from '@/test/fixtures';
 import type { MediaTrack } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';

--- a/src/hooks/useAccentColor.ts
+++ b/src/hooks/useAccentColor.ts
@@ -1,101 +1,9 @@
-/**
- * @fileoverview useAccentColor Hook
- *
- * Custom hook for managing accent color extraction and overrides in the Vorbis Player.
- * Handles automatic color extraction from album artwork and manual color overrides.
- *
- * @architecture
- * This hook encapsulates the logic for extracting dominant colors from album artwork
- * and managing manual color overrides. It provides a clean interface for accent color
- * management while maintaining separation of concerns from the main component.
- *
- * @responsibilities
- * - Extract dominant colors from album artwork
- * - Manage manual accent color overrides
- * - Handle color fallbacks and error states
- * - Provide color change handlers
- *
- * @features
- * - Automatic color extraction from track images
- * - Manual color override system
- * - Per-track color persistence
- * - Fallback to theme default colors
- * - Error handling for extraction failures
- *
- * @performance
- * - Uses memoized callbacks to prevent unnecessary re-renders
- * - Leverages existing color extraction caching
- * - Efficient state updates with useCallback
- *
- * @usage
- * ```typescript
- * const {
- *   accentColor,
- *   handleAccentColorChange,
- *   resetToAutoColor
- * } = useAccentColor(currentTrack, accentColorOverrides, setAccentColor, setAccentColorOverrides);
- * ```
- *
- * @dependencies
- * - extractDominantColor: Color extraction utility
- * - theme: Design system tokens
- *
- * @author Vorbis Player Team
- * @version 1.0.0
- */
-
 import { useCallback, useEffect, startTransition } from 'react';
-import { extractDominantColor } from '../utils/colorExtractor';
-import { theme } from '@/styles/theme';
-import { isProfilingEnabled } from '@/contexts/ProfilingContext';
 import type { MediaTrack } from '@/types/domain';
+import { isProfilingEnabled } from '@/contexts/ProfilingContext';
+import { theme } from '@/styles/theme';
+import { extractDominantColor } from '../utils/colorExtractor';
 
-/**
- * useAccentColor - Custom hook for accent color management
- *
- * Manages accent color extraction from album artwork and manual color overrides.
- * Provides handlers for color changes and automatic extraction logic.
- *
- * @hook
- *
- * @param currentTrack - The currently selected track with image data
- * @param accentColorOverrides - Map of manual color overrides per track
- * @param setAccentColor - State setter for the current accent color
- * @param setAccentColorOverrides - State setter for color overrides map
- *
- * @returns Object containing accent color management functions
- *
- * @example
- * ```typescript
- * const {
- *   handleAccentColorChange,
- *   resetToAutoColor
- * } = useAccentColor(
- *   currentTrack,
- *   accentColorOverrides,
- *   setAccentColor,
- *   setAccentColorOverrides
- * );
- *
- * // Handle manual color change
- * handleAccentColorChange('#ff6b6b');
- *
- * // Reset to extracted color
- * resetToAutoColor();
- * ```
- *
- * @features
- * - Automatic color extraction when track changes
- * - Manual color override with persistence
- * - Intelligent fallback to theme colors
- * - Error handling for extraction failures
- * - Reset functionality to return to auto-extracted colors
- *
- * @sideEffects
- * - Updates accent color state when track changes
- * - Triggers color extraction from album artwork
- * - Persists color overrides in state
- */
 export const useAccentColor = (
   currentTrack: MediaTrack | null,
   accentColorOverrides: Record<string, string>,
@@ -143,23 +51,14 @@ export const useAccentColor = (
     }
   }, [albumId, albumImage, albumOverride, setAccentColor]);
 
-  /**
-   * Handle manual accent color changes
-   *
-   * Manages both automatic extraction and manual color overrides.
-   * When color is 'auto', triggers re-extraction from artwork.
-   * Otherwise, saves the manual override for the current track.
-   *
-   * @param color - The new accent color ('auto' for extraction, or hex color)
-   */
   const handleAccentColorChange = useCallback((color: string) => {
-    const albumId = currentTrack?.albumId;
+    const currentAlbumId = currentTrack?.albumId;
 
     if (color === 'auto') {
-      if (albumId) {
+      if (currentAlbumId) {
         setAccentColorOverrides(prev => {
           const newOverrides = { ...prev };
-          delete newOverrides[albumId];
+          delete newOverrides[currentAlbumId];
           return newOverrides;
         });
       }
@@ -182,26 +81,20 @@ export const useAccentColor = (
       return;
     }
 
-    if (albumId) {
-      setAccentColorOverrides(prev => ({ ...prev, [albumId]: color }));
+    if (currentAlbumId) {
+      setAccentColorOverrides(prev => ({ ...prev, [currentAlbumId]: color }));
       setAccentColor(color);
     } else {
       setAccentColor(color);
     }
   }, [currentTrack?.albumId, currentTrack?.image, setAccentColorOverrides, setAccentColor]);
 
-  /**
-   * Reset to automatically extracted color
-   *
-   * Removes any manual override for the current track and triggers
-   * automatic color extraction from the artwork.
-   */
   const resetToAutoColor = useCallback(() => {
     handleAccentColorChange('auto');
   }, [handleAccentColorChange]);
 
   return {
     handleAccentColorChange,
-    resetToAutoColor
+    resetToAutoColor,
   };
 };

--- a/src/hooks/useAnimationFrame.ts
+++ b/src/hooks/useAnimationFrame.ts
@@ -1,25 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-/**
- * useAnimationFrame Hook
- * 
- * Custom hook for running animations using requestAnimationFrame.
- * Provides a clean way to manage animation loops with proper cleanup.
- * 
- * @hook
- * 
- * @param callback - Function to call on each animation frame. Receives current timestamp.
- * 
- * @example
- * ```typescript
- * useAnimationFrame((time) => {
- *   // Update animation state
- *   updateParticles(time);
- * });
- * ```
- * 
- * @returns void
- */
 export function useAnimationFrame(callback: (time: number) => void) {
   const requestRef = useRef<number>();
   const previousTimeRef = useRef<number>();
@@ -42,4 +22,3 @@ export function useAnimationFrame(callback: (time: number) => void) {
     };
   }, [callback]);
 }
-

--- a/src/hooks/useImageProcessingWorker.ts
+++ b/src/hooks/useImageProcessingWorker.ts
@@ -4,7 +4,7 @@ import type {
   ImageProcessingRequest, 
   ImageProcessingResponse, 
   ImageProcessingError 
-} from '../workers/imageProcessor.worker';
+} from '@/workers/imageProcessor.worker';
 
 interface UseImageProcessingWorkerReturn {
   processImage: (

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,22 +1,3 @@
-/**
-  * Centralized keyboard shortcuts hook for the player
-  * Consolidates all keyboard event handling in one place
-  *
-  * Supported shortcuts:
-  * - Space: Play/Pause
-  * - ArrowRight: Next track
-  * - ArrowLeft: Previous track
-  * - V: Toggle background visualizations
-  * - S: Toggle visual effects menu
-  * - G: Toggle glow effect
-  * - ?: Show keyboard shortcuts help
-  * - Escape: Close menus (queue drawer and visual effects)
-  * - M: Mute
-  * - ArrowUp / Q: (Pointer device) Toggle queue drawer; (Touch) ArrowUp = Volume up
-  * - ArrowDown / L: (Pointer device) Toggle library drawer; (Touch) ArrowDown = Volume down
-  * - K: Like/Unlike track
-  */
-
 import { useEffect } from 'react';
 
 interface KeyboardShortcutOptions {
@@ -25,29 +6,16 @@ interface KeyboardShortcutOptions {
 }
 
 interface KeyboardShortcutHandlers {
-  // Playback controls
   onPlayPause?: () => void;
   onNext?: () => void;
   onPrevious?: () => void;
-  
-  // Menu toggles
   onCloseQueue?: () => void;
   onToggleVisualEffectsMenu?: () => void;
   onCloseVisualEffects?: () => void;
-  
-  // Background visualizer
   onToggleBackgroundVisualizer?: () => void;
-  
-  // Glow effect
   onToggleGlow?: () => void;
-
-  // Translucence
   onToggleTranslucence?: () => void;
-
-  // Help
   onToggleHelp?: () => void;
-  
-  // Other
   onMute?: () => void;
   onVolumeUp?: () => void;
   onVolumeDown?: () => void;
@@ -62,20 +30,12 @@ interface KeyboardShortcutHandlers {
   onToggleZenMode?: () => void;
 }
 
-/**
- * Central keyboard shortcuts management hook
- * Prevents handler duplication across multiple components
- * 
- * @param handlers - Object containing callback functions for each shortcut
- * @param options - Configuration options (e.g. prefersPointerInput for drawer shortcuts)
- */
 export const useKeyboardShortcuts = (
   handlers: KeyboardShortcutHandlers,
   options?: KeyboardShortcutOptions
 ) => {
   const prefersPointerInput = options?.prefersPointerInput ?? false;
 
-  // Destructure handlers to avoid capturing entire object
   const {
     onPlayPause,
     onNext,
@@ -100,21 +60,17 @@ export const useKeyboardShortcuts = (
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Don't intercept keyboard events when typing in input fields
-      if (event.target instanceof HTMLInputElement || 
+      if (event.target instanceof HTMLInputElement ||
           event.target instanceof HTMLTextAreaElement) {
         return;
       }
 
-      // Check if target is contentEditable
       const target = event.target as HTMLElement;
       if (target && target.isContentEditable) {
         return;
       }
 
-      // Handle different key combinations
       switch (event.code) {
-        // Playback controls
         case 'Space':
           event.preventDefault();
           onPlayPause?.();
@@ -130,9 +86,7 @@ export const useKeyboardShortcuts = (
           onPrevious?.();
           break;
 
-        // Menu toggles
         case 'KeyV':
-          // V toggles background visualizations
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleBackgroundVisualizer?.();
@@ -140,7 +94,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyS':
-          // S toggles visual effects menu
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleVisualEffectsMenu?.();
@@ -148,7 +101,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyG':
-          // G toggles glow effect
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleGlow?.();
@@ -156,7 +108,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyT':
-          // T toggles translucence
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleTranslucence?.();
@@ -164,14 +115,12 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'Slash':
-          // / or ? (Shift+/) shows help modal
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleHelp?.();
           }
           break;
 
-        // Close menus
         case 'Escape':
           event.preventDefault();
           onCloseVisualEffects?.();
@@ -179,14 +128,12 @@ export const useKeyboardShortcuts = (
           onCloseMobileMenu?.();
           break;
 
-        // Volume controls
         case 'KeyM':
           event.preventDefault();
           onMute?.();
           break;
 
         case 'KeyL':
-          // L toggles library drawer (alternative to ArrowDown on pointer devices)
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onOpenLibraryDrawer?.();
@@ -194,7 +141,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyK':
-          // K toggles like/unlike
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleLike?.();
@@ -202,7 +148,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyQ':
-          // Q toggles queue drawer (alternative to ArrowUp on pointer devices)
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onShowQueue?.();
@@ -210,7 +155,6 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'KeyZ':
-          // Z toggles zen mode
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
             onToggleZenMode?.();

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -1,36 +1,12 @@
-/**
- * React hook that connects the LibrarySyncEngine to component state.
- *
- * Multi-provider aware: fetches collections from ALL enabled providers
- * simultaneously and merges results. Spotify uses the LibrarySyncEngine
- * (with IndexedDB cache and background polling); other providers call
- * catalog.listCollections() directly.
- */
-
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { librarySyncEngine } from '../services/cache/librarySyncEngine';
-import type { CachedPlaylistInfo, SyncState } from '../services/cache/cacheTypes';
-import type { AlbumInfo } from '../services/spotify';
-import { useProviderContext } from '../contexts/ProviderContext';
-import type { MediaCollection, ProviderId } from '../types/domain';
-import { providerRegistry } from '../providers/registry';
-import { logLibrary } from '../lib/debugLog';
-import { getOrSetFirstSeenAddedAtIso } from '../utils/libraryFirstSeen';
-
-function splitCollections(collections: MediaCollection[]): { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[] } {
-  const playlists: CachedPlaylistInfo[] = [];
-  const albums: AlbumInfo[] = [];
-  let playlistOrdinal = 0;
-  let albumOrdinal = 0;
-  for (const c of collections) {
-    if (c.kind === 'album') {
-      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
-    } else {
-      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
-    }
-  }
-  return { playlists, albums };
-}
+import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { MediaCollection, ProviderId } from '@/types/domain';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { providerRegistry } from '@/providers/registry';
+import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { logLibrary } from '@/lib/debugLog';
+import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
 
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
@@ -57,10 +33,6 @@ interface UseLibrarySyncResult {
   removeCollection: (collectionId: string) => void;
 }
 
-/**
- * Map a MediaCollection to CachedPlaylistInfo shape so the library UI can
- * render it regardless of provider.
- */
 function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
   return {
     id: c.id,
@@ -75,9 +47,6 @@ function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPl
   };
 }
 
-/**
- * Map a MediaCollection (album/folder kind) to AlbumInfo shape.
- */
 function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
   return {
     id: c.id,
@@ -91,6 +60,21 @@ function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
     provider: c.provider,
     added_at: getOrSetFirstSeenAddedAtIso(c.provider, `album:${c.id}`, ordinal),
   };
+}
+
+function splitCollections(collections: MediaCollection[]): { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[] } {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  let playlistOrdinal = 0;
+  let albumOrdinal = 0;
+  for (const c of collections) {
+    if (c.kind === 'album') {
+      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
+    } else {
+      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
+    }
+  }
+  return { playlists, albums };
 }
 
 export function useLibrarySync(): UseLibrarySyncResult {
@@ -108,11 +92,8 @@ export function useLibrarySync(): UseLibrarySyncResult {
 
   const engineRef = useRef(librarySyncEngine);
 
-  // The library sync engine manages one provider (currently Spotify) with IndexedDB cache + polling.
-  // All other providers fetch via catalog.listCollections() directly.
   const engineProviderId = librarySyncEngine.providerId as ProviderId | undefined;
 
-  // Per-provider data stored in refs so we can merge without re-fetching all
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,
   });
@@ -121,7 +102,6 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
   const catalogProviderIds = enabledProviderIds.filter(id => id !== engineProviderId);
 
-  // Merge all provider data into combined state
   const mergeAndSetData = useCallback(() => {
     const allPlaylists: CachedPlaylistInfo[] = [];
     const allAlbums: AlbumInfo[] = [];
@@ -154,7 +134,6 @@ export function useLibrarySync(): UseLibrarySyncResult {
     setLikedSongsPerProvider(perProvider);
   }, [isEngineProviderEnabled, engineProviderId, enabledProviderIds]);
 
-  // ── Engine provider path: delegate to existing sync engine ──────────────
   useEffect(() => {
     if (!isEngineProviderEnabled || !engineProviderId) {
       engineDataRef.current = { playlists: [], albums: [], likedCount: 0 };
@@ -196,7 +175,6 @@ export function useLibrarySync(): UseLibrarySyncResult {
     };
   }, [isEngineProviderEnabled, engineProviderId, mergeAndSetData]);
 
-  // ── Catalog providers path: call catalog.listCollections() for each provider not using the sync engine ───
   useEffect(() => {
     if (catalogProviderIds.length === 0) {
       catalogDataRef.current.clear();
@@ -262,7 +240,6 @@ export function useLibrarySync(): UseLibrarySyncResult {
     };
   }, [[...catalogProviderIds].sort().join(','), getDescriptor, mergeAndSetData]);
 
-  // ── Listen for likes-changed events to update count in real-time ──────
   useEffect(() => {
     const cleanups: Array<() => void> = [];
     for (const providerId of catalogProviderIds) {

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,45 +1,8 @@
-/**
- * @fileoverview useLocalStorage Hook
- * 
- * Generic hook for managing persistent state with localStorage.
- * Handles JSON serialization, error handling, and automatic persistence.
- * 
- * @architecture
- * This hook provides a simple API similar to useState but with automatic
- * localStorage persistence. It centralizes all localStorage logic and makes
- * it easy to mock/test.
- * 
- * @usage
- * ```typescript
- * const [value, setValue] = useLocalStorage('my-key', defaultValue);
- * ```
- */
-
 import { useState, useEffect, useCallback } from 'react';
 
-/**
- * useLocalStorage - Generic hook for persistent state with localStorage
- * 
- * Manages state that persists across browser sessions using localStorage.
- * Handles JSON serialization, error handling, and multi-tab synchronization.
- * 
- * @template T - The type of value being stored
- * @param key - The localStorage key
- * @param initialValue - The default value if nothing is stored
- * @returns [value, setValue] - Similar to useState but with persistence
- * 
- * @example
- * ```typescript
- * const [theme, setTheme] = useLocalStorage('app-theme', 'light');
- * const [filters, setFilters] = useLocalStorage('album-filters', defaultFilters);
- * ```
- */
 export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] => {
-  // State to store our value
-  // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
-      // Get from local storage by key
       const item = window.localStorage.getItem(key);
       if (item) {
         return JSON.parse(item);
@@ -51,28 +14,23 @@ export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T 
     }
   });
 
-  // Return a wrapped version of useState's setter function that
-  // persists the new value to localStorage
   const setValue = useCallback(
     (value: T | ((val: T) => T)) => {
-      // Allow value to be a function so we have same API as useState
       setStoredValue((prevStoredValue) => {
         const valueToStore = value instanceof Function ? value(prevStoredValue) : value;
-        
+
         try {
-          // Save to local storage
           window.localStorage.setItem(key, JSON.stringify(valueToStore));
         } catch (error) {
           console.warn(`Failed to write "${key}" to localStorage:`, error);
         }
-        
+
         return valueToStore;
       });
     },
     [key]
   );
 
-  // Listen for changes in other tabs/windows
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === key && e.newValue) {

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -20,10 +20,7 @@ import { useQueueManagement } from './useQueueManagement';
 import { useCollectionLoader } from './useCollectionLoader';
 import { usePlaybackSubscription } from './usePlaybackSubscription';
 import { useRadioSession } from './useRadioSession';
-import type { RadioProgress, RadioProgressPhase } from '@/types/radio';
-
-export type { RadioProgressPhase, RadioProgress };
-
+import type { RadioProgress } from '@/types/radio';
 
 export function usePlayerLogic() {
   // Terminology used in this hook:

--- a/src/hooks/usePlayerSizing.ts
+++ b/src/hooks/usePlayerSizing.ts
@@ -3,7 +3,7 @@ import type {
   ViewportInfo, 
   PlayerDimensions, 
   SizingConstraints
-} from '../utils/sizingUtils';
+} from '@/utils/sizingUtils';
 import {
   getViewportInfo,
   calculatePlayerDimensions,
@@ -11,13 +11,13 @@ import {
   calculateOptimalPadding,
   getOptimalAspectRatio,
   calculateAspectRatioConstraints
-} from '../utils/sizingUtils';
+} from '@/utils/sizingUtils';
 import {
   detectBrowserFeatures,
   getEnhancedViewportInfo,
   createEnhancedEventListeners,
   type BrowserFeatures
-} from '../utils/featureDetection';
+} from '@/utils/featureDetection';
 
 interface UsePlayerSizingReturn {
   dimensions: PlayerDimensions;

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -1,21 +1,10 @@
-/**
- * Centralized state management hook for the entire Vorbis Player application.
- * 
- * Manages tracks, playback state, visual effects, and user preferences with
- * persistent storage and performance optimizations. Serves as the single source
- * of truth for all player-related state.
- */
-
 import { useState, useEffect, useCallback } from 'react';
 import type { MediaTrack } from '@/types/domain';
+import type { VisualizerStyle } from '@/types/visualizer';
 import { theme } from '@/styles/theme';
-import type { VisualizerStyle } from '../types/visualizer';
-import { useLocalStorage } from './useLocalStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { useLocalStorage } from './useLocalStorage';
 
-/**
- * Internal state type definitions
- */
 interface TrackState {
   tracks: MediaTrack[];
   originalTracks: MediaTrack[];
@@ -112,13 +101,6 @@ interface PlayerStateSetters {
   };
 }
 
-/**
- * Global player state management hook.
- * 
- * Centralized state management for the entire player application.
- * Manages tracks, playback state, visual effects, and user preferences
- * with persistent storage and performance optimizations.
- */
 export function usePlayerState(): PlayerState & PlayerStateSetters {
   const [tracks, setTracks] = useState<MediaTrack[]>([]);
   const [originalTracks, setOriginalTracks] = useState<MediaTrack[]>([]);
@@ -138,17 +120,17 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
     STORAGE_KEYS.VISUAL_EFFECTS_ENABLED,
     true
   );
-  
+
   const [perAlbumGlow, setPerAlbumGlow] = useLocalStorage<Record<string, { intensity: number; rate: number }>>(
     STORAGE_KEYS.PER_ALBUM_GLOW,
     {}
   );
-  
+
   const [accentColorOverrides, setAccentColorOverrides] = useLocalStorage<Record<string, string>>(
     STORAGE_KEYS.ACCENT_COLOR_OVERRIDES,
     {}
   );
-  
+
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>(
     STORAGE_KEYS.BG_VISUALIZER_ENABLED,
     true
@@ -184,7 +166,7 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
   const handleSetAccentColorOverride = useCallback((albumId: string, color: string) => {
     setAccentColorOverrides(prev => ({
       ...prev,
-      [albumId]: color
+      [albumId]: color,
     }));
   }, [setAccentColorOverrides]);
 
@@ -203,15 +185,15 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
       currentIndex: currentTrackIndex,
       isLoading,
       error,
-      shuffleEnabled
+      shuffleEnabled,
     },
     queue: {
       selectedId: selectedPlaylistId,
-      isVisible: showQueue
+      isVisible: showQueue,
     },
     color: {
       current: accentColor,
-      overrides: accentColorOverrides
+      overrides: accentColorOverrides,
     },
     visualEffects: {
       enabled: visualEffectsEnabled,
@@ -220,15 +202,15 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
       backgroundVisualizer: {
         enabled: backgroundVisualizerEnabled,
         style: backgroundVisualizerStyle,
-        intensity: backgroundVisualizerIntensity
+        intensity: backgroundVisualizerIntensity,
       },
       accentColorBackground: {
         enabled: accentColorBackgroundEnabled,
-        preferred: accentColorBackgroundPreferred
-      }
+        preferred: accentColorBackgroundPreferred,
+      },
     },
     zenMode: {
-      enabled: zenModeEnabled
+      enabled: zenModeEnabled,
     },
     actions: {
       track: {
@@ -237,18 +219,18 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
         setCurrentIndex: setCurrentTrackIndex,
         setLoading: setIsLoading,
         setError,
-        setShuffleEnabled
+        setShuffleEnabled,
       },
       queue: {
         setSelectedId: setSelectedPlaylistId,
-        setVisible: setShowQueue
+        setVisible: setShowQueue,
       },
       color: {
         setCurrent: setAccentColor,
         setOverrides: setAccentColorOverrides,
         handleSetAccentColorOverride,
         handleRemoveAccentColorOverride,
-        handleResetAccentColorOverride: handleRemoveAccentColorOverride
+        handleResetAccentColorOverride: handleRemoveAccentColorOverride,
       },
       visualEffects: {
         setEnabled: setVisualEffectsEnabled,
@@ -257,15 +239,15 @@ export function usePlayerState(): PlayerState & PlayerStateSetters {
         backgroundVisualizer: {
           setEnabled: setBackgroundVisualizerEnabled,
           setStyle: setBackgroundVisualizerStyle,
-          setIntensity: setBackgroundVisualizerIntensity
+          setIntensity: setBackgroundVisualizerIntensity,
         },
         accentColorBackground: {
-          setPreferred: setAccentColorBackgroundPreferred
-        }
+          setPreferred: setAccentColorBackgroundPreferred,
+        },
       },
       zenMode: {
-        setEnabled: setZenModeEnabled
-      }
-    }
+        setEnabled: setZenModeEnabled,
+      },
+    },
   };
 }

--- a/src/hooks/useRadio.ts
+++ b/src/hooks/useRadio.ts
@@ -1,18 +1,9 @@
-/**
- * useRadio — React hook for radio state management.
- *
- * Manages starting radio sessions from tracks, artists, or albums.
- * Provider-agnostic: works with any catalog of MediaTracks.
- */
-
 import { useState, useCallback, useRef } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import type { RadioSeed, RadioResult, RadioState } from '@/types/radio';
 import { generateRadioQueue } from '@/services/radioService';
 import { isLastFmConfigured } from '@/services/lastfm';
 import { logRadio } from '@/lib/debugLog';
-
-export type { RadioState };
 
 interface UseRadioReturn {
   radioState: RadioState;

--- a/src/hooks/useRadioSession.ts
+++ b/src/hooks/useRadioSession.ts
@@ -2,13 +2,12 @@ import { useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import type { RadioSeed, RadioProgressPhase, RadioProgress } from '@/types/radio';
+import type { RadioSeed, RadioProgress } from '@/types/radio';
 import { RADIO_PLAYLIST_ID } from '@/constants/playlist';
 import { providerRegistry } from '@/providers/registry';
 import { runRadioPipeline } from '@/services/radioPipeline';
 import { queueSnapshot } from './playerLogicUtils';
 
-export type { RadioProgressPhase, RadioProgress };
 
 interface UseRadioSessionProps {
   trackOps: Pick<TrackOperations, 'setError' | 'setTracks' | 'setOriginalTracks' | 'setCurrentTrackIndex' | 'setSelectedPlaylistId' | 'mediaTracksRef'>;

--- a/src/hooks/useVisualEffectsState.ts
+++ b/src/hooks/useVisualEffectsState.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
-import { DEFAULT_GLOW_INTENSITY, DEFAULT_GLOW_RATE } from '../components/AccentColorGlowOverlay';
+import { DEFAULT_GLOW_INTENSITY, DEFAULT_GLOW_RATE } from '@/components/AccentColorGlowOverlay';
 import { useLocalStorage } from './useLocalStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
 

--- a/src/hooks/useVolume.ts
+++ b/src/hooks/useVolume.ts
@@ -4,6 +4,7 @@ import { useProviderContext } from '@/contexts/ProviderContext';
 import { providerRegistry } from '@/providers/registry';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ProviderId } from '@/types/domain';
+
 const DEFAULT_VOLUME = 50;
 
 export const useVolume = (currentTrackProvider?: ProviderId) => {


### PR DESCRIPTION
## Summary
- Standardizes hook file structure across src/hooks/
- Consistent ordering: imports → types → hook → export
- No logic or behavior changes

Closes #426

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes
- [x] No behavior changes