### PR TITLE
fix: reduce album art border-radius (#669)

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -68,7 +68,7 @@ const AlbumArtContainer = styled.div.withConfig({
   transform: translateZ(0);
   will-change: transform, opacity;
   isolation: isolate;
-  border-radius: ${theme.borderRadius['3xl']};
+  border-radius: ${theme.borderRadius.xl};
   position: relative;
   width: 100%;
   max-width: ${({ $zenMode }) => $zenMode


### PR DESCRIPTION
Reduces the AlbumArt component border-radius from 3xl (1.5rem/24px) to xl (0.75rem/12px) for a more subtle corner rounding effect as requested in issue #669.