### PR TITLE
feat: DevBug console log capture and circular buffer (#632)

### DIFF
--- a/src/services/devbug/__tests__/circularBuffer.test.ts
+++ b/src/services/devbug/__tests__/circularBuffer.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CircularBuffer } from '../circularBuffer';
+
+describe('CircularBuffer', () => {
+  describe('push and toArray', () => {
+    it('returns an empty array when nothing has been pushed', () => {
+      // #when
+      const buf = new CircularBuffer<number>(5);
+
+      // #then
+      expect(buf.toArray()).toEqual([]);
+    });
+
+    it('stores items in insertion order', () => {
+      // #given
+      const buf = new CircularBuffer<number>(5);
+
+      // #when
+      buf.push(1);
+      buf.push(2);
+      buf.push(3);
+
+      // #then
+      expect(buf.toArray()).toEqual([1, 2, 3]);
+    });
+
+    it('fills to capacity without eviction', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+
+      // #when
+      buf.push(1);
+      buf.push(2);
+      buf.push(3);
+
+      // #then
+      expect(buf.toArray()).toEqual([1, 2, 3]);
+      expect(buf.length).toBe(3);
+    });
+  });
+
+  describe('FIFO eviction on overflow', () => {
+    it('evicts the oldest item when capacity is exceeded', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+      buf.push(1);
+      buf.push(2);
+      buf.push(3);
+
+      // #when
+      buf.push(4);
+
+      // #then
+      expect(buf.toArray()).toEqual([2, 3, 4]);
+    });
+
+    it('evicts multiple oldest items as more are pushed', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+      buf.push(1);
+      buf.push(2);
+      buf.push(3);
+
+      // #when
+      buf.push(4);
+      buf.push(5);
+
+      // #then
+      expect(buf.toArray()).toEqual([3, 4, 5]);
+    });
+
+    it('handles pushing twice the capacity gracefully', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+
+      // #when
+      for (let i = 1; i <= 6; i++) buf.push(i);
+
+      // #then
+      expect(buf.toArray()).toEqual([4, 5, 6]);
+    });
+
+    it('keeps length at capacity after overflow', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+      for (let i = 0; i < 10; i++) buf.push(i);
+
+      // #then
+      expect(buf.length).toBe(3);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the buffer', () => {
+      // #given
+      const buf = new CircularBuffer<number>(5);
+      buf.push(1);
+      buf.push(2);
+
+      // #when
+      buf.clear();
+
+      // #then
+      expect(buf.toArray()).toEqual([]);
+      expect(buf.length).toBe(0);
+    });
+
+    it('allows pushing after clear', () => {
+      // #given
+      const buf = new CircularBuffer<number>(3);
+      buf.push(1);
+      buf.push(2);
+      buf.push(3);
+      buf.clear();
+
+      // #when
+      buf.push(4);
+
+      // #then
+      expect(buf.toArray()).toEqual([4]);
+    });
+  });
+
+  describe('length', () => {
+    it('tracks the current number of items', () => {
+      // #given
+      const buf = new CircularBuffer<string>(10);
+
+      // #then
+      expect(buf.length).toBe(0);
+
+      buf.push('a');
+      expect(buf.length).toBe(1);
+
+      buf.push('b');
+      expect(buf.length).toBe(2);
+    });
+  });
+
+  describe('generic type support', () => {
+    it('stores and retrieves objects', () => {
+      // #given
+      const buf = new CircularBuffer<{ id: number; name: string }>(2);
+
+      // #when
+      buf.push({ id: 1, name: 'alpha' });
+      buf.push({ id: 2, name: 'beta' });
+
+      // #then
+      expect(buf.toArray()).toEqual([
+        { id: 1, name: 'alpha' },
+        { id: 2, name: 'beta' },
+      ]);
+    });
+
+    it('evicts oldest object on overflow', () => {
+      // #given
+      const buf = new CircularBuffer<{ id: number }>(2);
+      buf.push({ id: 1 });
+      buf.push({ id: 2 });
+
+      // #when
+      buf.push({ id: 3 });
+
+      // #then
+      expect(buf.toArray()).toEqual([{ id: 2 }, { id: 3 }]);
+    });
+  });
+
+  describe('capacity of 1', () => {
+    it('only retains the most recent item', () => {
+      // #given
+      const buf = new CircularBuffer<number>(1);
+
+      // #when
+      buf.push(10);
+      buf.push(20);
+      buf.push(30);
+
+      // #then
+      expect(buf.toArray()).toEqual([30]);
+    });
+  });
+});

