### PR TITLE
feat: DevBug FAB speed-dial for mode switching (#638)

### DIFF
--- a/src/components/DevBug/DevBugFAB.tsx
+++ b/src/components/DevBug/DevBugFAB.tsx
@@ -1,23 +1,47 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styled, { keyframes, css } from 'styled-components';
 import { useDevBug } from '@/contexts/DevBugContext';
 import type { SelectedElement } from '@/types/devbug';
 import { DevBugTopBar } from './DevBugTopBar';
 import { InspectOverlay } from './InspectOverlay';
+import { AreaSelectOverlay } from './AreaSelectOverlay';
+import { AnnotationOverlay } from './AnnotationOverlay';
 import { FeedbackPanel } from './FeedbackPanel';
 import { useFeedbackPanel } from './useFeedbackPanel';
+
+type ActiveMode = 'inspect' | 'area' | 'annotate';
+
+const MODES: { id: ActiveMode; icon: string; label: string }[] = [
+  { id: 'inspect', icon: '🎯', label: 'Click to inspect' },
+  { id: 'area', icon: '▭', label: 'Area select' },
+  { id: 'annotate', icon: '📸', label: 'Screenshot annotate' },
+];
+
+const LONG_PRESS_MS = 500;
 
 const pulse = keyframes`
   0%, 100% { box-shadow: 0 0 0 0 rgba(255, 160, 0, 0.7); }
   50% { box-shadow: 0 0 0 8px rgba(255, 160, 0, 0); }
 `;
 
-const FABButton = styled.button<{ $active: boolean }>`
+const dialItemIn = keyframes`
+  from { opacity: 0; transform: translateY(12px) scale(0.8); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+`;
+
+const FABContainer = styled.div`
   position: fixed;
   bottom: 24px;
   right: 24px;
   z-index: 2147483647;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+`;
+
+const FABButton = styled.button<{ $active: boolean }>`
   width: 52px;
   height: 52px;
   border-radius: 50%;
@@ -49,6 +73,66 @@ const FABButton = styled.button<{ $active: boolean }>`
     `}
 `;
 
+const SpeedDialList = styled.div`
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 8px;
+`;
+
+const SpeedDialItem = styled.button<{ $selected: boolean; $index: number }>`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid
+    ${({ $selected }) => ($selected ? 'rgba(255, 160, 0, 0.9)' : 'rgba(255, 255, 255, 0.25)')};
+  background: ${({ $selected }) =>
+    $selected ? 'rgba(255, 160, 0, 0.18)' : 'rgba(20, 20, 20, 0.92)'};
+  color: ${({ $selected }) => ($selected ? 'rgba(255, 160, 0, 0.95)' : 'rgba(255, 255, 255, 0.8)')};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  backdrop-filter: blur(8px);
+  position: relative;
+  transition: background 0.15s, border-color 0.15s, transform 0.15s;
+  animation: ${dialItemIn} 0.2s ease both;
+  animation-delay: ${({ $index }) => $index * 60}ms;
+
+  &:hover {
+    transform: scale(1.12);
+    background: ${({ $selected }) =>
+      $selected ? 'rgba(255, 160, 0, 0.28)' : 'rgba(50, 50, 50, 0.95)'};
+  }
+
+  &:active {
+    transform: scale(0.94);
+  }
+`;
+
+const Tooltip = styled.span`
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  background: rgba(20, 20, 20, 0.95);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 11px;
+  font-family: system-ui, sans-serif;
+  padding: 4px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  ${SpeedDialItem}:hover & {
+    opacity: 1;
+  }
+`;
+
 const BugIcon = () => (
   <svg
     width="22"
@@ -61,9 +145,66 @@ const BugIcon = () => (
   </svg>
 );
 
+function modeIcon(mode: ActiveMode): string {
+  return MODES.find((m) => m.id === mode)?.icon ?? '🐛';
+}
+
 export function DevBugFAB() {
   const { isActive, toggle, deactivate } = useDevBug();
   const panel = useFeedbackPanel();
+
+  const [activeMode, setActiveMode] = useState<ActiveMode>('inspect');
+  const [dialOpen, setDialOpen] = useState(false);
+
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openDial = useCallback(() => setDialOpen(true), []);
+  const closeDial = useCallback(() => setDialOpen(false), []);
+
+  const handleFABClick = useCallback(() => {
+    if (isActive && dialOpen) {
+      closeDial();
+      return;
+    }
+    if (isActive) {
+      toggle();
+      return;
+    }
+    toggle();
+  }, [isActive, dialOpen, closeDial, toggle]);
+
+  const handleFABMouseDown = useCallback(() => {
+    if (!isActive) return;
+    longPressTimer.current = setTimeout(openDial, LONG_PRESS_MS);
+  }, [isActive, openDial]);
+
+  const handleFABMouseUp = useCallback(() => {
+    if (longPressTimer.current !== null) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const handleFABMouseEnter = useCallback(() => {
+    if (isActive && !dialOpen) {
+      openDial();
+    }
+  }, [isActive, dialOpen, openDial]);
+
+  const handleFABMouseLeave = useCallback(() => {
+    if (longPressTimer.current !== null) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const selectMode = useCallback(
+    (mode: ActiveMode) => {
+      setActiveMode(mode);
+      closeDial();
+    },
+    [closeDial],
+  );
 
   const handleElementSelected = useCallback(
     (_element: Element, info: SelectedElement) => {
@@ -71,6 +212,34 @@ export function DevBugFAB() {
     },
     [panel],
   );
+
+  const handleAreaSelected = useCallback(
+    (_elements: Element[], infos: SelectedElement[]) => {
+      if (infos.length > 0) {
+        panel.open(infos[0]);
+      }
+    },
+    [panel],
+  );
+
+  const handleAnnotationComplete = useCallback(
+    (_annotatedDataUrl: string) => {
+      const syntheticInfo: SelectedElement = {
+        cssSelector: 'screenshot',
+        xpath: '/screenshot',
+        reactComponentName: null,
+        boundingRect: { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0, x: 0, y: 0 },
+        computedStyles: {},
+        textContent: '',
+      };
+      panel.open(syntheticInfo);
+    },
+    [panel],
+  );
+
+  const handleOverlayCancel = useCallback(() => {
+    deactivate();
+  }, [deactivate]);
 
   const handlePanelCancel = useCallback(() => {
     panel.close();
@@ -84,6 +253,7 @@ export function DevBugFAB() {
     } else {
       import('@/services/devbug/consoleCapture').then(({ stopCapture }) => stopCapture());
       import('@/services/devbug/perfCapture').then(({ stopPerfCapture }) => stopPerfCapture());
+      setDialOpen(false);
     }
   }, [isActive]);
 
@@ -106,18 +276,60 @@ export function DevBugFAB() {
     };
   }, [isActive]);
 
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current !== null) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
+  }, []);
+
   return createPortal(
     <>
-      <FABButton
-        $active={isActive}
-        onClick={toggle}
-        aria-label={isActive ? 'Deactivate DevBug preview mode' : 'Activate DevBug preview mode'}
-        title="DevBug (Ctrl+Shift+D)"
-      >
-        <BugIcon />
-      </FABButton>
+      <FABContainer>
+        {isActive && dialOpen && (
+          <SpeedDialList>
+            {MODES.map((mode, index) => (
+              <SpeedDialItem
+                key={mode.id}
+                $selected={activeMode === mode.id}
+                $index={index}
+                onClick={() => selectMode(mode.id)}
+                aria-label={mode.label}
+                aria-pressed={activeMode === mode.id}
+              >
+                {mode.icon}
+                <Tooltip>{mode.label}</Tooltip>
+              </SpeedDialItem>
+            ))}
+          </SpeedDialList>
+        )}
+        <FABButton
+          $active={isActive}
+          onClick={handleFABClick}
+          onMouseDown={handleFABMouseDown}
+          onMouseUp={handleFABMouseUp}
+          onMouseEnter={handleFABMouseEnter}
+          onMouseLeave={handleFABMouseLeave}
+          aria-label={isActive ? 'Deactivate DevBug preview mode' : 'Activate DevBug preview mode'}
+          title="DevBug (Ctrl+Shift+D)"
+        >
+          {isActive ? modeIcon(activeMode) : <BugIcon />}
+        </FABButton>
+      </FABContainer>
+
       {isActive && <DevBugTopBar />}
-      <InspectOverlay onElementSelected={handleElementSelected} />
+
+      {isActive && activeMode === 'inspect' && (
+        <InspectOverlay onElementSelected={handleElementSelected} />
+      )}
+      {isActive && activeMode === 'area' && (
+        <AreaSelectOverlay onAreaSelected={handleAreaSelected} onCancel={handleOverlayCancel} />
+      )}
+      {isActive && activeMode === 'annotate' && (
+        <AnnotationOverlay onComplete={handleAnnotationComplete} onCancel={handleOverlayCancel} />
+      )}
+
       <FeedbackPanel
         isOpen={panel.isOpen}
         selectedElement={panel.selectedElement}


### PR DESCRIPTION
## Summary

- Adds a speed-dial UI that fans out vertically above the FAB when DevBug preview mode is active
- Introduces `activeMode: 'inspect' | 'area' | 'annotate'` state to `DevBugFAB`
- The FAB icon changes to reflect the active mode (🎯 / ▭ / 📸)
- Dial opens on hover over the FAB, and closes when a mode is selected or DevBug deactivates
- Long-press on the FAB also opens the dial
- Speed-dial items use staggered entry animation (~60ms between items) with tooltip labels on hover
- Active mode item has highlighted border/background
- Wires `AreaSelectOverlay.onAreaSelected` → feedback panel (first element), `onCancel` → deactivate
- Wires `AnnotationOverlay.onComplete` → feedback panel (synthetic element), `onCancel` → deactivate
- All existing behavior preserved: console/perf capture lifecycle, Ctrl+Shift+D shortcut, crosshair cursor

## Test plan

- [ ] TypeScript check passes (`npx tsc -b --noEmit`)
- [ ] All 858 tests pass (`npm run test:run`)
- [ ] Activate DevBug (Ctrl+Shift+D) — FAB shows active state, hovering opens speed-dial with 3 items
- [ ] Click each mode item — FAB icon updates, dial closes, correct overlay renders
- [ ] Long-press FAB — dial opens
- [ ] Deactivating DevBug — dial collapses, mode resets behavior on next activation
- [ ] Inspect mode: click element → FeedbackPanel opens
- [ ] Area mode: drag to select → FeedbackPanel opens with first element
- [ ] Annotate mode: complete annotation → FeedbackPanel opens