### PR TITLE
test: add tests for zen mode gestures and zone resolver (#567)

### DIFF
--- a/src/constants/__tests__/zenAnimation.test.ts
+++ b/src/constants/__tests__/zenAnimation.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveZenZone,
+  ZEN_DEAD_ZONE_TOP,
+  ZEN_DEAD_ZONE_BOTTOM,
+  ZEN_ZONE_LEFT_BOUNDARY,
+  ZEN_ZONE_RIGHT_BOUNDARY,
+} from '../zenAnimation';
+
+const makeRect = (left: number, top: number, width: number, height: number): DOMRect => ({
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+  x: left,
+  y: top,
+  toJSON: () => ({}),
+});
+
+describe('resolveZenZone', () => {
+  const rect = makeRect(0, 0, 400, 400);
+
+  describe('dead zones', () => {
+    it('returns null when click is in top dead zone', () => {
+      // #given - relY = 0.1 (below ZEN_DEAD_ZONE_TOP of 0.2)
+      const clientX = 200;
+      const clientY = rect.height * (ZEN_DEAD_ZONE_TOP - 0.05); // 60px — in top 20%
+
+      // #when
+      const zone = resolveZenZone(clientX, clientY, rect);
+
+      // #then
+      expect(zone).toBeNull();
+    });
+
+    it('returns null when click is in bottom dead zone', () => {
+      // #given - relY = 0.9 (above ZEN_DEAD_ZONE_BOTTOM of 0.8)
+      const clientX = 200;
+      const clientY = rect.height * (ZEN_DEAD_ZONE_BOTTOM + 0.05); // 340px — in bottom 20%
+
+      // #when
+      const zone = resolveZenZone(clientX, clientY, rect);
+
+      // #then
+      expect(zone).toBeNull();
+    });
+
+    it('returns null exactly at the top dead zone boundary', () => {
+      // #given - relY exactly = ZEN_DEAD_ZONE_TOP (0.2), which triggers the < check as equal → null
+      const clientY = rect.height * ZEN_DEAD_ZONE_TOP; // 80px
+
+      // #when
+      const zone = resolveZenZone(200, clientY, rect);
+
+      // #then — relY === 0.2 is NOT < 0.2, so this should resolve to a zone
+      expect(zone).not.toBeNull();
+    });
+
+    it('returns null exactly at the bottom dead zone boundary', () => {
+      // #given - relY exactly = ZEN_DEAD_ZONE_BOTTOM (0.8), which triggers > check as equal → not null
+      const clientY = rect.height * ZEN_DEAD_ZONE_BOTTOM; // 320px
+
+      // #when
+      const zone = resolveZenZone(200, clientY, rect);
+
+      // #then — relY === 0.8 is NOT > 0.8, so this should resolve to a zone
+      expect(zone).not.toBeNull();
+    });
+
+    it('returns null one pixel above top dead zone boundary', () => {
+      // #given - relY = (80 - 1) / 400 = 0.1975 < 0.2
+      const clientY = rect.height * ZEN_DEAD_ZONE_TOP - 1; // 79px
+
+      // #when
+      const zone = resolveZenZone(200, clientY, rect);
+
+      // #then
+      expect(zone).toBeNull();
+    });
+
+    it('returns null one pixel below bottom dead zone boundary', () => {
+      // #given - relY = (320 + 1) / 400 = 0.8025 > 0.8
+      const clientY = rect.height * ZEN_DEAD_ZONE_BOTTOM + 1; // 321px
+
+      // #when
+      const zone = resolveZenZone(200, clientY, rect);
+
+      // #then
+      expect(zone).toBeNull();
+    });
+  });
+
+  describe('zone resolution within active area', () => {
+    const activeY = rect.height * 0.5; // 200px — in the middle, safely within active area
+
+    it('returns "left" for click in left region (relX < 0.25)', () => {
+      // #given - relX = 0.1 (40px)
+      const clientX = rect.width * (ZEN_ZONE_LEFT_BOUNDARY - 0.15); // 40px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then
+      expect(zone).toBe('left');
+    });
+
+    it('returns "right" for click in right region (relX > 0.75)', () => {
+      // #given - relX = 0.9 (360px)
+      const clientX = rect.width * (ZEN_ZONE_RIGHT_BOUNDARY + 0.15); // 360px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then
+      expect(zone).toBe('right');
+    });
+
+    it('returns "center" for click between left and right boundaries', () => {
+      // #given - relX = 0.5 (200px)
+      const clientX = rect.width * 0.5;
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then
+      expect(zone).toBe('center');
+    });
+
+    it('returns "left" at exactly the left boundary', () => {
+      // #given - relX exactly = ZEN_ZONE_LEFT_BOUNDARY (0.25 → 100px), which is NOT < 0.25 → center
+      const clientX = rect.width * ZEN_ZONE_LEFT_BOUNDARY; // 100px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then — 0.25 is not < 0.25, falls through to center check
+      expect(zone).toBe('center');
+    });
+
+    it('returns "right" at exactly the right boundary', () => {
+      // #given - relX exactly = ZEN_ZONE_RIGHT_BOUNDARY (0.75 → 300px), which is NOT > 0.75 → center
+      const clientX = rect.width * ZEN_ZONE_RIGHT_BOUNDARY; // 300px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then — 0.75 is not > 0.75, falls through to center
+      expect(zone).toBe('center');
+    });
+
+    it('returns "left" one pixel before the left boundary', () => {
+      // #given - relX = (100 - 1) / 400 = 0.2475 < 0.25
+      const clientX = rect.width * ZEN_ZONE_LEFT_BOUNDARY - 1; // 99px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then
+      expect(zone).toBe('left');
+    });
+
+    it('returns "right" one pixel past the right boundary', () => {
+      // #given - relX = (300 + 1) / 400 = 0.7525 > 0.75
+      const clientX = rect.width * ZEN_ZONE_RIGHT_BOUNDARY + 1; // 301px
+
+      // #when
+      const zone = resolveZenZone(clientX, activeY, rect);
+
+      // #then
+      expect(zone).toBe('right');
+    });
+  });
+
+  describe('rect with non-zero offset', () => {
+    const offsetRect = makeRect(100, 50, 400, 400);
+
+    it('correctly resolves zone accounting for rect offset', () => {
+      // #given - the rect starts at (100, 50); center click at rect center (300, 250)
+      const clientX = 300; // (300 - 100) / 400 = 0.5 → center
+      const clientY = 250; // (250 - 50) / 400 = 0.5 → active area
+
+      // #when
+      const zone = resolveZenZone(clientX, clientY, offsetRect);
+
+      // #then
+      expect(zone).toBe('center');
+    });
+
+    it('returns null when y is in dead zone relative to offset rect', () => {
+      // #given - y within global viewport but in top dead zone of the offset rect
+      const clientX = 300;
+      const clientY = 60; // (60 - 50) / 400 = 0.025 < 0.2 → dead zone
+
+      // #when
+      const zone = resolveZenZone(clientX, clientY, offsetRect);
+
+      // #then
+      expect(zone).toBeNull();
+    });
+  });
+});

