### PR TITLE
fix: zen mode album art sizing — more breathing room for visualizers

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -2,7 +2,7 @@ import React, { memo, useEffect, useState, useCallback, useMemo } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import { breatheBorderGlow } from '../styles/animations';
-import { ZEN_ART_DURATION, ZEN_ART_EASING, ZEN_ART_ENTER_DELAY, ZEN_ART_MARGIN_H, ZEN_ART_MARGIN_V } from '@/constants/zenAnimation';
+import { ZEN_ART_DURATION, ZEN_ART_EASING, ZEN_ART_ENTER_DELAY, ZEN_ART_MARGIN_H, ZEN_ART_MARGIN_V, ZEN_ART_MARGIN_H_MOBILE, ZEN_ART_MARGIN_V_MOBILE } from '@/constants/zenAnimation';
 
 import AccentColorGlowOverlay, { DEFAULT_GLOW_RATE, DEFAULT_GLOW_INTENSITY } from './AccentColorGlowOverlay';
 import { hexToRgb } from '../utils/colorUtils';
@@ -143,6 +143,12 @@ const AlbumArtContainer = styled.div.withConfig({
   opacity: ${({ $translucenceOpacity }) => $translucenceOpacity ?? 1};
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
+
+  @media (max-width: ${theme.breakpoints.lg}) {
+    ${({ $zenMode }) => $zenMode && `
+      max-width: min(calc(100vw - ${ZEN_ART_MARGIN_H_MOBILE}px), calc(100dvh - ${ZEN_ART_MARGIN_V_MOBILE}px));
+    `}
+  }
 `;
 
 const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): boolean => {

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -17,6 +17,8 @@ import {
   ZEN_TRACK_INFO_EXIT_DURATION,
   ZEN_ART_MARGIN_H,
   ZEN_ART_MARGIN_V,
+  ZEN_ART_MARGIN_H_MOBILE,
+  ZEN_ART_MARGIN_V_MOBILE,
 } from '@/constants/zenAnimation';
 
 export const ContentWrapper = styled.div.withConfig({
@@ -78,6 +80,12 @@ export const PlayerStack = styled.div.withConfig({
     ? `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms`
     : `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`
   };
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.lg}) {
+    ${({ $zenMode }) => $zenMode && `
+      max-width: min(calc(100vw - ${ZEN_ART_MARGIN_H_MOBILE}px), calc(100dvh - ${ZEN_ART_MARGIN_V_MOBILE}px));
+    `}
+  }
 `;
 
 export const ZenControlsWrapper = styled.div.withConfig({

--- a/src/constants/zenAnimation.ts
+++ b/src/constants/zenAnimation.ts
@@ -10,6 +10,8 @@ export const ZEN_CONTROLS_TRANSFORM_EXIT_DELAY = 300;
 
 export const ZEN_ART_MARGIN_H = 96;
 export const ZEN_ART_MARGIN_V = 196;
+export const ZEN_ART_MARGIN_H_MOBILE = 32;
+export const ZEN_ART_MARGIN_V_MOBILE = 120;
 
 export const ZEN_BAR_DURATION = 300;
 


### PR DESCRIPTION
## Summary

- **Desktop**: Increase zen mode album art margins from 32px/130px to 96px/196px so background visualizers peek through tastefully
- **Mobile**: Use tighter 32px/120px margins to maximize album art on small screens
- Extract `ZEN_ART_MARGIN_H`, `ZEN_ART_MARGIN_V` (and mobile variants) as constants in `zenAnimation.ts`

Closes #572

## PRs included

- #578 (desktop margins)
- Direct commit to staging (mobile responsive override)

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] Tests pass (680/681, 1 pre-existing)
- [x] Visually verified on desktop — tasteful visualizer border visible
- [x] Visually verified on mobile — album art uses available space