### PR TITLE
fix: add vertical dead zones to zen mode hover overlay (#558)

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -145,6 +145,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
       const container = albumArtContainerRef.current;
       if (!container) return;
       const rect = container.getBoundingClientRect();
+      const relY = (e.clientY - rect.top) / rect.height;
+      if (relY < 0.2 || relY > 0.8) return;
       const relX = (e.clientX - rect.left) / rect.width;
       if (relX < 0.25) {
         onPrevious();

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -80,6 +80,11 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!onZoneHover) return;
     const rect = e.currentTarget.getBoundingClientRect();
+    const relY = (e.clientY - rect.top) / rect.height;
+    if (relY < 0.2 || relY > 0.8) {
+      onZoneHover(null);
+      return;
+    }
     const relX = (e.clientX - rect.left) / rect.width;
     if (relX < 0.25) {
       onZoneHover('left');


### PR DESCRIPTION
## What
- Top/bottom 20% of album art is now a dead zone for zen mode hover overlays
- Both hover detection (`GestureLayer`) and click handling (`AlbumArtSection`) ignore these edge regions

## Why
- The prev/play/next overlay triggers too easily when moving the cursor near the track info (bottom) or the top edge of the album art
- Closes #558

## Test plan
- [ ] Desktop zen mode: hover over top 20% of album art — no overlay appears
- [ ] Desktop zen mode: hover over bottom 20% — no overlay appears
- [ ] Desktop zen mode: hover in the middle 60% vertical band — overlays work as before (left/center/right zones)
- [ ] Click in dead zones does not trigger prev/play/next