### PR TITLE
feat: add Grid Wave (3D particle matrix) background visualizer

### DIFF
--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -4,6 +4,7 @@ import type { VisualizerStyle } from '../types/visualizer';
 import { ParticleVisualizer } from './visualizers/ParticleVisualizer';
 import { TrailVisualizer } from './visualizers/TrailVisualizer';
 import { WaveVisualizer } from './visualizers/WaveVisualizer';
+import { GridWaveVisualizer } from './visualizers/GridWaveVisualizer';
 
 interface AlbumArtBounds {
   left: number;
@@ -71,6 +72,8 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
         return TrailVisualizer;
       case 'wave':
         return WaveVisualizer;
+      case 'grid':
+        return GridWaveVisualizer;
       default:
         return ParticleVisualizer;
     }

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -318,6 +318,12 @@ function QuickEffectsRow({
               >
                 Wave
               </OptionButton>
+              <OptionButton
+                $isActive={backgroundVisualizerStyle === 'grid'}
+                onClick={() => onBackgroundVisualizerStyleChange('grid')}
+              >
+                Grid
+              </OptionButton>
             </OptionButtonGroup>
           </SubSettingRow>
           {hasVizIntensity && (

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback } from 'react';
+import { generateColorVariant } from '../../utils/visualizerUtils';
+import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
+import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
+
+interface GridWaveVisualizerProps {
+  intensity: number;
+  accentColor: string;
+  isPlaying: boolean;
+  playbackPosition?: number;
+  zenMode?: boolean;
+}
+
+interface GridParticle {
+  gridX: number;
+  gridY: number;
+  baseX: number;
+  baseY: number;
+  baseRadius: number;
+  color: string;
+}
+
+interface WaveState {
+  phase: number;
+  angleX: number;
+  angleY: number;
+  speed: number;
+  frequency: number;
+}
+
+interface GridWaveState {
+  particles: GridParticle[];
+  waves: WaveState[];
+  width: number;
+  height: number;
+}
+
+export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
+  intensity,
+  accentColor,
+  isPlaying,
+}) => {
+  const config = useVisualizerDebugConfig();
+  const g = config.grid;
+
+  const getItemCount = useCallback(
+    (width: number, _height: number, _intensity: number): number => {
+      const isMobile = width < 768;
+      return isMobile ? g.countBaseMobile : g.countBaseDesktop;
+    },
+    [g]
+  );
+
+  const initializeItems = useCallback(
+    (count: number, width: number, height: number, baseColor: string): GridWaveState[] => {
+      const spacing = g.spacing;
+      const cols = Math.ceil(width / spacing) + 1;
+      const rows = Math.ceil(height / spacing) + 1;
+
+      const particles: GridParticle[] = [];
+      for (let row = 0; row < rows; row++) {
+        for (let col = 0; col < cols; col++) {
+          const depthFactor = row / Math.max(1, rows - 1);
+          particles.push({
+            gridX: col,
+            gridY: row,
+            baseX: col * spacing,
+            baseY: row * spacing,
+            baseRadius: g.baseRadius * (0.7 + depthFactor * 0.6),
+            color: generateColorVariant(baseColor, 0.3 + depthFactor * 0.5),
+          });
+        }
+      }
+
+      const waves: WaveState[] = Array.from({ length: g.waveCount }, (_, i) => ({
+        phase: (Math.PI * 2 * i) / g.waveCount,
+        angleX: Math.cos((Math.PI * 2 * i) / g.waveCount),
+        angleY: Math.sin((Math.PI * 2 * i) / g.waveCount),
+        speed: g.waveSpeedBase + (i / g.waveCount) * g.waveSpeedSpread,
+        frequency: g.frequencyBase + (i / g.waveCount) * g.frequencySpread,
+      }));
+
+      void count;
+      return [{ particles, waves, width, height }];
+    },
+    [g]
+  );
+
+  const updateItems = useCallback(
+    (states: GridWaveState[], deltaTime: number, playing: boolean, width: number, height: number): void => {
+      const speedMult = playing ? 1.0 : g.pausedSpeedMult;
+      const dt = deltaTime / 16;
+
+      const state = states[0];
+      if (!state) return;
+
+      state.width = width;
+      state.height = height;
+
+      state.waves.forEach(wave => {
+        wave.phase += wave.speed * speedMult * dt;
+        if (wave.phase > Math.PI * 2) wave.phase -= Math.PI * 2;
+      });
+    },
+    [g]
+  );
+
+  const renderItems = useCallback(
+    (
+      ctx: CanvasRenderingContext2D,
+      states: GridWaveState[],
+      width: number,
+      height: number,
+      intensityValue: number
+    ): void => {
+      ctx.clearRect(0, 0, width, height);
+
+      const state = states[0];
+      if (!state) return;
+
+      const intensityScale = Math.max(0.3, intensityValue / 60);
+      const amplitude = g.amplitudeBase * Math.min(width, height) * intensityScale;
+      const rows = Math.ceil(height / g.spacing) + 1;
+
+      state.particles.forEach(particle => {
+        let displacement = 0;
+        state.waves.forEach(wave => {
+          const proj = particle.baseX * wave.angleX * wave.frequency + particle.baseY * wave.angleY * wave.frequency;
+          displacement += Math.sin(proj + wave.phase);
+        });
+        displacement /= g.waveCount;
+
+        const normalizedDisp = (displacement + 1) / 2;
+        const yOffset = displacement * amplitude;
+
+        const depthFactor = particle.gridY / Math.max(1, rows - 1);
+        const perspectiveScale = 1.0 - g.perspectiveStrength * (1.0 - depthFactor);
+
+        const radius = Math.max(0.5, particle.baseRadius * (1 + normalizedDisp * g.radiusWaveScale) * perspectiveScale);
+        const opacity = Math.max(0.05, Math.min(1.0,
+          (g.opacityBase + normalizedDisp * g.opacityWaveScale) * perspectiveScale * intensityScale
+        ));
+
+        const x = particle.baseX;
+        const y = particle.baseY + yOffset;
+
+        if (x < -radius || x > width + radius || y < -radius || y > height + radius) return;
+
+        ctx.save();
+        ctx.globalAlpha = opacity;
+        ctx.fillStyle = particle.color;
+        ctx.beginPath();
+        ctx.arc(x, y, radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      });
+    },
+    [g]
+  );
+
+  const handleColorChange = useCallback(
+    (states: GridWaveState[], color: string): void => {
+      const state = states[0];
+      if (!state) return;
+      const rows = Math.ceil(state.height / g.spacing) + 1;
+      state.particles.forEach(particle => {
+        const depthFactor = particle.gridY / Math.max(1, rows - 1);
+        particle.color = generateColorVariant(color, 0.3 + depthFactor * 0.5);
+      });
+    },
+    [g]
+  );
+
+  const canvasRef = useCanvasVisualizer<GridWaveState>({
+    accentColor,
+    isPlaying,
+    intensity,
+    getItemCount,
+    initializeItems,
+    updateItems,
+    renderItems,
+    onColorChange: handleColorChange,
+  });
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'block',
+      }}
+    />
+  );
+};

