### PR TITLE
refactor: eliminate prop waterfall in library components

### DIFF
--- a/src/components/PlaylistSelection/AlbumGrid.tsx
+++ b/src/components/PlaylistSelection/AlbumGrid.tsx
@@ -21,39 +21,25 @@ import {
   ClickableArtist,
 } from './styled';
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
+import { useLibraryContext } from './LibraryContext';
 
-interface AlbumGridProps {
-  inDrawer: boolean;
-  albums: AlbumInfo[];
-  isInitialLoadComplete: boolean;
-  showProviderBadges: boolean;
-  searchQuery: string;
-  artistFilter: string;
-  pinnedAlbums: AlbumInfo[];
-  unpinnedAlbums: AlbumInfo[];
-  isAlbumPinned: (id: string) => boolean;
-  canPinMoreAlbums: boolean;
-  onAlbumClick: (album: AlbumInfo) => void;
-  onAlbumContextMenu: (album: AlbumInfo, e: React.MouseEvent) => void;
-  onPinAlbumClick: (id: string, e: React.MouseEvent) => void;
-  onArtistClick: (artist: string, e: React.MouseEvent) => void;
-}
+export const AlbumGrid: React.FC = React.memo(function AlbumGrid() {
+  const {
+    inDrawer,
+    isInitialLoadComplete,
+    showProviderBadges,
+    searchQuery,
+    artistFilter,
+    pinnedAlbums,
+    unpinnedAlbums,
+    isAlbumPinned,
+    canPinMoreAlbums,
+    onAlbumClick,
+    onAlbumContextMenu,
+    onPinAlbumClick,
+    onArtistClick,
+  } = useLibraryContext();
 
-export const AlbumGrid: React.FC<AlbumGridProps> = React.memo(function AlbumGrid({
-  inDrawer,
-  isInitialLoadComplete,
-  showProviderBadges,
-  searchQuery,
-  artistFilter,
-  pinnedAlbums,
-  unpinnedAlbums,
-  isAlbumPinned,
-  canPinMoreAlbums,
-  onAlbumClick,
-  onAlbumContextMenu,
-  onPinAlbumClick,
-  onArtistClick,
-}) {
   const renderAlbumGrid = (album: AlbumInfo) => {
     const pinned = isAlbumPinned(album.id);
     return (

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext } from 'react';
+import type * as React from 'react';
+import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+
+interface LikedSongsEntry {
+  provider: ProviderId;
+  count: number;
+}
+
+export interface LibraryContextValue {
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+  viewMode: 'playlists' | 'albums';
+  setViewMode: (v: 'playlists' | 'albums') => void;
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  playlistSort: PlaylistSortOption;
+  setPlaylistSort: (v: PlaylistSortOption) => void;
+  albumSort: AlbumSortOption;
+  setAlbumSort: (v: AlbumSortOption) => void;
+  artistFilter: string;
+  setArtistFilter: (v: string) => void;
+  providerFilters: ProviderId[];
+  setProviderFilters: (v: ProviderId[]) => void;
+  handleProviderToggle: (provider: ProviderId) => void;
+  hasActiveFilters: boolean;
+  albums: AlbumInfo[];
+  isInitialLoadComplete: boolean;
+  showProviderBadges: boolean;
+  enabledProviderIds: ProviderId[];
+  likedSongsPerProvider: LikedSongsEntry[];
+  likedSongsCount: number;
+  isLikedSongsSyncing: boolean;
+  isUnifiedLikedActive: boolean;
+  unifiedLikedCount: number;
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  isPlaylistPinned: (id: string) => boolean;
+  canPinMorePlaylists: boolean;
+  isAlbumPinned: (id: string) => boolean;
+  canPinMoreAlbums: boolean;
+  activeDescriptor: ProviderDescriptor | null;
+  onPlaylistClick: (playlist: PlaylistInfo) => void;
+  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  onLikedSongsClick: (provider?: ProviderId) => void;
+  onAlbumClick: (album: AlbumInfo) => void;
+  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
+  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
+  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+const LibraryContext = createContext<LibraryContextValue | null>(null);
+
+export const LibraryProvider = LibraryContext.Provider;
+
+export function useLibraryContext(): LibraryContextValue {
+  const ctx = useContext(LibraryContext);
+  if (!ctx) {
+    throw new Error('useLibraryContext must be used within a LibraryProvider');
+  }
+  return ctx;
+}

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -1,14 +1,11 @@
 import type * as React from 'react';
-import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
-import type { ProviderDescriptor } from '@/types/providers';
-import type { ProviderId } from '@/types/domain';
-import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
 import FilterChipRow from '../FilterChipRow';
 import LibraryDrawerSortChip from '../LibraryDrawerSortChip';
 import LibraryProviderBar from '../LibraryProviderBar';
 import { PlaylistGrid } from './PlaylistGrid';
 import { AlbumGrid } from './AlbumGrid';
 import { LibraryControls } from './LibraryControls';
+import { useLibraryContext } from './LibraryContext';
 import {
   TabSpinner,
   TabsContainer,
@@ -20,104 +17,32 @@ import {
   DrawerClearFiltersButton,
 } from './styled';
 
-interface LikedSongsEntry {
-  provider: ProviderId;
-  count: number;
-}
+export function LibraryMainContent(): React.JSX.Element {
+  const {
+    inDrawer,
+    swipeZoneRef,
+    viewMode,
+    setViewMode,
+    searchQuery,
+    setSearchQuery,
+    playlistSort,
+    setPlaylistSort,
+    albumSort,
+    setAlbumSort,
+    artistFilter,
+    setArtistFilter,
+    providerFilters,
+    setProviderFilters,
+    handleProviderToggle,
+    hasActiveFilters,
+    albums,
+    isInitialLoadComplete,
+    showProviderBadges,
+    enabledProviderIds,
+    onLibraryRefresh,
+    isLibraryRefreshing,
+  } = useLibraryContext();
 
-interface LibraryMainContentProps {
-  inDrawer: boolean;
-  swipeZoneRef?: React.RefObject<HTMLDivElement>;
-  viewMode: 'playlists' | 'albums';
-  setViewMode: (v: 'playlists' | 'albums') => void;
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  playlistSort: PlaylistSortOption;
-  setPlaylistSort: (v: PlaylistSortOption) => void;
-  albumSort: AlbumSortOption;
-  setAlbumSort: (v: AlbumSortOption) => void;
-  artistFilter: string;
-  setArtistFilter: (v: string) => void;
-  providerFilters: ProviderId[];
-  setProviderFilters: (v: ProviderId[]) => void;
-  handleProviderToggle: (provider: ProviderId) => void;
-  hasActiveFilters: boolean;
-  albums: AlbumInfo[];
-  isInitialLoadComplete: boolean;
-  showProviderBadges: boolean;
-  enabledProviderIds: ProviderId[];
-  likedSongsPerProvider: LikedSongsEntry[];
-  likedSongsCount: number;
-  isLikedSongsSyncing: boolean;
-  isUnifiedLikedActive: boolean;
-  unifiedLikedCount: number;
-  pinnedPlaylists: PlaylistInfo[];
-  unpinnedPlaylists: PlaylistInfo[];
-  pinnedAlbums: AlbumInfo[];
-  unpinnedAlbums: AlbumInfo[];
-  isPlaylistPinned: (id: string) => boolean;
-  canPinMorePlaylists: boolean;
-  isAlbumPinned: (id: string) => boolean;
-  canPinMoreAlbums: boolean;
-  activeDescriptor: ProviderDescriptor | null;
-  onPlaylistClick: (playlist: PlaylistInfo) => void;
-  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
-  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
-  onLikedSongsClick: (provider?: ProviderId) => void;
-  onAlbumClick: (album: AlbumInfo) => void;
-  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
-  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
-  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
-  onLibraryRefresh?: () => void;
-  isLibraryRefreshing?: boolean;
-}
-
-export function LibraryMainContent({
-  inDrawer,
-  swipeZoneRef,
-  viewMode,
-  setViewMode,
-  searchQuery,
-  setSearchQuery,
-  playlistSort,
-  setPlaylistSort,
-  albumSort,
-  setAlbumSort,
-  artistFilter,
-  setArtistFilter,
-  providerFilters,
-  setProviderFilters,
-  handleProviderToggle,
-  hasActiveFilters,
-  albums,
-  isInitialLoadComplete,
-  showProviderBadges,
-  enabledProviderIds,
-  likedSongsPerProvider,
-  likedSongsCount,
-  isLikedSongsSyncing,
-  isUnifiedLikedActive,
-  unifiedLikedCount,
-  pinnedPlaylists,
-  unpinnedPlaylists,
-  pinnedAlbums,
-  unpinnedAlbums,
-  isPlaylistPinned,
-  canPinMorePlaylists,
-  isAlbumPinned,
-  canPinMoreAlbums,
-  activeDescriptor,
-  onPlaylistClick,
-  onPlaylistContextMenu,
-  onPinPlaylistClick,
-  onLikedSongsClick,
-  onAlbumClick,
-  onAlbumContextMenu,
-  onPinAlbumClick,
-  onArtistClick,
-  onLibraryRefresh,
-  isLibraryRefreshing,
-}: LibraryMainContentProps): React.JSX.Element {
   const tabsBar = (
     <TabsContainer>
       <TabButton
@@ -157,48 +82,9 @@ export function LibraryMainContent({
         />
       )}
 
-      {viewMode === 'playlists' && (
-        <PlaylistGrid
-          inDrawer={inDrawer}
-          likedSongsPerProvider={likedSongsPerProvider}
-          likedSongsCount={likedSongsCount}
-          isLikedSongsSyncing={isLikedSongsSyncing}
-          isUnifiedLikedActive={isUnifiedLikedActive}
-          unifiedLikedCount={unifiedLikedCount}
-          isInitialLoadComplete={isInitialLoadComplete}
-          showProviderBadges={showProviderBadges}
-          hasActiveFilters={hasActiveFilters}
-          searchQuery={searchQuery}
-          pinnedPlaylists={pinnedPlaylists}
-          unpinnedPlaylists={unpinnedPlaylists}
-          isPlaylistPinned={isPlaylistPinned}
-          canPinMorePlaylists={canPinMorePlaylists}
-          activeDescriptor={activeDescriptor}
-          onPlaylistClick={onPlaylistClick}
-          onPlaylistContextMenu={onPlaylistContextMenu}
-          onPinPlaylistClick={onPinPlaylistClick}
-          onLikedSongsClick={onLikedSongsClick}
-        />
-      )}
+      {viewMode === 'playlists' && <PlaylistGrid />}
 
-      {viewMode === 'albums' && (
-        <AlbumGrid
-          inDrawer={inDrawer}
-          albums={albums}
-          isInitialLoadComplete={isInitialLoadComplete}
-          showProviderBadges={showProviderBadges}
-          searchQuery={searchQuery}
-          artistFilter={artistFilter}
-          pinnedAlbums={pinnedAlbums}
-          unpinnedAlbums={unpinnedAlbums}
-          isAlbumPinned={isAlbumPinned}
-          canPinMoreAlbums={canPinMoreAlbums}
-          onAlbumClick={onAlbumClick}
-          onAlbumContextMenu={onAlbumContextMenu}
-          onPinAlbumClick={onPinAlbumClick}
-          onArtistClick={onArtistClick}
-        />
-      )}
+      {viewMode === 'albums' && <AlbumGrid />}
 
       {inDrawer && (
         <DrawerBottomControls>

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import type { PlaylistInfo } from '../../services/spotify';
-import type { ProviderId } from '@/types/domain';
-import type { ProviderDescriptor } from '@/types/providers';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import ProviderIcon from '../ProviderIcon';
 import {
@@ -25,50 +23,31 @@ import {
   TabSpinner,
 } from './styled';
 import { getLikedSongsGradient, likedSongsAsPlaylistInfo, PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
+import { useLibraryContext } from './LibraryContext';
 
-interface PlaylistGridProps {
-  inDrawer: boolean;
-  likedSongsPerProvider: { provider: ProviderId; count: number }[];
-  likedSongsCount: number;
-  isLikedSongsSyncing: boolean;
-  isUnifiedLikedActive: boolean;
-  unifiedLikedCount: number;
-  isInitialLoadComplete: boolean;
-  showProviderBadges: boolean;
-  hasActiveFilters: boolean;
-  searchQuery: string;
-  pinnedPlaylists: PlaylistInfo[];
-  unpinnedPlaylists: PlaylistInfo[];
-  isPlaylistPinned: (id: string) => boolean;
-  canPinMorePlaylists: boolean;
-  activeDescriptor: ProviderDescriptor | null;
-  onPlaylistClick: (playlist: PlaylistInfo) => void;
-  onPlaylistContextMenu: (playlist: PlaylistInfo, e: React.MouseEvent) => void;
-  onPinPlaylistClick: (id: string, e: React.MouseEvent) => void;
-  onLikedSongsClick: (provider?: ProviderId) => void;
-}
+export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
+  const {
+    inDrawer,
+    likedSongsPerProvider,
+    likedSongsCount,
+    isLikedSongsSyncing,
+    isUnifiedLikedActive,
+    unifiedLikedCount,
+    isInitialLoadComplete,
+    showProviderBadges,
+    hasActiveFilters,
+    searchQuery,
+    pinnedPlaylists,
+    unpinnedPlaylists,
+    isPlaylistPinned,
+    canPinMorePlaylists,
+    activeDescriptor,
+    onPlaylistClick,
+    onPlaylistContextMenu,
+    onPinPlaylistClick,
+    onLikedSongsClick,
+  } = useLibraryContext();
 
-export const PlaylistGrid: React.FC<PlaylistGridProps> = React.memo(function PlaylistGrid({
-  inDrawer,
-  likedSongsPerProvider,
-  likedSongsCount,
-  isLikedSongsSyncing,
-  isUnifiedLikedActive,
-  unifiedLikedCount,
-  isInitialLoadComplete,
-  showProviderBadges,
-  hasActiveFilters,
-  searchQuery,
-  pinnedPlaylists,
-  unpinnedPlaylists,
-  isPlaylistPinned,
-  canPinMorePlaylists,
-  activeDescriptor,
-  onPlaylistClick,
-  onPlaylistContextMenu,
-  onPinPlaylistClick,
-  onLikedSongsClick,
-}) {
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
   const likedSongsPinBtn = (
     <PinButton

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -27,6 +27,8 @@ import { useItemActions } from './useItemActions';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
 import LibraryDrawerHeader from './LibraryDrawerHeader';
+import { LibraryProvider } from './LibraryContext';
+import type { LibraryContextValue } from './LibraryContext';
 
 interface PlaylistSelectionProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -223,7 +225,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
   const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
 
-  const mainContentProps = {
+  const libraryContextValue: LibraryContextValue = {
     inDrawer,
     swipeZoneRef,
     viewMode,
@@ -280,29 +282,33 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
 
   if (inDrawer) {
     return (
-      <DrawerContentWrapper>
-        <LibraryDrawerHeader activeDescriptor={activeDescriptor ?? null} />
-        <LibraryStatusContent {...statusContentProps} />
-        {showMainContent && <LibraryMainContent {...mainContentProps} />}
-        {albumPopoverPortal}
-        {playlistPopoverPortal}
-        {confirmDeletePortal}
-      </DrawerContentWrapper>
+      <LibraryProvider value={libraryContextValue}>
+        <DrawerContentWrapper>
+          <LibraryDrawerHeader activeDescriptor={activeDescriptor ?? null} />
+          <LibraryStatusContent {...statusContentProps} />
+          {showMainContent && <LibraryMainContent />}
+          {albumPopoverPortal}
+          {playlistPopoverPortal}
+          {confirmDeletePortal}
+        </DrawerContentWrapper>
+      </LibraryProvider>
     );
   }
 
   return (
-    <Container $inDrawer={false}>
-      <SelectionCard $maxWidth={maxWidth} $inDrawer={false}>
-        <CardContent style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-          <LibraryStatusContent {...statusContentProps} />
-          {showMainContent && <LibraryMainContent {...mainContentProps} />}
-          {albumPopoverPortal}
-          {playlistPopoverPortal}
-          {confirmDeletePortal}
-        </CardContent>
-      </SelectionCard>
-    </Container>
+    <LibraryProvider value={libraryContextValue}>
+      <Container $inDrawer={false}>
+        <SelectionCard $maxWidth={maxWidth} $inDrawer={false}>
+          <CardContent style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+            <LibraryStatusContent {...statusContentProps} />
+            {showMainContent && <LibraryMainContent />}
+            {albumPopoverPortal}
+            {playlistPopoverPortal}
+            {confirmDeletePortal}
+          </CardContent>
+        </SelectionCard>
+      </Container>
+    </LibraryProvider>
   );
 });
 


### PR DESCRIPTION
## Summary

- Introduce `LibraryContext` (`src/components/PlaylistSelection/LibraryContext.tsx`) holding all shared library state and callbacks
- `PlaylistSelection/index.tsx` now wraps its render tree in `LibraryProvider` instead of assembling a ~40-property `mainContentProps` object
- `LibraryMainContent`, `PlaylistGrid`, and `AlbumGrid` consume state via `useLibraryContext()` — zero props passed between them
- No user-visible behavior changes; TypeScript clean; pre-existing test failure unrelated to this PR

## Test plan

- [ ] `npx tsc -b --noEmit` passes cleanly
- [ ] `npm run test:run` — 680/681 pass (1 pre-existing failure unrelated to this change)
- [ ] Library drawer opens and functions correctly (playlists, albums, liked songs, pins, filters, sort)

Closes #593