### PR TITLE
feat: DevBug FAB toggle and activation layer (#629)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import { getLikesSync } from './providers/dropbox/dropboxLikesSync';
 import { getPreferencesSync } from './providers/dropbox/dropboxPreferencesSync';
 import { AUTH_COMPLETE_EVENT } from '@/constants/events';
 import { logApp } from '@/lib/debugLog';
+import { DevBugProvider } from '@/contexts/DevBugContext';
+import { DevBugFAB } from '@/components/DevBug';
 
 /**
  * Cleanup function to remove deprecated localStorage keys
@@ -194,7 +196,7 @@ function App() {
     );
   }
 
-  return (
+  const player = (
     <ThemeProvider>
       <ProviderProvider>
         <PlayerSizingProvider>
@@ -216,6 +218,17 @@ function App() {
       </ProviderProvider>
     </ThemeProvider>
   );
+
+  if (import.meta.env.DEV) {
+    return (
+      <DevBugProvider>
+        {player}
+        <DevBugFAB />
+      </DevBugProvider>
+    );
+  }
+
+  return player;
 }
 
 export default App;

--- a/src/components/DevBug/DevBugFAB.tsx
+++ b/src/components/DevBug/DevBugFAB.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import styled, { keyframes, css } from 'styled-components';
+import { useDevBug } from '@/contexts/DevBugContext';
+import { DevBugTopBar } from './DevBugTopBar';
+
+const pulse = keyframes`
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 160, 0, 0.7); }
+  50% { box-shadow: 0 0 0 8px rgba(255, 160, 0, 0); }
+`;
+
+const FABButton = styled.button<{ $active: boolean }>`
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 2147483647;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 2px solid ${({ $active }) => ($active ? 'rgba(255, 160, 0, 0.9)' : 'rgba(255, 255, 255, 0.2)')};
+  background: ${({ $active }) => ($active ? 'rgba(40, 20, 0, 0.95)' : 'rgba(20, 20, 20, 0.9)')};
+  color: ${({ $active }) => ($active ? 'rgba(255, 160, 0, 0.95)' : 'rgba(255, 255, 255, 0.8)')};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  line-height: 1;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.15s;
+  backdrop-filter: blur(8px);
+
+  &:hover {
+    transform: scale(1.08);
+    background: ${({ $active }) => ($active ? 'rgba(60, 30, 0, 0.95)' : 'rgba(40, 40, 40, 0.95)')};
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  ${({ $active }) =>
+    $active &&
+    css`
+      animation: ${pulse} 1.8s ease-in-out infinite;
+    `}
+`;
+
+const BugIcon = () => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M20 8h-2.81A5.985 5.985 0 0 0 13 5.07V5a1 1 0 0 0-2 0v.07A5.985 5.985 0 0 0 6.81 8H4a1 1 0 0 0 0 2h2.09A6.011 6.011 0 0 0 6 11v1H4a1 1 0 0 0 0 2h2v1a6.011 6.011 0 0 0 .09 1H4a1 1 0 0 0 0 2h2.81A6 6 0 0 0 18 17v-1h2a1 1 0 0 0 0-2h-2v-1h2a1 1 0 0 0 0-2h-2v-1a6.011 6.011 0 0 0-.09-1H20a1 1 0 0 0 0-2zm-8 9a4 4 0 1 1 4-4 4 4 0 0 1-4 4z" />
+  </svg>
+);
+
+export function DevBugFAB() {
+  const { isActive, toggle } = useDevBug();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+        e.preventDefault();
+        toggle();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [toggle]);
+
+  useEffect(() => {
+    document.body.style.cursor = isActive ? 'crosshair' : '';
+    return () => {
+      document.body.style.cursor = '';
+    };
+  }, [isActive]);
+
+  return createPortal(
+    <>
+      <FABButton
+        $active={isActive}
+        onClick={toggle}
+        aria-label={isActive ? 'Deactivate DevBug preview mode' : 'Activate DevBug preview mode'}
+        title="DevBug (Ctrl+Shift+D)"
+      >
+        <BugIcon />
+      </FABButton>
+      {isActive && <DevBugTopBar />}
+    </>,
+    document.body,
+  );
+}

--- a/src/components/DevBug/DevBugTopBar.tsx
+++ b/src/components/DevBug/DevBugTopBar.tsx
@@ -1,0 +1,32 @@
+import { createPortal } from 'react-dom';
+import styled, { keyframes } from 'styled-components';
+
+const slideDown = keyframes`
+  from { transform: translateY(-100%); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+`;
+
+const TopBarContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 2147483646;
+  background: rgba(255, 160, 0, 0.95);
+  color: #000;
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 16px;
+  text-align: center;
+  cursor: crosshair;
+  animation: ${slideDown} 0.2s ease-out;
+  user-select: none;
+`;
+
+export function DevBugTopBar() {
+  return createPortal(
+    <TopBarContainer>Preview Mode — click an element to inspect</TopBarContainer>,
+    document.body,
+  );
+}

--- a/src/components/DevBug/index.ts
+++ b/src/components/DevBug/index.ts
@@ -1,0 +1,2 @@
+export { DevBugFAB } from './DevBugFAB';
+export { DevBugTopBar } from './DevBugTopBar';

--- a/src/contexts/DevBugContext.tsx
+++ b/src/contexts/DevBugContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+interface DevBugContextValue {
+  isActive: boolean;
+  activate: () => void;
+  deactivate: () => void;
+  toggle: () => void;
+}
+
+const DevBugContext = createContext<DevBugContextValue | null>(null);
+
+export function DevBugProvider({ children }: { children: ReactNode }) {
+  const [isActive, setIsActive] = useState(false);
+
+  const activate = useCallback(() => setIsActive(true), []);
+  const deactivate = useCallback(() => setIsActive(false), []);
+  const toggle = useCallback(() => setIsActive((prev) => !prev), []);
+
+  const value = useMemo<DevBugContextValue>(
+    () => ({ isActive, activate, deactivate, toggle }),
+    [isActive, activate, deactivate, toggle],
+  );
+
+  return <DevBugContext.Provider value={value}>{children}</DevBugContext.Provider>;
+}
+
+export function useDevBug(): DevBugContextValue {
+  const ctx = useContext(DevBugContext);
+  if (!ctx) throw new Error('useDevBug must be used within DevBugProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary

- Implements `DevBugContext` providing `{ isActive, activate, deactivate, toggle }` state
- `DevBugFAB` — portal-based fixed FAB (bottom-right, max z-index) with bug icon; pulsing border animation when active
- `DevBugTopBar` — portal-based amber banner shown while preview mode is on ("Preview Mode — click an element to inspect")
- `Ctrl+Shift+D` keyboard shortcut toggles preview mode via a `document` listener
- Body cursor changes to `crosshair` while active; restored on deactivate
- Entire feature gated behind `import.meta.env.DEV` — zero cost in production builds

## Files

- `src/contexts/DevBugContext.tsx` — context + provider
- `src/components/DevBug/DevBugFAB.tsx` — FAB component via portal
- `src/components/DevBug/DevBugTopBar.tsx` — top-bar indicator via portal
- `src/components/DevBug/index.ts` — barrel export
- `src/App.tsx` — conditional DevBugProvider + DevBugFAB mount in dev mode

## Test plan

- [ ] `npx tsc -b --noEmit` passes (0 errors)
- [ ] `npm run test:run` passes (698/698 tests)
- [ ] FAB appears bottom-right in dev mode
- [ ] Clicking FAB toggles preview mode on/off
- [ ] `Ctrl+Shift+D` toggles preview mode
- [ ] Top bar appears when active, disappears when deactivated
- [ ] Body cursor becomes crosshair when active
- [ ] No FAB or context in production build

Closes #629