### PR TITLE
fix: hide player controls overlay when flip menu is open in zen mode (#540)

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -138,7 +138,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   });
 
   const handleClick = useCallback((e: React.MouseEvent) => {
-    if (zenTouchActive || (isTouchDevice && zenModeEnabled && isFlipped)) {
+    if (zenTouchActive || (zenModeEnabled && isFlipped)) {
       return;
     }
     if (zenModeEnabled) {
@@ -344,11 +344,11 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           <ZenClickZoneOverlay
             isPlaying={isPlaying}
             hoveredZone={hoveredZone}
-            visible={zenModeEnabled && hasPointerInput && !zenTouchActive}
+            visible={zenModeEnabled && hasPointerInput && !zenTouchActive && !isFlipped}
           />
           <ZenLikeOverlay
             isLiked={isLiked}
-            isVisible={zenModeEnabled && hasPointerInput && isHovered}
+            isVisible={zenModeEnabled && hasPointerInput && isHovered && !isFlipped}
             canSaveTrack={canSaveTrack}
             onToggleLike={onLikeToggle}
             zenModeEnabled={zenModeEnabled}


### PR DESCRIPTION
Closes #540

## Summary
- Hide `ZenClickZoneOverlay` when `isFlipped` is true (flip menu open)
- Hide `ZenLikeOverlay` when `isFlipped` is true
- Prevent `handleClick` zone-based actions (prev/play/next) for both touch and desktop when flip menu is open