### PR TITLE
fix: exclude DevBug UI from click and area inspection (#665)

### DIFF
--- a/src/components/DevBug/DevBugFAB.tsx
+++ b/src/components/DevBug/DevBugFAB.tsx
@@ -286,7 +286,7 @@ export function DevBugFAB() {
 
   return createPortal(
     <>
-      <FABContainer>
+      <FABContainer data-devbug="">
         {isActive && dialOpen && (
           <SpeedDialList>
             {MODES.map((mode, index) => (

--- a/src/components/DevBug/DevBugTopBar.tsx
+++ b/src/components/DevBug/DevBugTopBar.tsx
@@ -34,7 +34,7 @@ export function DevBugTopBar() {
   const reducedMotion = useReducedMotion();
 
   return createPortal(
-    <TopBarContainer $reducedMotion={reducedMotion}>
+    <TopBarContainer $reducedMotion={reducedMotion} data-devbug="">
       Preview Mode — click an element to inspect
     </TopBarContainer>,
     document.body,

--- a/src/components/DevBug/FeedbackPanel.tsx
+++ b/src/components/DevBug/FeedbackPanel.tsx
@@ -520,6 +520,7 @@ export function FeedbackPanel(props: FeedbackPanelProps) {
     const host = document.createElement('div');
     host.style.cssText =
       'position:fixed;top:0;left:0;width:0;height:0;overflow:visible;z-index:2147483646;pointer-events:none;';
+    host.setAttribute('data-devbug', '');
     document.body.appendChild(host);
     const shadow = host.attachShadow({ mode: 'open' });
     hostRef.current = host;

--- a/src/components/DevBug/useAreaSelection.ts
+++ b/src/components/DevBug/useAreaSelection.ts
@@ -39,6 +39,8 @@ function collectOverlappingElements(rect: SelectionRect): { elements: Element[];
   for (const el of all) {
     if (seen.has(el)) continue;
 
+    if (el.closest('[data-devbug]')) continue;
+
     const computed = window.getComputedStyle(el);
     const isHidden =
       computed.display === 'none' ||

--- a/src/components/DevBug/useElementDetection.ts
+++ b/src/components/DevBug/useElementDetection.ts
@@ -36,6 +36,11 @@ export function useElementDetection(
           return;
         }
 
+        if (element.closest('[data-devbug]')) {
+          onDetectRef.current(null);
+          return;
+        }
+
         onDetectRef.current({
           element,
           tagName: element.tagName.toLowerCase(),


### PR DESCRIPTION
## Summary

- Added `data-devbug=""` attribute to `FABContainer` in `DevBugFAB.tsx`, `TopBarContainer` in `DevBugTopBar.tsx`, and the Shadow DOM host div in `FeedbackPanel.tsx`
- `useElementDetection.ts`: skip highlighting/selection when the resolved element has a `[data-devbug]` ancestor
- `useAreaSelection.ts`: skip elements with a `[data-devbug]` ancestor during `collectOverlappingElements`

## Test plan

- [ ] Activate DevBug (Ctrl+Shift+D)
- [ ] In inspect mode: hover over the FAB, speed-dial, and top bar — they should not highlight or be selectable
- [ ] In area-select mode: drag a selection over the FAB area — DevBug elements should be excluded from results
- [ ] Clicking the FAB still toggles DevBug mode normally
- [ ] All 868 existing tests pass (`npm run test:run`)