--- a/src/services/devbug/__tests__/consoleCapture.test.ts
+++ b/src/services/devbug/__tests__/consoleCapture.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { startCapture, stopCapture, getEntries, clearEntries } from '../consoleCapture';
+import type { ConsoleEntry } from '../consoleCapture';
+
+beforeEach(() => {
+  stopCapture();
+  clearEntries();
+});
+
+afterEach(() => {
+  stopCapture();
+  clearEntries();
+});
+
+describe('startCapture / stopCapture lifecycle', () => {
+  it('returns an empty array when stopped without any calls', () => {
+    // #when
+    startCapture();
+    const entries = stopCapture();
+
+    // #then
+    expect(entries).toEqual([]);
+  });
+
+  it('restores original console methods after stopCapture', () => {
+    // #given
+    const originalLog = console.log;
+    startCapture();
+    const patchedLog = console.log;
+
+    // #when
+    stopCapture();
+
+    // #then
+    expect(console.log).toBe(originalLog);
+    expect(console.log).not.toBe(patchedLog);
+  });
+
+  it('does not capture entries after stopCapture', () => {
+    // #given
+    startCapture();
+    stopCapture();
+
+    // #when
+    console.log('should not be captured');
+
+    // #then
+    expect(getEntries()).toEqual([]);
+  });
+
+  it('calling startCapture twice does not double-patch', () => {
+    // #given
+    startCapture();
+    const firstPatch = console.log;
+
+    // #when
+    startCapture();
+
+    // #then
+    expect(console.log).toBe(firstPatch);
+
+    stopCapture();
+  });
+
+  it('calling stopCapture when not capturing returns empty array', () => {
+    // #when
+    const entries = stopCapture();
+
+    // #then
+    expect(entries).toEqual([]);
+  });
+
+  it('clears buffer on stopCapture', () => {
+    // #given
+    startCapture();
+    console.log('entry one');
+    stopCapture();
+
+    // #when
+    startCapture();
+    const entries = stopCapture();
+
+    // #then
+    expect(entries).toEqual([]);
+  });
+});
+
+describe('console level interception', () => {
+  const levels = ['log', 'warn', 'error', 'info', 'debug'] as const;
+
+  for (const level of levels) {
+    it(`captures console.${level} calls`, () => {
+      // #given
+      startCapture();
+
+      // #when
+      console[level]('test message');
+      const entries = stopCapture();
+
+      // #then
+      expect(entries).toHaveLength(1);
+      expect(entries[0].level).toBe(level);
+      expect(entries[0].args[0]).toBe('test message');
+    });
+  }
+
+  it('still calls through to the original console method', () => {
+    // #given
+    const spy = vi.fn();
+    const origLog = console.log;
+    console.log = spy;
+
+    startCapture();
+
+    // #when
+    console.log('passthrough check');
+    stopCapture();
+
+    // #then
+    expect(spy).toHaveBeenCalledWith('passthrough check');
+
+    console.log = origLog;
+  });
+});
+
+describe('entry shape', () => {
+  it('records timestamp as an ISO 8601 string', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log('ts check');
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('records a stack trace string', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log('stack check');
+    const entries = stopCapture();
+
+    // #then
+    expect(typeof entries[0].stack).toBe('string');
+  });
+
+  it('serializes multiple arguments', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log('first', 'second', 'third');
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args).toEqual(['first', 'second', 'third']);
+  });
+});
+
+describe('safe serialization', () => {
+  it('handles circular references gracefully', () => {
+    // #given
+    const obj: Record<string, unknown> = { key: 'value' };
+    obj.self = obj;
+
+    startCapture();
+
+    // #when
+    console.log(obj);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toContain('[Circular]');
+  });
+
+  it('handles Error objects', () => {
+    // #given
+    const err = new Error('something went wrong');
+
+    startCapture();
+
+    // #when
+    console.error(err);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toContain('Error');
+    expect(entries[0].args[0]).toContain('something went wrong');
+  });
+
+  it('truncates very long strings', () => {
+    // #given
+    const longString = 'x'.repeat(2000);
+
+    startCapture();
+
+    // #when
+    console.log(longString);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0].length).toBeLessThan(1100);
+    expect(entries[0].args[0]).toContain('[truncated]');
+  });
+
+  it('handles null and undefined', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log(null, undefined);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toBe('null');
+    expect(entries[0].args[1]).toBe('undefined');
+  });
+
+  it('handles numbers and booleans', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log(42, true, false);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toBe('42');
+    expect(entries[0].args[1]).toBe('true');
+    expect(entries[0].args[2]).toBe('false');
+  });
+
+  it('handles nested arrays', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log([1, 2, [3, 4]]);
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toContain('1');
+    expect(entries[0].args[0]).toContain('2');
+    expect(entries[0].args[0]).toContain('3');
+  });
+
+  it('handles plain objects', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log({ name: 'Alice', age: 30 });
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toContain('name');
+    expect(entries[0].args[0]).toContain('Alice');
+  });
+
+  it('handles functions', () => {
+    // #given
+    startCapture();
+
+    // #when
+    console.log(function myFunc() {});
+    const entries = stopCapture();
+
+    // #then
+    expect(entries[0].args[0]).toContain('Function');
+    expect(entries[0].args[0]).toContain('myFunc');
+  });
+});
+
+describe('getEntries', () => {
+  it('returns current buffer contents without stopping capture', () => {
+    // #given
+    startCapture();
+    console.log('entry one');
+    console.warn('entry two');
+
+    // #when
+    const entries = getEntries();
+
+    // #then
+    expect(entries).toHaveLength(2);
+    stopCapture();
+  });
+
+  it('returns an empty array before capture starts', () => {
+    // #when
+    const entries = getEntries();
+
+    // #then
+    expect(entries).toEqual([]);
+  });
+});
+
+describe('clearEntries', () => {
+  it('empties the buffer without stopping capture', () => {
+    // #given
+    startCapture();
+    console.log('to be cleared');
+    expect(getEntries()).toHaveLength(1);
+
+    // #when
+    clearEntries();
+
+    // #then
+    expect(getEntries()).toHaveLength(0);
+    stopCapture();
+  });
+
+  it('allows new entries to be captured after clearing', () => {
+    // #given
+    startCapture();
+    console.log('first');
+    clearEntries();
+
+    // #when
+    console.log('second');
+    const entries = stopCapture();
+
+    // #then
+    expect(entries).toHaveLength(1);
+    expect(entries[0].args[0]).toBe('second');
+  });
+});
+
+describe('circular buffer — 200 entry limit', () => {
+  it('keeps only the most recent 200 entries', () => {
+    // #given
+    startCapture();
+
+    // #when
+    for (let i = 0; i < 250; i++) {
+      console.log(`entry ${i}`);
+    }
+    const entries = stopCapture();
+
+    // #then
+    expect(entries).toHaveLength(200);
+    expect(entries[0].args[0]).toBe('entry 50');
+    expect(entries[199].args[0]).toBe('entry 249');
+  });
+});
+
+describe('type contract', () => {
+  it('ConsoleEntry has the expected shape', () => {
+    // #given
+    startCapture();
+    console.info('type check');
+    const entries = stopCapture();
+
+    // #then
+    const entry: ConsoleEntry = entries[0];
+    expect(typeof entry.timestamp).toBe('string');
+    expect(entry.level).toBe('info');
+    expect(Array.isArray(entry.args)).toBe(true);
+    expect(typeof entry.stack).toBe('string');
+  });
+});

