### PR TITLE
feat: reassign S to shuffle, Shift+S to settings

### DIFF
--- a/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
@@ -105,6 +105,7 @@ describe('Keyboard Shortcuts Integration', () => {
       onToggleGlow: vi.fn(),
       onMute: vi.fn(),
       onToggleLike: vi.fn(),
+      onToggleShuffle: vi.fn(),
       onToggleHelp: vi.fn()
     };
 
@@ -123,11 +124,11 @@ describe('Keyboard Shortcuts Integration', () => {
       { key: 'KeyK', handler: handlers.onToggleLike },
       { key: 'KeyG', handler: handlers.onToggleGlow },
       { key: 'KeyV', handler: handlers.onToggleBackgroundVisualizer },
-      { key: 'KeyO', handler: handlers.onToggleVisualEffectsMenu },
+      { key: 'KeyS', handler: handlers.onToggleShuffle, shift: false },
     ];
 
-    tests.forEach(({ key, handler: expectedHandler }) => {
-      const event = new KeyboardEvent('keydown', { code: key, bubbles: true });
+    tests.forEach(({ key, handler: expectedHandler, shift }) => {
+      const event = new KeyboardEvent('keydown', { code: key, shiftKey: shift || false, bubbles: true });
       Object.defineProperty(event, 'target', { value: document.body, enumerable: true });
       handler(event);
       expect(expectedHandler).toHaveBeenCalled();

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -119,16 +119,32 @@ describe('useKeyboardShortcuts', () => {
     addEventListenerSpy.mockRestore();
   });
 
-  it('should call onToggleVisualEffectsMenu when KeyO is pressed', () => {
+  it('should call onToggleShuffle when KeyS is pressed', () => {
+    const onToggleShuffle = vi.fn();
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+    renderHook(() => useKeyboardShortcuts({ onToggleShuffle }));
+
+    const handler = addEventListenerSpy.mock.calls[0][1] as EventListener;
+    const event = new KeyboardEvent('keydown', { code: 'KeyS', bubbles: true });
+    Object.defineProperty(event, 'target', { value: document.body, enumerable: true });
+    handler(event);
+
+    expect(onToggleShuffle).toHaveBeenCalled();
+    addEventListenerSpy.mockRestore();
+  });
+
+  it('should call onToggleVisualEffectsMenu when Shift+S is pressed', () => {
     const onToggleVisualEffectsMenu = vi.fn();
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
-    
+
     renderHook(() => useKeyboardShortcuts({ onToggleVisualEffectsMenu }));
-    
+
     const handler = addEventListenerSpy.mock.calls[0][1] as EventListener;
-    const event = createKeyboardEvent('KeyO');
+    const event = new KeyboardEvent('keydown', { code: 'KeyS', shiftKey: true, bubbles: true });
+    Object.defineProperty(event, 'target', { value: document.body, enumerable: true });
     handler(event);
-    
+
     expect(onToggleVisualEffectsMenu).toHaveBeenCalled();
     addEventListenerSpy.mockRestore();
   });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -96,7 +96,11 @@ export const useKeyboardShortcuts = (
         case 'KeyS':
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
-            onToggleVisualEffectsMenu?.();
+            if (event.shiftKey) {
+              onToggleVisualEffectsMenu?.();
+            } else {
+              onToggleShuffle?.();
+            }
           }
           break;
 


### PR DESCRIPTION
## Summary
- S now toggles shuffle mode
- Shift+S opens settings/effects menu
- Updates keyboard shortcuts tests to reflect new bindings

Closes #485

## Test plan
- [ ] Press S — shuffle toggles
- [ ] Press Shift+S — settings/effects menu opens
- [ ] Keyboard help overlay shows updated bindings
- [ ] No conflicts with other shortcuts