### PR TITLE
feat: instant Liked Songs display on reload

### DIFF
--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -48,6 +48,7 @@ interface LibraryMainContentProps {
   enabledProviderIds: ProviderId[];
   likedSongsPerProvider: LikedSongsEntry[];
   likedSongsCount: number;
+  isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
   pinnedPlaylists: PlaylistInfo[];
@@ -94,6 +95,7 @@ export function LibraryMainContent({
   enabledProviderIds,
   likedSongsPerProvider,
   likedSongsCount,
+  isLikedSongsSyncing,
   isUnifiedLikedActive,
   unifiedLikedCount,
   pinnedPlaylists,
@@ -160,6 +162,7 @@ export function LibraryMainContent({
           inDrawer={inDrawer}
           likedSongsPerProvider={likedSongsPerProvider}
           likedSongsCount={likedSongsCount}
+          isLikedSongsSyncing={isLikedSongsSyncing}
           isUnifiedLikedActive={isUnifiedLikedActive}
           unifiedLikedCount={unifiedLikedCount}
           isInitialLoadComplete={isInitialLoadComplete}

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -22,6 +22,7 @@ import {
   PinnableGridCard,
   PinnedSectionLabel,
   EmptyState,
+  TabSpinner,
 } from './styled';
 import { getLikedSongsGradient, likedSongsAsPlaylistInfo, PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 
@@ -29,6 +30,7 @@ interface PlaylistGridProps {
   inDrawer: boolean;
   likedSongsPerProvider: { provider: ProviderId; count: number }[];
   likedSongsCount: number;
+  isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
   isInitialLoadComplete: boolean;
@@ -50,6 +52,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
   inDrawer,
   likedSongsPerProvider,
   likedSongsCount,
+  isLikedSongsSyncing,
   isUnifiedLikedActive,
   unifiedLikedCount,
   isInitialLoadComplete,
@@ -81,6 +84,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
 
   const usePerProviderLiked = showProviderBadges && likedSongsPerProvider.length >= 1 && !isUnifiedLikedActive;
   const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
+  const syncSpinner = isLikedSongsSyncing ? <TabSpinner /> : null;
 
   const likedSongsGridCard = effectiveLikedCount > 0 && (isUnifiedLikedActive ? (
     <PinnableGridCard
@@ -96,7 +100,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </GridCardArtWrapper>
       <GridCardTextArea>
         <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{effectiveLikedCount} tracks</GridCardSubtitle>
+        <GridCardSubtitle>{effectiveLikedCount} tracks{syncSpinner}</GridCardSubtitle>
       </GridCardTextArea>
     </PinnableGridCard>
   ) : usePerProviderLiked ? (
@@ -117,7 +121,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
         </GridCardArtWrapper>
         <GridCardTextArea>
           <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-          <GridCardSubtitle>{count} tracks</GridCardSubtitle>
+          <GridCardSubtitle>{count} tracks{syncSpinner}</GridCardSubtitle>
         </GridCardTextArea>
       </PinnableGridCard>
     ))
@@ -135,7 +139,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </GridCardArtWrapper>
       <GridCardTextArea>
         <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{likedSongsCount} tracks</GridCardSubtitle>
+        <GridCardSubtitle>{likedSongsCount} tracks{syncSpinner}</GridCardSubtitle>
       </GridCardTextArea>
     </PinnableGridCard>
   ));
@@ -147,7 +151,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </PlaylistImageWrapper>
       <PlaylistInfoDiv>
         <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{effectiveLikedCount} tracks • Shuffle enabled</PlaylistDetails>
+        <PlaylistDetails>{effectiveLikedCount} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
       </PlaylistInfoDiv>
       {likedSongsPinBtn}
     </PinnableListItem>
@@ -164,7 +168,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
         </div>
         <PlaylistInfoDiv>
           <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-          <PlaylistDetails>{count} tracks • Shuffle enabled</PlaylistDetails>
+          <PlaylistDetails>{count} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
         </PlaylistInfoDiv>
         {likedSongsPinBtn}
       </PinnableListItem>
@@ -176,7 +180,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </PlaylistImageWrapper>
       <PlaylistInfoDiv>
         <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{likedSongsCount} tracks • Shuffle enabled</PlaylistDetails>
+        <PlaylistDetails>{likedSongsCount} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
       </PlaylistInfoDiv>
       {likedSongsPinBtn}
     </PinnableListItem>

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -69,6 +69,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     likedSongsCount,
     likedSongsPerProvider,
     isInitialLoadComplete,
+    isLikedSongsSyncing,
     removeCollection,
   } = useLibrarySync();
 
@@ -189,10 +190,10 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   }, [activeDescriptor, enabledProviderIds, getDescriptor]);
 
   useEffect(() => {
-    if (isInitialLoadComplete || playlists.length > 0 || albums.length > 0) {
+    if (isInitialLoadComplete || playlists.length > 0 || albums.length > 0 || likedSongsCount > 0) {
       setIsLoading(false);
     }
-  }, [isInitialLoadComplete, playlists.length, albums.length]);
+  }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount]);
 
   function handlePlaylistClick(playlist: PlaylistInfo): void {
     logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
@@ -250,6 +251,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     enabledProviderIds,
     likedSongsPerProvider,
     likedSongsCount,
+    isLikedSongsSyncing,
     isUnifiedLikedActive,
     unifiedLikedCount,
     pinnedPlaylists,

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -52,6 +52,7 @@ export const STORAGE_KEYS = {
   // Cache
   CACHE_ALBUMS: 'vorbis-player-cache-albums',
   CACHE_PLAYLISTS: 'vorbis-player-cache-playlists',
+  LIKED_COUNT_SNAPSHOTS: 'vorbis-player-liked-count-snapshots',
   LIBRARY: 'vorbis-player-library',
   SETTINGS: 'vorbis-player-settings',
 

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
 import type { AlbumInfo } from '@/services/spotify';
 import type { MediaCollection, ProviderId } from '@/types/domain';
@@ -7,6 +7,7 @@ import { providerRegistry } from '@/providers/registry';
 import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { logLibrary } from '@/lib/debugLog';
 import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
+import { readLikedCountSnapshots, writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
 
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
@@ -25,12 +26,27 @@ interface UseLibrarySyncResult {
   likedSongsPerProvider: PerProviderLikedCount[];
   isInitialLoadComplete: boolean;
   isSyncing: boolean;
+  /** True while liked counts from the synchronous cache seed are being verified by async sources. */
+  isLikedSongsSyncing: boolean;
   lastSyncTimestamp: number | null;
   syncError: string | null;
   /** Force an immediate sync */
   refreshNow: () => Promise<void>;
   /** Optimistically remove a collection from the local list (instant UI update). */
   removeCollection: (collectionId: string) => void;
+}
+
+function initLikedCountsFromSnapshot(): { total: number; perProvider: PerProviderLikedCount[] } {
+  const snapshots = readLikedCountSnapshots();
+  const perProvider: PerProviderLikedCount[] = [];
+  let total = 0;
+  for (const [provider, entry] of Object.entries(snapshots)) {
+    if (entry.count > 0) {
+      perProvider.push({ provider: provider as ProviderId, count: entry.count });
+      total += entry.count;
+    }
+  }
+  return { total, perProvider };
 }
 
 function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
@@ -79,10 +95,11 @@ function splitCollections(collections: MediaCollection[]): { playlists: CachedPl
 
 export function useLibrarySync(): UseLibrarySyncResult {
   const { enabledProviderIds, getDescriptor } = useProviderContext();
+  const initialSnapshot = useMemo(() => initLikedCountsFromSnapshot(), []);
   const [playlists, setPlaylists] = useState<CachedPlaylistInfo[]>([]);
   const [albums, setAlbums] = useState<AlbumInfo[]>([]);
-  const [likedSongsCount, setLikedSongsCount] = useState(0);
-  const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>([]);
+  const [likedSongsCount, setLikedSongsCount] = useState(() => initialSnapshot.total);
+  const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>(() => initialSnapshot.perProvider);
   const [syncState, setSyncState] = useState<SyncState>({
     isInitialLoadComplete: false,
     isSyncing: false,
@@ -212,6 +229,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
         logLibrary('[%s] after splitCollections — albums: %o', providerId,
           albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
         catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
           ...prev,
@@ -291,6 +309,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
         ]);
         const { playlists, albums } = splitCollections(collections);
         catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
           ...prev,
@@ -334,6 +353,10 @@ export function useLibrarySync(): UseLibrarySyncResult {
     mergeAndSetData();
   }, [mergeAndSetData]);
 
+  const isLikedSongsSyncing = enabledProviderIds.length > 0
+    && !syncState.isInitialLoadComplete
+    && initialSnapshot.total > 0;
+
   return {
     playlists,
     albums,
@@ -341,6 +364,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     likedSongsPerProvider,
     isInitialLoadComplete: syncState.isInitialLoadComplete,
     isSyncing: syncState.isSyncing,
+    isLikedSongsSyncing,
     lastSyncTimestamp: syncState.lastSyncTimestamp,
     syncError: syncState.error,
     refreshNow,

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -19,6 +19,7 @@ import {
 } from '../spotify';
 import * as cache from './libraryCache';
 import { detectChanges, applyChanges } from './libraryDiffEngine';
+import { writeLikedCountSnapshot } from './likedCountSnapshot';
 import type {
   CachedPlaylistInfo,
   LibraryChanges,
@@ -350,7 +351,10 @@ export class LibrarySyncEngine {
   ): void {
     if (playlists !== undefined) this.lastKnownPlaylists = playlists;
     if (albums !== undefined) this.lastKnownAlbums = albums;
-    if (likedSongsCount !== undefined) this.lastKnownLikedCount = likedSongsCount;
+    if (likedSongsCount !== undefined) {
+      this.lastKnownLikedCount = likedSongsCount;
+      writeLikedCountSnapshot(this.providerId as 'spotify', likedSongsCount);
+    }
 
     for (const listener of this.listeners) {
       try {

--- a/src/services/cache/likedCountSnapshot.ts
+++ b/src/services/cache/likedCountSnapshot.ts
@@ -1,0 +1,35 @@
+import type { ProviderId } from '@/types/domain';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+interface SnapshotEntry {
+  count: number;
+  cachedAt: number;
+}
+
+type LikedCountSnapshots = Record<string, SnapshotEntry>;
+
+export function readLikedCountSnapshots(): LikedCountSnapshots {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS);
+    if (!raw) return {};
+    return JSON.parse(raw) as LikedCountSnapshots;
+  } catch {
+    return {};
+  }
+}
+
+export function writeLikedCountSnapshot(providerId: ProviderId, count: number): void {
+  try {
+    const snapshots = readLikedCountSnapshots();
+    snapshots[providerId] = { count, cachedAt: Date.now() };
+    localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
+  } catch { /* quota exceeded — silent */ }
+}
+
+export function clearLikedCountSnapshot(providerId: ProviderId): void {
+  try {
+    const snapshots = readLikedCountSnapshots();
+    delete snapshots[providerId];
+    localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
+  } catch { /* silent */ }
+}

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -8,12 +8,14 @@ import {
   TRACK_SAVED_CACHE_TTL,
   LIKED_SONGS_CACHE_TTL,
   LIKED_SONGS_COUNT_TTL,
+  TRACK_LIST_PERSIST_TTL,
   invalidateTrackSavedCache,
   getLikedSongsCountCache,
   setLikedSongsCountCache,
   getLikedSongsCache,
   setLikedSongsCache,
 } from './cache';
+import * as libraryCache from '../cache/libraryCache';
 
 // =============================================================================
 // Shared Utilities
@@ -110,6 +112,16 @@ export async function getLikedSongs(limit?: number): Promise<MediaTrack[]> {
     }
   }
 
+  if (limit === undefined) {
+    try {
+      const idbCached = await libraryCache.getTrackList('liked-songs');
+      if (idbCached && Date.now() - idbCached.timestamp < TRACK_LIST_PERSIST_TTL) {
+        setLikedSongsCache({ data: idbCached.tracks, limit: Infinity, timestamp: idbCached.timestamp });
+        return tracksToMediaTracks(idbCached.tracks);
+      }
+    } catch { /* IndexedDB unavailable — fall through to API */ }
+  }
+
   const token = await spotifyAuth.ensureValidToken();
 
   interface SavedTrackItem {
@@ -137,6 +149,9 @@ export async function getLikedSongs(limit?: number): Promise<MediaTrack[]> {
   );
 
   setLikedSongsCache({ data: tracks, limit: limit ?? Infinity, timestamp: Date.now() });
+  if (limit === undefined) {
+    libraryCache.putTrackList('liked-songs', tracks).catch(() => {});
+  }
   return tracksToMediaTracks(tracks);
 }
 


### PR DESCRIPTION
## Summary

- Liked Songs card now appears immediately on app reload using cached count from localStorage
- Added L2 IndexedDB cache for Spotify liked songs track list, enabling instant playback on reload (24h TTL)
- Shows a small spinning indicator on the Liked Songs card while the cached count is verified in the background
- Fixed `isLoading` gate to include `likedSongsCount`, so the skeleton clears as soon as the cached count is available

## How it works

1. `likedCountSnapshot.ts` reads/writes per-provider liked counts to localStorage (synchronous, ~0ms)
2. `useLibrarySync` seeds initial state from the snapshot on first render — card renders immediately
3. Background sync verifies the count and updates if changed; spinner disappears when confirmed
4. `getLikedSongs()` now checks IndexedDB before hitting the Spotify API, so pressing Play on Liked Songs is also instant after the first session

## Test plan

- [ ] Reload with Spotify liked songs — card should appear instantly with cached count and brief spinner
- [ ] Reload with Spotify + Dropbox — both provider counts should appear instantly
- [ ] First-ever load (clear localStorage) — should behave identically to before (no regression)
- [ ] Remove all liked songs, reload — card should not appear (count is 0)
- [ ] Disconnect provider, reload — no phantom liked songs card
- [ ] Click Liked Songs immediately after reload — should play from IndexedDB cache without API delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)