### PR TITLE
feat: GitHubService for DevBug issue creation and screenshot upload (#634)

### DIFF
--- a/src/services/devbug/__tests__/githubService.test.ts
+++ b/src/services/devbug/__tests__/githubService.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createGitHubService } from '../githubService';
+import type { BugReport } from '@/types/devbug';
+
+const BASE_REPORT: BugReport = {
+  id: 'report-uuid-5678',
+  timestamp: '2026-04-06T12:00:00.000Z',
+  selectionMode: 'click',
+  elements: [],
+  screenshotDataUrl: '',
+  comment: 'Something is off',
+  categories: ['broken'],
+  consoleLogs: [],
+  browserInfo: {
+    userAgent: 'Mozilla/5.0 (Test)',
+    viewport: { width: 1440, height: 900 },
+    url: 'http://127.0.0.1:3000',
+    timestamp: '2026-04-06T12:00:00.000Z',
+  },
+  performanceMetrics: {
+    fcp: null,
+    lcp: null,
+    memoryUsed: null,
+    memoryTotal: null,
+    longTasks: [],
+  },
+};
+
+const CONFIG = {
+  token: 'ghp_test_token',
+  owner: 'smallorbit',
+  repo: 'vorbis-player',
+};
+
+beforeEach(() => {
+  Object.defineProperty(import.meta, 'env', {
+    value: { ...import.meta.env, DEV: true },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('createGitHubService', () => {
+  it('throws when token is empty string', () => {
+    // #when / #then
+    expect(() => createGitHubService({ ...CONFIG, token: '' })).toThrow('requires a GitHub token');
+  });
+
+  it('creates a service instance when token and dev mode are valid', () => {
+    // #when
+    const service = createGitHubService(CONFIG);
+
+    // #then
+    expect(service).toBeDefined();
+    expect(typeof service.uploadScreenshot).toBe('function');
+    expect(typeof service.createIssue).toBe('function');
+    expect(typeof service.isConfigured).toBe('function');
+  });
+});
+
+describe('GitHubService.isConfigured', () => {
+  it('returns true when token is present', () => {
+    // #when
+    const service = createGitHubService(CONFIG);
+
+    // #then
+    expect(service.isConfigured()).toBe(true);
+  });
+});
+
+describe('GitHubService.uploadScreenshot', () => {
+  it('strips the data URL prefix and calls the GitHub contents API', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ content: {}, commit: {} }), { status: 201 }),
+    );
+
+    // #when
+    const rawUrl = await service.uploadScreenshot('data:image/png;base64,abc123==', 'shot.png');
+
+    // #then
+    expect(global.fetch).toHaveBeenCalledOnce();
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/repos/smallorbit/vorbis-player/contents/docs/bug-screenshots/shot.png');
+    expect(options.method).toBe('PUT');
+    const body = JSON.parse(options.body as string) as { content: string };
+    expect(body.content).toBe('abc123==');
+    expect(rawUrl).toBe(
+      'https://raw.githubusercontent.com/smallorbit/vorbis-player/main/docs/bug-screenshots/shot.png',
+    );
+  });
+
+  it('throws a descriptive error when the API returns a non-ok response', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response('Unauthorized', { status: 401 }),
+    );
+
+    // #when / #then
+    await expect(service.uploadScreenshot('data:image/png;base64,abc', 'x.png')).rejects.toThrow(
+      'Failed to upload screenshot (401)',
+    );
+  });
+
+  it('handles non-png data URLs by stripping the prefix generically', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 201 }),
+    );
+
+    // #when
+    await service.uploadScreenshot('data:image/jpeg;base64,jpegdata==', 'img.png');
+
+    // #then
+    const [, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string) as { content: string };
+    expect(body.content).toBe('jpegdata==');
+  });
+});
+
+describe('GitHubService.createIssue', () => {
+  function mockLabelCheck(status: number): void {
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('', { status }));
+  }
+
+  function mockIssueCreation(issueNumber: number): void {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ number: issueNumber, html_url: `https://github.com/smallorbit/vorbis-player/issues/${issueNumber}` }),
+        { status: 201 },
+      ),
+    );
+  }
+
+  it('creates a GitHub issue and returns number and url', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(200);
+    mockIssueCreation(42);
+
+    // #when
+    const result = await service.createIssue(BASE_REPORT);
+
+    // #then
+    expect(result.number).toBe(42);
+    expect(result.url).toBe('https://github.com/smallorbit/vorbis-player/issues/42');
+  });
+
+  it('sends issue with devbug label', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(200);
+    mockIssueCreation(10);
+
+    // #when
+    await service.createIssue(BASE_REPORT);
+
+    // #then
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string, RequestInit][];
+    const issueCall = calls.find(([url]) => url.endsWith('/issues'));
+    expect(issueCall).toBeDefined();
+    const body = JSON.parse(issueCall![1].body as string) as { labels: string[] };
+    expect(body.labels).toContain('devbug');
+  });
+
+  it('sends Authorization header with bearer token', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(200);
+    mockIssueCreation(7);
+
+    // #when
+    await service.createIssue(BASE_REPORT);
+
+    // #then
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string, RequestInit][];
+    const issueCall = calls.find(([url]) => url.endsWith('/issues'));
+    const headers = issueCall![1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer ghp_test_token');
+  });
+
+  it('creates the devbug label when it does not exist yet', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(404);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ name: 'devbug' }), { status: 201 }));
+    mockIssueCreation(3);
+
+    // #when
+    await service.createIssue(BASE_REPORT);
+
+    // #then
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string, RequestInit][];
+    const labelCreateCall = calls.find(([url, opts]) => url.endsWith('/labels') && opts.method === 'POST');
+    expect(labelCreateCall).toBeDefined();
+  });
+
+  it('continues creating issue even if label creation fails', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(404);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
+    mockIssueCreation(9);
+
+    // #when
+    const result = await service.createIssue(BASE_REPORT);
+
+    // #then
+    expect(result.number).toBe(9);
+  });
+
+  it('uploads screenshot before creating issue when screenshotDataUrl is present', async () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      screenshotDataUrl: 'data:image/png;base64,screenshot123',
+    };
+    const service = createGitHubService(CONFIG);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 201 }));
+    mockLabelCheck(200);
+    mockIssueCreation(15);
+
+    // #when
+    const result = await service.createIssue(report);
+
+    // #then
+    expect(result.number).toBe(15);
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as [string, RequestInit][];
+    expect(calls[0][0]).toContain('/contents/docs/bug-screenshots/');
+    const issueCall = calls.find(([url]) => url.endsWith('/issues'));
+    const issueBody = JSON.parse(issueCall![1].body as string) as { body: string };
+    expect(issueBody.body).toContain('![screenshot]');
+  });
+
+  it('continues creating issue without screenshot when upload fails', async () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      screenshotDataUrl: 'data:image/png;base64,screenshot123',
+    };
+    const service = createGitHubService(CONFIG);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Forbidden', { status: 403 }));
+    mockLabelCheck(200);
+    mockIssueCreation(20);
+
+    // #when
+    const result = await service.createIssue(report);
+
+    // #then
+    expect(result.number).toBe(20);
+  });
+
+  it('throws when issue creation API returns non-ok', async () => {
+    // #given
+    const service = createGitHubService(CONFIG);
+    mockLabelCheck(200);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Not Found', { status: 404 }));
+
+    // #when / #then
+    await expect(service.createIssue(BASE_REPORT)).rejects.toThrow('Failed to create issue (404)');
+  });
+});

