### PR TITLE
fix: zen mode click zones unresponsive after closing flip menu

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -160,7 +160,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     } else {
       toggleFlip();
     }
-  }, [zenTouchActive, zenModeEnabled, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
+  }, [zenTouchActive, zenModeEnabled, isFlipped, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
 
   const handleRetryAlbumArt = useCallback(async () => {
     const providerId = currentTrackProvider ?? currentTrack?.provider;


### PR DESCRIPTION
## What
- Added `isFlipped` to the `handleClick` `useCallback` dependency array in `AlbumArtSection`

## Why
- PR #552 added `isFlipped` to the early return guard but missed adding it to the deps array
- The stale closure kept `isFlipped = true` after the flip menu closed, causing the early return to fire on every click
- Result: zen mode click zones (prev/play-pause/next) became completely unresponsive after using the flip menu

## Test plan
- [ ] Enter zen mode → open flip menu → close flip menu → hover click zones should appear and work (prev/play/next)
- [ ] Verify flip menu still suppresses click zones while open