### PR TITLE
feat: DevBug keyboard shortcuts, animations, and UX polish (#641)

### DIFF
--- a/src/components/DevBug/DevBugTopBar.tsx
+++ b/src/components/DevBug/DevBugTopBar.tsx
@@ -1,12 +1,13 @@
 import { createPortal } from 'react-dom';
-import styled, { keyframes } from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 const slideDown = keyframes`
   from { transform: translateY(-100%); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
 `;
 
-const TopBarContainer = styled.div`
+const TopBarContainer = styled.div<{ $reducedMotion: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
@@ -20,13 +21,22 @@ const TopBarContainer = styled.div`
   padding: 6px 16px;
   text-align: center;
   cursor: crosshair;
-  animation: ${slideDown} 0.2s ease-out;
   user-select: none;
+
+  ${({ $reducedMotion }) =>
+    !$reducedMotion &&
+    css`
+      animation: ${slideDown} 0.2s ease-out;
+    `}
 `;
 
 export function DevBugTopBar() {
+  const reducedMotion = useReducedMotion();
+
   return createPortal(
-    <TopBarContainer>Preview Mode — click an element to inspect</TopBarContainer>,
+    <TopBarContainer $reducedMotion={reducedMotion}>
+      Preview Mode — click an element to inspect
+    </TopBarContainer>,
     document.body,
   );
 }

--- a/src/components/DevBug/index.ts
+++ b/src/components/DevBug/index.ts
@@ -15,3 +15,4 @@ export { AnnotationOverlay } from './AnnotationOverlay';
 export type { AnnotationOverlayProps } from './AnnotationOverlay';
 export { useAnnotationDrawing } from './useAnnotationDrawing';
 export type { AnnotationTool, DrawingPhase, Annotation } from './useAnnotationDrawing';
+export { useDevBugKeyboard } from './useDevBugKeyboard';

--- a/src/components/DevBug/useDevBugKeyboard.ts
+++ b/src/components/DevBug/useDevBugKeyboard.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { useDevBug } from '@/contexts/DevBugContext';
+import type { DevBugMode } from '@/contexts/DevBugContext';
+
+const MODE_KEYS: Record<string, DevBugMode> = {
+  '1': 'inspect',
+  '2': 'area',
+  '3': 'annotate',
+};
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === 'input' || tag === 'textarea' || target.isContentEditable;
+}
+
+export function useDevBugKeyboard(
+  isFeedbackPanelOpen: boolean,
+  hasSelection: boolean,
+  onCancelSelection: () => void,
+  onCloseFeedbackPanel: () => void,
+): void {
+  const { isActive, deactivate, setMode } = useDevBug();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (isFeedbackPanelOpen) {
+          onCloseFeedbackPanel();
+          return;
+        }
+        if (hasSelection) {
+          onCancelSelection();
+          return;
+        }
+        if (isActive) {
+          deactivate();
+        }
+        return;
+      }
+
+      if (!isActive) return;
+
+      const mode = MODE_KEYS[e.key];
+      if (mode) {
+        e.preventDefault();
+        setMode(mode);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isActive, isFeedbackPanelOpen, hasSelection, deactivate, setMode, onCancelSelection, onCloseFeedbackPanel]);
+}

--- a/src/contexts/DevBugContext.tsx
+++ b/src/contexts/DevBugContext.tsx
@@ -1,25 +1,31 @@
 import { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
 
+export type DevBugMode = 'inspect' | 'area' | 'annotate';
+
 interface DevBugContextValue {
   isActive: boolean;
+  activeMode: DevBugMode;
   activate: () => void;
   deactivate: () => void;
   toggle: () => void;
+  setMode: (mode: DevBugMode) => void;
 }
 
 const DevBugContext = createContext<DevBugContextValue | null>(null);
 
 export function DevBugProvider({ children }: { children: ReactNode }) {
   const [isActive, setIsActive] = useState(false);
+  const [activeMode, setActiveMode] = useState<DevBugMode>('inspect');
 
   const activate = useCallback(() => setIsActive(true), []);
   const deactivate = useCallback(() => setIsActive(false), []);
   const toggle = useCallback(() => setIsActive((prev) => !prev), []);
+  const setMode = useCallback((mode: DevBugMode) => setActiveMode(mode), []);
 
   const value = useMemo<DevBugContextValue>(
-    () => ({ isActive, activate, deactivate, toggle }),
-    [isActive, activate, deactivate, toggle],
+    () => ({ isActive, activeMode, activate, deactivate, toggle, setMode }),
+    [isActive, activeMode, activate, deactivate, toggle, setMode],
   );
 
   return <DevBugContext.Provider value={value}>{children}</DevBugContext.Provider>;

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return reducedMotion;
+}


### PR DESCRIPTION
## Summary

- **`useReducedMotion` hook** — reads `prefers-reduced-motion` media query with live change listener; returns `boolean`
- **`DevBugContext` extended** — adds `activeMode: 'inspect' | 'area' | 'annotate'` state and `setMode` action alongside existing `isActive`/`activate`/`deactivate`/`toggle`
- **`useDevBugKeyboard` hook** — centralized DevBug keyboard shortcuts: cascading `Escape` (close panel → cancel selection → deactivate preview), `1`/`2`/`3` quick-switch between modes when preview is active; suppressed when focus is in `input`/`textarea`/`contenteditable`
- **`DevBugTopBar`** — reduced-motion aware: slide-down animation is skipped when `prefers-reduced-motion: reduce` is set

## Files changed

| File | Action |
|------|--------|
| `src/hooks/useReducedMotion.ts` | New |
| `src/components/DevBug/useDevBugKeyboard.ts` | New |
| `src/contexts/DevBugContext.tsx` | Extended with `activeMode` + `setMode` |
| `src/components/DevBug/DevBugTopBar.tsx` | Reduced-motion prop wired |
| `src/components/DevBug/index.ts` | Export `useDevBugKeyboard` |

## Test plan

- [ ] TypeScript: `npx tsc -b --noEmit` — clean
- [ ] Tests: `npm run test:run` — 858/858 passed (66 files)
- [ ] `prefers-reduced-motion: reduce` in OS → TopBar appears instantly (no slide)
- [ ] With DevBug active: keys `1`, `2`, `3` switch `activeMode` in context
- [ ] With DevBug active and feedback panel open: `Escape` closes panel first, second press deactivates
- [ ] Typing in comment textarea: `Escape` / `1`/`2`/`3` do NOT trigger DevBug shortcuts