### PR TITLE
fix(tests): unwrap functional updater assertions in queue/collection tests

### DIFF
--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -88,9 +88,12 @@ describe('useCollectionLoader', () => {
       return result.current.loadCollection('playlist_123');
     });
 
+    const expectedTracks = [makeMediaTrack('1'), makeMediaTrack('2'), makeMediaTrack('3')];
+
     expect(mockSetIsLoading).toHaveBeenCalledWith(true);
-    expect(mockSetTracks).toHaveBeenCalled();
-    expect(mockSetOriginalTracks).toHaveBeenCalled();
+    // applyTracks passes the track array directly (no functional updater)
+    expect(mockSetTracks).toHaveBeenCalledWith(expectedTracks);
+    expect(mockSetOriginalTracks).toHaveBeenCalledWith(expectedTracks);
     expect(mockPlayTrack).toHaveBeenCalledWith(0);
     expect(trackCount).toBe(3);
   });
@@ -144,8 +147,10 @@ describe('useCollectionLoader', () => {
       return result.current.loadCollection(LIKED_SONGS_ID);
     });
 
-    // Should merge and sort by addedAt (newest first): track 3 (1500), track 1 (1000), track 2 (500)
-    expect(mockSetTracks).toHaveBeenCalled();
+    // applyTracks passes the merged+sorted array directly — newest addedAt first
+    const expectedMergedOrder = [makeMediaTrack('3', 1500), makeMediaTrack('1', 1000), makeMediaTrack('2', 500)];
+    expect(mockSetTracks).toHaveBeenCalledWith(expectedMergedOrder);
+    expect(mockSetOriginalTracks).toHaveBeenCalledWith(expectedMergedOrder);
     expect(trackCount).toBe(3);
   });
 
@@ -275,9 +280,13 @@ describe('useCollectionLoader', () => {
       await result.current.loadCollection('playlist_123');
     });
 
-    // setOriginalTracks gets the unshuffled list; setTracks gets whatever order
+    // setOriginalTracks always receives the original unshuffled order
     expect(mockSetOriginalTracks).toHaveBeenCalledWith(tracks);
-    expect(mockSetTracks).toHaveBeenCalled();
+    // setTracks receives a shuffled permutation — same elements, possibly different order
+    expect(mockSetTracks).toHaveBeenCalledTimes(1);
+    const shuffledTracks = mockSetTracks.mock.calls[0][0] as MediaTrack[];
+    expect(shuffledTracks).toHaveLength(tracks.length);
+    expect(shuffledTracks.map(t => t.id).sort()).toEqual(['1', '2', '3']);
   });
 
   it('switches active provider when loading a collection from a different provider', async () => {

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -62,6 +62,7 @@ describe('useQueueManagement', () => {
   });
 
   it('handleRemoveFromQueue adjusts currentTrackIndex when removing a track before the current one', () => {
+    // #given
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2'), makeMediaTrack('3')];
     const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' }), makeTrack({ id: '3' })];
     const { result } = renderHook(() =>
@@ -77,13 +78,21 @@ describe('useQueueManagement', () => {
       })
     );
 
+    // #when
     act(() => {
       result.current.handleRemoveFromQueue(0);
     });
 
-    // Should decrement currentTrackIndex from 2 to 1
+    // #then — setCurrentTrackIndex receives a functional updater that decrements by 1
     expect(mockSetCurrentTrackIndex).toHaveBeenCalledWith(expect.any(Function));
-    expect(mockSetTracks).toHaveBeenCalled();
+    const indexUpdater = mockSetCurrentTrackIndex.mock.calls[0][0] as (prev: number) => number;
+    expect(indexUpdater(2)).toBe(1);
+
+    // setTracks receives a functional updater that removes the track at index 0
+    expect(mockSetTracks).toHaveBeenCalledWith(expect.any(Function));
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: typeof tracks) => typeof tracks;
+    expect(tracksUpdater(tracks)).toEqual([makeTrack({ id: '2' }), makeTrack({ id: '3' })]);
+
     expect(mockSetOriginalTracks).toHaveBeenCalled();
   });
 
@@ -165,6 +174,15 @@ describe('useQueueManagement', () => {
 
     // Should have appended the new tracks
     expect(mockSetTracks).toHaveBeenCalledWith(expect.any(Function));
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: ReturnType<typeof makeMediaTrack>[]) => ReturnType<typeof makeMediaTrack>[];
+    const existingTracks = [makeMediaTrack('1'), makeMediaTrack('2')];
+    const appended = tracksUpdater(existingTracks);
+    expect(appended).toHaveLength(4);
+    expect(appended[0].id).toBe('1');
+    expect(appended[1].id).toBe('2');
+    expect(appended[2].id).toBe('3');
+    expect(appended[3].id).toBe('4');
+
     expect(mockSetOriginalTracks).toHaveBeenCalled();
     expect(response).toEqual({ added: 2, collectionName: undefined });
     // currentTrackIndex should NOT be reset


### PR DESCRIPTION
## Summary

- Capture and invoke `setCurrentTrackIndex`'s functional updater in `useQueueManagement` to assert it decrements the index from 2 → 1 when removing a track before the current one
- Capture and invoke `setTracks`'s functional updater in `useQueueManagement` to assert the append operation produces `[track1, track2, track3, track4]` when adding to an existing queue
- Strengthen `setTracks`/`setOriginalTracks` assertions in `useCollectionLoader` to verify exact arrays passed by `applyTracks` (standard collection load path)
- Verify unified liked songs are merged and sorted newest-first (addedAt: 1500 > 1000 > 500)
- Verify the shuffle path produces the same elements regardless of order, not just that `setTracks` was called

## Test plan

- [x] `npm run test:run -- src/hooks/__tests__/useQueueManagement.test.ts src/hooks/__tests__/useCollectionLoader.test.ts` — 15/15 pass
- [x] No source files modified (test-only change)
- [x] No `as any`, `@ts-ignore`, or suppression annotations added

Closes #607