### PR TITLE
fix: resolve actual React component names instead of styled.div (#666)

### DIFF
--- a/src/services/devbug/__tests__/issueFormatter.test.ts
+++ b/src/services/devbug/__tests__/issueFormatter.test.ts
@@ -93,6 +93,54 @@ describe('formatIssueTitle', () => {
     // #then
     expect(title).toContain('broken, slower');
   });
+
+  it('falls back to tag name from cssSelector when reactComponentName is a styled wrapper', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      categories: ['broken'],
+      elements: [
+        {
+          cssSelector: 'div.sc-abc123',
+          xpath: '/div',
+          reactComponentName: 'styled.div',
+          boundingRect: { top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50, x: 0, y: 0 },
+          computedStyles: {},
+          textContent: '',
+        },
+      ],
+    };
+
+    // #when
+    const title = formatIssueTitle(report);
+
+    // #then
+    expect(title).toBe('[DevBug] broken — div');
+  });
+
+  it('falls back to tag name from cssSelector when reactComponentName is null', () => {
+    // #given
+    const report: BugReport = {
+      ...BASE_REPORT,
+      categories: ['broken'],
+      elements: [
+        {
+          cssSelector: 'button.some-class',
+          xpath: '/button',
+          reactComponentName: null,
+          boundingRect: { top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50, x: 0, y: 0 },
+          computedStyles: {},
+          textContent: '',
+        },
+      ],
+    };
+
+    // #when
+    const title = formatIssueTitle(report);
+
+    // #then
+    expect(title).toBe('[DevBug] broken — button');
+  });
 });
 
 describe('formatIssueBody', () => {

--- a/src/services/devbug/__tests__/reportBuilder.test.ts
+++ b/src/services/devbug/__tests__/reportBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildBugReport, collectBrowserInfo, extractElementInfo } from '../reportBuilder';
+import { buildBugReport, collectBrowserInfo, extractElementInfo, getReactComponentName } from '../reportBuilder';
 import type { SelectedElement } from '@/types/devbug';
 
 const FIXED_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
@@ -253,5 +253,129 @@ describe('extractElementInfo', () => {
     expect(info.computedStyles).toHaveProperty('position');
 
     document.body.removeChild(el);
+  });
+});
+
+describe('getReactComponentName', () => {
+  function makeElementWithFiber(fiberType: unknown): Element {
+    const el = document.createElement('div');
+    Object.defineProperty(el, '__reactFiber$test', {
+      value: { type: fiberType, return: null },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+    return el;
+  }
+
+  it('returns null when element has no React fiber key', () => {
+    // #given
+    const el = document.createElement('div');
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBeNull();
+  });
+
+  it('resolves displayName from an object type (styled-component wrapper)', () => {
+    // #given
+    const styledType = { displayName: 'Styled(AlbumArtContainer)' };
+    const el = makeElementWithFiber(styledType);
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('AlbumArtContainer');
+  });
+
+  it('resolves displayName from a ForwardRef wrapper', () => {
+    // #given
+    const forwardRefType = { displayName: 'ForwardRef(PlayerContainer)' };
+    const el = makeElementWithFiber(forwardRefType);
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('PlayerContainer');
+  });
+
+  it('resolves displayName from a Memo wrapper', () => {
+    // #given
+    const memoType = { displayName: 'Memo(TrackList)' };
+    const el = makeElementWithFiber(memoType);
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('TrackList');
+  });
+
+  it('skips generic styled.div function name and walks up the fiber tree', () => {
+    // #given
+    const el = document.createElement('div');
+    const styledFn = function styled() {};
+    Object.defineProperty(styledFn, 'name', { value: 'styled.div', configurable: true });
+    const parentFiber = { type: function AlbumArtContainer() {}, return: null };
+    Object.defineProperty(el, '__reactFiber$test', {
+      value: { type: styledFn, return: parentFiber },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('AlbumArtContainer');
+  });
+
+  it('resolves displayName on a function type before checking name', () => {
+    // #given
+    const fn = function _c() {};
+    Object.defineProperty(fn, 'displayName', { value: 'VolumeBar', configurable: true });
+    const el = makeElementWithFiber(fn);
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('VolumeBar');
+  });
+
+  it('returns plain function name when not generic', () => {
+    // #given
+    const fn = function TrackInfo() {};
+    const el = makeElementWithFiber(fn);
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBe('TrackInfo');
+  });
+
+  it('returns null when all fiber types are generic', () => {
+    // #given
+    const el = document.createElement('div');
+    const styledFn = function styled() {};
+    Object.defineProperty(styledFn, 'name', { value: 'styled.div', configurable: true });
+    Object.defineProperty(el, '__reactFiber$test', {
+      value: { type: styledFn, return: null },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+
+    // #when
+    const name = getReactComponentName(el);
+
+    // #then
+    expect(name).toBeNull();
   });
 });

--- a/src/services/devbug/issueFormatter.ts
+++ b/src/services/devbug/issueFormatter.ts
@@ -2,12 +2,19 @@ import type { BugReport, ConsoleEntry, SelectedElement } from '@/types/devbug';
 
 const CONSOLE_LOG_LIMIT = 10;
 
+function resolveComponentLabel(element: SelectedElement): string {
+  const name = element.reactComponentName;
+  if (name && !/^styled\./i.test(name) && !/^Styled\(/i.test(name)) {
+    return name;
+  }
+  const tagMatch = element.cssSelector.match(/^[a-z][a-z0-9]*/i);
+  return tagMatch ? tagMatch[0] : element.cssSelector;
+}
+
 export function formatIssueTitle(report: BugReport): string {
   const categories = report.categories.length > 0 ? report.categories.join(', ') : 'general';
   const component =
-    report.elements.length > 0
-      ? (report.elements[0].reactComponentName ?? report.elements[0].cssSelector)
-      : 'unknown';
+    report.elements.length > 0 ? resolveComponentLabel(report.elements[0]) : 'unknown';
   return `[DevBug] ${categories} — ${component}`;
 }
 

--- a/src/services/devbug/reportBuilder.ts
+++ b/src/services/devbug/reportBuilder.ts
@@ -77,6 +77,23 @@ export function extractElementInfo(element: Element): SelectedElement {
   };
 }
 
+function isGenericName(name: string): boolean {
+  return (
+    /^styled\./.test(name) ||
+    /^Styled\(/.test(name) ||
+    /^forwardRef$/i.test(name) ||
+    /^_c\d*$/.test(name) ||
+    name === 'div' ||
+    name === 'span' ||
+    name === 'button'
+  );
+}
+
+function unwrapDisplayName(displayName: string): string {
+  const match = displayName.match(/^(?:Styled|ForwardRef|Memo)\((.+)\)$/);
+  return match ? match[1] : displayName;
+}
+
 export function getReactComponentName(element: Element): string | null {
   const fiberKey = Object.keys(element).find(
     (key) => key.startsWith('__reactFiber') || key.startsWith('__reactInternalInstance'),
@@ -91,13 +108,26 @@ export function getReactComponentName(element: Element): string | null {
 
   while (fiber) {
     const type = fiber.type;
-    if (typeof type === 'function' && type.name) {
-      return type.name;
-    }
+
     if (typeof type === 'object' && type !== null) {
       const displayName = (type as Record<string, unknown>).displayName;
-      if (typeof displayName === 'string') return displayName;
+      if (typeof displayName === 'string') {
+        const unwrapped = unwrapDisplayName(displayName);
+        if (!isGenericName(unwrapped)) return unwrapped;
+      }
     }
+
+    if (typeof type === 'function') {
+      const fnType = type as { displayName?: string; name?: string };
+      if (typeof fnType.displayName === 'string') {
+        const unwrapped = unwrapDisplayName(fnType.displayName);
+        if (!isGenericName(unwrapped)) return unwrapped;
+      }
+      if (fnType.name && !isGenericName(fnType.name)) {
+        return fnType.name;
+      }
+    }
+
     fiber = fiber.return as typeof fiber;
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `getReactComponentName` checked `type.name` before `displayName`. For styled-components, `type.name` is the generic `"styled.div"` wrapper, so the meaningful `displayName` (e.g. `"Styled(AlbumArtContainer)"`) was never reached.
- **Fix**: Rewrote the fiber walk in `reportBuilder.ts` to check `displayName` first, unwrap `Styled(...)` / `ForwardRef(...)` / `Memo(...)` wrappers, and skip generic names (walking up the fiber tree to find the nearest real component name).
- **Fallback**: Updated `issueFormatter.ts` title generation to fall back to the HTML tag name extracted from the CSS selector when the component name is still null or generic.

## Changes

- `src/services/devbug/reportBuilder.ts` — rewrote `getReactComponentName` with `isGenericName` + `unwrapDisplayName` helpers and corrected fiber walk order
- `src/services/devbug/issueFormatter.ts` — added `resolveComponentLabel` helper that strips generic styled-component names and falls back to the tag name
- `src/services/devbug/__tests__/reportBuilder.test.ts` — added `getReactComponentName` describe block with 7 new tests covering all resolution paths
- `src/services/devbug/__tests__/issueFormatter.test.ts` — added 2 tests for the styled-component and null-component fallback paths

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 868 tests pass (66 test files)