### PR TITLE
fix(tests): remove duplicate back-to-library test in BottomBar

### DIFF
--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -96,13 +96,6 @@ describe('BottomBar', () => {
     expect(props.onBackToLibrary).toHaveBeenCalledOnce();
   });
 
-  it('clicking back-to-library calls onBackToLibrary callback', () => {
-    const onBackToLibrary = vi.fn();
-    renderBottomBar({ onBackToLibrary });
-    fireEvent.click(screen.getByTitle('Back to Library'));
-    expect(onBackToLibrary).toHaveBeenCalledOnce();
-  });
-
   it('zen mode button is visible when onZenModeToggle is provided', () => {
     renderBottomBar({ onZenModeToggle: vi.fn() });
     expect(screen.getByTitle(/zen mode/i)).toBeTruthy();


### PR DESCRIPTION
Removes the duplicate test at lines 99-104 that was testing the same behavior as the test at lines 92-97.

Both tests were clicking the same 'Back to Library' button and asserting that onBackToLibrary was called once. Keeping the first test and removing the second for code deduplication.

Closes #612