### PR TITLE
feat: auto-hide bottom bar after 1s idle

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -13,7 +13,7 @@ import {
   RadioIcon,
 } from '../icons/QuickActionIcons';
 
-const ZEN_HIDE_DELAY = 3000;
+const AUTOHIDE_DELAY = 1000;
 
 interface BottomBarProps {
   zenModeEnabled?: boolean;
@@ -47,9 +47,9 @@ const BottomBar = React.memo(function BottomBar({
   radioGenerating,
 }: BottomBarProps) {
   const { isMobile, isTablet } = usePlayerSizingContext();
-  const [zenBarVisible, setZenBarVisible] = useState(false);
+  const [barVisible, setBarVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const zenEntryGuardRef = useRef(false);
+  const isHoveringRef = useRef(false);
 
   const clearHideTimer = useCallback(() => {
     if (hideTimerRef.current) {
@@ -61,66 +61,42 @@ const BottomBar = React.memo(function BottomBar({
   const startHideTimer = useCallback(() => {
     clearHideTimer();
     hideTimerRef.current = setTimeout(() => {
-      setZenBarVisible(false);
-    }, ZEN_HIDE_DELAY);
+      setBarVisible(false);
+    }, AUTOHIDE_DELAY);
   }, [clearHideTimer]);
 
   const showBar = useCallback(() => {
-    if (zenEntryGuardRef.current) return;
-    setZenBarVisible(true);
-    startHideTimer();
+    setBarVisible(true);
+    if (!isHoveringRef.current) {
+      startHideTimer();
+    }
   }, [startHideTimer]);
 
   const handleBarMouseEnter = useCallback(() => {
-    if (!zenModeEnabled) return;
-    setZenBarVisible(true);
+    isHoveringRef.current = true;
+    setBarVisible(true);
     clearHideTimer();
-  }, [zenModeEnabled, clearHideTimer]);
-
-  const handleBarMouseLeave = useCallback(() => {
-    if (!zenModeEnabled) return;
-    startHideTimer();
-  }, [zenModeEnabled, startHideTimer]);
-
-  const handleBarInteraction = useCallback(() => {
-    if (!zenModeEnabled) return;
-    clearHideTimer();
-    startHideTimer();
-  }, [zenModeEnabled, clearHideTimer, startHideTimer]);
-
-  useEffect(() => {
-    if (zenModeEnabled) {
-      zenEntryGuardRef.current = true;
-      const guardTimer = setTimeout(() => {
-        zenEntryGuardRef.current = false;
-      }, 500);
-      return () => clearTimeout(guardTimer);
-    } else {
-      zenEntryGuardRef.current = false;
-      setZenBarVisible(false);
-      clearHideTimer();
-    }
-  }, [zenModeEnabled, clearHideTimer]);
-
-  useEffect(() => {
-    return () => clearHideTimer();
   }, [clearHideTimer]);
 
-  const isHidden = zenModeEnabled && !zenBarVisible;
+  const handleBarMouseLeave = useCallback(() => {
+    isHoveringRef.current = false;
+    startHideTimer();
+  }, [startHideTimer]);
+
+  useEffect(() => {
+    startHideTimer();
+    return () => clearHideTimer();
+  }, [startHideTimer, clearHideTimer]);
+
+  const isHidden = !barVisible;
 
   return createPortal(
     <>
-      {zenModeEnabled && (
-        <ZenTriggerZone
-          onMouseEnter={showBar}
-          onTouchStart={showBar}
-        />
-      )}
+      <ZenTriggerZone onMouseEnter={showBar} onTouchStart={showBar} />
       <BottomBarContainer
-        $zenHidden={isHidden}
+        $hidden={isHidden}
         onMouseEnter={handleBarMouseEnter}
         onMouseLeave={handleBarMouseLeave}
-        onClick={handleBarInteraction}
       >
         <BottomBarInner>
           <VolumeControl

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -4,8 +4,8 @@ import { theme } from '@/styles/theme';
 export const BOTTOM_BAR_HEIGHT = 60;
 
 export const BottomBarContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$zenHidden'].includes(prop),
-})<{ $zenHidden?: boolean }>`
+  shouldForwardProp: (prop) => !['$hidden'].includes(prop),
+})<{ $hidden?: boolean }>`
   position: fixed;
   bottom: 0;
   left: 0;
@@ -16,14 +16,10 @@ export const BottomBarContainer = styled.div.withConfig({
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-top: 1px solid ${({ theme }) => theme.colors.popover.border};
   padding-bottom: env(safe-area-inset-bottom, 0px);
-  opacity: ${({ $zenHidden }) => $zenHidden ? 0 : 1};
-  transform: ${({ $zenHidden }) => $zenHidden ? 'translateY(100%)' : 'translateY(0)'};
-  pointer-events: ${({ $zenHidden }) => $zenHidden ? 'none' : 'auto'};
-  /* When revealing (exiting zen): longer fade-in with short delay so it’s not jarring. When hiding: quick. */
-  transition: ${({ $zenHidden, theme }) =>
-    $zenHidden
-      ? `opacity ${theme.transitions.slow} ease, transform ${theme.transitions.slow} ease`
-      : `opacity 0.5s ease-out 0.15s, transform 0.5s ease-out 0.15s`};
+  opacity: ${({ $hidden }) => $hidden ? 0 : 1};
+  transform: ${({ $hidden }) => $hidden ? 'translateY(100%)' : 'translateY(0)'};
+  pointer-events: ${({ $hidden }) => $hidden ? 'none' : 'auto'};
+  transition: opacity 0.3s ease, transform 0.3s ease;
 `;
 
 export const BottomBarInner = styled.div`
@@ -35,7 +31,7 @@ export const BottomBarInner = styled.div`
   height: ${BOTTOM_BAR_HEIGHT}px;
 `;
 
-/** Invisible hover/touch zone at the bottom of the viewport to reveal the bar in zen mode */
+/** Invisible hover/touch zone at the bottom of the viewport to reveal the bar */
 export const ZenTriggerZone = styled.div`
   position: fixed;
   bottom: 0;

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { cardBase } from '@/styles/utils';
-import { BOTTOM_BAR_HEIGHT } from '@/components/BottomBar/styled';
 
 export const ContentWrapper = styled.div.withConfig({
   shouldForwardProp: (prop) => !['width', 'padding', 'useFluidSizing', 'transitionDuration', 'transitionEasing', '$zenMode'].includes(prop),
@@ -17,7 +16,7 @@ export const ContentWrapper = styled.div.withConfig({
 
   margin: 0 auto;
   padding: ${props => props.padding}px;
-  padding-bottom: ${props => props.$zenMode ? props.padding : `calc(${props.padding + BOTTOM_BAR_HEIGHT}px + env(safe-area-inset-bottom, 0px))`};
+  padding-bottom: ${props => props.padding}px;
   box-sizing: border-box;
   position: relative;
   z-index: 2;
@@ -25,7 +24,7 @@ export const ContentWrapper = styled.div.withConfig({
 
   transition: width ${props => props.$zenMode ? '1000ms cubic-bezier(0.4, 0, 0.2, 1) 300ms' : '1000ms cubic-bezier(0.4, 0, 0.2, 1)'},
             padding ${props => props.transitionDuration}ms ${props => props.transitionEasing},
-            padding-bottom ${props => props.$zenMode ? '1000ms cubic-bezier(0.4, 0, 0.2, 1) 300ms' : '1000ms cubic-bezier(0.4, 0, 0.2, 1)'},
+            padding-bottom 1000ms cubic-bezier(0.4, 0, 0.2, 1),
             max-width ${props => props.$zenMode ? '1000ms cubic-bezier(0.4, 0, 0.2, 1) 300ms' : '1000ms cubic-bezier(0.4, 0, 0.2, 1)'};
 
   container-type: inline-size;


### PR DESCRIPTION
## Summary
- Bottom bar auto-hides after 1 second of inactivity in all modes (not just zen mode)
- Reappears on hover/touch via trigger zone at viewport bottom
- Stays visible while user hovers over bar; hides 1s after mouse leaves
- No global pointermove listener (avoids animation feedback loop from CSS transitions)
- Symmetric 0.3s transitions for show/hide; renamed `$zenHidden` → `$hidden`
- Removed `BOTTOM_BAR_HEIGHT` padding-bottom offset from `ContentWrapper` since bar now overlays content

Closes #490

## Test plan
- [ ] Bar visible on load, hides after 1s
- [ ] Move mouse to bottom of screen → bar appears
- [ ] Hover over bar → stays visible
- [ ] Move mouse away → hides after 1s
- [ ] Touch bottom of screen (mobile) → bar appears
- [ ] No flickering or feedback loops
- [ ] Zen mode still works