### PR TITLE
feat: BugReport data model and structured report builder (#635)

### DIFF
--- a/src/services/devbug/__tests__/reportBuilder.test.ts
+++ b/src/services/devbug/__tests__/reportBuilder.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildBugReport, collectBrowserInfo, extractElementInfo } from '../reportBuilder';
+import type { SelectedElement } from '@/types/devbug';
+
+const FIXED_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const FIXED_ISO = '2026-04-06T12:00:00.000Z';
+
+beforeEach(() => {
+  Object.defineProperty(global.crypto, 'randomUUID', {
+    value: vi.fn().mockReturnValue(FIXED_UUID),
+    writable: true,
+    configurable: true,
+  });
+  vi.spyOn(Date.prototype, 'toISOString').mockReturnValue(FIXED_ISO);
+});
+
+const makeSelectedElement = (overrides: Partial<SelectedElement> = {}): SelectedElement => ({
+  cssSelector: 'div',
+  xpath: '/div',
+  reactComponentName: null,
+  boundingRect: { top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50, x: 0, y: 0 },
+  computedStyles: {},
+  textContent: '',
+  ...overrides,
+});
+
+describe('buildBugReport', () => {
+  it('auto-populates id with a UUID', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.id).toBe(FIXED_UUID);
+    expect(crypto.randomUUID as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+  });
+
+  it('auto-populates timestamp as ISO 8601', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.timestamp).toBe(FIXED_ISO);
+  });
+
+  it('auto-populates browserInfo', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.browserInfo).toBeDefined();
+    expect(typeof report.browserInfo.userAgent).toBe('string');
+    expect(report.browserInfo.viewport).toHaveProperty('width');
+    expect(report.browserInfo.viewport).toHaveProperty('height');
+    expect(report.browserInfo.url).toBeDefined();
+    expect(report.browserInfo.timestamp).toBe(FIXED_ISO);
+  });
+
+  it('passes through selectionMode', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'area', elements: [] });
+
+    // #then
+    expect(report.selectionMode).toBe('area');
+  });
+
+  it('passes through elements array', () => {
+    // #given
+    const elements = [makeSelectedElement({ cssSelector: '#my-el' })];
+
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements });
+
+    // #then
+    expect(report.elements).toHaveLength(1);
+    expect(report.elements[0].cssSelector).toBe('#my-el');
+  });
+
+  it('defaults screenshotDataUrl to empty string when not provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.screenshotDataUrl).toBe('');
+  });
+
+  it('passes through screenshotDataUrl when provided', () => {
+    // #given
+    const dataUrl = 'data:image/png;base64,abc123';
+
+    // #when
+    const report = buildBugReport({ selectionMode: 'screenshot', elements: [], screenshotDataUrl: dataUrl });
+
+    // #then
+    expect(report.screenshotDataUrl).toBe(dataUrl);
+  });
+
+  it('defaults comment to empty string when not provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.comment).toBe('');
+  });
+
+  it('passes through comment when provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [], comment: 'Something is broken' });
+
+    // #then
+    expect(report.comment).toBe('Something is broken');
+  });
+
+  it('defaults categories to empty array when not provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.categories).toEqual([]);
+  });
+
+  it('passes through categories when provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [], categories: ['broken', 'slower'] });
+
+    // #then
+    expect(report.categories).toEqual(['broken', 'slower']);
+  });
+
+  it('defaults consoleLogs to empty array when not provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.consoleLogs).toEqual([]);
+  });
+
+  it('passes through consoleLogs when provided', () => {
+    // #given
+    const logs = [{ timestamp: FIXED_ISO, level: 'error' as const, args: ['Something failed'], stack: null }];
+
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [], consoleLogs: logs });
+
+    // #then
+    expect(report.consoleLogs).toHaveLength(1);
+    expect(report.consoleLogs[0].level).toBe('error');
+  });
+
+  it('defaults performanceMetrics with null values when not provided', () => {
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [] });
+
+    // #then
+    expect(report.performanceMetrics.fcp).toBeNull();
+    expect(report.performanceMetrics.lcp).toBeNull();
+    expect(report.performanceMetrics.memoryUsed).toBeNull();
+    expect(report.performanceMetrics.memoryTotal).toBeNull();
+    expect(report.performanceMetrics.longTasks).toEqual([]);
+  });
+
+  it('passes through performanceMetrics when provided', () => {
+    // #given
+    const metrics = {
+      fcp: 1200,
+      lcp: 2500,
+      memoryUsed: 50_000_000,
+      memoryTotal: 100_000_000,
+      longTasks: [{ duration: 80, startTime: 1000 }],
+    };
+
+    // #when
+    const report = buildBugReport({ selectionMode: 'click', elements: [], performanceMetrics: metrics });
+
+    // #then
+    expect(report.performanceMetrics).toEqual(metrics);
+  });
+});
+
+describe('collectBrowserInfo', () => {
+  it('returns userAgent, viewport, url, and timestamp', () => {
+    // #when
+    const info = collectBrowserInfo();
+
+    // #then
+    expect(typeof info.userAgent).toBe('string');
+    expect(typeof info.viewport.width).toBe('number');
+    expect(typeof info.viewport.height).toBe('number');
+    expect(typeof info.url).toBe('string');
+    expect(info.timestamp).toBe(FIXED_ISO);
+  });
+});
+
+describe('extractElementInfo', () => {
+  it('returns element metadata including cssSelector, xpath, boundingRect, and textContent', () => {
+    // #given
+    const el = document.createElement('div');
+    el.id = 'test-node';
+    el.textContent = 'Hello world';
+    document.body.appendChild(el);
+
+    // #when
+    const info = extractElementInfo(el);
+
+    // #then
+    expect(info.cssSelector).toBe('#test-node');
+    expect(info.xpath).toMatch(/^\//);
+    expect(info.textContent).toBe('Hello world');
+    expect(typeof info.boundingRect.width).toBe('number');
+    expect(typeof info.computedStyles).toBe('object');
+
+    document.body.removeChild(el);
+  });
+
+  it('truncates textContent to 200 characters', () => {
+    // #given
+    const el = document.createElement('p');
+    el.textContent = 'a'.repeat(300);
+    document.body.appendChild(el);
+
+    // #when
+    const info = extractElementInfo(el);
+
+    // #then
+    expect(info.textContent).toHaveLength(200);
+
+    document.body.removeChild(el);
+  });
+
+  it('sets reactComponentName to null when no React fiber is present', () => {
+    // #given
+    const el = document.createElement('span');
+    document.body.appendChild(el);
+
+    // #when
+    const info = extractElementInfo(el);
+
+    // #then
+    expect(info.reactComponentName).toBeNull();
+
+    document.body.removeChild(el);
+  });
+
+  it('includes known computed style properties', () => {
+    // #given
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    // #when
+    const info = extractElementInfo(el);
+
+    // #then
+    expect(info.computedStyles).toHaveProperty('display');
+    expect(info.computedStyles).toHaveProperty('position');
+
+    document.body.removeChild(el);
+  });
+});

--- a/src/services/devbug/__tests__/selectorGenerator.test.ts
+++ b/src/services/devbug/__tests__/selectorGenerator.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { generateCssSelector, generateXPath } from '../selectorGenerator';
+
+function createElement(tag: string, attrs: Record<string, string> = {}): Element {
+  const el = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === 'class') {
+      el.className = value;
+    } else {
+      el.setAttribute(key, value);
+    }
+  }
+  return el;
+}
+
+describe('generateCssSelector', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('uses ID selector when element has an id', () => {
+    // #given
+    const el = createElement('div', { id: 'my-element' });
+    container.appendChild(el);
+
+    // #when
+    const selector = generateCssSelector(el);
+
+    // #then
+    expect(selector).toBe('#my-element');
+  });
+
+  it('escapes special characters in IDs', () => {
+    // #given
+    const el = createElement('div', { id: 'foo:bar' });
+    container.appendChild(el);
+
+    // #when
+    const selector = generateCssSelector(el);
+
+    // #then
+    expect(selector).toBe('#foo\\:bar');
+  });
+
+  it('uses unique class combination when no ID is present', () => {
+    // #given
+    const el = createElement('button', { class: 'play-btn primary' });
+    container.appendChild(el);
+
+    // #when
+    const selector = generateCssSelector(el);
+
+    // #then
+    expect(selector).toBe('.play-btn.primary');
+  });
+
+  it('falls back to nth-child path when classes are not unique', () => {
+    // #given
+    const el1 = createElement('div', { class: 'item' });
+    const el2 = createElement('div', { class: 'item' });
+    container.appendChild(el1);
+    container.appendChild(el2);
+
+    // #when
+    const selector = generateCssSelector(el2);
+
+    // #then
+    expect(selector).toContain('div');
+    expect(selector).not.toBe('.item');
+  });
+
+  it('generates nth-child path for element without id or unique class', () => {
+    // #given
+    const wrapper = createElement('section');
+    const el = createElement('p');
+    wrapper.appendChild(createElement('p'));
+    wrapper.appendChild(el);
+    container.appendChild(wrapper);
+
+    // #when
+    const selector = generateCssSelector(el);
+
+    // #then
+    expect(selector).toContain('p:nth-child');
+  });
+
+  it('omits nth-child when element is the only sibling of its tag', () => {
+    // #given
+    const wrapper = createElement('nav');
+    const el = createElement('ul');
+    wrapper.appendChild(el);
+    container.appendChild(wrapper);
+
+    // #when
+    const selector = generateCssSelector(el);
+
+    // #then
+    expect(selector).not.toContain(':nth-child');
+    expect(selector).toContain('ul');
+  });
+});
+
+describe('generateXPath', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('generates an absolute XPath starting with /', () => {
+    // #given
+    const el = createElement('span');
+    container.appendChild(el);
+
+    // #when
+    const xpath = generateXPath(el);
+
+    // #then
+    expect(xpath).toMatch(/^\//);
+  });
+
+  it('includes tag name in XPath', () => {
+    // #given
+    const el = createElement('article');
+    container.appendChild(el);
+
+    // #when
+    const xpath = generateXPath(el);
+
+    // #then
+    expect(xpath).toContain('article');
+  });
+
+  it('adds index when multiple siblings of same tag exist', () => {
+    // #given
+    const el1 = createElement('li');
+    const el2 = createElement('li');
+    const el3 = createElement('li');
+    container.appendChild(el1);
+    container.appendChild(el2);
+    container.appendChild(el3);
+
+    // #when
+    const xpath = generateXPath(el2);
+
+    // #then
+    expect(xpath).toContain('li[2]');
+  });
+
+  it('omits index when element is the only sibling of its tag', () => {
+    // #given
+    const wrapper = createElement('main');
+    const el = createElement('header');
+    wrapper.appendChild(el);
+    container.appendChild(wrapper);
+
+    // #when
+    const xpath = generateXPath(el);
+
+    // #then
+    expect(xpath).not.toMatch(/header\[\d+\]/);
+    expect(xpath).toContain('header');
+  });
+
+  it('can resolve element via document.evaluate', () => {
+    // #given
+    const wrapper = createElement('section');
+    const el = createElement('p');
+    wrapper.appendChild(createElement('p'));
+    wrapper.appendChild(el);
+    container.appendChild(wrapper);
+    el.textContent = 'target';
+
+    // #when
+    const xpath = generateXPath(el);
+    const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+
+    // #then
+    expect(result.singleNodeValue).toBe(el);
+  });
+});

