### PR TITLE
feat: DevBug area selection mode — drag-to-select rectangle (#636)

### DIFF
--- a/src/components/DevBug/AreaSelectOverlay.tsx
+++ b/src/components/DevBug/AreaSelectOverlay.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+import type { SelectedElement } from '@/types/devbug';
+import { useAreaSelection } from './useAreaSelection';
+import type { SelectionRect } from './useAreaSelection';
+
+const SELECTION_STROKE = 'rgba(255, 140, 0, 1)';
+const SELECTION_FILL = 'rgba(255, 140, 0, 0.12)';
+const HIGHLIGHT_STROKE = 'rgba(255, 140, 0, 0.9)';
+const HIGHLIGHT_FILL = 'rgba(255, 140, 0, 0.08)';
+const CANVAS_Z = 2147483644;
+const OVERLAY_Z = 2147483645;
+
+const HighlightCanvas = styled.canvas`
+  position: fixed;
+  inset: 0;
+  z-index: ${CANVAS_Z};
+  pointer-events: none;
+`;
+
+const CaptureLayer = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: ${OVERLAY_Z};
+  pointer-events: auto;
+  cursor: crosshair;
+  user-select: none;
+`;
+
+export interface AreaSelectOverlayProps {
+  onAreaSelected: (elements: Element[], infos: SelectedElement[]) => void;
+  onCancel: () => void;
+}
+
+export function AreaSelectOverlay({ onAreaSelected, onCancel }: AreaSelectOverlayProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const { phase, selectionRect, collectedElements, handleMouseDown, handleMouseMove, handleMouseUp } =
+    useAreaSelection(onAreaSelected, onCancel);
+
+  const drawFrame = useCallback(
+    (rect: SelectionRect | null, done: boolean, elements: Element[]) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      if (done && elements.length > 0) {
+        for (const el of elements) {
+          const r = el.getBoundingClientRect();
+          ctx.strokeStyle = HIGHLIGHT_STROKE;
+          ctx.lineWidth = 2;
+          ctx.fillStyle = HIGHLIGHT_FILL;
+          ctx.beginPath();
+          ctx.rect(r.left, r.top, r.width, r.height);
+          ctx.fill();
+          ctx.stroke();
+        }
+      }
+
+      if (rect && rect.width > 0 && rect.height > 0) {
+        ctx.strokeStyle = SELECTION_STROKE;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([6, 3]);
+        ctx.fillStyle = SELECTION_FILL;
+        ctx.beginPath();
+        ctx.rect(rect.x, rect.y, rect.width, rect.height);
+        ctx.fill();
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    drawFrame(selectionRect, phase === 'done', collectedElements);
+  }, [selectionRect, phase, collectedElements, drawFrame]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const syncSize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+
+    syncSize();
+    window.addEventListener('resize', syncSize);
+    return () => window.removeEventListener('resize', syncSize);
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onCancel]);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      handleMouseDown(e.nativeEvent);
+    },
+    [handleMouseDown],
+  );
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      handleMouseMove(e.nativeEvent);
+    },
+    [handleMouseMove],
+  );
+
+  const onMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      handleMouseUp(e.nativeEvent);
+    },
+    [handleMouseUp],
+  );
+
+  return createPortal(
+    <>
+      <HighlightCanvas ref={canvasRef} />
+      <CaptureLayer
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+      />
+    </>,
+    document.body,
+  );
+}

--- a/src/components/DevBug/index.ts
+++ b/src/components/DevBug/index.ts
@@ -1,5 +1,9 @@
 export { DevBugFAB } from './DevBugFAB';
 export { DevBugTopBar } from './DevBugTopBar';
 export { InspectOverlay } from './InspectOverlay';
+export { AreaSelectOverlay } from './AreaSelectOverlay';
+export type { AreaSelectOverlayProps } from './AreaSelectOverlay';
+export { useAreaSelection } from './useAreaSelection';
+export type { SelectionPhase, SelectionRect, UseAreaSelectionResult } from './useAreaSelection';
 export { useElementDetection } from './useElementDetection';
 export type { DetectedElement } from './useElementDetection';

--- a/src/components/DevBug/useAreaSelection.ts
+++ b/src/components/DevBug/useAreaSelection.ts
@@ -1,0 +1,138 @@
+import { useState, useRef, useCallback } from 'react';
+import { extractElementInfo, getReactComponentName } from '@/services/devbug/reportBuilder';
+import type { SelectedElement } from '@/types/devbug';
+
+export type SelectionPhase = 'idle' | 'dragging' | 'done';
+
+export interface SelectionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface UseAreaSelectionResult {
+  phase: SelectionPhase;
+  selectionRect: SelectionRect | null;
+  collectedElements: Element[];
+  handleMouseDown: (e: MouseEvent) => void;
+  handleMouseMove: (e: MouseEvent) => void;
+  handleMouseUp: (e: MouseEvent) => void;
+  reset: () => void;
+}
+
+function rectsOverlap(a: SelectionRect, b: DOMRect): boolean {
+  return (
+    a.x < b.right &&
+    a.x + a.width > b.left &&
+    a.y < b.bottom &&
+    a.y + a.height > b.top
+  );
+}
+
+function collectOverlappingElements(rect: SelectionRect): { elements: Element[]; infos: SelectedElement[] } {
+  const all = document.querySelectorAll('*');
+  const seen = new Set<Element>();
+  const elements: Element[] = [];
+  const infos: SelectedElement[] = [];
+
+  for (const el of all) {
+    if (seen.has(el)) continue;
+
+    const computed = window.getComputedStyle(el);
+    const isHidden =
+      computed.display === 'none' ||
+      computed.visibility === 'hidden' ||
+      computed.opacity === '0';
+    if (isHidden) continue;
+
+    const domRect = el.getBoundingClientRect();
+    if (domRect.width === 0 && domRect.height === 0) continue;
+
+    if (rectsOverlap(rect, domRect)) {
+      seen.add(el);
+      elements.push(el);
+      infos.push(extractElementInfo(el));
+    }
+  }
+
+  return { elements, infos };
+}
+
+function normalizeRect(startX: number, startY: number, currentX: number, currentY: number): SelectionRect {
+  return {
+    x: Math.min(startX, currentX),
+    y: Math.min(startY, currentY),
+    width: Math.abs(currentX - startX),
+    height: Math.abs(currentY - startY),
+  };
+}
+
+export function useAreaSelection(
+  onAreaSelected: (elements: Element[], infos: SelectedElement[]) => void,
+  onCancel: () => void,
+): UseAreaSelectionResult {
+  const [phase, setPhase] = useState<SelectionPhase>('idle');
+  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
+  const [collectedElements, setCollectedElements] = useState<Element[]>([]);
+
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const phaseRef = useRef<SelectionPhase>('idle');
+
+  const updatePhase = useCallback((next: SelectionPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
+
+  const reset = useCallback(() => {
+    startRef.current = null;
+    setSelectionRect(null);
+    setCollectedElements([]);
+    updatePhase('idle');
+  }, [updatePhase]);
+
+  const handleMouseDown = useCallback((e: MouseEvent) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, y: e.clientY };
+    setSelectionRect({ x: e.clientX, y: e.clientY, width: 0, height: 0 });
+    updatePhase('dragging');
+  }, [updatePhase]);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (phaseRef.current !== 'dragging' || !startRef.current) return;
+    const rect = normalizeRect(startRef.current.x, startRef.current.y, e.clientX, e.clientY);
+    setSelectionRect(rect);
+  }, []);
+
+  const handleMouseUp = useCallback((e: MouseEvent) => {
+    if (phaseRef.current !== 'dragging' || !startRef.current) return;
+
+    const rect = normalizeRect(startRef.current.x, startRef.current.y, e.clientX, e.clientY);
+
+    if (rect.width < 4 && rect.height < 4) {
+      onCancel();
+      reset();
+      return;
+    }
+
+    const { elements, infos } = collectOverlappingElements(rect);
+
+    setSelectionRect(rect);
+    setCollectedElements(elements);
+    updatePhase('done');
+
+    onAreaSelected(elements, infos);
+  }, [onAreaSelected, onCancel, reset, updatePhase]);
+
+  return {
+    phase,
+    selectionRect,
+    collectedElements,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    reset,
+  };
+}
+
+export { getReactComponentName };


### PR DESCRIPTION
## Summary

- Adds `useAreaSelection` hook implementing the drag-select state machine (`idle → dragging → done`) with element collection on mouseup
- Adds `AreaSelectOverlay` component: full-viewport canvas portal with dashed orange selection rectangle during drag and per-element highlight boxes after release
- Exports both from `src/components/DevBug/index.ts`

## Details

**`useAreaSelection.ts`**
- Tracks drag start/end coordinates via `useRef` to avoid stale closures
- On mouseup: iterates all visible DOM elements, tests `getBoundingClientRect` overlap against the normalized selection rect, deduplicates by element reference
- Calls `extractElementInfo()` for each collected element; returns `(elements, infos)` to `onAreaSelected`
- Cancels (calls `onCancel`) if the drag covers less than 4×4 px (click misfire)

**`AreaSelectOverlay.tsx`**
- Follows `InspectOverlay` pattern exactly: `createPortal` to `document.body`, same `CANVAS_Z` / `OVERLAY_Z` constants
- Canvas renders: dashed 2px orange rect during drag, semi-transparent orange fill; switches to solid per-element highlight boxes in `done` phase
- Escape key triggers `onCancel`
- Standalone — no dependency on `useDevBug` context; activated purely via props

## Test plan

- [ ] TypeScript check passes: `npx tsc -b --noEmit`
- [ ] Full test suite passes: `npm run test:run` (838 tests, 65 files)
- [ ] Verify component renders a canvas portal when mounted
- [ ] Drag across elements → `onAreaSelected` called with correct element list and infos
- [ ] Tiny click (< 4px drag) → `onCancel` called
- [ ] Escape key → `onCancel` called