### PR TITLE
docs: add Architecture link and Spotify redirect URI warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # Get these values from https://developer.spotify.com/dashboard
 VITE_SPOTIFY_CLIENT_ID=your_spotify_client_id_here
 
-# For local development, use 127.0.0.1:3000
-# For Vercel deployment, use your Vercel domain
+# IMPORTANT: Redirect URI must match your registered URI in Spotify Developer Dashboard
+# Local development: http://127.0.0.1:3000/auth/spotify/callback
+# Vercel deployment: https://your-app-name.vercel.app/auth/spotify/callback
 VITE_SPOTIFY_REDIRECT_URI=https://your-app-name.vercel.app/auth/spotify/callback
 
 VITE_DROPBOX_CLIENT_ID=your-dropbox-app-key-here

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ git clone git@github.com:smallorbit/vorbis-player.git
 cd vorbis-player
 npm install
 cp .env.example .env.local   # Add your provider credentials
+# For local dev, set VITE_SPOTIFY_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback
 npm run dev                   # Open http://127.0.0.1:3000
 ```
 
@@ -57,6 +58,7 @@ For radio recommendations, also set `VITE_LASTFM_API_KEY` in `.env.local` (see `
 | **[Getting Started](./docs/getting-started.md)** | Installation, environment setup, and first run |
 | **[User Guide](./docs/user-guide.md)** | All player features, controls, and keyboard shortcuts |
 | **[Contributing](./docs/contributing.md)** | Development setup, project structure, coding conventions |
+| **[Architecture](./CLAUDE.md#architecture)** | System design, provider model, playback flow |
 | **[Troubleshooting](./docs/troubleshooting.md)** | Common issues and solutions |
 
 ### Provider Setup


### PR DESCRIPTION
## Summary
- Add Architecture row to README docs table (#514)
- Add Quick Start note about Spotify redirect URI for local dev (#517)
- Improve .env.example comments to emphasize local dev configuration

## Test plan
- [x] Links verified in README.md

Resolves #514, #517