### PR TITLE
fix: show Liked Songs placeholder with spinner while loading

### DIFF
--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -84,9 +84,16 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
 
   const usePerProviderLiked = showProviderBadges && likedSongsPerProvider.length >= 1 && !isUnifiedLikedActive;
   const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
-  const syncSpinner = isLikedSongsSyncing ? <TabSpinner /> : null;
+  const isLikedLoading = !isInitialLoadComplete && effectiveLikedCount === 0;
+  const showLikedSongs = effectiveLikedCount > 0 || isLikedLoading;
+  const likedSubtitle = effectiveLikedCount > 0
+    ? <>{effectiveLikedCount} tracks{isLikedSongsSyncing && <TabSpinner />}</>
+    : <TabSpinner />;
+  const likedListSubtitle = effectiveLikedCount > 0
+    ? <>{effectiveLikedCount} tracks{isLikedSongsSyncing && <TabSpinner />} • Shuffle enabled</>
+    : <TabSpinner />;
 
-  const likedSongsGridCard = effectiveLikedCount > 0 && (isUnifiedLikedActive ? (
+  const likedSongsGridCard = showLikedSongs && (isUnifiedLikedActive ? (
     <PinnableGridCard
       key="liked-songs-unified"
       onClick={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(), e)}
@@ -100,7 +107,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </GridCardArtWrapper>
       <GridCardTextArea>
         <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{effectiveLikedCount} tracks{syncSpinner}</GridCardSubtitle>
+        <GridCardSubtitle>{likedSubtitle}</GridCardSubtitle>
       </GridCardTextArea>
     </PinnableGridCard>
   ) : usePerProviderLiked ? (
@@ -121,7 +128,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
         </GridCardArtWrapper>
         <GridCardTextArea>
           <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-          <GridCardSubtitle>{count} tracks{syncSpinner}</GridCardSubtitle>
+          <GridCardSubtitle>{count} tracks{isLikedSongsSyncing && <TabSpinner />}</GridCardSubtitle>
         </GridCardTextArea>
       </PinnableGridCard>
     ))
@@ -139,19 +146,19 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </GridCardArtWrapper>
       <GridCardTextArea>
         <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{likedSongsCount} tracks{syncSpinner}</GridCardSubtitle>
+        <GridCardSubtitle>{likedSubtitle}</GridCardSubtitle>
       </GridCardTextArea>
     </PinnableGridCard>
   ));
 
-  const likedSongsListItem = effectiveLikedCount > 0 && (isUnifiedLikedActive ? (
+  const likedSongsListItem = showLikedSongs && (isUnifiedLikedActive ? (
     <PinnableListItem key="liked-songs-unified" onClick={() => onLikedSongsClick()}>
       <PlaylistImageWrapper>
         <div style={{ background: getLikedSongsGradient('unified'), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', borderRadius: '0.5rem', fontSize: '1.5rem', color: 'white' }}>♥</div>
       </PlaylistImageWrapper>
       <PlaylistInfoDiv>
         <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{effectiveLikedCount} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
+        <PlaylistDetails>{likedListSubtitle}</PlaylistDetails>
       </PlaylistInfoDiv>
       {likedSongsPinBtn}
     </PinnableListItem>
@@ -168,7 +175,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
         </div>
         <PlaylistInfoDiv>
           <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-          <PlaylistDetails>{count} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
+          <PlaylistDetails>{count} tracks{isLikedSongsSyncing && <TabSpinner />} • Shuffle enabled</PlaylistDetails>
         </PlaylistInfoDiv>
         {likedSongsPinBtn}
       </PinnableListItem>
@@ -180,7 +187,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
       </PlaylistImageWrapper>
       <PlaylistInfoDiv>
         <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{likedSongsCount} tracks{syncSpinner} • Shuffle enabled</PlaylistDetails>
+        <PlaylistDetails>{likedListSubtitle}</PlaylistDetails>
       </PlaylistInfoDiv>
       {likedSongsPinBtn}
     </PinnableListItem>
@@ -249,7 +256,7 @@ export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function Pla
   };
 
   const renderFn = inDrawer ? renderPlaylistGrid : renderPlaylistList;
-  const hasPinnedSection = pinnedPlaylists.length > 0 || (likedSongsPinned && likedSongsCount > 0 && !hasActiveFilters);
+  const hasPinnedSection = pinnedPlaylists.length > 0 || (likedSongsPinned && showLikedSongs && !hasActiveFilters);
   const likedSongsItem = inDrawer ? likedSongsGridCard : likedSongsListItem;
 
   const filteredPlaylistsCount = pinnedPlaylists.length + unpinnedPlaylists.length;


### PR DESCRIPTION
## Summary

- Shows a Liked Songs card placeholder with a spinner during initial load, instead of hiding the card entirely until the count arrives
- Card disappears only when the count is confirmed to be 0 after load completes
- On subsequent reloads, the cached count from localStorage still renders instantly (from #543)

## Before
Liked Songs card invisible for 5-10 seconds during initial load — no indication it exists.

## After
Liked Songs card appears immediately with a heart icon and spinner. Count fills in when the async data arrives.

## Test plan

- [ ] Cold start (clear localStorage/IndexedDB) — Liked Songs card shows with spinner, count fills in when API responds
- [ ] Warm start (reload after first load) — Liked Songs card shows instantly with cached count
- [ ] No liked songs — card hides after load confirms count is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)