--- a/src/constants/visualizerDebugConfig.ts
+++ b/src/constants/visualizerDebugConfig.ts
@@ -54,6 +54,24 @@ export interface TrailVisualizerConfig {
   countPixelDivisorMobile: number;
 }
 
+export interface GridWaveVisualizerConfig {
+  spacing: number;
+  waveCount: number;
+  waveSpeedBase: number;
+  waveSpeedSpread: number;
+  amplitudeBase: number;
+  frequencyBase: number;
+  frequencySpread: number;
+  perspectiveStrength: number;
+  baseRadius: number;
+  radiusWaveScale: number;
+  opacityBase: number;
+  opacityWaveScale: number;
+  pausedSpeedMult: number;
+  countBaseMobile: number;
+  countBaseDesktop: number;
+}
+
 export interface WaveVisualizerConfig {
   waveCount: number;
   phaseSpeedMin: number;
@@ -73,6 +91,7 @@ export interface VisualizerDebugConfig {
   particle: ParticleVisualizerConfig;
   trail: TrailVisualizerConfig;
   wave: WaveVisualizerConfig;
+  grid: GridWaveVisualizerConfig;
 }
 
 /** Partial overrides for debug panel; nested keys are optional. */
@@ -80,6 +99,7 @@ export interface VisualizerDebugOverrides {
   particle?: Partial<ParticleVisualizerConfig>;
   trail?: Partial<TrailVisualizerConfig>;
   wave?: Partial<WaveVisualizerConfig>;
+  grid?: Partial<GridWaveVisualizerConfig>;
 }
 
 const DEFAULT_PARTICLE: ParticleVisualizerConfig = {
@@ -126,6 +146,24 @@ const DEFAULT_TRAIL: TrailVisualizerConfig = {
 
 
 
+const DEFAULT_GRID_WAVE: GridWaveVisualizerConfig = {
+  spacing: 35,
+  waveCount: 3,
+  waveSpeedBase: 0.018,
+  waveSpeedSpread: 0.012,
+  amplitudeBase: 0.06,
+  frequencyBase: 0.012,
+  frequencySpread: 0.008,
+  perspectiveStrength: 0.4,
+  baseRadius: 2.5,
+  radiusWaveScale: 1.2,
+  opacityBase: 0.25,
+  opacityWaveScale: 0.45,
+  pausedSpeedMult: 0.3,
+  countBaseMobile: 1,
+  countBaseDesktop: 1,
+};
+
 const DEFAULT_WAVE: WaveVisualizerConfig = {
   waveCount: 4,
   phaseSpeedMin: 0.004,
@@ -145,6 +183,7 @@ export const DEFAULT_VISUALIZER_DEBUG_CONFIG: VisualizerDebugConfig = {
   particle: { ...DEFAULT_PARTICLE },
   trail: { ...DEFAULT_TRAIL },
   wave: { ...DEFAULT_WAVE },
+  grid: { ...DEFAULT_GRID_WAVE },
 };
 
 /** Deep merge: overrides only replace provided keys; nested objects are merged. */
@@ -164,5 +203,9 @@ export function mergeVisualizerConfig(
     ...base.wave,
     ...(overrides?.wave ?? {}),
   };
-  return { particle, trail, wave };
+  const grid = {
+    ...base.grid,
+    ...(overrides?.grid ?? {}),
+  };
+  return { particle, trail, wave, grid };
 }

--- a/src/contexts/VisualizerDebugContext.tsx
+++ b/src/contexts/VisualizerDebugContext.tsx
@@ -122,7 +122,7 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       const parsed = JSON.parse(json) as VisualizerDebugConfig | VisualizerDebugOverrides;
       const overrides: VisualizerDebugOverrides =
         parsed?.particle && parsed?.trail
-          ? { particle: parsed.particle, trail: parsed.trail }
+          ? { particle: parsed.particle, trail: parsed.trail, wave: parsed.wave, grid: parsed.grid }
           : (parsed as VisualizerDebugOverrides);
       setOverridesState(overrides);
       writeStoredOverrides(overrides);

--- a/src/types/visualizer.d.ts
+++ b/src/types/visualizer.d.ts
@@ -8,7 +8,8 @@
 export type VisualizerStyle =
   | 'fireflies'
   | 'comet'
-  | 'wave';
+  | 'wave'
+  | 'grid';
 
 interface VisualizerConfig {
   particleCount?: number;


### PR DESCRIPTION
## Summary

- Adds a new `GridWaveVisualizer` background visualizer that renders a regular grid of particles whose Y positions are modulated by 2-3 overlapping sine waves, creating a pulsing 3D matrix effect
- Particle radius and opacity scale with wave displacement (peaks brighter/larger), with a perspective depth gradient making far particles appear smaller
- Paused state slows wave speed to 30% matching the existing `PAUSED_SPEED_MULT` pattern used by other visualizers
- Registers `'grid'` in the `VisualizerStyle` union, adds it to the `BackgroundVisualizer` switch, and adds a "Grid" button to the `QuickEffectsRow` style picker
- Adds `GridWaveVisualizerConfig` interface and `DEFAULT_GRID_WAVE` constants to `visualizerDebugConfig.ts`, integrated with `mergeVisualizerConfig` for debug panel support

## Test plan

- [ ] Enable visualizer in settings, select "Grid" style — particles should appear in a regular grid with wave motion
- [ ] Pause playback — wave motion should slow to ~30% speed
- [ ] Change accent color — grid particle colors should update to match
- [ ] Resize viewport — grid should cover full canvas
- [ ] Verify on mobile (<768px) — uses mobile particle count path
- [ ] Verify other visualizers (Fireflies, Comet, Wave) still work correctly
- [ ] `npm run test:run` — 697 tests pass (1 pre-existing failure in PlaylistSelection unrelated to this change)
- [ ] `npx tsc -b --noEmit` — clean
- [ ] `npm run build` — clean

Closes #625