### PR TITLE
fix: batch checkTrackSaved calls to prevent Spotify 429 rate limiting

### DIFF
--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -178,20 +178,55 @@ export async function getLikedSongsCount(signal?: AbortSignal): Promise<number> 
   return count;
 }
 
-export async function checkTrackSaved(trackId: string): Promise<boolean> {
+interface BatchEntry {
+  id: string;
+  resolve: (value: boolean) => void;
+  reject: (reason: unknown) => void;
+}
+
+let _batchQueue: BatchEntry[] = [];
+let _batchFlushScheduled = false;
+
+async function _flushBatch(): Promise<void> {
+  const queue = _batchQueue;
+  _batchQueue = [];
+  _batchFlushScheduled = false;
+
+  const BATCH_SIZE = 50;
+  for (let i = 0; i < queue.length; i += BATCH_SIZE) {
+    const chunk = queue.slice(i, i + BATCH_SIZE);
+    const ids = chunk.map((entry) => entry.id);
+    try {
+      const token = await spotifyAuth.ensureValidToken();
+      const data = await spotifyApiRequest<boolean[]>(
+        `https://api.spotify.com/v1/me/tracks/contains?ids=${ids.join(',')}`,
+        token
+      );
+      const now = Date.now();
+      chunk.forEach((entry, index) => {
+        const result = data[index] ?? false;
+        trackSavedCache.set(entry.id, { value: result, timestamp: now });
+        entry.resolve(result);
+      });
+    } catch (err) {
+      chunk.forEach((entry) => entry.reject(err));
+    }
+  }
+}
+
+export function checkTrackSaved(trackId: string): Promise<boolean> {
   const cached = trackSavedCache.get(trackId);
   if (cached && Date.now() - cached.timestamp < TRACK_SAVED_CACHE_TTL) {
-    return cached.value;
+    return Promise.resolve(cached.value);
   }
 
-  const token = await spotifyAuth.ensureValidToken();
-  const data = await spotifyApiRequest<boolean[]>(
-    `https://api.spotify.com/v1/me/tracks/contains?ids=${trackId}`,
-    token
-  );
-  const result = data[0] ?? false;
-  trackSavedCache.set(trackId, { value: result, timestamp: Date.now() });
-  return result;
+  return new Promise((resolve, reject) => {
+    _batchQueue.push({ id: trackId, resolve, reject });
+    if (!_batchFlushScheduled) {
+      _batchFlushScheduled = true;
+      Promise.resolve().then(_flushBatch);
+    }
+  });
 }
 
 async function modifyTrackSaved(trackId: string, save: boolean): Promise<void> {


### PR DESCRIPTION
## What
- Batches `checkTrackSaved` calls using microtask scheduling so all calls in the same render cycle are collected and flushed as a single `/me/tracks/contains` request (up to 50 IDs per Spotify API limit)
- Cached results still return immediately without entering the batch queue

## Why
- Multiple `useLikeTrack` hooks fire simultaneously when queue items or player content renders, each independently calling `/me/tracks/contains?ids=<single_id>`
- This floods the Spotify API and triggers hundreds of 429 (Too Many Requests) errors

## Test plan
- [ ] Load a playlist with 20+ tracks — verify only 1 batch request to `/me/tracks/contains` instead of 20+ individual calls
- [ ] Like/unlike a track — verify individual save/unsave still works correctly
- [ ] Verify no 429 errors in the network tab