--- a/src/services/devbug/__tests__/issueFormatter.test.ts
+++ b/src/services/devbug/__tests__/issueFormatter.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { formatIssueTitle, formatIssueBody } from '../issueFormatter';
+import type { BugReport } from '@/types/devbug';
+
+const BASE_REPORT: BugReport = {
+  id: 'test-uuid-1234',
+  timestamp: '2026-04-06T12:00:00.000Z',
+  selectionMode: 'click',
+  elements: [],
+  screenshotDataUrl: '',
+  comment: '',
+  categories: [],
+  consoleLogs: [],
+  browserInfo: {
+    userAgent: 'Mozilla/5.0 (Test)',
+    viewport: { width: 1440, height: 900 },
+    url: 'http://127.0.0.1:3000',
+    timestamp: '2026-04-06T12:00:00.000Z',
+  },
+  performanceMetrics: {
+    fcp: null,
+    lcp: null,
+    memoryUsed: null,
+    memoryTotal: null,
+    longTasks: [],
+  },
+};
+
+describe('formatIssueTitle', () => {
+  it('uses categories and element component name when available', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      categories: ['broken'],
+      elements: [
+        {
+          cssSelector: '.player',
+          xpath: '/div',
+          reactComponentName: 'AudioPlayer',
+          boundingRect: { top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50, x: 0, y: 0 },
+          computedStyles: {},
+          textContent: '',
+        },
+      ],
+    };
+
+    // #when
+    const title = formatIssueTitle(report);
+
+    // #then
+    expect(title).toBe('[DevBug] broken — AudioPlayer');
+  });
+
+  it('falls back to cssSelector when reactComponentName is null', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      categories: ['slower'],
+      elements: [
+        {
+          cssSelector: '#track-list',
+          xpath: '/div/ul',
+          reactComponentName: null,
+          boundingRect: { top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50, x: 0, y: 0 },
+          computedStyles: {},
+          textContent: '',
+        },
+      ],
+    };
+
+    // #when
+    const title = formatIssueTitle(report);
+
+    // #then
+    expect(title).toBe('[DevBug] slower — #track-list');
+  });
+
+  it('uses "general" when no categories and "unknown" when no elements', () => {
+    // #when
+    const title = formatIssueTitle(BASE_REPORT);
+
+    // #then
+    expect(title).toBe('[DevBug] general — unknown');
+  });
+
+  it('joins multiple categories with comma', () => {
+    // #given
+    const report: BugReport = { ...BASE_REPORT, categories: ['broken', 'slower'] };
+
+    // #when
+    const title = formatIssueTitle(report);
+
+    // #then
+    expect(title).toContain('broken, slower');
+  });
+});
+
+describe('formatIssueBody', () => {
+  it('includes the report ID in the header', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).toContain('test-uuid-1234');
+  });
+
+  it('includes screenshot markdown when screenshotUrl is provided', () => {
+    // #given
+    const url = 'https://raw.githubusercontent.com/smallorbit/vorbis-player/main/docs/bug-screenshots/abc.png';
+
+    // #when
+    const body = formatIssueBody(BASE_REPORT, url);
+
+    // #then
+    expect(body).toContain(`![screenshot](${url})`);
+  });
+
+  it('omits screenshot section when screenshotUrl is null', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).not.toContain('![screenshot]');
+  });
+
+  it('includes user comment when present', () => {
+    // #given
+    const report: BugReport = { ...BASE_REPORT, comment: 'The button is invisible' };
+
+    // #when
+    const body = formatIssueBody(report, null);
+
+    // #then
+    expect(body).toContain('The button is invisible');
+  });
+
+  it('omits comment section when comment is empty', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).not.toContain('## Comment');
+  });
+
+  it('includes element details when elements are present', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      elements: [
+        {
+          cssSelector: '.volume-slider',
+          xpath: '/html/body/div',
+          reactComponentName: 'VolumeControl',
+          boundingRect: { top: 10, right: 200, bottom: 50, left: 10, width: 190, height: 40, x: 10, y: 10 },
+          computedStyles: { display: 'flex', position: 'relative' },
+          textContent: 'Volume',
+        },
+      ],
+    };
+
+    // #when
+    const body = formatIssueBody(report, null);
+
+    // #then
+    expect(body).toContain('## Selected Elements');
+    expect(body).toContain('VolumeControl');
+    expect(body).toContain('.volume-slider');
+    expect(body).toContain('190×40');
+  });
+
+  it('includes last 10 console logs', () => {
+    // #given
+    const logs = Array.from({ length: 15 }, (_, i) => ({
+      timestamp: '2026-04-06T12:00:00.000Z',
+      level: 'error' as const,
+      args: [`Error ${i + 1}`],
+      stack: null,
+    }));
+    const report: BugReport = { ...BASE_REPORT, consoleLogs: logs };
+
+    // #when
+    const body = formatIssueBody(report, null);
+
+    // #then
+    expect(body).toContain('## Console Logs');
+    expect(body).toContain('Error 15');
+    expect(body).not.toContain('Error 1\n');
+    expect(body).toContain('last 10');
+  });
+
+  it('omits console logs section when no logs', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).not.toContain('## Console Logs');
+  });
+
+  it('includes browser info section', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).toContain('## Browser Info');
+    expect(body).toContain('Mozilla/5.0 (Test)');
+    expect(body).toContain('1440×900');
+    expect(body).toContain('http://127.0.0.1:3000');
+  });
+
+  it('includes performance metrics section', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      performanceMetrics: {
+        fcp: 1200,
+        lcp: 2500,
+        memoryUsed: 52_428_800,
+        memoryTotal: 104_857_600,
+        longTasks: [{ duration: 85, startTime: 500 }],
+      },
+    };
+
+    // #when
+    const body = formatIssueBody(report, null);
+
+    // #then
+    expect(body).toContain('## Performance Metrics');
+    expect(body).toContain('1200ms');
+    expect(body).toContain('2500ms');
+    expect(body).toContain('50.0 MB');
+    expect(body).toContain('duration: 85ms');
+  });
+
+  it('shows unavailable for null performance metrics', () => {
+    // #when
+    const body = formatIssueBody(BASE_REPORT, null);
+
+    // #then
+    expect(body).toContain('_unavailable_');
+  });
+});

