### PR TITLE
fix: keep bottom bar visible in normal mode, auto-hide only in zen

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -84,15 +84,22 @@ const BottomBar = React.memo(function BottomBar({
   }, [startHideTimer]);
 
   useEffect(() => {
+    if (!zenModeEnabled) return;
     startHideTimer();
     return () => clearHideTimer();
-  }, [startHideTimer, clearHideTimer]);
+  }, [zenModeEnabled, startHideTimer, clearHideTimer]);
 
-  const isHidden = !barVisible;
+  useEffect(() => {
+    if (zenModeEnabled) return;
+    clearHideTimer();
+    setBarVisible(true);
+  }, [zenModeEnabled, clearHideTimer]);
+
+  const isHidden = !barVisible && !!zenModeEnabled;
 
   return createPortal(
     <>
-      <ZenTriggerZone onMouseEnter={showBar} onTouchStart={showBar} />
+      {zenModeEnabled && <ZenTriggerZone onMouseEnter={showBar} onTouchStart={showBar} />}
       <BottomBarContainer
         $hidden={isHidden}
         onMouseEnter={handleBarMouseEnter}

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -137,4 +137,37 @@ describe('BottomBar', () => {
     fireEvent.click(screen.getByTitle(/zen mode/i));
     expect(props.onZenModeToggle).toHaveBeenCalledOnce();
   });
+
+  it('bar remains visible in normal mode — no hide timer is started', () => {
+    vi.useFakeTimers();
+
+    // #given
+    renderBottomBar({ zenModeEnabled: false });
+
+    // #when
+    vi.advanceTimersByTime(2000);
+
+    // #then
+    expect(screen.getByTitle('App settings')).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+
+  it('portal renders fewer elements in normal mode than in zen mode', () => {
+    // #given — count baseline children before any render
+    const baselineCount = document.body.childElementCount;
+
+    // #when — render in zen mode
+    const { unmount: unmountZen } = renderBottomBar({ zenModeEnabled: true });
+    const zenCount = document.body.childElementCount - baselineCount;
+    unmountZen();
+
+    // render in normal mode
+    const baselineCount2 = document.body.childElementCount;
+    renderBottomBar({ zenModeEnabled: false });
+    const normalCount = document.body.childElementCount - baselineCount2;
+
+    // #then — zen mode adds one extra element (ZenTriggerZone)
+    expect(zenCount).toBe(normalCount + 1);
+  });
 });


### PR DESCRIPTION
## Summary
- BottomBar now stays visible in normal mode
- Auto-hide behavior (1s timer, trigger zone reveal) only activates in zen mode
- ZenTriggerZone only renders in zen mode

## Test plan
- [x] TypeScript clean
- [x] Tests updated and passing

Resolves #522