### PR TITLE
fix: tune Grid Wave visualizer — slower, fewer, bigger waves

### DIFF
--- a/src/constants/visualizerDebugConfig.ts
+++ b/src/constants/visualizerDebugConfig.ts
@@ -148,12 +148,12 @@ const DEFAULT_TRAIL: TrailVisualizerConfig = {
 
 const DEFAULT_GRID_WAVE: GridWaveVisualizerConfig = {
   spacing: 35,
-  waveCount: 3,
-  waveSpeedBase: 0.018,
-  waveSpeedSpread: 0.012,
-  amplitudeBase: 0.06,
-  frequencyBase: 0.012,
-  frequencySpread: 0.008,
+  waveCount: 2,
+  waveSpeedBase: 0.006,
+  waveSpeedSpread: 0.004,
+  amplitudeBase: 0.12,
+  frequencyBase: 0.005,
+  frequencySpread: 0.003,
   perspectiveStrength: 0.4,
   baseRadius: 2.5,
   radiusWaveScale: 1.2,


### PR DESCRIPTION
## Summary

- Reduce wave count from 3 to 2
- Slow wave speed ~3x (0.018 → 0.006 base)
- Double amplitude (0.06 → 0.12) for bigger, more sweeping motion
- Lower frequency ~2.5x (0.012 → 0.005) for broader waves

The original defaults were too fast and disorienting. These values produce a calmer, more meditative effect.

## Test plan

- [ ] Select Grid visualizer — waves should move slowly with broad, sweeping motion
- [ ] Compare play vs pause — paused should be noticeably slower
- [ ] `npm run build` passes