--- a/src/services/devbug/reportBuilder.ts
+++ b/src/services/devbug/reportBuilder.ts
@@ -1,0 +1,136 @@
+import type {
+  BugReport,
+  BrowserInfo,
+  BoundingRect,
+  SelectedElement,
+  SelectionMode,
+  Category,
+  ConsoleEntry,
+  PerfData,
+} from '@/types/devbug';
+import { generateCssSelector, generateXPath } from './selectorGenerator';
+
+const INTERESTING_STYLES = [
+  'display',
+  'position',
+  'width',
+  'height',
+  'margin',
+  'padding',
+  'color',
+  'background-color',
+  'font-size',
+  'font-weight',
+  'border',
+  'border-radius',
+  'overflow',
+  'z-index',
+  'opacity',
+  'visibility',
+  'flex-direction',
+  'align-items',
+  'justify-content',
+];
+
+const TEXT_CONTENT_MAX_LENGTH = 200;
+
+export function collectBrowserInfo(): BrowserInfo {
+  return {
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    url: window.location.href,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function extractElementInfo(element: Element): SelectedElement {
+  const rect = element.getBoundingClientRect();
+  const boundingRect: BoundingRect = {
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+    x: rect.x,
+    y: rect.y,
+  };
+
+  const computed = window.getComputedStyle(element);
+  const computedStyles: Record<string, string> = {};
+  for (const prop of INTERESTING_STYLES) {
+    computedStyles[prop] = computed.getPropertyValue(prop);
+  }
+
+  const rawText = element.textContent ?? '';
+  const textContent = rawText.slice(0, TEXT_CONTENT_MAX_LENGTH);
+
+  const reactComponentName = getReactComponentName(element);
+
+  return {
+    cssSelector: generateCssSelector(element),
+    xpath: generateXPath(element),
+    reactComponentName,
+    boundingRect,
+    computedStyles,
+    textContent,
+  };
+}
+
+function getReactComponentName(element: Element): string | null {
+  const fiberKey = Object.keys(element).find(
+    (key) => key.startsWith('__reactFiber') || key.startsWith('__reactInternalInstance'),
+  );
+
+  if (!fiberKey) return null;
+
+  let fiber = (element as unknown as Record<string, unknown>)[fiberKey] as
+    | { type?: unknown; return?: unknown }
+    | null
+    | undefined;
+
+  while (fiber) {
+    const type = fiber.type;
+    if (typeof type === 'function' && type.name) {
+      return type.name;
+    }
+    if (typeof type === 'object' && type !== null) {
+      const displayName = (type as Record<string, unknown>).displayName;
+      if (typeof displayName === 'string') return displayName;
+    }
+    fiber = fiber.return as typeof fiber;
+  }
+
+  return null;
+}
+
+export interface BuildBugReportParams {
+  selectionMode: SelectionMode;
+  elements: SelectedElement[];
+  screenshotDataUrl?: string;
+  comment?: string;
+  categories?: Category[];
+  consoleLogs?: ConsoleEntry[];
+  performanceMetrics?: PerfData;
+}
+
+export function buildBugReport(params: BuildBugReportParams): BugReport {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    selectionMode: params.selectionMode,
+    elements: params.elements,
+    screenshotDataUrl: params.screenshotDataUrl ?? '',
+    comment: params.comment ?? '',
+    categories: params.categories ?? [],
+    consoleLogs: params.consoleLogs ?? [],
+    browserInfo: collectBrowserInfo(),
+    performanceMetrics: params.performanceMetrics ?? {
+      fcp: null,
+      lcp: null,
+      memoryUsed: null,
+      memoryTotal: null,
+      longTasks: [],
+    },
+  };
+}

--- a/src/services/devbug/selectorGenerator.ts
+++ b/src/services/devbug/selectorGenerator.ts
@@ -1,0 +1,75 @@
+export function generateCssSelector(element: Element): string {
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`;
+  }
+
+  const classes = Array.from(element.classList).filter(Boolean);
+  if (classes.length > 0) {
+    const classSelector = classes.map((c) => `.${CSS.escape(c)}`).join('');
+    if (document.querySelectorAll(classSelector).length === 1) {
+      return classSelector;
+    }
+  }
+
+  return buildNthChildPath(element);
+}
+
+function buildNthChildPath(element: Element): string {
+  const parts: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current !== document.documentElement) {
+    const tag = current.tagName.toLowerCase();
+    const parentEl: HTMLElement | null = current.parentElement;
+
+    if (!parentEl) {
+      parts.unshift(tag);
+      break;
+    }
+
+    const siblings = Array.from(parentEl.children).filter(
+      (child: Element) => child.tagName === current!.tagName,
+    );
+
+    if (siblings.length === 1) {
+      parts.unshift(tag);
+    } else {
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(`${tag}:nth-child(${index})`);
+    }
+
+    current = parentEl;
+  }
+
+  return parts.join(' > ');
+}
+
+export function generateXPath(element: Element): string {
+  const parts: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current.nodeType === Node.ELEMENT_NODE) {
+    const tag = current.tagName.toLowerCase();
+    const parentEl: HTMLElement | null = current.parentElement;
+
+    if (!parentEl) {
+      parts.unshift(tag);
+      break;
+    }
+
+    const siblings = Array.from(parentEl.children).filter(
+      (child: Element) => child.tagName === current!.tagName,
+    );
+
+    if (siblings.length === 1) {
+      parts.unshift(tag);
+    } else {
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(`${tag}[${index}]`);
+    }
+
+    current = parentEl;
+  }
+
+  return `/${parts.join('/')}`;
+}

--- a/src/types/devbug.ts
+++ b/src/types/devbug.ts
@@ -1,0 +1,58 @@
+export type SelectionMode = 'click' | 'area' | 'screenshot';
+
+export type Category = 'faster' | 'slower' | 'bigger' | 'smaller' | 'broken';
+
+export interface ConsoleEntry {
+  timestamp: string;
+  level: 'log' | 'warn' | 'error' | 'info' | 'debug';
+  args: string[];
+  stack: string | null;
+}
+
+export interface BoundingRect {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
+export interface SelectedElement {
+  cssSelector: string;
+  xpath: string;
+  reactComponentName: string | null;
+  boundingRect: BoundingRect;
+  computedStyles: Record<string, string>;
+  textContent: string;
+}
+
+export interface BrowserInfo {
+  userAgent: string;
+  viewport: { width: number; height: number };
+  url: string;
+  timestamp: string;
+}
+
+export interface PerfData {
+  fcp: number | null;
+  lcp: number | null;
+  memoryUsed: number | null;
+  memoryTotal: number | null;
+  longTasks: Array<{ duration: number; startTime: number }>;
+}
+
+export interface BugReport {
+  id: string;
+  timestamp: string;
+  selectionMode: SelectionMode;
+  elements: SelectedElement[];
+  screenshotDataUrl: string;
+  comment: string;
+  categories: Category[];
+  consoleLogs: ConsoleEntry[];
+  browserInfo: BrowserInfo;
+  performanceMetrics: PerfData;
+}


### PR DESCRIPTION
## Summary

- Defines the full `BugReport` TypeScript data model in `src/types/devbug.ts` (all interfaces and types per spec: `BugReport`, `SelectedElement`, `BoundingRect`, `BrowserInfo`, `PerfData`, `ConsoleEntry`, `Category`, `SelectionMode`)
- Implements CSS selector generation in `src/services/devbug/selectorGenerator.ts` — tries ID first, then unique class combination, then tag+nth-child path fallback
- Implements XPath generation in the same module
- Implements `buildBugReport`, `extractElementInfo`, and `collectBrowserInfo` in `src/services/devbug/reportBuilder.ts`
- 31 tests across two test files with BDD-style `#given`/`#when`/`#then` comments

## Test plan

- [x] `npm run test:run` — all 729 tests pass
- [x] `npx tsc -b --noEmit` — no TypeScript errors
- [x] Selector tests: ID, unique class, nth-child fallback, XPath evaluation via `document.evaluate`
- [x] Report builder tests: auto-populated fields (id, timestamp, browserInfo), defaults for optional fields, passthrough of all params