--- a/src/services/devbug/circularBuffer.ts
+++ b/src/services/devbug/circularBuffer.ts
@@ -1,0 +1,43 @@
+export class CircularBuffer<T> {
+  private readonly capacity: number;
+  private readonly buffer: (T | undefined)[];
+  private head = 0;
+  private size = 0;
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.buffer = new Array<T | undefined>(capacity);
+  }
+
+  push(item: T): void {
+    const index = (this.head + this.size) % this.capacity;
+    this.buffer[index] = item;
+
+    if (this.size < this.capacity) {
+      this.size++;
+    } else {
+      this.head = (this.head + 1) % this.capacity;
+    }
+  }
+
+  toArray(): T[] {
+    const result: T[] = [];
+    for (let i = 0; i < this.size; i++) {
+      const item = this.buffer[(this.head + i) % this.capacity];
+      if (item !== undefined) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+
+  clear(): void {
+    this.head = 0;
+    this.size = 0;
+    this.buffer.fill(undefined);
+  }
+
+  get length(): number {
+    return this.size;
+  }
+}

--- a/src/services/devbug/consoleCapture.ts
+++ b/src/services/devbug/consoleCapture.ts
@@ -1,0 +1,151 @@
+import createDebug from 'debug';
+import { CircularBuffer } from './circularBuffer';
+
+const log = createDebug('vorbis:devbug');
+
+const MAX_STRING_LENGTH = 1000;
+const BUFFER_CAPACITY = 200;
+
+export type ConsoleLevel = 'log' | 'warn' | 'error' | 'info' | 'debug';
+
+export interface ConsoleEntry {
+  timestamp: string;
+  level: ConsoleLevel;
+  args: string[];
+  stack: string;
+}
+
+type ConsolePatch = Record<ConsoleLevel, typeof console.log>;
+
+const buffer = new CircularBuffer<ConsoleEntry>(BUFFER_CAPACITY);
+let originals: ConsolePatch | null = null;
+
+function safeStringify(value: unknown, seen = new Set<unknown>()): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH ? value.slice(0, MAX_STRING_LENGTH) + '...[truncated]' : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function') {
+    return `[Function: ${value.name || 'anonymous'}]`;
+  }
+
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}${value.stack ? '\n' + value.stack : ''}`;
+  }
+
+  if (typeof window !== 'undefined' && value instanceof Element) {
+    const el = value as Element;
+    let descriptor = el.tagName.toLowerCase();
+    if (el.id) descriptor += `#${el.id}`;
+    if (el.className && typeof el.className === 'string') {
+      const classes = el.className.trim().split(/\s+/).filter(Boolean);
+      if (classes.length > 0) descriptor += `.${classes.join('.')}`;
+    }
+    return `[Element: <${descriptor}>]`;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  seen.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      const items = value.map((item) => safeStringify(item, seen));
+      seen.delete(value);
+      return `[${items.join(', ')}]`;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>).map(
+      ([k, v]) => `${k}: ${safeStringify(v, seen)}`
+    );
+    seen.delete(value);
+    const result = `{${entries.join(', ')}}`;
+    return result.length > MAX_STRING_LENGTH ? result.slice(0, MAX_STRING_LENGTH) + '...[truncated]' : result;
+  } catch {
+    seen.delete(value);
+    return '[Unserializable]';
+  }
+}
+
+function serializeArgs(args: unknown[]): string[] {
+  return args.map((arg) => safeStringify(arg));
+}
+
+function captureEntry(level: ConsoleLevel, args: unknown[]): void {
+  buffer.push({
+    timestamp: new Date().toISOString(),
+    level,
+    args: serializeArgs(args),
+    stack: new Error().stack ?? '',
+  });
+}
+
+function patchMethod(level: ConsoleLevel, original: typeof console.log): typeof console.log {
+  return function (...args: unknown[]): void {
+    captureEntry(level, args);
+    original.apply(console, args);
+  };
+}
+
+export function startCapture(): void {
+  if (originals !== null) {
+    log('startCapture called while already capturing — ignoring');
+    return;
+  }
+
+  originals = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    info: console.info,
+    debug: console.debug,
+  };
+
+  const levels: ConsoleLevel[] = ['log', 'warn', 'error', 'info', 'debug'];
+  for (const level of levels) {
+    console[level] = patchMethod(level, originals[level]);
+  }
+
+  log('console capture started');
+}
+
+export function stopCapture(): ConsoleEntry[] {
+  if (originals === null) {
+    log('stopCapture called while not capturing — returning empty');
+    return [];
+  }
+
+  const levels: ConsoleLevel[] = ['log', 'warn', 'error', 'info', 'debug'];
+  for (const level of levels) {
+    console[level] = originals[level];
+  }
+
+  originals = null;
+
+  const entries = buffer.toArray();
+  buffer.clear();
+
+  log('console capture stopped, %d entries collected', entries.length);
+  return entries;
+}
+
+export function getEntries(): ConsoleEntry[] {
+  return buffer.toArray();
+}
+
+export function clearEntries(): void {
+  buffer.clear();
+}


