### PR TITLE
fix: show liked songs placeholder on cold start with no cache

### DIFF
--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -183,17 +183,12 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     }) || activeDescriptor?.auth.isAuthenticated();
     if (hasAuth) {
       setIsAuthenticated(true);
+      setIsLoading(false);
     } else {
       setIsAuthenticated(false);
       setIsLoading(false);
     }
   }, [activeDescriptor, enabledProviderIds, getDescriptor]);
-
-  useEffect(() => {
-    if (isInitialLoadComplete || playlists.length > 0 || albums.length > 0 || likedSongsCount > 0) {
-      setIsLoading(false);
-    }
-  }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount]);
 
   function handlePlaylistClick(playlist: PlaylistInfo): void {
     logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);


### PR DESCRIPTION
## What
- Clear `isLoading` immediately when auth is confirmed (instead of waiting for content to arrive)
- Remove a now-redundant `useEffect` that set `isLoading=false` based on `isInitialLoadComplete` or playlist counts

## Why
The placeholder card with spinner introduced in #544 was unreachable on a true cold start (no localStorage cache). `isLoading` stayed `true` until content arrived from the API, which kept `showMainContent=false`, preventing `PlaylistGrid` from mounting. The `isLikedLoading` logic inside `PlaylistGrid` never ran.

By clearing `isLoading` as soon as we know the user is authenticated, `showMainContent` becomes `true` immediately, `PlaylistGrid` renders, and the spinner placeholder appears while the API call is in flight.

## Test plan
- [ ] Cold start (clear localStorage) with Spotify connected — Liked Songs placeholder card with spinner should appear immediately in the library
- [ ] Returning user (localStorage has count) — Liked Songs card should show the cached count instantly, no regression
- [ ] Unauthenticated user — Connect button still appears, no regression