### PR TITLE
fix: toggle pointer-events on DevBug panel host when open (#658)

### DIFF
--- a/src/components/DevBug/FeedbackPanel.tsx
+++ b/src/components/DevBug/FeedbackPanel.tsx
@@ -531,6 +531,12 @@ export function FeedbackPanel(props: FeedbackPanelProps) {
   }, []);
 
   useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    host.style.pointerEvents = props.isOpen ? 'auto' : 'none';
+  }, [props.isOpen]);
+
+  useEffect(() => {
     if (props.isOpen) {
       import('@/services/devbug/consoleCapture').then(({ getEntries }) => {
         setConsoleEntries(getEntries().slice(-10));


### PR DESCRIPTION
## Summary
Fixes the DevBug feedback panel being non-interactive after sliding in. The Shadow DOM host div was created with `pointer-events: none` to prevent interaction on the background, but this was never toggled when the panel opened.

## Changes
- Added `useEffect` to toggle `host.style.pointerEvents` between `'auto'` (when open) and `'none'` (when closed)
- Effect dependency is `[props.isOpen]`
- Placed after the initial mount effect to ensure host exists

## Testing
- `npx tsc -b --noEmit` passes (no type errors)
- `npm run test:run` runs successfully (pre-existing test failures unrelated to FeedbackPanel)
- No new tests added (minimal fix as specified)

Fixes #658