### PR TITLE
feat: add touch gestures for zen mode on mobile

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -9,6 +9,7 @@ import { useColorContext } from '@/contexts/ColorContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
+import { useZenTouchGestures } from '@/hooks/useZenTouchGestures';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { VisualizerStyle } from '@/types/visualizer';
 import { FlipInner, ZenTrackInfo, ZenTrackName, ZenTrackArtist } from './styled';
@@ -125,7 +126,21 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     return () => { if (flipToggleRef) flipToggleRef.current = null; };
   }, [flipToggleRef, toggleFlip]);
 
+  const zenTouchActive = isTouchDevice && zenModeEnabled;
+
+  const zenTouchGestures = useZenTouchGestures({
+    enabled: zenTouchActive,
+    isPlaying,
+    onPlay,
+    onPause,
+    onLikeToggle,
+    onFlipToggle: toggleFlip,
+  });
+
   const handleClick = useCallback((e: React.MouseEvent) => {
+    if (zenTouchActive) {
+      return;
+    }
     if (zenModeEnabled) {
       const container = albumArtContainerRef.current;
       if (!container) return;
@@ -145,7 +160,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     } else {
       toggleFlip();
     }
-  }, [zenModeEnabled, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
+  }, [zenTouchActive, zenModeEnabled, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
 
   const handleRetryAlbumArt = useCallback(async () => {
     const providerId = currentTrackProvider ?? currentTrack?.provider;
@@ -283,7 +298,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
             onSwipeDown={onSwipeDown}
             isTouchDevice={isTouchDevice}
             onClick={handleClick}
-            onLongPress={zenModeEnabled ? toggleFlip : undefined}
+            onLongPress={zenModeEnabled && !zenTouchActive ? toggleFlip : undefined}
+            zenTouchHandlers={zenTouchActive ? zenTouchGestures : undefined}
             albumArtContainerRef={albumArtContainerRef}
             onZoneHover={setHoveredZone}
             zenModeEnabled={zenModeEnabled}
@@ -333,7 +349,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           <ZenClickZoneOverlay
             isPlaying={isPlaying}
             hoveredZone={hoveredZone}
-            visible={zenModeEnabled && hasPointerInput}
+            visible={zenModeEnabled && hasPointerInput && !zenTouchActive}
           />
           <ZenLikeOverlay
             isLiked={isLiked}

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -6,6 +6,13 @@ import { ClickableAlbumArtContainer } from './styled';
 
 type Zone = 'left' | 'center' | 'right';
 
+interface ZenTouchHandlers {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+}
+
 interface GestureLayerProps {
   onSwipeLeft: () => void;
   onSwipeRight: () => void;
@@ -14,6 +21,7 @@ interface GestureLayerProps {
   isTouchDevice: boolean;
   onClick: (e: React.MouseEvent) => void;
   onLongPress?: () => void;
+  zenTouchHandlers?: ZenTouchHandlers;
   albumArtContainerRef: React.MutableRefObject<HTMLDivElement | null>;
   children: React.ReactNode;
   onZoneHover?: (zone: Zone | null) => void;
@@ -29,6 +37,7 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
   isTouchDevice,
   onClick,
   onLongPress,
+  zenTouchHandlers,
   albumArtContainerRef,
   children,
   onZoneHover,
@@ -89,14 +98,21 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
     ? { onMouseMove: handleMouseMove, onMouseLeave: handleMouseLeave }
     : {};
 
-  const zenLongPressHandlers = zenModeEnabled && onLongPress
+  const activePointerHandlers = zenTouchHandlers
     ? {
-        onPointerDown: longPressHandlers.onPointerDown,
-        onPointerUp: longPressHandlers.onPointerUp,
-        onPointerCancel: longPressHandlers.onPointerCancel,
-        onPointerMove: longPressHandlers.onPointerMove,
+        onPointerDown: zenTouchHandlers.onPointerDown,
+        onPointerUp: zenTouchHandlers.onPointerUp,
+        onPointerCancel: zenTouchHandlers.onPointerCancel,
+        onPointerMove: zenTouchHandlers.onPointerMove,
       }
-    : {};
+    : zenModeEnabled && onLongPress
+      ? {
+          onPointerDown: longPressHandlers.onPointerDown,
+          onPointerUp: longPressHandlers.onPointerUp,
+          onPointerCancel: longPressHandlers.onPointerCancel,
+          onPointerMove: longPressHandlers.onPointerMove,
+        }
+      : {};
 
   return (
     <ClickableAlbumArtContainer
@@ -105,7 +121,7 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
       $bothGestures={isTouchDevice}
       {...(isTouchDevice ? gestureHandlers : {})}
       {...zoneHoverHandlers}
-      {...zenLongPressHandlers}
+      {...activePointerHandlers}
       onClick={handleClick}
       style={{
         transform: `translateX(${offsetX}px)`,

--- a/src/hooks/useZenTouchGestures.ts
+++ b/src/hooks/useZenTouchGestures.ts
@@ -1,0 +1,117 @@
+import { useRef, useCallback } from 'react';
+
+const DOUBLE_TAP_THRESHOLD_MS = 300;
+const LONG_PRESS_DURATION_MS = 500;
+const MOVE_CANCEL_THRESHOLD = 10;
+
+interface UseZenTouchGesturesOptions {
+  enabled: boolean;
+  isPlaying: boolean;
+  onPlay: () => void;
+  onPause: () => void;
+  onLikeToggle: () => void;
+  onFlipToggle: () => void;
+}
+
+interface UseZenTouchGesturesReturn {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+}
+
+export function useZenTouchGestures({
+  enabled,
+  isPlaying,
+  onPlay,
+  onPause,
+  onLikeToggle,
+  onFlipToggle,
+}: UseZenTouchGesturesOptions): UseZenTouchGesturesReturn {
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const singleTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastTapTimeRef = useRef<number>(0);
+  const longPressFiredRef = useRef(false);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const isPlayingRef = useRef(isPlaying);
+  isPlayingRef.current = isPlaying;
+
+  const cancelLongPress = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelSingleTap = useCallback(() => {
+    if (singleTapTimerRef.current !== null) {
+      clearTimeout(singleTapTimerRef.current);
+      singleTapTimerRef.current = null;
+    }
+  }, []);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (!enabled) return;
+    longPressFiredRef.current = false;
+    startXRef.current = e.clientX;
+    startYRef.current = e.clientY;
+
+    longPressTimerRef.current = setTimeout(() => {
+      longPressFiredRef.current = true;
+      longPressTimerRef.current = null;
+      cancelSingleTap();
+      onFlipToggle();
+    }, LONG_PRESS_DURATION_MS);
+  }, [enabled, cancelSingleTap, onFlipToggle]);
+
+  const onPointerUp = useCallback((_e: React.PointerEvent) => {
+    if (!enabled) return;
+    const wasPending = longPressTimerRef.current !== null;
+    cancelLongPress();
+
+    if (longPressFiredRef.current) {
+      longPressFiredRef.current = false;
+      return;
+    }
+
+    if (!wasPending) return;
+
+    const now = Date.now();
+    const timeSinceLastTap = now - lastTapTimeRef.current;
+
+    if (timeSinceLastTap < DOUBLE_TAP_THRESHOLD_MS) {
+      cancelSingleTap();
+      lastTapTimeRef.current = 0;
+      onLikeToggle();
+    } else {
+      lastTapTimeRef.current = now;
+      singleTapTimerRef.current = setTimeout(() => {
+        singleTapTimerRef.current = null;
+        lastTapTimeRef.current = 0;
+        if (isPlayingRef.current) {
+          onPause();
+        } else {
+          onPlay();
+        }
+      }, DOUBLE_TAP_THRESHOLD_MS);
+    }
+  }, [enabled, cancelLongPress, cancelSingleTap, onLikeToggle, onPlay, onPause]);
+
+  const onPointerCancel = useCallback((_e: React.PointerEvent) => {
+    cancelLongPress();
+    cancelSingleTap();
+    longPressFiredRef.current = false;
+  }, [cancelLongPress, cancelSingleTap]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!enabled) return;
+    const dx = Math.abs(e.clientX - startXRef.current);
+    const dy = Math.abs(e.clientY - startYRef.current);
+    if (dx > MOVE_CANCEL_THRESHOLD || dy > MOVE_CANCEL_THRESHOLD) {
+      cancelLongPress();
+    }
+  }, [enabled, cancelLongPress]);
+
+  return { onPointerDown, onPointerUp, onPointerCancel, onPointerMove };
+}


### PR DESCRIPTION
## Summary
- On touch devices in zen mode: tap = play/pause, double-tap = like, long-press = flip menu
- Hides next/prev hover overlay zones on touch devices (swipe handles this)
- Desktop hover overlay behavior unchanged
- Uses tap/double-tap/long-press disambiguation with 300ms threshold

## Test plan
- [x] TypeScript clean
- [x] All tests pass
- [ ] Visual: tap toggles play/pause in zen mode on touch device
- [ ] Visual: double-tap toggles like
- [ ] Visual: long-press opens flip menu
- [ ] Visual: desktop hover overlays still work

Resolves #530