### PR DESCRIPTION
## Summary

- Implements `CircularBuffer<T>` — a generic FIFO ring buffer with configurable capacity and O(1) push/eviction
- Implements `consoleCapture` module that monkey-patches all five console methods (`log`, `warn`, `error`, `info`, `debug`) while preserving any existing patches (Sentry, LogRocket, etc.)
- Safe serialization handles circular references, DOM elements, Error objects, and truncates strings > 1000 chars
- Module is a pure utility with no React or DevBugContext dependencies — lifecycle is controlled via `startCapture()` / `stopCapture()`

## Files

- `src/services/devbug/circularBuffer.ts` — generic circular buffer, 200-entry cap
- `src/services/devbug/consoleCapture.ts` — console interception, entry serialization, buffer management
- `src/services/devbug/__tests__/circularBuffer.test.ts` — 13 tests
- `src/services/devbug/__tests__/consoleCapture.test.ts` — 29 tests

## Test plan

- [x] TypeScript: `npx tsc -b --noEmit` — clean
- [x] Devbug tests: 42 tests pass
- [x] Full suite: 740 tests pass (59 test files)
- [x] Buffer overflow eviction verified (250 pushes → 200 kept, correct FIFO order)
- [x] Circular reference handling verified
- [x] All 5 console levels captured and passed through to original

Closes #632