### PR TITLE
Release: Liked Songs provider filter fix

### DIFF
--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -56,7 +56,7 @@ const LikedSongsCard: React.FC<LikedSongsCardProps> = React.memo(function LikedS
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
   const isPerProvider = provider !== undefined;
   const gradient = getLikedSongsGradient(
-    isUnifiedLikedActive ? 'unified' : (isPerProvider ? provider : activeDescriptor?.id)
+    isPerProvider ? provider : (isUnifiedLikedActive ? 'unified' : activeDescriptor?.id)
   );
 
   const syncSpinner = isLikedSongsSyncing ? <TabSpinner /> : null;

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -35,6 +35,7 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
     showProviderBadges,
     hasActiveFilters,
     searchQuery,
+    providerFilters,
     pinnedPlaylists,
     unpinnedPlaylists,
     isPlaylistPinned,
@@ -45,15 +46,21 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   } = useLibraryContext();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
-  const usePerProviderLiked = showProviderBadges && likedSongsPerProvider.length >= 1 && !isUnifiedLikedActive;
-  const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
+
+  const filteredLikedSongsPerProvider = providerFilters.length > 0
+    ? likedSongsPerProvider.filter(e => providerFilters.includes(e.provider))
+    : likedSongsPerProvider;
+
+  const shouldShowUnified = isUnifiedLikedActive && filteredLikedSongsPerProvider.length !== 1;
+  const usePerProviderLiked = showProviderBadges && filteredLikedSongsPerProvider.length >= 1 && !shouldShowUnified;
+  const effectiveLikedCount = shouldShowUnified ? unifiedLikedCount : likedSongsCount;
   const isLikedLoading = !isInitialLoadComplete && effectiveLikedCount === 0;
   const showLikedSongs = effectiveLikedCount > 0 || isLikedLoading;
 
   const layout = inDrawer ? 'grid' : 'list';
 
   const likedSongsItem = showLikedSongs && (usePerProviderLiked
-    ? likedSongsPerProvider.map(({ provider, count }) => (
+    ? filteredLikedSongsPerProvider.map(({ provider, count }) => (
         <LikedSongsCard key={`liked-songs-${provider}`} layout={layout} provider={provider} count={count} />
       ))
     : <LikedSongsCard layout={layout} count={effectiveLikedCount} />


### PR DESCRIPTION
## Summary

- Fix Liked Songs card showing unified color gradient and track count even when only one provider is selected in library filter chips (#672)
- When a single provider is filtered, the card now shows that provider's color and count; unified view is preserved when both (or no) providers are selected

## PRs included

- #677 — fix: Liked Songs respects provider filter selection (#672)

## Test plan

- [ ] Connect both Spotify and Dropbox
- [ ] Open the library drawer — verify Liked Songs shows unified gradient and combined count
- [ ] Filter to only Spotify — verify Liked Songs shows Spotify's color and Spotify-only count
- [ ] Filter to only Dropbox — verify Liked Songs shows Dropbox's color and Dropbox-only count
- [ ] Select both providers — verify unified gradient and combined count return
- [ ] Clear all filters — verify unified gradient and combined count