### PR TITLE
feat: add visualizer speed control (Slower/Normal/Faster)

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -22,6 +22,8 @@ interface AlbumArtQuickSwapBackProps {
   onBackgroundVisualizerStyleChange: (style: VisualizerStyle) => void;
   backgroundVisualizerIntensity: number;
   onBackgroundVisualizerIntensityChange: (intensity: number) => void;
+  backgroundVisualizerSpeed: number;
+  onBackgroundVisualizerSpeedChange: (speed: number) => void;
   translucenceEnabled: boolean;
   onTranslucenceToggle: () => void;
   isMobile: boolean;
@@ -147,6 +149,8 @@ function AlbumArtQuickSwapBack({
   onBackgroundVisualizerStyleChange,
   backgroundVisualizerIntensity,
   onBackgroundVisualizerIntensityChange,
+  backgroundVisualizerSpeed,
+  onBackgroundVisualizerSpeedChange,
   translucenceEnabled,
   onTranslucenceToggle,
   isMobile,
@@ -181,6 +185,8 @@ function AlbumArtQuickSwapBack({
           onBackgroundVisualizerStyleChange={onBackgroundVisualizerStyleChange}
           backgroundVisualizerIntensity={backgroundVisualizerIntensity}
           onBackgroundVisualizerIntensityChange={onBackgroundVisualizerIntensityChange}
+          backgroundVisualizerSpeed={backgroundVisualizerSpeed}
+          onBackgroundVisualizerSpeedChange={onBackgroundVisualizerSpeedChange}
           translucenceEnabled={translucenceEnabled}
           onTranslucenceToggle={onTranslucenceToggle}
           isMobile={isMobile}

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -43,6 +43,7 @@ const AudioPlayerComponent = () => {
     backgroundVisualizerEnabled,
     backgroundVisualizerStyle,
     backgroundVisualizerIntensity,
+    backgroundVisualizerSpeed,
     accentColorBackgroundEnabled,
     zenModeEnabled,
     showVisualEffects,
@@ -216,6 +217,7 @@ const AudioPlayerComponent = () => {
             enabled={backgroundVisualizerEnabled && isMainPlayerActive}
             style={backgroundVisualizerStyle}
             intensity={backgroundVisualizerIntensity}
+            speed={backgroundVisualizerSpeed}
             accentColor={accentColor}
             isPlaying={state.isPlaying}
             playbackPosition={state.playbackPosition}

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -17,6 +17,7 @@ interface BackgroundVisualizerProps {
   enabled: boolean;
   style: VisualizerStyle;
   intensity: number;
+  speed?: number;
   accentColor: string;
   isPlaying: boolean;
   playbackPosition?: number;
@@ -56,6 +57,7 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   enabled,
   style,
   intensity,
+  speed,
   accentColor,
   isPlaying,
   playbackPosition,
@@ -87,6 +89,7 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
     <VisualizerContainer>
       <VisualizerComponent
         intensity={intensity}
+        speed={speed ?? 1.0}
         accentColor={accentColor}
         isPlaying={isPlaying}
         playbackPosition={playbackPosition}

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -103,6 +103,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     setBackgroundVisualizerStyle,
     backgroundVisualizerIntensity,
     setBackgroundVisualizerIntensity,
+    backgroundVisualizerSpeed,
+    setBackgroundVisualizerSpeed,
     setTranslucenceEnabled,
     setVisualEffectsEnabled,
   } = useVisualEffectsContext();
@@ -278,6 +280,10 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     setBackgroundVisualizerIntensity(Math.max(0, Math.min(100, intensity)));
   }, [setBackgroundVisualizerIntensity]);
 
+  const handleBackgroundVisualizerSpeedChange = useCallback((speed: number) => {
+    setBackgroundVisualizerSpeed(speed);
+  }, [setBackgroundVisualizerSpeed]);
+
   return (
     <>
       <CardContent style={{
@@ -334,6 +340,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
                 onBackgroundVisualizerStyleChange={handleBackgroundVisualizerStyleChange}
                 backgroundVisualizerIntensity={backgroundVisualizerIntensity}
                 onBackgroundVisualizerIntensityChange={handleBackgroundVisualizerIntensityChange}
+                backgroundVisualizerSpeed={backgroundVisualizerSpeed}
+                onBackgroundVisualizerSpeedChange={handleBackgroundVisualizerSpeedChange}
                 translucenceEnabled={translucenceEnabled}
                 onTranslucenceToggle={handleTranslucenceToggle}
                 isMobile={isMobile}

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -28,6 +28,8 @@ interface QuickEffectsRowProps {
   onBackgroundVisualizerStyleChange: (style: VisualizerStyle) => void;
   backgroundVisualizerIntensity?: number;
   onBackgroundVisualizerIntensityChange?: (intensity: number) => void;
+  backgroundVisualizerSpeed?: number;
+  onBackgroundVisualizerSpeedChange?: (speed: number) => void;
   translucenceEnabled: boolean;
   onTranslucenceToggle: () => void;
   isMobile: boolean;
@@ -186,6 +188,8 @@ function QuickEffectsRow({
   onBackgroundVisualizerStyleChange,
   backgroundVisualizerIntensity,
   onBackgroundVisualizerIntensityChange,
+  backgroundVisualizerSpeed,
+  onBackgroundVisualizerSpeedChange,
   translucenceEnabled,
   onTranslucenceToggle,
 }: QuickEffectsRowProps) {
@@ -212,6 +216,7 @@ function QuickEffectsRow({
   const hasGlowSubSettings = glowIntensity !== undefined && onGlowIntensityChange;
   const hasGlowRate = glowRate !== undefined && onGlowRateChange;
   const hasVizIntensity = backgroundVisualizerIntensity !== undefined && onBackgroundVisualizerIntensityChange;
+  const hasVizSpeed = backgroundVisualizerSpeed !== undefined && onBackgroundVisualizerSpeedChange;
 
   return (
     <QuickRow>
@@ -348,6 +353,16 @@ function QuickEffectsRow({
                 >
                   More
                 </OptionButton>
+              </OptionButtonGroup>
+            </SubSettingRow>
+          )}
+          {hasVizSpeed && (
+            <SubSettingRow>
+              <SubLabel>Speed</SubLabel>
+              <OptionButtonGroup>
+                <OptionButton $isActive={backgroundVisualizerSpeed === 0.5} onClick={() => onBackgroundVisualizerSpeedChange(0.5)}>Slower</OptionButton>
+                <OptionButton $isActive={backgroundVisualizerSpeed === 1.0} onClick={() => onBackgroundVisualizerSpeedChange(1.0)}>Normal</OptionButton>
+                <OptionButton $isActive={backgroundVisualizerSpeed === 2.0} onClick={() => onBackgroundVisualizerSpeedChange(2.0)}>Faster</OptionButton>
               </OptionButtonGroup>
             </SubSettingRow>
           )}

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -5,6 +5,7 @@ import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext'
 
 interface GridWaveVisualizerProps {
   intensity: number;
+  speed?: number;
   accentColor: string;
   isPlaying: boolean;
   playbackPosition?: number;
@@ -37,6 +38,7 @@ interface GridWaveState {
 
 export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
   intensity,
+  speed,
   accentColor,
   isPlaying,
 }) => {
@@ -88,7 +90,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
 
   const updateItems = useCallback(
     (states: GridWaveState[], deltaTime: number, playing: boolean, width: number, height: number): void => {
-      const speedMult = playing ? 1.0 : g.pausedSpeedMult;
+      const speedMult = (playing ? 1.0 : g.pausedSpeedMult) * (speed ?? 1.0);
       const dt = deltaTime / 16;
 
       const state = states[0];
@@ -102,7 +104,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
         if (wave.phase > Math.PI * 2) wave.phase -= Math.PI * 2;
       });
     },
-    [g]
+    [g, speed]
   );
 
   const renderItems = useCallback(

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -5,6 +5,7 @@ import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext'
 
 interface ParticleVisualizerProps {
   intensity: number;
+  speed?: number;
   accentColor: string;
   isPlaying: boolean;
   playbackPosition?: number;
@@ -35,6 +36,7 @@ interface Particle {
  */
 export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
   intensity,
+  speed,
   accentColor,
   isPlaying,
 }) => {
@@ -80,7 +82,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     height: number
   ): void => {
     const baseSpeed = isPlaying ? 1.0 : p.pausedSpeed;
-    const speedMultiplier = baseSpeed * p.speedMultiplier;
+    const speedMultiplier = baseSpeed * p.speedMultiplier * (speed ?? 1.0);
 
     particles.forEach(particle => {
       particle.x += particle.vx * speedMultiplier * (deltaTime / 16);
@@ -98,7 +100,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
       particle.radius = Math.max(1.5, particle.baseRadius + (pulseValue - 0.5) * p.pulseVariation);
       particle.opacity = Math.max(0.1, Math.min(1.0, particle.baseOpacity + (pulseValue - 0.5) * p.opacityVariation));
     });
-  }, [p]);
+  }, [p, speed]);
 
   const renderParticles = useCallback((
     ctx: CanvasRenderingContext2D,

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -12,6 +12,7 @@ interface AlbumArtBounds {
 
 interface TrailVisualizerProps {
   intensity: number;
+  speed?: number;
   accentColor: string;
   isPlaying: boolean;
   playbackPosition?: number;
@@ -52,6 +53,7 @@ interface ShipState {
  */
 export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
   intensity,
+  speed,
   accentColor,
   isPlaying,
   albumArtBounds,
@@ -133,7 +135,7 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
       ship.inited = true;
     }
 
-    const speedMult = playing ? 1.0 : t.pausedSpeedMult;
+    const speedMult = (playing ? 1.0 : t.pausedSpeedMult) * (speed ?? 1.0);
     const dt = deltaTime / 16;
 
     const viewportScale = Math.max(0.5, Math.sqrt(width / 1400));
@@ -186,7 +188,7 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
         particle.vy *= t.driftDecay;
       }
     });
-  }, [t]);
+  }, [t, speed]);
 
   const renderParticles = useCallback((
     ctx: CanvasRenderingContext2D,

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -4,6 +4,7 @@ import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 
 interface WaveVisualizerProps {
   intensity: number;
+  speed?: number;
   accentColor: string;
   isPlaying: boolean;
   playbackPosition?: number;
@@ -35,6 +36,7 @@ const PAUSED_SPEED_MULT = 0.3;
  */
 export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
   intensity,
+  speed,
   accentColor,
   isPlaying,
 }) => {
@@ -63,7 +65,7 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
 
   const updateItems = useCallback(
     (waves: Wave[], deltaTime: number, playing: boolean, _width: number, height: number): void => {
-      const speedMult = playing ? 1.0 : PAUSED_SPEED_MULT;
+      const speedMult = (playing ? 1.0 : PAUSED_SPEED_MULT) * (speed ?? 1.0);
       const dt = deltaTime / 16;
       waves.forEach((wave, i) => {
         wave.phase += wave.phaseSpeed * speedMult * dt;
@@ -72,7 +74,7 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
         wave.amplitude = height * (0.06 + (i / WAVE_COUNT) * 0.05);
       });
     },
-    []
+    [speed]
   );
 
   const renderItems = useCallback(

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -21,6 +21,7 @@ export const STORAGE_KEYS = {
   BG_VISUALIZER_ENABLED: 'vorbis-player-background-visualizer-enabled',
   BG_VISUALIZER_STYLE: 'vorbis-player-background-visualizer-style',
   BG_VISUALIZER_INTENSITY: 'vorbis-player-background-visualizer-intensity',
+  BG_VISUALIZER_SPEED: 'vorbis-player-background-visualizer-speed',
 
   // Accent color configuration
   ACCENT_COLOR_BG_PREFERRED: 'vorbis-player-accent-color-background-preferred',

--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -11,6 +11,7 @@ interface VisualEffectsContextValue {
   backgroundVisualizerEnabled: boolean;
   backgroundVisualizerStyle: VisualizerStyle;
   backgroundVisualizerIntensity: number;
+  backgroundVisualizerSpeed: number;
   accentColorBackgroundPreferred: boolean;
   accentColorBackgroundEnabled: boolean;
   translucenceEnabled: boolean;
@@ -23,6 +24,7 @@ interface VisualEffectsContextValue {
   setBackgroundVisualizerEnabled: (enabled: boolean | ((prev: boolean) => boolean)) => void;
   setBackgroundVisualizerStyle: (style: VisualizerStyle | ((prev: VisualizerStyle) => VisualizerStyle)) => void;
   setBackgroundVisualizerIntensity: (intensity: number | ((prev: number) => number)) => void;
+  setBackgroundVisualizerSpeed: (speed: number | ((prev: number) => number)) => void;
   setAccentColorBackgroundPreferred: (preferred: boolean | ((prev: boolean) => boolean)) => void;
   setTranslucenceEnabled: (enabled: boolean | ((prev: boolean) => boolean)) => void;
   setTranslucenceOpacity: (opacity: number | ((prev: number) => number)) => void;
@@ -38,6 +40,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.BG_VISUALIZER_ENABLED, true);
   const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>(STORAGE_KEYS.BG_VISUALIZER_STYLE, 'fireflies');
   const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_INTENSITY, 40);
+  const [backgroundVisualizerSpeed, setBackgroundVisualizerSpeed] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_SPEED, 1.0);
   const [accentColorBackgroundPreferred, setAccentColorBackgroundPreferred] = useLocalStorage<boolean>(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED, false);
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
   const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.TRANSLUCENCE_ENABLED, false);
@@ -76,6 +79,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     backgroundVisualizerEnabled,
     backgroundVisualizerStyle,
     backgroundVisualizerIntensity,
+    backgroundVisualizerSpeed,
     accentColorBackgroundPreferred,
     accentColorBackgroundEnabled,
     translucenceEnabled,
@@ -87,6 +91,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     setBackgroundVisualizerEnabled,
     setBackgroundVisualizerStyle,
     setBackgroundVisualizerIntensity,
+    setBackgroundVisualizerSpeed,
     setAccentColorBackgroundPreferred,
     setTranslucenceEnabled,
     setTranslucenceOpacity,
@@ -98,6 +103,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     backgroundVisualizerEnabled,
     backgroundVisualizerStyle,
     backgroundVisualizerIntensity,
+    backgroundVisualizerSpeed,
     accentColorBackgroundPreferred,
     accentColorBackgroundEnabled,
     translucenceEnabled,
@@ -109,6 +115,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
     setBackgroundVisualizerEnabled,
     setBackgroundVisualizerStyle,
     setBackgroundVisualizerIntensity,
+    setBackgroundVisualizerSpeed,
     setAccentColorBackgroundPreferred,
     setTranslucenceEnabled,
     setTranslucenceOpacity,


### PR DESCRIPTION
## Summary

- Adds a Speed row (Slower 0.5×, Normal 1.0×, Faster 2.0×) to the Visualizer section of the visual effects flip menu, displayed below the Intensity row
- Speed persists to `localStorage` via `VisualEffectsContext` using the `vorbis-player-background-visualizer-speed` key
- Speed multiplier is applied in all 4 visualizers: ParticleVisualizer, TrailVisualizer, WaveVisualizer, GridWaveVisualizer

## Test plan

- [ ] Open the visual effects flip menu (click album art)
- [ ] Visualizer section shows Style, Intensity, and Speed rows when visualizer is enabled
- [ ] Selecting Slower/Normal/Faster changes animation speed visibly
- [ ] Setting persists across page reloads
- [ ] All 4 visualizer styles (Fireflies, Comet, Wave, Grid) respect the speed setting
- [ ] TypeScript compiles clean (`npx tsc -b --noEmit`)
- [ ] All 868 tests pass

Closes #678