### PR TITLE
chore: copy Claude settings into new worktrees

### DIFF
--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -33,6 +33,15 @@ else
   echo "  WARNING: No .env.local or .env found in main repo — copy it manually."
 fi
 
+echo "Copying Claude settings..."
+mkdir -p "${WORKTREE_PATH}/.claude"
+for f in settings.json settings.local.json; do
+  if [ -f "${REPO_ROOT}/.claude/${f}" ]; then
+    cp "${REPO_ROOT}/.claude/${f}" "${WORKTREE_PATH}/.claude/${f}"
+    echo "  .claude/${f} copied."
+  fi
+done
+
 echo ""
 echo "Done! Open a new terminal and run:"
 echo ""


### PR DESCRIPTION
## Summary
- Updates `scripts/new-worktree.sh` to copy `.claude/settings.json` and `.claude/settings.local.json` into newly created worktrees
- Ensures worktrees inherit permission rules so agents don't get blocked on git push/gh pr commands

## Test plan
- [x] Script runs without errors
- [x] Settings files are copied to worktree's `.claude/` directory