### PR TITLE
fix: useAccentColor race condition on rapid track changes (#583)

### DIFF
--- a/src/hooks/useAccentColor.ts
+++ b/src/hooks/useAccentColor.ts
@@ -15,20 +15,27 @@ export const useAccentColor = (
   const albumOverride = albumId ? accentColorOverrides[albumId] : undefined;
 
   useEffect(() => {
+    let isCurrent = true;
+
     if (!albumId && !albumImage) {
       setAccentColor(theme.colors.accent);
-      return;
+      return () => {
+        isCurrent = false;
+      };
     }
 
     if (albumId && albumOverride) {
       setAccentColor(albumOverride);
-      return;
+      return () => {
+        isCurrent = false;
+      };
     }
 
     if (albumImage) {
       const extractStart = isProfilingEnabled() ? performance.now() : 0;
       extractDominantColor(albumImage)
         .then(dominantColor => {
+          if (!isCurrent) return;
           if (extractStart > 0) {
             console.debug(`[Profiling] useAccentColor.extract: ${(performance.now() - extractStart).toFixed(1)}ms`);
           }
@@ -44,11 +51,16 @@ export const useAccentColor = (
           }
         })
         .catch(() => {
+          if (!isCurrent) return;
           setAccentColor(theme.colors.accent);
         });
     } else {
       setAccentColor(theme.colors.accent);
     }
+
+    return () => {
+      isCurrent = false;
+    };
   }, [albumId, albumImage, albumOverride, setAccentColor]);
 
   const handleAccentColorChange = useCallback((color: string) => {


### PR DESCRIPTION
## Summary

- Adds `isCurrent` flag to the `useAccentColor` effect to discard stale `extractDominantColor` results when the effect re-runs before a prior async call resolves
- Guards both `.then()` and `.catch()` callbacks with `if (!isCurrent) return`
- Returns cleanup `() => { isCurrent = false }` from all code paths (early returns and the main async branch)

## Test plan

- [ ] TypeScript: `npx tsc -b --noEmit` passes clean
- [ ] Tests: `npm run test:run` — 680/681 pass; 1 pre-existing failure in `PlaylistSelection.test.tsx` unrelated to this change
- [ ] Manual: rapid track skipping no longer flashes stale album colors