### PR TITLE
fix: useImageProcessingWorker isProcessing never triggers re-renders (#581)

### DIFF
--- a/src/hooks/useImageProcessingWorker.ts
+++ b/src/hooks/useImageProcessingWorker.ts
@@ -1,15 +1,15 @@
-import { useRef, useEffect, useCallback } from 'react';
-import type { 
-  WorkerResponse, 
-  ImageProcessingRequest, 
-  ImageProcessingResponse, 
-  ImageProcessingError 
+import { useRef, useEffect, useCallback, useState } from 'react';
+import type {
+  WorkerResponse,
+  ImageProcessingRequest,
+  ImageProcessingResponse,
+  ImageProcessingError
 } from '@/workers/imageProcessor.worker';
 
 interface UseImageProcessingWorkerReturn {
   processImage: (
-    imageData: ImageData, 
-    accentColor: [number, number, number], 
+    imageData: ImageData,
+    accentColor: [number, number, number],
     maxDistance?: number
   ) => Promise<ImageData>;
   isProcessing: boolean;
@@ -17,29 +17,26 @@ interface UseImageProcessingWorkerReturn {
 
 export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
   const workerRef = useRef<Worker | null>(null);
-  const isProcessingRef = useRef(false);
+  const [isProcessing, setIsProcessing] = useState(false);
   const pendingPromisesRef = useRef<Map<number, {
     resolve: (imageData: ImageData) => void;
     reject: (error: Error) => void;
   }>>(new Map());
   const requestIdRef = useRef(0);
 
-  // Initialize worker on first use
   const initializeWorker = useCallback(() => {
     if (!workerRef.current) {
       try {
-        // Create worker from the TypeScript file - Vite will handle compilation
         workerRef.current = new Worker(
           new URL('../workers/imageProcessor.worker.ts', import.meta.url),
           { type: 'module' }
         );
 
-        // Handle worker messages
         workerRef.current.onmessage = (event: MessageEvent<WorkerResponse>) => {
           const { type } = event.data;
-          const requestId = (event.data as WorkerResponse & { requestId: string }).requestId;
+          const requestId = (event.data as WorkerResponse & { requestId: number }).requestId;
           const pendingPromise = pendingPromisesRef.current.get(requestId);
-          
+
           if (!pendingPromise) {
             console.warn('Received response for unknown request ID:', requestId);
             return;
@@ -53,20 +50,17 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
             pendingPromise.reject(new Error(response.error));
           }
 
-          // Clean up
           pendingPromisesRef.current.delete(requestId);
-          isProcessingRef.current = pendingPromisesRef.current.size > 0;
+          setIsProcessing(pendingPromisesRef.current.size > 0);
         };
 
-        // Handle worker errors
         workerRef.current.onerror = (error) => {
           console.error('Image processing worker error:', error);
-          // Reject all pending promises
           pendingPromisesRef.current.forEach((promise) => {
             promise.reject(new Error('Worker encountered an error'));
           });
           pendingPromisesRef.current.clear();
-          isProcessingRef.current = false;
+          setIsProcessing(false);
         };
 
       } catch (error) {
@@ -76,7 +70,6 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
     }
   }, []);
 
-  // Process image function
   const processImage = useCallback(async (
     imageData: ImageData,
     accentColor: [number, number, number],
@@ -85,18 +78,16 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
     return new Promise((resolve, reject) => {
       try {
         initializeWorker();
-        
+
         if (!workerRef.current) {
           throw new Error('Failed to initialize worker');
         }
 
         const requestId = requestIdRef.current++;
-        isProcessingRef.current = true;
+        setIsProcessing(true);
 
-        // Store promise resolvers
         pendingPromisesRef.current.set(requestId, { resolve, reject });
 
-        // Send message to worker with request ID
         const message: ImageProcessingRequest & { requestId: number } = {
           type: 'PROCESS_IMAGE',
           imageData,
@@ -107,44 +98,40 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
 
         workerRef.current.postMessage(message);
 
-        // Set a timeout to prevent hanging promises
         setTimeout(() => {
           const pendingPromise = pendingPromisesRef.current.get(requestId);
           if (pendingPromise) {
             pendingPromisesRef.current.delete(requestId);
-            isProcessingRef.current = pendingPromisesRef.current.size > 0;
+            setIsProcessing(pendingPromisesRef.current.size > 0);
             reject(new Error('Image processing timeout'));
           }
-        }, 10000); // 10 second timeout
+        }, 10000);
 
       } catch (error) {
-        isProcessingRef.current = false;
+        setIsProcessing(false);
         reject(error instanceof Error ? error : new Error('Unknown error'));
       }
     });
   }, [initializeWorker]);
 
-  // Cleanup worker on unmount
   useEffect(() => {
     const pendingPromises = pendingPromisesRef.current;
     return () => {
       if (workerRef.current) {
-        // Reject all pending promises
         pendingPromises.forEach((promise) => {
           promise.reject(new Error('Component unmounted'));
         });
         pendingPromises.clear();
-        
-        // Terminate worker
+
         workerRef.current.terminate();
         workerRef.current = null;
-        isProcessingRef.current = false;
+        setIsProcessing(false);
       }
     };
   }, []);
 
   return {
     processImage,
-    isProcessing: isProcessingRef.current
+    isProcessing
   };
 };


### PR DESCRIPTION
## Summary

- Replaces `isProcessingRef` (`useRef(false)`) with `useState(false)` so that `isProcessing` is reactive state that triggers re-renders when its value changes
- Fixes type mismatch: `requestId` was cast as `string` but is actually a `number` (set via `requestIdRef.current++`)

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc -b --noEmit`)
- [ ] All tests pass (`npm run test:run`) — 1 pre-existing failure in `PlaylistSelection.test.tsx` is unrelated
- [ ] Consumers of `isProcessing` will now re-render correctly when image processing starts/stops