### PR TITLE
refactor: deduplicate zone boundary hit-testing logic (#566)

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { ZEN_DEAD_ZONE_TOP, ZEN_DEAD_ZONE_BOTTOM, ZEN_ZONE_LEFT_BOUNDARY, ZEN_ZONE_RIGHT_BOUNDARY } from '@/constants/zenAnimation';
+import { resolveZenZone } from '@/constants/zenAnimation';
 import styled from 'styled-components';
 import { CardContent } from '@/components/styled';
 import AlbumArt from '@/components/AlbumArt';
@@ -146,12 +146,11 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
       const container = albumArtContainerRef.current;
       if (!container) return;
       const rect = container.getBoundingClientRect();
-      const relY = (e.clientY - rect.top) / rect.height;
-      if (relY < ZEN_DEAD_ZONE_TOP || relY > ZEN_DEAD_ZONE_BOTTOM) return;
-      const relX = (e.clientX - rect.left) / rect.width;
-      if (relX < ZEN_ZONE_LEFT_BOUNDARY) {
+      const zone = resolveZenZone(e.clientX, e.clientY, rect);
+      if (zone === null) return;
+      if (zone === 'left') {
         onPrevious();
-      } else if (relX > ZEN_ZONE_RIGHT_BOUNDARY) {
+      } else if (zone === 'right') {
         onNext();
       } else {
         if (isPlaying) {

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback } from 'react';
-import { ZEN_DEAD_ZONE_TOP, ZEN_DEAD_ZONE_BOTTOM, ZEN_ZONE_LEFT_BOUNDARY, ZEN_ZONE_RIGHT_BOUNDARY, ZEN_CONTROLS_DURATION, ZEN_ART_EASING } from '@/constants/zenAnimation';
+import { ZEN_CONTROLS_DURATION, ZEN_ART_EASING, resolveZenZone } from '@/constants/zenAnimation';
+import type { Zone } from '@/constants/zenAnimation';
 import { useSwipeGesture } from '@/hooks/useSwipeGesture';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
 import { useLongPress } from '@/hooks/useLongPress';
 import { ClickableAlbumArtContainer } from './styled';
-
-type Zone = 'left' | 'center' | 'right';
 
 interface ZenTouchHandlers {
   onPointerDown: (e: React.PointerEvent) => void;
@@ -81,19 +80,7 @@ export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!onZoneHover) return;
     const rect = e.currentTarget.getBoundingClientRect();
-    const relY = (e.clientY - rect.top) / rect.height;
-    if (relY < ZEN_DEAD_ZONE_TOP || relY > ZEN_DEAD_ZONE_BOTTOM) {
-      onZoneHover(null);
-      return;
-    }
-    const relX = (e.clientX - rect.left) / rect.width;
-    if (relX < ZEN_ZONE_LEFT_BOUNDARY) {
-      onZoneHover('left');
-    } else if (relX > ZEN_ZONE_RIGHT_BOUNDARY) {
-      onZoneHover('right');
-    } else {
-      onZoneHover('center');
-    }
+    onZoneHover(resolveZenZone(e.clientX, e.clientY, rect));
   }, [onZoneHover]);
 
   const handleMouseLeave = useCallback(() => {

--- a/src/constants/zenAnimation.ts
+++ b/src/constants/zenAnimation.ts
@@ -21,6 +21,17 @@ export const ZEN_DEAD_ZONE_BOTTOM = 0.8;
 export const ZEN_ZONE_LEFT_BOUNDARY = 0.25;
 export const ZEN_ZONE_RIGHT_BOUNDARY = 0.75;
 
+export type Zone = 'left' | 'center' | 'right';
+
+export function resolveZenZone(clientX: number, clientY: number, rect: DOMRect): Zone | null {
+  const relY = (clientY - rect.top) / rect.height;
+  if (relY < ZEN_DEAD_ZONE_TOP || relY > ZEN_DEAD_ZONE_BOTTOM) return null;
+  const relX = (clientX - rect.left) / rect.width;
+  if (relX < ZEN_ZONE_LEFT_BOUNDARY) return 'left';
+  if (relX > ZEN_ZONE_RIGHT_BOUNDARY) return 'right';
+  return 'center';
+}
+
 export function zenArtTransition(zenMode: boolean): string {
   return zenMode
     ? `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms`


### PR DESCRIPTION
Closes #566

Extracts the repeated zone boundary hit-testing math from `AlbumArtSection.tsx` (`handleClick`) and `GestureLayer.tsx` (`handleMouseMove`) into a shared `resolveZenZone` utility function.

## Changes

- `src/constants/zenAnimation.ts` — adds `resolveZenZone(clientX, clientY, rect)` returning `Zone | null`, and exports the `Zone` type
- `src/components/PlayerContent/GestureLayer.tsx` — replaces inline zone math in `handleMouseMove` with `resolveZenZone`; imports `Zone` type from constants
- `src/components/PlayerContent/AlbumArtSection.tsx` — replaces inline zone math in `handleClick` with `resolveZenZone`

No behavior changes — pure refactor.