### PR TITLE
fix: Liked Songs respects provider filter selection (#672)

### DIFF
--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -56,7 +56,7 @@ const LikedSongsCard: React.FC<LikedSongsCardProps> = React.memo(function LikedS
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
   const isPerProvider = provider !== undefined;
   const gradient = getLikedSongsGradient(
-    isUnifiedLikedActive ? 'unified' : (isPerProvider ? provider : activeDescriptor?.id)
+    isPerProvider ? provider : (isUnifiedLikedActive ? 'unified' : activeDescriptor?.id)
   );
 
   const syncSpinner = isLikedSongsSyncing ? <TabSpinner /> : null;

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -35,6 +35,7 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
     showProviderBadges,
     hasActiveFilters,
     searchQuery,
+    providerFilters,
     pinnedPlaylists,
     unpinnedPlaylists,
     isPlaylistPinned,
@@ -45,15 +46,21 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   } = useLibraryContext();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
-  const usePerProviderLiked = showProviderBadges && likedSongsPerProvider.length >= 1 && !isUnifiedLikedActive;
-  const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
+
+  const filteredLikedSongsPerProvider = providerFilters.length > 0
+    ? likedSongsPerProvider.filter(e => providerFilters.includes(e.provider))
+    : likedSongsPerProvider;
+
+  const shouldShowUnified = isUnifiedLikedActive && filteredLikedSongsPerProvider.length !== 1;
+  const usePerProviderLiked = showProviderBadges && filteredLikedSongsPerProvider.length >= 1 && !shouldShowUnified;
+  const effectiveLikedCount = shouldShowUnified ? unifiedLikedCount : likedSongsCount;
   const isLikedLoading = !isInitialLoadComplete && effectiveLikedCount === 0;
   const showLikedSongs = effectiveLikedCount > 0 || isLikedLoading;
 
   const layout = inDrawer ? 'grid' : 'list';
 
   const likedSongsItem = showLikedSongs && (usePerProviderLiked
-    ? likedSongsPerProvider.map(({ provider, count }) => (
+    ? filteredLikedSongsPerProvider.map(({ provider, count }) => (
         <LikedSongsCard key={`liked-songs-${provider}`} layout={layout} provider={provider} count={count} />
       ))
     : <LikedSongsCard layout={layout} count={effectiveLikedCount} />


### PR DESCRIPTION
## Summary

- When exactly one provider is selected in the library filter chips, Liked Songs now shows that provider's color gradient and track count instead of the unified multi-provider view
- When both providers (or no filter) are active, unified view is preserved as before

## Root cause

Two separate bugs:

1. **`PlaylistGrid.tsx`**: `usePerProviderLiked` was gated on `!isUnifiedLikedActive` which is determined purely by how many providers are *connected*, not what the user has *filtered* to. Filtering to one provider never switched out of unified mode.

2. **`LikedSongsCard.tsx`**: Gradient logic checked `isUnifiedLikedActive` before `isPerProvider`, so even when a `provider` prop was passed, the unified gradient overrode it.

## Fix

- `PlaylistGrid`: filter `likedSongsPerProvider` by active `providerFilters`, then derive `shouldShowUnified` from the filtered count (`>= 2` = unified, `1` = per-provider)
- `LikedSongsCard`: swap precedence — check `isPerProvider` first so per-provider cards always use the provider's own color

Closes #672