### PR TITLE
fix: clear liked count snapshot on provider logout (#541)

### DIFF
--- a/src/providers/dropbox/dropboxAuthAdapter.ts
+++ b/src/providers/dropbox/dropboxAuthAdapter.ts
@@ -7,6 +7,7 @@ import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { resetPlaylistsFolderCache } from './dropboxPlaylistStorage';
+import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
 
 export const DROPBOX_AUTH_ERROR_EVENT = 'vorbis-dropbox-auth-error';
 
@@ -202,6 +203,7 @@ export class DropboxAuthAdapter implements AuthProvider {
     localStorage.removeItem(STORAGE_KEYS.DROPBOX_CODE_VERIFIER);
     localStorage.removeItem(STORAGE_KEYS.DROPBOX_OAUTH_STATE);
     resetPlaylistsFolderCache();
+    clearLikedCountSnapshot('dropbox');
   }
 
   /**

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -6,6 +6,7 @@
 import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { spotifyAuth } from '@/services/spotify';
+import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
 
 export class SpotifyAuthAdapter implements AuthProvider {
   readonly providerId: ProviderId = 'spotify';
@@ -57,5 +58,6 @@ export class SpotifyAuthAdapter implements AuthProvider {
 
   logout(): void {
     spotifyAuth.logout();
+    clearLikedCountSnapshot('spotify');
   }
 }


### PR DESCRIPTION
Closes #541

## Summary
- Call `clearLikedCountSnapshot('spotify')` in `SpotifyAuthAdapter.logout()`
- Call `clearLikedCountSnapshot('dropbox')` in `DropboxAuthAdapter.logout()`

This prevents the phantom Liked Songs card from appearing on cold load after a provider has been disconnected, by removing the stale liked count from localStorage at logout time.