### PR TITLE
refactor: extract LikedSongsCard to collapse duplicate JSX branches

### DIFF
--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import ProviderIcon from '../ProviderIcon';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
+import type { ProviderId } from '@/types/domain';
+import {
+  GridCardArtWrapper,
+  GridCardTextArea,
+  GridCardTitle,
+  GridCardSubtitle,
+  PlaylistImageWrapper,
+  PlaylistInfoDiv,
+  PlaylistName,
+  PlaylistDetails,
+  PinButton,
+  PinnableListItem,
+  GridCardPinOverlay,
+  ProviderBadgeOverlay,
+  PinnableGridCard,
+  TabSpinner,
+} from './styled';
+import { getLikedSongsGradient, likedSongsAsPlaylistInfo, PinIcon } from './utils';
+import { useLibraryContext } from './LibraryContext';
+
+interface LikedSongsCardProps {
+  layout: 'grid' | 'list';
+  provider?: ProviderId;
+  count: number;
+}
+
+const HeartArt: React.FC<{ gradient: string; layout: 'grid' | 'list' }> = ({ gradient, layout }) => (
+  <div style={{
+    background: gradient,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+    borderRadius: layout === 'list' ? '0.5rem' : undefined,
+    fontSize: layout === 'list' ? '1.5rem' : '3rem',
+    color: 'white',
+  }}>♥</div>
+);
+
+const LikedSongsCard: React.FC<LikedSongsCardProps> = React.memo(function LikedSongsCard({ layout, provider, count }) {
+  const {
+    isLikedSongsSyncing,
+    isUnifiedLikedActive,
+    isPlaylistPinned,
+    canPinMorePlaylists,
+    activeDescriptor,
+    onPlaylistContextMenu,
+    onPinPlaylistClick,
+    onLikedSongsClick,
+  } = useLibraryContext();
+
+  const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
+  const isPerProvider = provider !== undefined;
+  const gradient = getLikedSongsGradient(
+    isUnifiedLikedActive ? 'unified' : (isPerProvider ? provider : activeDescriptor?.id)
+  );
+
+  const syncSpinner = isLikedSongsSyncing ? <TabSpinner /> : null;
+  const subtitle = count > 0
+    ? <>{count} tracks{syncSpinner}</>
+    : <TabSpinner />;
+  const listSubtitle = count > 0
+    ? <>{count} tracks{syncSpinner} • Shuffle enabled</>
+    : <TabSpinner />;
+
+  const cardKey = isUnifiedLikedActive
+    ? 'liked-songs-unified'
+    : isPerProvider ? `liked-songs-${provider}` : 'liked-songs';
+
+  if (layout === 'grid') {
+    return (
+      <PinnableGridCard
+        key={cardKey}
+        onClick={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(isPerProvider ? provider : undefined), e)}
+        onContextMenu={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(isPerProvider ? provider : undefined), e)}
+      >
+        <GridCardArtWrapper style={{ position: 'relative' }}>
+          <HeartArt gradient={gradient} layout="grid" />
+          {isPerProvider && (
+            <ProviderBadgeOverlay>
+              <ProviderIcon provider={provider} size={22} />
+            </ProviderBadgeOverlay>
+          )}
+          <GridCardPinOverlay $isPinned={likedSongsPinned} onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}>
+            <PinIcon filled={likedSongsPinned} />
+          </GridCardPinOverlay>
+        </GridCardArtWrapper>
+        <GridCardTextArea>
+          <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
+          <GridCardSubtitle>{isPerProvider ? <>{count} tracks{syncSpinner}</> : subtitle}</GridCardSubtitle>
+        </GridCardTextArea>
+      </PinnableGridCard>
+    );
+  }
+
+  const pinBtn = (
+    <PinButton
+      $isPinned={likedSongsPinned}
+      $disabled={!canPinMorePlaylists && !likedSongsPinned}
+      onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}
+      title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
+      aria-label={likedSongsPinned ? 'Unpin Liked Songs' : 'Pin Liked Songs to top'}
+    >
+      <PinIcon filled={likedSongsPinned} />
+    </PinButton>
+  );
+
+  return (
+    <PinnableListItem key={cardKey} onClick={() => onLikedSongsClick(isPerProvider ? provider : undefined)}>
+      {isPerProvider ? (
+        <div style={{ position: 'relative' }}>
+          <PlaylistImageWrapper>
+            <HeartArt gradient={gradient} layout="list" />
+          </PlaylistImageWrapper>
+          <div style={{ position: 'absolute', top: -4, right: -4, zIndex: 2 }}>
+            <ProviderIcon provider={provider} size={18} />
+          </div>
+        </div>
+      ) : (
+        <PlaylistImageWrapper>
+          <HeartArt gradient={gradient} layout="list" />
+        </PlaylistImageWrapper>
+      )}
+      <PlaylistInfoDiv>
+        <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
+        <PlaylistDetails>{isPerProvider ? <>{count} tracks{syncSpinner} • Shuffle enabled</> : listSubtitle}</PlaylistDetails>
+      </PlaylistInfoDiv>
+      {pinBtn}
+    </PinnableListItem>
+  );
+});
+
+export { LikedSongsCard };

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { PlaylistInfo } from '../../services/spotify';
-import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
+import { LIKED_SONGS_ID } from '@/constants/playlist';
 import ProviderIcon from '../ProviderIcon';
 import {
   MobileGrid,
@@ -9,7 +9,6 @@ import {
   GridCardTextArea,
   GridCardTitle,
   GridCardSubtitle,
-  PlaylistImageWrapper,
   PlaylistInfoDiv,
   PlaylistName,
   PlaylistDetails,
@@ -20,17 +19,16 @@ import {
   PinnableGridCard,
   PinnedSectionLabel,
   EmptyState,
-  TabSpinner,
 } from './styled';
-import { getLikedSongsGradient, likedSongsAsPlaylistInfo, PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
+import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 import { useLibraryContext } from './LibraryContext';
+import { LikedSongsCard } from './LikedSongsCard';
 
 export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const {
     inDrawer,
     likedSongsPerProvider,
     likedSongsCount,
-    isLikedSongsSyncing,
     isUnifiedLikedActive,
     unifiedLikedCount,
     isInitialLoadComplete,
@@ -41,136 +39,25 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
     unpinnedPlaylists,
     isPlaylistPinned,
     canPinMorePlaylists,
-    activeDescriptor,
     onPlaylistClick,
     onPlaylistContextMenu,
     onPinPlaylistClick,
-    onLikedSongsClick,
   } = useLibraryContext();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
-  const likedSongsPinBtn = (
-    <PinButton
-      $isPinned={likedSongsPinned}
-      $disabled={!canPinMorePlaylists && !likedSongsPinned}
-      onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}
-      title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
-      aria-label={likedSongsPinned ? 'Unpin Liked Songs' : 'Pin Liked Songs to top'}
-    >
-      <PinIcon filled={likedSongsPinned} />
-    </PinButton>
-  );
-
   const usePerProviderLiked = showProviderBadges && likedSongsPerProvider.length >= 1 && !isUnifiedLikedActive;
   const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
   const isLikedLoading = !isInitialLoadComplete && effectiveLikedCount === 0;
   const showLikedSongs = effectiveLikedCount > 0 || isLikedLoading;
-  const likedSubtitle = effectiveLikedCount > 0
-    ? <>{effectiveLikedCount} tracks{isLikedSongsSyncing && <TabSpinner />}</>
-    : <TabSpinner />;
-  const likedListSubtitle = effectiveLikedCount > 0
-    ? <>{effectiveLikedCount} tracks{isLikedSongsSyncing && <TabSpinner />} • Shuffle enabled</>
-    : <TabSpinner />;
 
-  const likedSongsGridCard = showLikedSongs && (isUnifiedLikedActive ? (
-    <PinnableGridCard
-      key="liked-songs-unified"
-      onClick={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(), e)}
-      onContextMenu={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(), e)}
-    >
-      <GridCardArtWrapper style={{ position: 'relative' }}>
-        <div style={{ background: getLikedSongsGradient('unified'), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', fontSize: '3rem', color: 'white' }}>♥</div>
-        <GridCardPinOverlay $isPinned={likedSongsPinned} onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}>
-          <PinIcon filled={likedSongsPinned} />
-        </GridCardPinOverlay>
-      </GridCardArtWrapper>
-      <GridCardTextArea>
-        <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{likedSubtitle}</GridCardSubtitle>
-      </GridCardTextArea>
-    </PinnableGridCard>
-  ) : usePerProviderLiked ? (
-    likedSongsPerProvider.map(({ provider, count }) => (
-      <PinnableGridCard
-        key={`liked-songs-${provider}`}
-        onClick={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(provider), e)}
-        onContextMenu={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(provider), e)}
-      >
-        <GridCardArtWrapper style={{ position: 'relative' }}>
-          <div style={{ background: getLikedSongsGradient(provider), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', fontSize: '3rem', color: 'white' }}>♥</div>
-          <ProviderBadgeOverlay>
-            <ProviderIcon provider={provider} size={22} />
-          </ProviderBadgeOverlay>
-          <GridCardPinOverlay $isPinned={likedSongsPinned} onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}>
-            <PinIcon filled={likedSongsPinned} />
-          </GridCardPinOverlay>
-        </GridCardArtWrapper>
-        <GridCardTextArea>
-          <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-          <GridCardSubtitle>{count} tracks{isLikedSongsSyncing && <TabSpinner />}</GridCardSubtitle>
-        </GridCardTextArea>
-      </PinnableGridCard>
-    ))
-  ) : (
-    <PinnableGridCard
-      key="liked-songs"
-      onClick={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(), e)}
-      onContextMenu={(e) => onPlaylistContextMenu(likedSongsAsPlaylistInfo(), e)}
-    >
-      <GridCardArtWrapper style={{ position: 'relative' }}>
-        <div style={{ background: getLikedSongsGradient(activeDescriptor?.id), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', fontSize: '3rem', color: 'white' }}>♥</div>
-        <GridCardPinOverlay $isPinned={likedSongsPinned} onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}>
-          <PinIcon filled={likedSongsPinned} />
-        </GridCardPinOverlay>
-      </GridCardArtWrapper>
-      <GridCardTextArea>
-        <GridCardTitle>{LIKED_SONGS_NAME}</GridCardTitle>
-        <GridCardSubtitle>{likedSubtitle}</GridCardSubtitle>
-      </GridCardTextArea>
-    </PinnableGridCard>
-  ));
+  const layout = inDrawer ? 'grid' : 'list';
 