--- a/src/services/devbug/githubService.ts
+++ b/src/services/devbug/githubService.ts
@@ -1,0 +1,134 @@
+import type { BugReport } from '@/types/devbug';
+import { formatIssueBody, formatIssueTitle } from './issueFormatter';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const SCREENSHOT_PATH_PREFIX = 'docs/bug-screenshots';
+const DEVBUG_LABEL = 'devbug';
+
+export interface GitHubServiceConfig {
+  token: string;
+  owner: string;
+  repo: string;
+}
+
+export interface GitHubService {
+  uploadScreenshot(dataUrl: string, filename: string): Promise<string>;
+  createIssue(report: BugReport): Promise<{ number: number; url: string }>;
+  isConfigured(): boolean;
+}
+
+export function createGitHubService(config: GitHubServiceConfig): GitHubService {
+  if (!import.meta.env.DEV) {
+    throw new Error('GitHubService is only available in development builds.');
+  }
+
+  if (!config.token) {
+    throw new Error(
+      'GitHubService requires a GitHub token. Set VITE_DEVBUG_GITHUB_TOKEN in your .env.local file.',
+    );
+  }
+
+  const { token, owner, repo } = config;
+
+  function authHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async function uploadScreenshot(dataUrl: string, filename: string): Promise<string> {
+    const base64Content = dataUrl.replace(/^data:image\/[a-z]+;base64,/, '');
+    const path = `${SCREENSHOT_PATH_PREFIX}/${filename}`;
+    const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/contents/${path}`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        message: `devbug: upload screenshot ${filename}`,
+        content: base64Content,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(`Failed to upload screenshot (${response.status}): ${errorText}`);
+    }
+
+    return `https://raw.githubusercontent.com/${owner}/${repo}/main/${path}`;
+  }
+
+  async function ensureLabel(): Promise<void> {
+    const checkUrl = `${GITHUB_API_BASE}/repos/${owner}/${repo}/labels/${DEVBUG_LABEL}`;
+    const checkResponse = await fetch(checkUrl, { headers: authHeaders() });
+
+    if (checkResponse.ok) return;
+
+    const createUrl = `${GITHUB_API_BASE}/repos/${owner}/${repo}/labels`;
+    await fetch(createUrl, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        name: DEVBUG_LABEL,
+        color: 'd73a4a',
+        description: 'Automatically created bug report from DevBug tool',
+      }),
+    });
+  }
+
+  async function createIssue(report: BugReport): Promise<{ number: number; url: string }> {
+    let screenshotUrl: string | null = null;
+    if (report.screenshotDataUrl) {
+      const filename = `${report.id}.png`;
+      try {
+        screenshotUrl = await uploadScreenshot(report.screenshotDataUrl, filename);
+      } catch {
+        // Continue without screenshot — don't block issue creation
+      }
+    }
+
+    await ensureLabel().catch(() => {
+      // Don't fail if label creation fails
+    });
+
+    const title = formatIssueTitle(report);
+    const body = formatIssueBody(report, screenshotUrl);
+
+    const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/issues`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        title,
+        body,
+        labels: [DEVBUG_LABEL],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(`Failed to create issue (${response.status}): ${errorText}`);
+    }
+
+    const data = (await response.json()) as { number: number; html_url: string };
+    return { number: data.number, url: data.html_url };
+  }
+
+  function isConfigured(): boolean {
+    return Boolean(token);
+  }
+
+  return { uploadScreenshot, createIssue, isConfigured };
+}
+
+export function createDefaultGitHubService(): GitHubService {
+  const token = import.meta.env.VITE_DEVBUG_GITHUB_TOKEN as string | undefined;
+  return createGitHubService({
+    token: token ?? '',
+    owner: 'smallorbit',
+    repo: 'vorbis-player',
+  });
+}

--- a/src/services/devbug/issueFormatter.ts
+++ b/src/services/devbug/issueFormatter.ts
@@ -1,0 +1,152 @@
+import type { BugReport, ConsoleEntry, SelectedElement } from '@/types/devbug';
+
+const CONSOLE_LOG_LIMIT = 10;
+
+export function formatIssueTitle(report: BugReport): string {
+  const categories = report.categories.length > 0 ? report.categories.join(', ') : 'general';
+  const component =
+    report.elements.length > 0
+      ? (report.elements[0].reactComponentName ?? report.elements[0].cssSelector)
+      : 'unknown';
+  return `[DevBug] ${categories} — ${component}`;
+}
+
+export function formatIssueBody(report: BugReport, screenshotUrl: string | null): string {
+  const sections: string[] = [];
+
+  sections.push(formatHeader(report));
+
+  if (screenshotUrl) {
+    sections.push(formatScreenshot(screenshotUrl));
+  }
+
+  if (report.comment) {
+    sections.push(formatComment(report.comment));
+  }
+
+  if (report.elements.length > 0) {
+    sections.push(formatElements(report.elements));
+  }
+
+  if (report.consoleLogs.length > 0) {
+    sections.push(formatConsoleLogs(report.consoleLogs));
+  }
+
+  sections.push(formatBrowserInfo(report));
+  sections.push(formatPerformanceMetrics(report));
+
+  return sections.join('\n\n');
+}
+
+function formatHeader(report: BugReport): string {
+  const categoryList =
+    report.categories.length > 0 ? report.categories.map((c) => `\`${c}\``).join(', ') : '_none_';
+
+  return [
+    `## DevBug Report`,
+    ``,
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| **ID** | \`${report.id}\` |`,
+    `| **Timestamp** | ${report.timestamp} |`,
+    `| **Selection Mode** | ${report.selectionMode} |`,
+    `| **Categories** | ${categoryList} |`,
+  ].join('\n');
+}
+
+function formatScreenshot(screenshotUrl: string): string {
+  return [`## Screenshot`, ``, `![screenshot](${screenshotUrl})`].join('\n');
+}
+
+function formatComment(comment: string): string {
+  return [`## Comment`, ``, comment].join('\n');
+}
+
+function formatElements(elements: SelectedElement[]): string {
+  const lines: string[] = [`## Selected Elements`];
+
+  elements.forEach((el, index) => {
+    lines.push(``, `### Element ${index + 1}`);
+
+    if (el.reactComponentName) {
+      lines.push(`- **React Component**: \`${el.reactComponentName}\``);
+    }
+    lines.push(`- **CSS Selector**: \`${el.cssSelector}\``);
+    lines.push(`- **XPath**: \`${el.xpath}\``);
+    lines.push(
+      `- **Bounding Rect**: ${el.boundingRect.width}×${el.boundingRect.height} at (${el.boundingRect.x}, ${el.boundingRect.y})`,
+    );
+
+    if (el.textContent) {
+      const truncated = el.textContent.length > 100 ? el.textContent.slice(0, 100) + '…' : el.textContent;
+      lines.push(`- **Text Content**: ${truncated}`);
+    }
+
+    const styleEntries = Object.entries(el.computedStyles).filter(([, v]) => v && v !== 'none' && v !== 'normal');
+    if (styleEntries.length > 0) {
+      lines.push(``, `**Computed Styles**`);
+      lines.push('```');
+      styleEntries.forEach(([k, v]) => lines.push(`${k}: ${v}`));
+      lines.push('```');
+    }
+  });
+
+  return lines.join('\n');
+}
+
+function formatConsoleLogs(logs: ConsoleEntry[]): string {
+  const recent = logs.slice(-CONSOLE_LOG_LIMIT);
+  const lines: string[] = [`## Console Logs (last ${recent.length})`, ``, '```'];
+
+  recent.forEach((entry) => {
+    const args = entry.args.join(' ');
+    lines.push(`[${entry.level.toUpperCase()}] ${entry.timestamp} ${args}`);
+    if (entry.stack) {
+      lines.push(entry.stack);
+    }
+  });
+
+  lines.push('```');
+  return lines.join('\n');
+}
+
+function formatBrowserInfo(report: BugReport): string {
+  const { browserInfo } = report;
+  return [
+    `## Browser Info`,
+    ``,
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| **User Agent** | ${browserInfo.userAgent} |`,
+    `| **Viewport** | ${browserInfo.viewport.width}×${browserInfo.viewport.height} |`,
+    `| **URL** | ${browserInfo.url} |`,
+  ].join('\n');
+}
+
+function formatPerformanceMetrics(report: BugReport): string {
+  const { performanceMetrics: m } = report;
+  const fcp = m.fcp !== null ? `${m.fcp}ms` : '_unavailable_';
+  const lcp = m.lcp !== null ? `${m.lcp}ms` : '_unavailable_';
+  const memUsed = m.memoryUsed !== null ? `${(m.memoryUsed / 1_048_576).toFixed(1)} MB` : '_unavailable_';
+  const memTotal = m.memoryTotal !== null ? `${(m.memoryTotal / 1_048_576).toFixed(1)} MB` : '_unavailable_';
+
+  const lines = [
+    `## Performance Metrics`,
+    ``,
+    `| Metric | Value |`,
+    `|--------|-------|`,
+    `| **FCP** | ${fcp} |`,
+    `| **LCP** | ${lcp} |`,
+    `| **Memory Used** | ${memUsed} |`,
+    `| **Memory Total** | ${memTotal} |`,
+  ];
+
+  if (m.longTasks.length > 0) {
+    lines.push(``, `**Long Tasks** (${m.longTasks.length})`);
+    lines.push('```');
+    m.longTasks.forEach((t) => lines.push(`duration: ${t.duration}ms, startTime: ${t.startTime}ms`));
+    lines.push('```');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

- Adds `src/services/devbug/githubService.ts` — a raw-fetch GitHub API client that uploads screenshots to `docs/bug-screenshots/{uuid}.png` and creates structured issues tagged with the `devbug` label. Gated behind `import.meta.env.DEV` and requires `VITE_DEVBUG_GITHUB_TOKEN` in `.env.local`.
- Adds `src/services/devbug/issueFormatter.ts` — formats a `BugReport` into a GitHub issue title (`[DevBug] {categories} — {component}`) and a well-structured markdown body with sections for screenshot, user comment, selected elements, console logs (last 10), browser info, and performance metrics.
- 29 tests across `githubService.test.ts` and `issueFormatter.test.ts` covering upload, issue creation, label auto-creation, graceful error recovery (failed screenshot upload or label creation do not block issue creation), and markdown formatting correctness.

## Test plan

- [x] `npx tsc -b --noEmit` passes clean
- [x] Full test suite: 800 tests pass (63 test files)
- [x] githubService tests: upload strips data URL prefix, sets correct path, passes auth header, creates label when missing, continues on label/screenshot failure
- [x] issueFormatter tests: title construction, screenshot embed, element details, console log capping, performance metric formatting

Closes #634