### PR TITLE
fix: add scroll fade indicator to FilterChipRow on desktop

### DIFF
--- a/src/components/FilterChipRow.tsx
+++ b/src/components/FilterChipRow.tsx
@@ -4,6 +4,8 @@ import { createPortal } from 'react-dom';
 import { theme } from '@/styles/theme';
 import {
   ChipRow,
+  ChipRowContainer,
+  ChipRowFade,
   Chip,
   SearchChipWrapper,
   SearchChipIcon,
@@ -66,9 +68,11 @@ const FilterChipRow = React.memo(function FilterChipRow({
   const [searchExpanded, setSearchExpanded] = useState(false);
   const [artistListOpen, setArtistListOpen] = useState(false);
   const [artistMenuPos, setArtistMenuPos] = useState<{ top: number; left: number } | null>(null);
+  const [showRightFade, setShowRightFade] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const artistRef = useRef<HTMLDivElement>(null);
   const artistDropdownRef = useRef<HTMLDivElement>(null);
+  const chipRowRef = useRef<HTMLDivElement>(null);
 
   const MENU_GAP_PX = 4;
 
@@ -129,6 +133,26 @@ const FilterChipRow = React.memo(function FilterChipRow({
     if (searchQuery && !searchExpanded) setSearchExpanded(true);
   }, [searchQuery, searchExpanded]);
 
+  const checkOverflow = useCallback(() => {
+    const el = chipRowRef.current;
+    if (!el) return;
+    const hasMore = el.scrollLeft + el.clientWidth < el.scrollWidth - 2;
+    setShowRightFade(hasMore);
+  }, []);
+
+  useEffect(() => {
+    const el = chipRowRef.current;
+    if (!el) return;
+    checkOverflow();
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(el);
+    el.addEventListener('scroll', checkOverflow);
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', checkOverflow);
+    };
+  }, [checkOverflow]);
+
   const handleSearchToggle = useCallback(() => {
     if (searchExpanded) {
       onSearchChange('');
@@ -155,7 +179,8 @@ const FilterChipRow = React.memo(function FilterChipRow({
   const hasMoreArtists = topArtists.length > 5;
 
   return (
-    <ChipRow>
+    <ChipRowContainer>
+      <ChipRow ref={chipRowRef}>
       <SearchChipWrapper $expanded={searchExpanded}>
         <SearchChipIcon onClick={handleSearchToggle} aria-label={searchExpanded ? 'Close search' : 'Search'}>
           {searchExpanded ? <CloseIcon /> : <SearchIcon />}
@@ -229,7 +254,9 @@ const FilterChipRow = React.memo(function FilterChipRow({
             )}
         </SortChipWrapper>
       )}
-    </ChipRow>
+      </ChipRow>
+      {showRightFade && <ChipRowFade />}
+    </ChipRowContainer>
   );
 });
 

--- a/src/components/styled/FilterChips.tsx
+++ b/src/components/styled/FilterChips.tsx
@@ -188,3 +188,22 @@ export const ArtistCount = styled.span`
   color: ${theme.colors.muted.foreground};
   margin-left: ${theme.spacing.sm};
 `;
+
+/** Outer wrapper to contain the chip row and gradient fade overlay */
+export const ChipRowContainer = styled.div`
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+`;
+
+/** Right-edge gradient fade indicating more chips are available */
+export const ChipRowFade = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 40px;
+  background: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.8));
+  pointer-events: none;
+  z-index: 1;
+`;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -83,6 +83,13 @@ Object.defineProperty(global, 'crypto', {
 global.btoa = vi.fn((str) => Buffer.from(str, 'binary').toString('base64'));
 global.atob = vi.fn((b64) => Buffer.from(b64, 'base64').toString('binary'));
 
+// Mock ResizeObserver (not available in jsdom)
+global.ResizeObserver = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
 // Clean up after each test
 afterEach(() => {
   vi.clearAllMocks();


### PR DESCRIPTION
## Summary

- Wraps `ChipRow` in a `ChipRowContainer` (`position: relative; overflow: hidden`) to scope the gradient overlay
- Adds a `ChipRowFade` styled component — a 40px right-edge gradient from transparent to `rgba(0,0,0,0.8)` — to `FilterChips.tsx`
- Uses `ResizeObserver` + `scroll` event listener on the chip row ref to detect when `scrollWidth > clientWidth` and conditionally renders the fade
- Fade disappears when fully scrolled to the right (`scrollLeft + clientWidth >= scrollWidth - 2`)
- Also adds a global `ResizeObserver` mock to the test setup (`src/test/setup.ts`) — it was missing from jsdom, causing one pre-existing test failure

## Test plan

- [ ] Open the library drawer on desktop with enough albums/providers to overflow the chip row — gradient fade appears on the right edge
- [ ] Scroll the chip row to the right — fade disappears when no more chips are hidden
- [ ] Resize the window to a width where chips no longer overflow — fade disappears
- [ ] Run `npm run test:run` — all 868 tests pass
- [ ] Run `npx tsc -b --noEmit` — no type errors

Closes #675