### PR TITLE
enhance: match player panel corner rounding to album art

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -36,7 +36,7 @@ const BacksideRoot = styled.div`
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
   transform: rotateY(180deg);
-  border-radius: ${theme.borderRadius['3xl']};
+  border-radius: ${theme.borderRadius.xl};
   overflow: hidden;
 `;
 

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -205,7 +205,7 @@ export const LoadingCard = styled.div.withConfig({
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-radius: 1.25rem;
+  border-radius: ${({ theme }) => theme.borderRadius.xl};
   border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
   box-shadow: ${({ theme }) => theme.shadows.card};
   transition: box-shadow ${({ theme }) => theme.transitions.normal}, border-color ${({ theme }) => theme.transitions.normal};
@@ -217,7 +217,7 @@ export const LoadingCard = styled.div.withConfig({
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
-      border-radius: 1.25rem;
+      border-radius: ${theme.borderRadius.xl};
       z-index: 0;
     }
     &::before {
@@ -226,7 +226,7 @@ export const LoadingCard = styled.div.withConfig({
       background: ${theme.colors.card.overlay};
       backdrop-filter: blur(40px) saturate(180%);
       -webkit-backdrop-filter: blur(40px) saturate(180%);
-      border-radius: 1.25rem;
+      border-radius: ${theme.borderRadius.xl};
       z-index: 1;
     }
   ` : `


### PR DESCRIPTION
## Summary

- Updated `LoadingCard` in `src/components/PlayerContent/styled.ts` to use `theme.borderRadius.xl` instead of the hardcoded `1.25rem` value (applied to the component itself and both `::after` / `::before` pseudo-elements)
- Updated `BacksideRoot` in `src/components/AlbumArtQuickSwapBack.tsx` to use `theme.borderRadius.xl` instead of `theme.borderRadius['3xl']`
- Both panels now match the album art corner rounding for visual consistency

## Test plan

- [x] TypeScript check passes (`npx tsc -b --noEmit`)
- [x] All 868 tests pass (`npm run test:run`)

Closes #679