--- a/src/hooks/__tests__/useZenTouchGestures.test.ts
+++ b/src/hooks/__tests__/useZenTouchGestures.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useZenTouchGestures } from '../useZenTouchGestures';
+
+const DOUBLE_TAP_THRESHOLD_MS = 300;
+const LONG_PRESS_DURATION_MS = 500;
+const MOVE_CANCEL_THRESHOLD = 10;
+
+const createPointerEvent = (clientX = 100, clientY = 100): React.PointerEvent => ({
+  clientX,
+  clientY,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+} as unknown as React.PointerEvent);
+
+const defaultOptions = () => ({
+  enabled: true,
+  isPlaying: false,
+  onPlay: vi.fn(),
+  onPause: vi.fn(),
+  onLikeToggle: vi.fn(),
+  onFlipToggle: vi.fn(),
+});
+
+describe('useZenTouchGestures', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns the four pointer event handlers', () => {
+    // #when
+    const { result } = renderHook(() => useZenTouchGestures(defaultOptions()));
+
+    // #then
+    expect(typeof result.current.onPointerDown).toBe('function');
+    expect(typeof result.current.onPointerUp).toBe('function');
+    expect(typeof result.current.onPointerCancel).toBe('function');
+    expect(typeof result.current.onPointerMove).toBe('function');
+  });
+
+  describe('single tap → play/pause', () => {
+    it('calls onPlay when track is paused and single tap completes', () => {
+      // #given
+      const opts = { ...defaultOptions(), isPlaying: false };
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - tap down then up
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      // advance past double-tap window — single tap timer fires
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 10);
+      });
+
+      // #then
+      expect(opts.onPlay).toHaveBeenCalledTimes(1);
+      expect(opts.onPause).not.toHaveBeenCalled();
+    });
+
+    it('calls onPause when track is playing and single tap completes', () => {
+      // #given
+      const opts = { ...defaultOptions(), isPlaying: true };
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        result.current.onPointerUp(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 10);
+      });
+
+      // #then
+      expect(opts.onPause).toHaveBeenCalledTimes(1);
+      expect(opts.onPlay).not.toHaveBeenCalled();
+    });
+
+    it('does not call onPlay or onPause before the double-tap window expires', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - tap but do not advance time
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      // #then - timer hasn't fired yet
+      expect(opts.onPlay).not.toHaveBeenCalled();
+      expect(opts.onPause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('double tap → like toggle', () => {
+    it('calls onLikeToggle when two taps arrive within the threshold', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - first tap
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      // advance less than DOUBLE_TAP_THRESHOLD_MS so it still counts as double tap
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS - 50);
+      });
+
+      // second tap
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      // #then
+      expect(opts.onLikeToggle).toHaveBeenCalledTimes(1);
+      expect(opts.onPlay).not.toHaveBeenCalled();
+      expect(opts.onPause).not.toHaveBeenCalled();
+    });
+
+    it('does not call onLikeToggle when taps are too far apart', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - first tap
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      // let the first single-tap timer fully expire
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 50);
+      });
+
+      // second tap (now treated as a new first tap)
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+        result.current.onPointerUp(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 10);
+      });
+
+      // #then - two separate single taps, not a double tap
+      expect(opts.onLikeToggle).not.toHaveBeenCalled();
+      expect(opts.onPlay).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('long press → flip toggle', () => {
+    it('calls onFlipToggle when pointer is held for the long-press duration', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - press and hold
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then
+      expect(opts.onFlipToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onFlipToggle if pointer is released before long-press duration', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - press and release quickly
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS - 100);
+        result.current.onPointerUp(createPointerEvent());
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger a single tap after long press fires', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - full long press then release
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+      act(() => {
+        result.current.onPointerUp(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 10);
+      });
+
+      // #then - only flip fired, no play/pause
+      expect(opts.onFlipToggle).toHaveBeenCalledTimes(1);
+      expect(opts.onPlay).not.toHaveBeenCalled();
+      expect(opts.onPause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pointer move cancels long press', () => {
+    it('cancels long press when pointer moves beyond the threshold', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - press down, then move beyond MOVE_CANCEL_THRESHOLD
+      act(() => {
+        result.current.onPointerDown(createPointerEvent(100, 100));
+      });
+      act(() => {
+        result.current.onPointerMove(createPointerEvent(100 + MOVE_CANCEL_THRESHOLD + 1, 100));
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then - long press timer was cancelled, flip never fires
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+    });
+
+    it('does not cancel long press when movement is within threshold', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - press down, move within threshold
+      act(() => {
+        result.current.onPointerDown(createPointerEvent(100, 100));
+      });
+      act(() => {
+        result.current.onPointerMove(createPointerEvent(100 + MOVE_CANCEL_THRESHOLD - 1, 100));
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then - long press still fires
+      expect(opts.onFlipToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels long press when vertical movement exceeds threshold', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when
+      act(() => {
+        result.current.onPointerDown(createPointerEvent(100, 100));
+      });
+      act(() => {
+        result.current.onPointerMove(createPointerEvent(100, 100 + MOVE_CANCEL_THRESHOLD + 5));
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pointer cancel', () => {
+    it('cancels all pending timers on pointer cancel', () => {
+      // #given
+      const opts = defaultOptions();
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - start a long press then cancel it
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        result.current.onPointerCancel(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS + DOUBLE_TAP_THRESHOLD_MS);
+      });
+
+      // #then - nothing fires
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+      expect(opts.onPlay).not.toHaveBeenCalled();
+      expect(opts.onPause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('ignores pointer down when disabled', () => {
+      // #given
+      const opts = { ...defaultOptions(), enabled: false };
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_DURATION_MS);
+      });
+
+      // #then
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+    });
+
+    it('ignores pointer up when disabled', () => {
+      // #given
+      const opts = { ...defaultOptions(), enabled: false };
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - simulate down/up (down is ignored so up should also be a no-op)
+      act(() => {
+        result.current.onPointerDown(createPointerEvent());
+        result.current.onPointerUp(createPointerEvent());
+      });
+      act(() => {
+        vi.advanceTimersByTime(DOUBLE_TAP_THRESHOLD_MS + 10);
+      });
+
+      // #then
+      expect(opts.onPlay).not.toHaveBeenCalled();
+      expect(opts.onPause).not.toHaveBeenCalled();
+      expect(opts.onLikeToggle).not.toHaveBeenCalled();
+    });
+
+    it('ignores pointer move when disabled', () => {
+      // #given - enable for down, then simulate disabled move (move guard does nothing)
+      const opts = { ...defaultOptions(), enabled: false };
+      const { result } = renderHook(() => useZenTouchGestures(opts));
+
+      // #when - move far; since down was already ignored, no timer to cancel
+      act(() => {
+        result.current.onPointerMove(createPointerEvent(200, 200));
+      });
+
+      // #then - no side effects
+      expect(opts.onFlipToggle).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/constants/__tests__/zenAnimation.test.ts` — 15 tests for `resolveZenZone`: zone resolution (left/center/right), dead zones (top 20%, bottom 20%), boundary edges, and rect offset handling
- Add `src/hooks/__tests__/useZenTouchGestures.test.ts` — 16 tests for `useZenTouchGestures`: single tap play/pause, double tap like toggle, long press flip toggle, move-cancel, pointer cancel, and disabled state

## Test plan

- [x] `resolveZenZone` returns correct zone for left (< 0.25), center, right (> 0.75)
- [x] Dead zones at top 20% and bottom 20% return null
- [x] Boundary edges behave correctly (exact boundary = center, one pixel past = left/right)
- [x] Rect offset is accounted for correctly
- [x] Single tap calls `onPlay` / `onPause` after double-tap window expires
- [x] Double tap within threshold calls `onLikeToggle`
- [x] Long press for 500ms calls `onFlipToggle`
- [x] Pointer move beyond 10px cancels long press
- [x] `onPointerCancel` clears all pending timers
- [x] `enabled: false` suppresses all gesture handling
- [x] All 31 tests pass (`npm run test:run`)

Closes #567