### PR TITLE
chore: add it.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ Thumbs.db
 .cursor/plans/
 .certs/
 
+# Conversation exports
+it.txt
+
 # Playwright
 test-results/
 


### PR DESCRIPTION
## Summary
- Adds `it.txt` (conversation export artifact) to `.gitignore`

## Test plan
- [x] `it.txt` no longer shows in `git status`