### PR TITLE
test: add tests for QueueBottomSheet and QueueTrackItem

### DIFF
--- a/src/components/__tests__/QueueBottomSheet.test.tsx
+++ b/src/components/__tests__/QueueBottomSheet.test.tsx
@@ -1,0 +1,163 @@
+import React, { Suspense } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+
+vi.mock('@/hooks/useVerticalSwipeGesture', () => ({
+  useVerticalSwipeGesture: vi.fn(() => ({
+    ref: { current: null },
+    isDragging: false,
+    dragOffset: 0,
+  })),
+}));
+
+vi.mock('@/components/QueueTrackList', () => ({
+  default: ({ tracks, currentTrackIndex, onTrackSelect }: {
+    tracks: { id: string; name: string }[];
+    currentTrackIndex: number;
+    onTrackSelect: (i: number) => void;
+  }) => (
+    <div data-testid="queue-track-list">
+      {tracks.map((t, i) => (
+        <div key={t.id} data-testid={`track-${i}`}>
+          <span>{t.name}</span>
+          <button onClick={() => onTrackSelect(i)}>select</button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import QueueBottomSheet from '../QueueBottomSheet';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <Suspense fallback={<div>Loading...</div>}>
+      {children}
+    </Suspense>
+  </ThemeProvider>
+);
+
+describe('QueueBottomSheet', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    tracks: [
+      makeMediaTrack({ id: 'a', name: 'Track A' }),
+      makeMediaTrack({ id: 'b', name: 'Track B' }),
+    ],
+    currentTrackIndex: 0,
+    onTrackSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders "Queue" title when not in radio mode', () => {
+      // #given
+      render(<Wrapper><QueueBottomSheet {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Queue')).toBeInTheDocument();
+    });
+
+    it('renders "Radio" title when radioActive is true', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueBottomSheet {...defaultProps} radioActive radioSeedDescription="Based on Track A" />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByText('Radio')).toBeInTheDocument();
+    });
+
+    it('renders seed description when radioActive and radioSeedDescription are set', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueBottomSheet {...defaultProps} radioActive radioSeedDescription="Based on Track A" />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByText('Based on Track A')).toBeInTheDocument();
+    });
+
+    it('renders track list when open', () => {
+      // #given
+      render(<Wrapper><QueueBottomSheet {...defaultProps} isOpen={true} /></Wrapper>);
+
+      // #then
+      expect(screen.getByTestId('queue-track-list')).toBeInTheDocument();
+      expect(screen.getByText('Track A')).toBeInTheDocument();
+      expect(screen.getByText('Track B')).toBeInTheDocument();
+    });
+
+    it('does not render track list when closed', () => {
+      // #given
+      render(<Wrapper><QueueBottomSheet {...defaultProps} isOpen={false} /></Wrapper>);
+
+      // #then
+      expect(screen.queryByTestId('queue-track-list')).not.toBeInTheDocument();
+    });
+
+    it('renders save button when canSaveQueue is true', () => {
+      // #given
+      render(
+        <Wrapper>
+          <QueueBottomSheet {...defaultProps} canSaveQueue onSaveQueue={vi.fn()} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByLabelText('Save queue as playlist')).toBeInTheDocument();
+    });
+
+    it('does not render save button when canSaveQueue is false', () => {
+      // #given
+      render(<Wrapper><QueueBottomSheet {...defaultProps} /></Wrapper>);
+
+      // #then
+      expect(screen.queryByLabelText('Save queue as playlist')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClose when overlay is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(<Wrapper><QueueBottomSheet {...defaultProps} onClose={onClose} /></Wrapper>);
+
+      // #when — find the overlay by aria-hidden attribute
+      const overlay = document.body.querySelector('[aria-hidden="true"]');
+      if (overlay) fireEvent.click(overlay);
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onTrackSelect and onClose when a track is selected', () => {
+      // #given
+      const onTrackSelect = vi.fn();
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <QueueBottomSheet {...defaultProps} onTrackSelect={onTrackSelect} onClose={onClose} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getAllByText('select')[1]);
+
+      // #then
+      expect(onTrackSelect).toHaveBeenCalledWith(1);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/__tests__/QueueTrackItem.test.tsx
+++ b/src/components/__tests__/QueueTrackItem.test.tsx
@@ -1,0 +1,238 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  })),
+}));
+
+vi.mock('@/hooks/useHorizontalSwipeToRemove', () => ({
+  useHorizontalSwipeToRemove: vi.fn(() => ({
+    ref: { current: null },
+    offsetX: 0,
+    isSwiping: false,
+    isRevealed: false,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useLongPress', () => ({
+  useLongPress: vi.fn(() => ({
+    onPointerDown: vi.fn(),
+    onPointerUp: vi.fn(),
+    onPointerCancel: vi.fn(),
+    onPointerMove: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useLikeTrack', () => ({
+  useLikeTrack: vi.fn(() => ({
+    isLiked: false,
+    isLikePending: false,
+    handleLikeToggle: vi.fn(),
+    canSaveTrack: false,
+  })),
+}));
+
+vi.mock('@/components/ProviderIcon', () => ({
+  default: () => <span data-testid="provider-icon" />,
+}));
+
+vi.mock('@/components/QueueContextMenu', () => ({
+  QueueContextMenu: () => null,
+}));
+
+import { SortableQueueItem, SwipeableQueueItem } from '../QueueTrackItem';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('SortableQueueItem', () => {
+  const defaultProps = {
+    track: makeMediaTrack({ id: 'track-1', name: 'Test Track', artists: 'Test Artist' }),
+    index: 0,
+    isSelected: false,
+    onSelect: vi.fn(),
+    onRemove: vi.fn(),
+    isDragActive: false,
+    isEditMode: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders track name and artist', () => {
+    // #when
+    render(<Wrapper><SortableQueueItem {...defaultProps} /></Wrapper>);
+
+    // #then
+    expect(screen.getByText('Test Track')).toBeInTheDocument();
+    expect(screen.getByText('Test Artist')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when clicked and not in edit or drag mode', () => {
+    // #given
+    const onSelect = vi.fn();
+    render(<Wrapper><SortableQueueItem {...defaultProps} onSelect={onSelect} /></Wrapper>);
+
+    // #when
+    fireEvent.click(screen.getByText('Test Track'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith(0);
+  });
+
+  it('does not call onSelect when isDragActive is true', () => {
+    // #given
+    const onSelect = vi.fn();
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} onSelect={onSelect} isDragActive={true} />
+      </Wrapper>
+    );
+
+    // #when
+    fireEvent.click(screen.getByText('Test Track'));
+
+    // #then
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not call onSelect when isEditMode is true', () => {
+    // #given
+    const onSelect = vi.fn();
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} onSelect={onSelect} isEditMode={true} />
+      </Wrapper>
+    );
+
+    // #when
+    fireEvent.click(screen.getByText('Test Track'));
+
+    // #then
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows drag handle in edit mode', () => {
+    // #given / #when
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} isEditMode={true} />
+      </Wrapper>
+    );
+
+    // #then — GripIcon renders 6 circles; drag handle container must exist in DOM
+    // The DragHandle wraps the GripIcon SVG; assert at least one circle is present
+    const svgCircles = document.querySelectorAll('circle');
+    expect(svgCircles.length).toBeGreaterThan(0);
+  });
+
+  it('shows remove button in edit mode for non-selected track', () => {
+    // #given / #when
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} isEditMode={true} isSelected={false} />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.getByLabelText('Remove Test Track')).toBeInTheDocument();
+  });
+
+  it('does not show remove button for selected track in edit mode', () => {
+    // #given / #when
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} isEditMode={true} isSelected={true} />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.queryByLabelText('Remove Test Track')).not.toBeInTheDocument();
+  });
+
+  it('calls onRemove when remove button is clicked', () => {
+    // #given
+    const onRemove = vi.fn();
+    render(
+      <Wrapper>
+        <SortableQueueItem {...defaultProps} onRemove={onRemove} isEditMode={true} isSelected={false} />
+      </Wrapper>
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Remove Test Track'));
+
+    // #then
+    expect(onRemove).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('SwipeableQueueItem', () => {
+  const defaultProps = {
+    track: makeMediaTrack({ id: 'track-2', name: 'Swipeable Track', artists: 'Swipe Artist' }),
+    index: 1,
+    isSelected: false,
+    onSelect: vi.fn(),
+    onRemove: vi.fn(),
+    isEditMode: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders track name and artist', () => {
+    // #when
+    render(<Wrapper><SwipeableQueueItem {...defaultProps} /></Wrapper>);
+
+    // #then
+    expect(screen.getByText('Swipeable Track')).toBeInTheDocument();
+    expect(screen.getByText('Swipe Artist')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when clicked and not in edit mode', () => {
+    // #given
+    const onSelect = vi.fn();
+    render(<Wrapper><SwipeableQueueItem {...defaultProps} onSelect={onSelect} /></Wrapper>);
+
+    // #when
+    fireEvent.click(screen.getByText('Swipeable Track'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('does not render swipe UI when not in edit mode', () => {
+    // #given / #when
+    render(<Wrapper><SwipeableQueueItem {...defaultProps} isEditMode={false} /></Wrapper>);
+
+    // #then — SwipeRemoveBackdrop "Remove" button should not be present
+    expect(screen.queryByRole('button', { name: 'Remove Swipeable Track' })).not.toBeInTheDocument();
+  });
+
+  it('does not render swipe UI for the currently selected track even in edit mode', () => {
+    // #given / #when
+    render(
+      <Wrapper>
+        <SwipeableQueueItem {...defaultProps} isEditMode={true} isSelected={true} />
+      </Wrapper>
+    );
+
+    // #then — selected track is not removable, so swipe UI should not appear
+    expect(screen.queryByRole('button', { name: 'Remove Swipeable Track' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `QueueBottomSheet.test.tsx` (9 tests) — title rendering, conditional track list, save button, interactions
- Adds `QueueTrackItem.test.tsx` (12 tests) — SortableQueueItem and SwipeableQueueItem rendering, click behavior, edit mode, drag/swipe guards
- 21 new tests, all 681 pass

## Test plan
- [x] All 681 tests pass

Resolves #496