### PR TITLE
fix: allow dismissing bottom bar by tapping outside in mobile zen mode (#547)

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone } from './styled';
+import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBackdrop } from './styled';
 import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
@@ -88,6 +88,11 @@ const BottomBar = React.memo(function BottomBar({
     }
   }, [barVisible, clearHideTimer]);
 
+  const handleBackdropDismiss = useCallback(() => {
+    touchLockedRef.current = false;
+    setBarVisible(false);
+  }, []);
+
   const handleBarMouseEnter = useCallback(() => {
     isHoveringRef.current = true;
     setBarVisible(true);
@@ -116,6 +121,9 @@ const BottomBar = React.memo(function BottomBar({
 
   return createPortal(
     <>
+      {zenModeEnabled && barVisible && isTouchDevice && (
+        <ZenBackdrop onTouchStart={handleBackdropDismiss} onClick={handleBackdropDismiss} />
+      )}
       {zenModeEnabled && (
         <ZenTriggerZone
           onMouseEnter={isTouchDevice ? undefined : showBar}

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -57,3 +57,10 @@ export const ZenTriggerZone = styled.div`
   z-index: ${Number(theme.zIndex.mobileMenu) - 1};
   background: transparent;
 `;
+
+export const ZenBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: ${Number(theme.zIndex.mobileMenu) - 2};
+  background: transparent;
+`;


### PR DESCRIPTION
Closes #547

## Problem
In mobile zen mode, tapping the grip pill showed the bottom bar but there was no way to dismiss it — tapping anywhere outside had no effect.

## Fix
Add a transparent full-screen `ZenBackdrop` overlay that renders in `document.body` (via the existing `createPortal`) when the bar is visible in zen mode on touch devices. Tapping the backdrop sets `barVisible(false)` and clears `touchLockedRef`, dismissing the bar.

The backdrop sits at `mobileMenu z-index - 2`, below both the bar and the `ZenTriggerZone`, so it doesn't interfere with any existing hit targets.

## Changes
- `src/components/BottomBar/styled.ts` — added `ZenBackdrop` styled component (`position: fixed; inset: 0; background: transparent`)
- `src/components/BottomBar/index.tsx` — render `ZenBackdrop` when `zenModeEnabled && barVisible && isTouchDevice`; added `handleBackdropDismiss` callback