### PR TITLE
feat(devbug): screenshot capture service with html2canvas (#633)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "debug": "^4.4.3",
+        "html2canvas": "^1.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "styled-components": "^6.1.12"
@@ -3412,6 +3413,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3619,6 +3629,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-to-react-native": {
@@ -4392,6 +4411,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6016,6 +6048,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6296,6 +6337,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "debug": "^4.4.3",
+    "html2canvas": "^1.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "styled-components": "^6.1.12"

--- a/src/services/devbug/__tests__/screenshotCapture.test.ts
+++ b/src/services/devbug/__tests__/screenshotCapture.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BoundingRect } from '@/types/devbug';
+
+const mockToDataURL = vi.fn().mockReturnValue('data:image/png;base64,mock');
+const mockFillRect = vi.fn();
+const mockStrokeRect = vi.fn();
+const mockSave = vi.fn();
+const mockRestore = vi.fn();
+
+const mockCtx = {
+  strokeStyle: '',
+  fillStyle: '',
+  lineWidth: 0,
+  fillRect: mockFillRect,
+  strokeRect: mockStrokeRect,
+  save: mockSave,
+  restore: mockRestore,
+};
+
+const mockCanvas = {
+  toDataURL: mockToDataURL,
+  getContext: vi.fn().mockReturnValue(mockCtx),
+};
+
+const mockHtml2canvas = vi.fn().mockResolvedValue(mockCanvas);
+
+vi.mock('html2canvas', () => ({
+  default: (...args: unknown[]) => mockHtml2canvas(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHtml2canvas.mockResolvedValue(mockCanvas);
+  mockCanvas.getContext.mockReturnValue(mockCtx);
+  mockToDataURL.mockReturnValue('data:image/png;base64,mock');
+  Object.defineProperty(window, 'devicePixelRatio', { value: 1, configurable: true, writable: true });
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true, writable: true });
+  Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true, writable: true });
+  Object.defineProperty(window, 'scrollX', { value: 0, configurable: true, writable: true });
+  Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
+});
+
+describe('captureViewport', () => {
+  it('lazy-loads html2canvas on first call', async () => {
+    // #when
+    const { captureViewport } = await import('../screenshotCapture');
+    await captureViewport();
+
+    // #then
+    expect(mockHtml2canvas).toHaveBeenCalledOnce();
+  });
+
+  it('passes viewport dimensions and scroll position to html2canvas', async () => {
+    // #given
+    Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 900, configurable: true, writable: true });
+    Object.defineProperty(window, 'scrollX', { value: 100, configurable: true, writable: true });
+    Object.defineProperty(window, 'scrollY', { value: 50, configurable: true, writable: true });
+
+    // #when
+    const { captureViewport } = await import('../screenshotCapture');
+    await captureViewport();
+
+    // #then
+    expect(mockHtml2canvas).toHaveBeenCalledWith(
+      document.body,
+      expect.objectContaining({
+        width: 1440,
+        height: 900,
+        windowWidth: 1440,
+        windowHeight: 900,
+        x: 100,
+        y: 50,
+      })
+    );
+  });
+
+  it('sets scale to device pixel ratio', async () => {
+    // #given
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true, writable: true });
+
+    // #when
+    const { captureViewport } = await import('../screenshotCapture');
+    await captureViewport();
+
+    // #then
+    expect(mockHtml2canvas).toHaveBeenCalledWith(
+      document.body,
+      expect.objectContaining({ scale: 2 })
+    );
+  });
+
+  it('returns the canvas produced by html2canvas', async () => {
+    // #when
+    const { captureViewport } = await import('../screenshotCapture');
+    const result = await captureViewport();
+
+    // #then
+    expect(result).toBe(mockCanvas);
+  });
+});
+
+describe('captureScreenshot', () => {
+  it('returns a PNG data URL', async () => {
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    const result = await captureScreenshot();
+
+    // #then
+    expect(result).toBe('data:image/png;base64,mock');
+    expect(mockToDataURL).toHaveBeenCalledWith('image/png');
+  });
+
+  it('does not draw highlight when no rect is provided', async () => {
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot();
+
+    // #then
+    expect(mockFillRect).not.toHaveBeenCalled();
+    expect(mockStrokeRect).not.toHaveBeenCalled();
+  });
+
+  it('draws highlight rect at provided bounding rect coordinates', async () => {
+    // #given
+    const rect: BoundingRect = { x: 10, y: 20, width: 100, height: 50, top: 20, right: 110, bottom: 70, left: 10 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot(rect);
+
+    // #then
+    expect(mockFillRect).toHaveBeenCalledWith(10, 20, 100, 50);
+    expect(mockStrokeRect).toHaveBeenCalledWith(10, 20, 100, 50);
+  });
+
+  it('scales highlight coordinates by device pixel ratio', async () => {
+    // #given
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true, writable: true });
+    const rect: BoundingRect = { x: 10, y: 20, width: 100, height: 50, top: 20, right: 110, bottom: 70, left: 10 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot(rect);
+
+    // #then
+    expect(mockFillRect).toHaveBeenCalledWith(20, 40, 200, 100);
+    expect(mockStrokeRect).toHaveBeenCalledWith(20, 40, 200, 100);
+  });
+
+  it('uses orange stroke and semi-transparent orange fill for highlight', async () => {
+    // #given
+    const rect: BoundingRect = { x: 0, y: 0, width: 50, height: 50, top: 0, right: 50, bottom: 50, left: 0 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot(rect);
+
+    // #then
+    expect(mockCtx.strokeStyle).toBe('rgba(255, 165, 0, 1)');
+    expect(mockCtx.fillStyle).toBe('rgba(255, 165, 0, 0.3)');
+  });
+
+  it('saves and restores canvas context state when drawing highlight', async () => {
+    // #given
+    const rect: BoundingRect = { x: 0, y: 0, width: 50, height: 50, top: 0, right: 50, bottom: 50, left: 0 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot(rect);
+
+    // #then
+    expect(mockSave).toHaveBeenCalledOnce();
+    expect(mockRestore).toHaveBeenCalledOnce();
+  });
+
+  it('skips highlight drawing when canvas context is unavailable', async () => {
+    // #given
+    mockCanvas.getContext.mockReturnValueOnce(null);
+    const rect: BoundingRect = { x: 0, y: 0, width: 50, height: 50, top: 0, right: 50, bottom: 50, left: 0 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    const result = await captureScreenshot(rect);
+
+    // #then
+    expect(result).toBe('data:image/png;base64,mock');
+    expect(mockFillRect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to dpr=1 when devicePixelRatio is not set', async () => {
+    // #given
+    Object.defineProperty(window, 'devicePixelRatio', { value: 0, configurable: true, writable: true });
+    const rect: BoundingRect = { x: 5, y: 5, width: 10, height: 10, top: 5, right: 15, bottom: 15, left: 5 };
+
+    // #when
+    const { captureScreenshot } = await import('../screenshotCapture');
+    await captureScreenshot(rect);
+
+    // #then
+    expect(mockFillRect).toHaveBeenCalledWith(5, 5, 10, 10);
+  });
+});

--- a/src/services/devbug/screenshotCapture.ts
+++ b/src/services/devbug/screenshotCapture.ts
@@ -1,0 +1,63 @@
+import createDebug from 'debug';
+import type { BoundingRect } from '@/types/devbug';
+
+const log = createDebug('vorbis:devbug');
+
+const HIGHLIGHT_STROKE = 'rgba(255, 165, 0, 1)';
+const HIGHLIGHT_FILL = 'rgba(255, 165, 0, 0.3)';
+const HIGHLIGHT_LINE_WIDTH = 2;
+
+async function loadHtml2canvas(): Promise<typeof import('html2canvas').default> {
+  const mod = await import('html2canvas');
+  return mod.default;
+}
+
+export async function captureViewport(): Promise<HTMLCanvasElement> {
+  const html2canvas = await loadHtml2canvas();
+  const dpr = window.devicePixelRatio || 1;
+
+  log('capturing viewport at dpr=%f', dpr);
+
+  const canvas = await html2canvas(document.body, {
+    scale: dpr,
+    useCORS: true,
+    allowTaint: true,
+    logging: false,
+    width: window.innerWidth,
+    height: window.innerHeight,
+    windowWidth: window.innerWidth,
+    windowHeight: window.innerHeight,
+    x: window.scrollX,
+    y: window.scrollY,
+  });
+
+  return canvas;
+}
+
+export async function captureScreenshot(highlightRect?: BoundingRect): Promise<string> {
+  const canvas = await captureViewport();
+
+  if (highlightRect) {
+    const dpr = window.devicePixelRatio || 1;
+    const ctx = canvas.getContext('2d');
+
+    if (ctx) {
+      const x = highlightRect.x * dpr;
+      const y = highlightRect.y * dpr;
+      const width = highlightRect.width * dpr;
+      const height = highlightRect.height * dpr;
+
+      ctx.save();
+      ctx.strokeStyle = HIGHLIGHT_STROKE;
+      ctx.fillStyle = HIGHLIGHT_FILL;
+      ctx.lineWidth = HIGHLIGHT_LINE_WIDTH * dpr;
+      ctx.fillRect(x, y, width, height);
+      ctx.strokeRect(x, y, width, height);
+      ctx.restore();
+
+      log('drew highlight rect at x=%f y=%f w=%f h=%f (dpr=%f)', x, y, width, height, dpr);
+    }
+  }
+
+  return canvas.toDataURL('image/png');
+}


### PR DESCRIPTION
## Summary

- Adds `src/services/devbug/screenshotCapture.ts` with two exported functions: `captureViewport()` and `captureScreenshot()`
- Lazy-loads `html2canvas` on first call via dynamic `import()` — zero cost until used
- Captures the full viewport at the current device pixel ratio
- `captureScreenshot(highlightRect?)` draws an orange bounding box (2px stroke, `rgba(255,165,0,0.3)` fill) scaled by DPR before returning a PNG data URL
- 12 tests covering: lazy loading, DPR scaling, viewport dimensions, highlight drawing, null context fallback, and DPR=0 edge case

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 783/783 tests pass
- [x] All 12 new tests for `screenshotCapture` pass

Closes #633