-  const likedSongsListItem = showLikedSongs && (isUnifiedLikedActive ? (
-    <PinnableListItem key="liked-songs-unified" onClick={() => onLikedSongsClick()}>
-      <PlaylistImageWrapper>
-        <div style={{ background: getLikedSongsGradient('unified'), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', borderRadius: '0.5rem', fontSize: '1.5rem', color: 'white' }}>♥</div>
-      </PlaylistImageWrapper>
-      <PlaylistInfoDiv>
-        <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{likedListSubtitle}</PlaylistDetails>
-      </PlaylistInfoDiv>
-      {likedSongsPinBtn}
-    </PinnableListItem>
-  ) : usePerProviderLiked ? (
-    likedSongsPerProvider.map(({ provider, count }) => (
-      <PinnableListItem key={`liked-songs-${provider}`} onClick={() => onLikedSongsClick(provider)}>
-        <div style={{ position: 'relative' }}>
-          <PlaylistImageWrapper>
-            <div style={{ background: getLikedSongsGradient(provider), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', borderRadius: '0.5rem', fontSize: '1.5rem', color: 'white' }}>♥</div>
-          </PlaylistImageWrapper>
-          <div style={{ position: 'absolute', top: -4, right: -4, zIndex: 2 }}>
-            <ProviderIcon provider={provider} size={18} />
-          </div>
-        </div>
-        <PlaylistInfoDiv>
-          <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-          <PlaylistDetails>{count} tracks{isLikedSongsSyncing && <TabSpinner />} • Shuffle enabled</PlaylistDetails>
-        </PlaylistInfoDiv>
-        {likedSongsPinBtn}
-      </PinnableListItem>
-    ))
-  ) : (
-    <PinnableListItem key="liked-songs" onClick={() => onLikedSongsClick()}>
-      <PlaylistImageWrapper>
-        <div style={{ background: getLikedSongsGradient(activeDescriptor?.id), display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', borderRadius: '0.5rem', fontSize: '1.5rem', color: 'white' }}>♥</div>
-      </PlaylistImageWrapper>
-      <PlaylistInfoDiv>
-        <PlaylistName>{LIKED_SONGS_NAME}</PlaylistName>
-        <PlaylistDetails>{likedListSubtitle}</PlaylistDetails>
-      </PlaylistInfoDiv>
-      {likedSongsPinBtn}
-    </PinnableListItem>
-  ));
+  const likedSongsItem = showLikedSongs && (usePerProviderLiked
+    ? likedSongsPerProvider.map(({ provider, count }) => (
+        <LikedSongsCard key={`liked-songs-${provider}`} layout={layout} provider={provider} count={count} />
+      ))
+    : <LikedSongsCard layout={layout} count={effectiveLikedCount} />
+  );
 
   const renderPlaylistGrid = (playlist: PlaylistInfo) => {
     const pinned = isPlaylistPinned(playlist.id);
@@ -236,7 +123,6 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
 
   const renderFn = inDrawer ? renderPlaylistGrid : renderPlaylistList;
   const hasPinnedSection = pinnedPlaylists.length > 0 || (likedSongsPinned && showLikedSongs && !hasActiveFilters);
-  const likedSongsItem = inDrawer ? likedSongsGridCard : likedSongsListItem;
 
   const filteredPlaylistsCount = pinnedPlaylists.length + unpinnedPlaylists.length;
   const emptyState = filteredPlaylistsCount === 0 && likedSongsCount === 0 && isInitialLoadComplete && (
@@ -250,11 +136,9 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const Grid = inDrawer ? MobileGrid : PlaylistGridDiv;
   return (
     <Grid $inDrawer={inDrawer ? undefined : false}>
-      {/* Pinned section: liked songs (if pinned) + pinned playlists */}
       {!hasActiveFilters && likedSongsPinned && likedSongsItem}
       {pinnedPlaylists.map(renderFn)}
       {hasPinnedSection && <PinnedSectionLabel key="__pin-sep">Pinned</PinnedSectionLabel>}
-      {/* Unpinned section: liked songs (if not pinned) + remaining playlists */}
       {(hasActiveFilters || !likedSongsPinned) && likedSongsItem}
       {unpinnedPlaylists.map(renderFn)}
       {emptyState}


### PR DESCRIPTION
## Summary

- Extracts a `LikedSongsCard` component (`src/components/PlaylistSelection/LikedSongsCard.tsx`) that handles all 3 liked songs variants (unified / per-provider / single-provider) and both layouts (grid card / list item)
- Replaces 6 near-identical JSX blocks in `PlaylistGrid.tsx` with 2 lean call sites (one for per-provider map, one for the unified/single case)
- No user-visible behavior changes; TypeScript clean, pre-existing test failure unaffected

## Test plan

- [ ] `npx tsc -b --noEmit` passes with no errors
- [ ] `npm run test:run` — 696/697 pass (1 pre-existing failure in `PlaylistSelection.test.tsx` unrelated to this change)
- [ ] Grid layout (drawer): liked songs renders correctly for all 3 variants
- [ ] List layout (sidebar): liked songs renders correctly for all 3 variants

Closes #594