### PR TITLE
feat: add flip menu button and grip pill to zen mode bottom bar

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { BottomBarContainer, BottomBarInner, ZenTriggerZone } from './styled';
+import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone } from './styled';
 import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
@@ -11,6 +11,7 @@ import {
   ZenModeIcon,
   ShuffleIcon,
   RadioIcon,
+  FlipMenuIcon,
 } from '../icons/QuickActionIcons';
 
 const AUTOHIDE_DELAY = 1000;
@@ -29,6 +30,7 @@ interface BottomBarProps {
   onShuffleToggle?: () => void;
   onStartRadio?: () => void;
   radioGenerating?: boolean;
+  onFlipToggle?: () => void;
 }
 
 const BottomBar = React.memo(function BottomBar({
@@ -45,6 +47,7 @@ const BottomBar = React.memo(function BottomBar({
   onShuffleToggle,
   onStartRadio,
   radioGenerating,
+  onFlipToggle,
 }: BottomBarProps) {
   const { isMobile, isTablet } = usePlayerSizingContext();
   const [barVisible, setBarVisible] = useState(true);
@@ -99,7 +102,11 @@ const BottomBar = React.memo(function BottomBar({
 
   return createPortal(
     <>
-      {zenModeEnabled && <ZenTriggerZone onMouseEnter={showBar} onTouchStart={showBar} />}
+      {zenModeEnabled && (
+        <ZenTriggerZone onMouseEnter={showBar} onTouchStart={showBar}>
+          <ZenGripPill $visible={!barVisible} />
+        </ZenTriggerZone>
+      )}
       <BottomBarContainer
         $hidden={isHidden}
         onMouseEnter={handleBarMouseEnter}
@@ -140,6 +147,19 @@ const BottomBar = React.memo(function BottomBar({
               aria-label="Generate radio playlist from current track"
             >
               <RadioIcon />
+            </ControlButton>
+          )}
+
+          {zenModeEnabled && onFlipToggle && (
+            <ControlButton
+              $isMobile={isMobile}
+              $isTablet={isTablet}
+              $compact
+              onClick={onFlipToggle}
+              title="Flip menu"
+              aria-label="Flip menu"
+            >
+              <FlipMenuIcon />
             </ControlButton>
           )}
 

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -31,7 +31,23 @@ export const BottomBarInner = styled.div`
   height: ${BOTTOM_BAR_HEIGHT}px;
 `;
 
-/** Invisible hover/touch zone at the bottom of the viewport to reveal the bar */
+export const ZenGripPill = styled.div.withConfig({
+  shouldForwardProp: (prop) => !['$visible'].includes(prop),
+})<{ $visible: boolean }>`
+  width: 36px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 2px;
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+`;
+
+/** Hover/touch zone at the bottom of the viewport to reveal the bar */
 export const ZenTriggerZone = styled.div`
   position: fixed;
   bottom: 0;

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -52,6 +52,7 @@ interface AlbumArtSectionProps {
   isLiked: boolean;
   canSaveTrack: boolean;
   onLikeToggle: () => void;
+  flipToggleRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
@@ -75,6 +76,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   isLiked,
   canSaveTrack,
   onLikeToggle,
+  flipToggleRef,
 }) => {
   const { connectedProviderIds } = useProviderContext();
 
@@ -117,6 +119,11 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
 
   const toggleFlip = useCallback(() => setIsFlipped(f => !f), []);
+
+  useEffect(() => {
+    if (flipToggleRef) flipToggleRef.current = toggleFlip;
+    return () => { if (flipToggleRef) flipToggleRef.current = null; };
+  }, [flipToggleRef, toggleFlip]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     if (zenModeEnabled) {

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -85,6 +85,7 @@ interface PlayerControlsSectionProps {
   isLiked: boolean;
   isLikePending: boolean;
   onLikeToggle: () => void;
+  onFlipToggle?: () => void;
 }
 
 export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React.memo(({
@@ -113,6 +114,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   isLiked,
   isLikePending,
   onLikeToggle,
+  onFlipToggle,
 }) => {
   const { tracks, shuffleEnabled, handleShuffleToggle } = useTrackListContext();
   const { accentColor } = useColorContext();
@@ -320,6 +322,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
           onShuffleToggle={handleShuffleToggle}
           onStartRadio={isRadioAvailable ? onStartRadio : undefined}
           radioGenerating={radioState?.isGenerating}
+          onFlipToggle={onFlipToggle}
         />
       </ProfiledComponent>
       <Suspense fallback={<VisualEffectsLoadingFallback />}>

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -75,6 +75,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
 
   const controlsRef = useRef<HTMLDivElement>(null);
   const stableControlsHeightRef = useRef<number>(220);
+  const flipToggleRef = useRef<(() => void) | null>(null);
+  const handleFlipToggle = useCallback(() => flipToggleRef.current?.(), []);
 
   useEffect(() => {
     const el = controlsRef.current;
@@ -194,6 +196,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
             isLiked={isLiked}
             canSaveTrack={canSaveTrack}
             onLikeToggle={handleLikeToggle}
+            flipToggleRef={flipToggleRef}
           />
           <PlayerControlsSection
             currentTrack={currentTrack}
@@ -221,6 +224,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
             isLiked={isLiked}
             isLikePending={isLikePending}
             onLikeToggle={handleLikeToggle}
+            onFlipToggle={handleFlipToggle}
           />
         </PlayerStack>
       </PlayerContainer>

--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -56,3 +56,10 @@ export const RadioIcon = () => (
   </svg>
 );
 
+export const FlipMenuIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="3" y="5" width="14" height="14" rx="2" stroke="currentColor" strokeWidth="1.75" />
+    <rect x="7" y="5" width="14" height="14" rx="2" fill="currentColor" fillOpacity="0.15" stroke="currentColor" strokeWidth="1.75" />
+  </svg>
+);
+


### PR DESCRIPTION
## Summary
- Adds flip menu toggle button to bottom bar (zen mode only)
- Adds subtle grip pill indicator to the trigger zone so users know to tap the bottom edge
- Grip pill fades when bottom bar is revealed

## Test plan
- [x] TypeScript clean
- [x] All tests pass
- [ ] Visual: flip button appears in bottom bar only in zen mode
- [ ] Visual: grip pill visible at bottom edge in zen mode, fades when bar shows

Resolves #527, #528