### PR TITLE
Zen mode hover overlay dead zones

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -145,6 +145,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
       const container = albumArtContainerRef.current;
       if (!container) return;
       const rect = container.getBoundingClientRect();
+      const relY = (e.clientY - rect.top) / rect.height;
+      if (relY < 0.2 || relY > 0.8) return;
       const relX = (e.clientX - rect.left) / rect.width;
       if (relX < 0.25) {
         onPrevious();

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -80,6 +80,11 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!onZoneHover) return;
     const rect = e.currentTarget.getBoundingClientRect();
+    const relY = (e.clientY - rect.top) / rect.height;
+    if (relY < 0.2 || relY > 0.8) {
+      onZoneHover(null);
+      return;
+    }
     const relX = (e.clientX - rect.left) / rect.width;
     if (relX < 0.25) {
       onZoneHover('left');


### PR DESCRIPTION
## Summary

- **Vertical dead zones**: Hovering over the top or bottom 20% of album art in desktop zen mode no longer triggers the prev/play/next control overlays (#558)
- Applied to both hover detection (`GestureLayer`) and click handling (`AlbumArtSection`) to prevent accidental triggers near track info and the like overlay

## PRs included
- #559 — fix: add vertical dead zones to zen mode hover overlay (#558)

## Test plan
- [ ] Desktop zen mode: hover top/bottom 20% of album art — no overlay
- [ ] Desktop zen mode: hover middle 60% — overlays work as before
- [ ] Click in dead zones does nothing; click in active zones triggers prev/play/next