### PR TITLE
fix: correct PlaylistSelection loading state test

### DIFF
--- a/src/components/__tests__/PlaylistSelection.test.tsx
+++ b/src/components/__tests__/PlaylistSelection.test.tsx
@@ -176,7 +176,12 @@ describe('PlaylistSelection', () => {
     renderPlaylistSelection();
 
     // #then
-    expect(screen.getByText('Loading your library...')).toBeTruthy();
+    // When auth is resolved but initial load is not complete, the component renders
+    // tab buttons with inline spinners — not the "Loading your library..." skeleton
+    // (that skeleton only shows when isLoading=true, i.e. before auth resolves).
+    expect(screen.getByRole('button', { name: /playlists/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /albums/i })).toBeTruthy();
+    expect(screen.queryByText('Loading your library...')).toBeNull();
   });
 
   it('shows error message when no content is found after load', () => {


### PR DESCRIPTION
## Summary

- The test `'shows loading state while isSyncing is true and no data yet'` asserted `'Loading your library...'` would appear when `isSyncing=true` and `isInitialLoadComplete=false`
- That text is only rendered by `LibraryStatusContent` when `isLoading` (auth-derived state) is `true` — but since auth is mocked as authenticated in tests, `isLoading` is set to `false` immediately via `useEffect`
- When auth is resolved but data is still loading, the component renders `LibraryMainContent` with tab buttons containing `TabSpinner` elements — not the skeleton text
- Updated the assertion to match actual behavior: tab buttons present, loading skeleton text absent

## Test plan

- [x] `npx vitest run src/components/__tests__/PlaylistSelection.test.tsx` — 14/14 pass
- [x] `npm run test:run` — 698/698 pass
- [x] `npx tsc -b --noEmit` — clean

Closes #624