### PR TITLE
fix: wire screenshot capture into click-to-inspect feedback panel (#663)

### DIFF
--- a/src/components/DevBug/DevBugFAB.tsx
+++ b/src/components/DevBug/DevBugFAB.tsx
@@ -208,7 +208,13 @@ export function DevBugFAB() {
 
   const handleElementSelected = useCallback(
     (_element: Element, info: SelectedElement) => {
-      panel.open(info);
+      import('@/services/devbug/screenshotCapture').then(({ captureScreenshot }) => {
+        captureScreenshot(info.boundingRect).then((dataUrl) => {
+          panel.open(info, dataUrl);
+        }).catch(() => {
+          panel.open(info);
+        });
+      });
     },
     [panel],
   );
@@ -223,7 +229,7 @@ export function DevBugFAB() {
   );
 
   const handleAnnotationComplete = useCallback(
-    (_annotatedDataUrl: string) => {
+    (annotatedDataUrl: string) => {
       const syntheticInfo: SelectedElement = {
         cssSelector: 'screenshot',
         xpath: '/screenshot',
@@ -232,7 +238,7 @@ export function DevBugFAB() {
         computedStyles: {},
         textContent: '',
       };
-      panel.open(syntheticInfo);
+      panel.open(syntheticInfo, annotatedDataUrl);
     },
     [panel],
   );
@@ -333,6 +339,7 @@ export function DevBugFAB() {
       <FeedbackPanel
         isOpen={panel.isOpen}
         selectedElement={panel.selectedElement}
+        screenshotDataUrl={panel.screenshotDataUrl}
         categories={panel.categories}
         comment={panel.comment}
         onToggleCategory={panel.toggleCategory}

--- a/src/components/DevBug/FeedbackPanel.tsx
+++ b/src/components/DevBug/FeedbackPanel.tsx
@@ -372,6 +372,7 @@ interface ToastState {
 export interface FeedbackPanelProps {
   isOpen: boolean;
   selectedElement: SelectedElement | null;
+  screenshotDataUrl: string | null;
   categories: Category[];
   comment: string;
   onToggleCategory: (category: Category) => void;
@@ -389,6 +390,7 @@ interface PanelContentProps extends FeedbackPanelProps {
 function PanelContent({
   isOpen,
   selectedElement,
+  screenshotDataUrl,
   categories,
   comment,
   consoleEntries,
@@ -416,10 +418,18 @@ function PanelContent({
         <div className="panel-body">
           <div>
             <p className="section-label">Screenshot</p>
-            <div className="screenshot-placeholder">
-              <span className="screenshot-placeholder-icon">📸</span>
-              <span className="screenshot-placeholder-text">Screenshot capture coming soon</span>
-            </div>
+            {screenshotDataUrl ? (
+              <img
+                src={screenshotDataUrl}
+                alt="Screenshot"
+                style={{ width: '100%', borderRadius: '6px', border: '1px solid #333' }}
+              />
+            ) : (
+              <div className="screenshot-placeholder">
+                <span className="screenshot-placeholder-icon">📸</span>
+                <span className="screenshot-placeholder-text">No screenshot captured</span>
+              </div>
+            )}
           </div>
 
           {selectedElement && (
@@ -562,6 +572,7 @@ export function FeedbackPanel(props: FeedbackPanelProps) {
       const report = buildBugReport({
         selectionMode: 'click',
         elements: props.selectedElement ? [props.selectedElement] : [],
+        screenshotDataUrl: props.screenshotDataUrl ?? undefined,
         comment: props.comment,
         categories: props.categories,
         consoleLogs: entries,

--- a/src/components/DevBug/useFeedbackPanel.ts
+++ b/src/components/DevBug/useFeedbackPanel.ts
@@ -4,12 +4,13 @@ import type { Category, SelectedElement } from '@/types/devbug';
 export interface FeedbackPanelState {
   isOpen: boolean;
   selectedElement: SelectedElement | null;
+  screenshotDataUrl: string | null;
   categories: Category[];
   comment: string;
 }
 
 export interface FeedbackPanelActions {
-  open: (element: SelectedElement) => void;
+  open: (element: SelectedElement, screenshotDataUrl?: string) => void;
   close: () => void;
   toggleCategory: (category: Category) => void;
   setComment: (comment: string) => void;
@@ -19,6 +20,7 @@ export interface FeedbackPanelActions {
 const INITIAL_STATE: FeedbackPanelState = {
   isOpen: false,
   selectedElement: null,
+  screenshotDataUrl: null,
   categories: [],
   comment: '',
 };
@@ -26,8 +28,8 @@ const INITIAL_STATE: FeedbackPanelState = {
 export function useFeedbackPanel(): FeedbackPanelState & FeedbackPanelActions {
   const [state, setState] = useState<FeedbackPanelState>(INITIAL_STATE);
 
-  const open = useCallback((element: SelectedElement) => {
-    setState({ isOpen: true, selectedElement: element, categories: [], comment: '' });
+  const open = useCallback((element: SelectedElement, screenshotDataUrl?: string) => {
+    setState({ isOpen: true, selectedElement: element, screenshotDataUrl: screenshotDataUrl ?? null, categories: [], comment: '' });
   }, []);
 
   const close = useCallback(() => {


### PR DESCRIPTION
## Summary

- Adds `screenshotDataUrl` field to `FeedbackPanelState` and updates `open()` to accept it as an optional parameter
- `handleElementSelected` in `DevBugFAB` now dynamically imports `captureScreenshot` and passes the result to `panel.open()`; falls back gracefully on error
- `handleAnnotationComplete` now passes the annotated data URL through to `panel.open()` instead of discarding it
- `FeedbackPanel` accepts and displays the screenshot as an `<img>` when available, replacing the static "coming soon" placeholder
- `screenshotDataUrl` is included in the `buildBugReport` call so it appears in submitted GitHub issues

## Test plan

- [ ] TypeScript check passes: `npx tsc -b --noEmit`
- [ ] All 868 tests pass: `npm run test:run`
- [ ] Click an element in inspect mode — screenshot should appear in the feedback panel
- [ ] Complete a screenshot annotation — annotated image should appear in the feedback panel
- [ ] When no screenshot is available, "No screenshot captured" placeholder is shown