### PR TITLE
fix: filter ancestor elements from area selection (#664)

### DIFF
--- a/src/components/DevBug/useAreaSelection.ts
+++ b/src/components/DevBug/useAreaSelection.ts
@@ -50,6 +50,14 @@ function collectOverlappingElements(rect: SelectionRect): { elements: Element[];
     if (domRect.width === 0 && domRect.height === 0) continue;
 
     if (rectsOverlap(rect, domRect)) {
+      // Skip elements that fully enclose the selection — they're ancestors, not targets
+      const enclosesSelection =
+        domRect.left <= rect.x &&
+        domRect.top <= rect.y &&
+        domRect.right >= rect.x + rect.width &&
+        domRect.bottom >= rect.y + rect.height;
+      if (enclosesSelection) continue;
+
       seen.add(el);
       elements.push(el);
       infos.push(extractElementInfo(el));


### PR DESCRIPTION
## Summary
- Adds enclosesSelection check to skip elements that fully contain the selection rectangle
- Prevents full-viewport ancestors (html, body, layout wrappers) from being collected as targets
- Fixes overcollection of elements when drawing small selection rectangles in DevBug area select

## Root Cause
The `collectOverlappingElements` function only checked for rectangle overlap but didn't filter out elements whose bounding rect fully encloses the selection. This meant any ancestor element that overlapped the selection (which includes nearly all viewport-level ancestors) would be collected.

## Solution
After the overlap check, skip elements where:
- `domRect.left <= rect.x`
- `domRect.top <= rect.y`
- `domRect.right >= rect.x + rect.width`
- `domRect.bottom >= rect.y + rect.height`

These conditions identify elements that completely enclose the selection rectangle, indicating they're ancestors rather than actual targets.

## Testing
- All 858 existing tests pass
- TypeScript check passes (no type errors)