### PR TITLE
Release: Fix Spotify 429 rate limiting on queue additions

### DIFF
--- a/src/services/__tests__/spotify.test.ts
+++ b/src/services/__tests__/spotify.test.ts
@@ -216,15 +216,67 @@ describe('Spotify API', () => {
 
   describe('like/save', () => {
     it('checkTrackSaved returns cached value within TTL', async () => {
+      vi.useFakeTimers();
       const mod = await freshSpotify();
 
       mockFetchResponse([true]);
-      const result1 = await mod.checkTrackSaved('track-123');
+      const promise = mod.checkTrackSaved('track-123');
+      await vi.runAllTimersAsync();
+      const result1 = await promise;
       expect(result1).toBe(true);
 
       const result2 = await mod.checkTrackSaved('track-123');
       expect(result2).toBe(true);
       expect(global.fetch).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('checkTrackSaved batches concurrent calls across render cycles into one request', async () => {
+      vi.useFakeTimers();
+      const mod = await freshSpotify();
+
+      // #given — simulate calls arriving across two separate microtask ticks (different render cycles)
+      mockFetchResponse([true, false, true]);
+      const p1 = mod.checkTrackSaved('track-a');
+      const p2 = mod.checkTrackSaved('track-b');
+      // advance microtasks to simulate a new render cycle adding more calls before the 50ms timer fires
+      await Promise.resolve();
+      const p3 = mod.checkTrackSaved('track-c');
+
+      // #when — advance past the 50ms collection window
+      await vi.runAllTimersAsync();
+
+      // #then — all three resolved in a single API request
+      expect(await p1).toBe(true);
+      expect(await p2).toBe(false);
+      expect(await p3).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const url = vi.mocked(global.fetch).mock.calls[0][0] as string;
+      expect(url).toContain('ids=track-a,track-b,track-c');
+      vi.useRealTimers();
+    });
+
+    it('checkTrackSaved splits >50 ids into sequential chunks with inter-chunk delay', async () => {
+      vi.useFakeTimers();
+      const mod = await freshSpotify();
+
+      // #given — 60 distinct track IDs
+      const ids = Array.from({ length: 60 }, (_, i) => `track-${i}`);
+      // First chunk of 50 returns all false, second chunk of 10 returns all true
+      mockFetchResponse(Array(50).fill(false));
+      mockFetchResponse(Array(10).fill(true));
+
+      // #when
+      const promises = ids.map((id) => mod.checkTrackSaved(id));
+      await vi.runAllTimersAsync();
+      const results = await Promise.all(promises);
+
+      // #then — two API calls were made (chunked)
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // First 50 resolved false, last 10 resolved true
+      expect(results.slice(0, 50).every((r) => r === false)).toBe(true);
+      expect(results.slice(50).every((r) => r === true)).toBe(true);
+      vi.useRealTimers();
     });
 
     it('saveTrack makes PUT request and updates cache', async () => {

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -184,16 +184,26 @@ interface BatchEntry {
   reject: (reason: unknown) => void;
 }
 
+const BATCH_SIZE = 50;
+const BATCH_COLLECT_DELAY_MS = 50;
+const BATCH_INTER_CHUNK_DELAY_MS = 100;
+
 let _batchQueue: BatchEntry[] = [];
-let _batchFlushScheduled = false;
+let _batchFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function _sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 async function _flushBatch(): Promise<void> {
+  _batchFlushTimer = null;
   const queue = _batchQueue;
   _batchQueue = [];
-  _batchFlushScheduled = false;
 
-  const BATCH_SIZE = 50;
   for (let i = 0; i < queue.length; i += BATCH_SIZE) {
+    if (i > 0) {
+      await _sleep(BATCH_INTER_CHUNK_DELAY_MS);
+    }
     const chunk = queue.slice(i, i + BATCH_SIZE);
     const ids = chunk.map((entry) => entry.id);
     try {
@@ -222,9 +232,8 @@ export function checkTrackSaved(trackId: string): Promise<boolean> {
 
   return new Promise((resolve, reject) => {
     _batchQueue.push({ id: trackId, resolve, reject });
-    if (!_batchFlushScheduled) {
-      _batchFlushScheduled = true;
-      Promise.resolve().then(_flushBatch);
+    if (_batchFlushTimer === null) {
+      _batchFlushTimer = setTimeout(_flushBatch, BATCH_COLLECT_DELAY_MS);
     }
   });
 }


### PR DESCRIPTION
## Summary

- **#604** — Fixed Spotify `/me/tracks/contains` 429 rate limiting when adding playlists to a large queue. Replaced microtask-level batching with a 50ms debounce collection window and added 100ms inter-chunk delays for large batches.

## Changes

- `src/services/spotify/tracks.ts` — 50ms debounce + sequential chunk execution
- `src/services/__tests__/spotify.test.ts` — 3 new tests for cross-render batching and chunk splitting

## Test plan

- [ ] Load Liked Songs (~700 tracks), skip a few, then add a playlist with overlap — verify no 429 errors
- [ ] Verify like-status hearts still appear correctly after queue loads
- [ ] `npm run test:run` passes