### PR TITLE
fix: guard useLikeTrack against non-Spotify track IDs

### DIFF
--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -68,7 +68,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
   const { currentTrack, showQueue, setShowQueue } = useCurrentTrackContext();
   const { zenModeEnabled, setZenModeEnabled, setShowVisualEffects } = useVisualEffectsContext();
   const { dimensions, useFluidSizing, padding, transitionDuration, transitionEasing, isMobile, isTablet, hasPointerInput, isTouchDevice } = usePlayerSizingContext();
-  const { isLiked, isLikePending, handleLikeToggle, canSaveTrack } = useLikeTrack(currentTrack?.id, currentTrackProvider);
+  const { isLiked, isLikePending, handleLikeToggle, canSaveTrack } = useLikeTrack(currentTrack?.id, currentTrack?.provider);
 
   const [librarySearchQuery, setLibrarySearchQuery] = useState<string | undefined>(undefined);
   const [libraryViewMode, setLibraryViewMode] = useState<'playlists' | 'albums' | undefined>(undefined);

--- a/src/hooks/__tests__/useLikeTrack.test.ts
+++ b/src/hooks/__tests__/useLikeTrack.test.ts
@@ -35,6 +35,8 @@ vi.mock('@/services/spotify', () => ({
 import { useLikeTrack } from '../useLikeTrack';
 import { checkTrackSaved, saveTrack, unsaveTrack } from '@/services/spotify';
 import { ProviderWrapper } from '@/test/providerTestUtils';
+import { providerRegistry } from '@/providers/registry';
+import type { ProviderDescriptor } from '@/types/providers';
 
 const opts = { wrapper: ProviderWrapper };
 
@@ -192,5 +194,117 @@ describe('useLikeTrack', () => {
     });
 
     expect(result.current.isLiked).toBe(false);
+  });
+});
+
+describe('useLikeTrack — cross-provider guard', () => {
+  const dropboxIsTrackSaved = vi.fn();
+  const dropboxSetTrackSaved = vi.fn();
+
+  const dropboxDescriptor: ProviderDescriptor = {
+    id: 'dropbox',
+    name: 'Dropbox',
+    capabilities: { hasSaveTrack: true, hasLikedCollection: true, hasExternalLink: false },
+    auth: {
+      providerId: 'dropbox',
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      getAccessToken: vi.fn().mockResolvedValue(null),
+      beginLogin: vi.fn(),
+      handleCallback: vi.fn().mockResolvedValue(false),
+      logout: vi.fn(),
+    },
+    catalog: {
+      providerId: 'dropbox',
+      listCollections: vi.fn().mockResolvedValue([]),
+      listTracks: vi.fn().mockResolvedValue([]),
+      isTrackSaved: dropboxIsTrackSaved,
+      setTrackSaved: dropboxSetTrackSaved,
+    },
+    playback: {
+      providerId: 'dropbox',
+      initialize: vi.fn().mockResolvedValue(undefined),
+      playTrack: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn().mockResolvedValue(undefined),
+      resume: vi.fn().mockResolvedValue(undefined),
+      seek: vi.fn().mockResolvedValue(undefined),
+      next: vi.fn().mockResolvedValue(undefined),
+      previous: vi.fn().mockResolvedValue(undefined),
+      setVolume: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue(null),
+      subscribe: vi.fn().mockReturnValue(vi.fn()),
+      getLastPlayTime: vi.fn().mockReturnValue(Date.now()),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerRegistry.register(dropboxDescriptor);
+    dropboxIsTrackSaved.mockResolvedValue(false);
+    dropboxSetTrackSaved.mockResolvedValue(undefined);
+    vi.mocked(checkTrackSaved).mockResolvedValue(false);
+  });
+
+  it('does not call Spotify API when trackProvider is dropbox', async () => {
+    // #given - a Dropbox track ID
+    dropboxIsTrackSaved.mockResolvedValue(true);
+
+    // #when
+    const { result } = renderHook(
+      () => useLikeTrack('id:Esy6aoXsEfIAAAAAAAAAmw', 'dropbox'),
+      { wrapper: ProviderWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLikePending).toBe(false);
+    });
+
+    // #then - Dropbox catalog used, Spotify API not called
+    expect(dropboxIsTrackSaved).toHaveBeenCalledWith('id:Esy6aoXsEfIAAAAAAAAAmw');
+    expect(checkTrackSaved).not.toHaveBeenCalled();
+    expect(result.current.isLiked).toBe(true);
+  });
+
+  it('routes like toggle to Dropbox catalog, not Spotify', async () => {
+    // #given
+    dropboxIsTrackSaved.mockResolvedValue(false);
+
+    const { result } = renderHook(
+      () => useLikeTrack('id:Esy6aoXsEfIAAAAAAAAAmw', 'dropbox'),
+      { wrapper: ProviderWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLikePending).toBe(false);
+    });
+
+    // #when
+    await act(async () => {
+      result.current.handleLikeToggle();
+    });
+
+    // #then
+    expect(dropboxSetTrackSaved).toHaveBeenCalledWith('id:Esy6aoXsEfIAAAAAAAAAmw', true);
+    expect(saveTrack).not.toHaveBeenCalled();
+    expect(unsaveTrack).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when trackProvider is an unregistered provider', async () => {
+    // #when - cast to ProviderId to simulate a stale/unknown provider reaching the hook
+    const unknownProvider = 'unknown-provider' as import('@/types/domain').ProviderId;
+
+    const { result } = renderHook(
+      () => useLikeTrack('some-track-id', unknownProvider),
+      { wrapper: ProviderWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLikePending).toBe(false);
+    });
+
+    // #then - nothing called, graceful no-op
+    expect(checkTrackSaved).not.toHaveBeenCalled();
+    expect(dropboxIsTrackSaved).not.toHaveBeenCalled();
+    expect(result.current.isLiked).toBe(false);
+    expect(result.current.canSaveTrack).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Prevents Dropbox track IDs from being sent to Spotify's like API
- Routes like operations through the correct provider by deriving `trackProvider` from `currentTrack?.provider` (always in sync) instead of the `currentTrackProvider` prop (a `useState` that can lag behind during provider transitions)

## Root cause

`AudioPlayer` passes `displayProviderId` to `PlayerContent` as the `currentTrackProvider` prop. That value is a `useState` updated via `useEffect`, creating a window where `currentTrack?.id` is a Dropbox ID but `currentTrackProvider` still holds `'spotify'` — causing `useLikeTrack` to route the like check to Spotify's catalog → 400 Bad Request.

## Test plan
- [x] TypeScript clean (`npx tsc -b --noEmit`)
- [x] All 643 tests pass (`npm run test:run`)
- [x] New tests: Dropbox track ID does not reach `checkTrackSaved` (Spotify API)
- [x] New tests: like toggle for Dropbox track calls Dropbox catalog, not Spotify
- [x] New tests: unregistered provider gracefully no-ops

Resolves #534