### PR TITLE
feat: mosaic thumbnails for Dropbox playlists

### DIFF
--- a/src/components/MosaicThumbnail.tsx
+++ b/src/components/MosaicThumbnail.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+const MosaicGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: inherit;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+interface MosaicThumbnailProps {
+  coverUrls: string[];
+  alt: string;
+}
+
+export const MosaicThumbnail: React.FC<MosaicThumbnailProps> = React.memo(
+  function MosaicThumbnail({ coverUrls, alt }) {
+    if (coverUrls.length === 0) return null;
+
+    if (coverUrls.length === 1) {
+      return <img src={coverUrls[0]} alt={alt} loading="lazy" decoding="async" />;
+    }
+
+    const [a, b] = coverUrls;
+    const quadrants = coverUrls.length >= 4
+      ? [coverUrls[0], coverUrls[1], coverUrls[2], coverUrls[3]]
+      : [a, b, b, a];
+
+    return (
+      <MosaicGrid>
+        {quadrants.map((url, i) => (
+          <img key={i} src={url} alt={`${alt} cover ${i + 1}`} loading="lazy" decoding="async" />
+        ))}
+      </MosaicGrid>
+    );
+  },
+);

--- a/src/components/PlaylistSelection/utils.tsx
+++ b/src/components/PlaylistSelection/utils.tsx
@@ -6,6 +6,7 @@ import type { ProviderId } from '@/types/domain';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import type { PlaylistInfo } from '../../services/spotify';
 import { GridCardArtWrapper, PlaylistImageWrapper } from './styled';
+import { MosaicThumbnail } from '../MosaicThumbnail';
 
 function selectOptimalImage(
   images: { url: string; width: number | null; height: number | null }[],
@@ -101,8 +102,36 @@ interface LazyImageProps {
   alt: string;
 }
 
+function isMosaicImageSet(images: { url: string; width: number | null; height: number | null }[]): boolean {
+  return images.length > 1 && images.every(img => img.width === null && img.height === null);
+}
+
 export const PlaylistImage: React.FC<LazyImageProps> = React.memo(function PlaylistImage({ images, alt }) {
-  const { ref, imageUrl } = useLazyImage(images, 64, '50px');
+  const isMosaic = isMosaicImageSet(images);
+  const { ref, imageUrl } = useLazyImage(isMosaic ? [] : images, 64, '50px');
+  const [isVisible, setIsVisible] = useState(false);
+  const visRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isMosaic || !visRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0]?.isIntersecting) { setIsVisible(true); observer.disconnect(); } },
+      { rootMargin: '50px', threshold: 0.01 },
+    );
+    observer.observe(visRef.current);
+    return () => observer.disconnect();
+  }, [isMosaic]);
+
+  if (isMosaic) {
+    return (
+      <PlaylistImageWrapper ref={visRef}>
+        {isVisible ? (
+          <MosaicThumbnail coverUrls={images.map(img => img.url)} alt={alt} />
+        ) : null}
+      </PlaylistImageWrapper>
+    );
+  }
+
   return (
     <PlaylistImageWrapper ref={ref}>
       {imageUrl ? (
@@ -115,7 +144,31 @@ export const PlaylistImage: React.FC<LazyImageProps> = React.memo(function Playl
 });
 
 export const GridCardImageComponent: React.FC<LazyImageProps> = React.memo(function GridCardImageComponent({ images, alt }) {
-  const { ref, imageUrl } = useLazyImage(images, 300, '100px');
+  const isMosaic = isMosaicImageSet(images);
+  const { ref, imageUrl } = useLazyImage(isMosaic ? [] : images, 300, '100px');
+  const [isVisible, setIsVisible] = useState(false);
+  const visRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isMosaic || !visRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0]?.isIntersecting) { setIsVisible(true); observer.disconnect(); } },
+      { rootMargin: '100px', threshold: 0.01 },
+    );
+    observer.observe(visRef.current);
+    return () => observer.disconnect();
+  }, [isMosaic]);
+
+  if (isMosaic) {
+    return (
+      <GridCardArtWrapper ref={visRef}>
+        {isVisible ? (
+          <MosaicThumbnail coverUrls={images.map(img => img.url)} alt={alt} />
+        ) : null}
+      </GridCardArtWrapper>
+    );
+  }
+
   return (
     <GridCardArtWrapper ref={ref}>
       {imageUrl ? (

--- a/src/components/QuickAccessPanel/PinRing.tsx
+++ b/src/components/QuickAccessPanel/PinRing.tsx
@@ -3,6 +3,7 @@ import type { PlaylistInfo, AlbumInfo } from '@/services/spotify';
 import type { ProviderId } from '@/types/domain';
 import { getLikedSongsGradient } from '@/components/PlaylistSelection/utils';
 import { useLongPress } from '@/hooks/useLongPress';
+import { MosaicThumbnail } from '../MosaicThumbnail';
 import {
   GridSection,
   GridContainer,
@@ -49,18 +50,23 @@ interface GridItemCardProps {
   name: string;
   provider?: ProviderId;
   imgUrl?: string;
+  mosaicUrls?: string[];
   fallback: string;
   onPlay: (id: string, name: string, provider?: ProviderId) => void;
   onAddToQueue: (id: string, name: string, provider?: ProviderId) => void;
 }
 
 const GridItemCard: React.FC<GridItemCardProps> = ({
-  id, name, provider, imgUrl, fallback, onPlay, onAddToQueue,
+  id, name, provider, imgUrl, mosaicUrls, fallback, onPlay, onAddToQueue,
 }) => {
   const handlePlay = useCallback(() => onPlay(id, name, provider), [id, name, provider, onPlay]);
   const handleAdd = useCallback(() => onAddToQueue(id, name, provider), [id, name, provider, onAddToQueue]);
 
   const longPress = useLongPress({ onShortPress: handlePlay, onLongPress: handleAdd });
+
+  const artContent = mosaicUrls && mosaicUrls.length > 1
+    ? <MosaicThumbnail coverUrls={mosaicUrls} alt={name} />
+    : imgUrl ? <img src={imgUrl} alt={name} loading="lazy" /> : fallback;
 
   return (
     <GridItem
@@ -68,9 +74,7 @@ const GridItemCard: React.FC<GridItemCardProps> = ({
       onContextMenu={(e) => { e.preventDefault(); handleAdd(); }}
       {...longPress}
     >
-      <GridItemArt>
-        {imgUrl ? <img src={imgUrl} alt={name} loading="lazy" /> : fallback}
-      </GridItemArt>
+      <GridItemArt>{artContent}</GridItemArt>
       <GridItemName>{name}</GridItemName>
     </GridItem>
   );
@@ -134,13 +138,15 @@ const PinRing: React.FC<PinRingProps> = ({
             {items.map((sat) => {
               if (sat.kind === 'playlist') {
                 const p = sat.item;
+                const isMosaic = p.images.length > 1 && p.images.every(img => img.width === null && img.height === null);
                 return (
                   <GridItemCard
                     key={`playlist-${p.id}`}
                     id={p.id}
                     name={p.name}
                     provider={p.provider}
-                    imgUrl={getImageUrl(p.images)}
+                    imgUrl={isMosaic ? undefined : getImageUrl(p.images)}
+                    mosaicUrls={isMosaic ? p.images.map(img => img.url) : undefined}
                     fallback="♪"
                     onPlay={onLoadCollection}
                     onAddToQueue={onAddToQueue}

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -50,11 +50,20 @@ function initLikedCountsFromSnapshot(): { total: number; perProvider: PerProvide
 }
 
 function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
+  let images: { url: string; height: number | null; width: number | null }[];
+  if (c.mosaicImageUrls && c.mosaicImageUrls.length > 1) {
+    images = c.mosaicImageUrls.map(url => ({ url, height: null, width: null }));
+  } else if (c.imageUrl) {
+    images = [{ url: c.imageUrl, height: null, width: null }];
+  } else {
+    images = [];
+  }
+
   return {
     id: c.id,
     name: c.name,
     description: c.description ?? null,
-    images: c.imageUrl ? [{ url: c.imageUrl, height: null, width: null }] : [],
+    images,
     tracks: c.trackCount != null ? { total: c.trackCount } : null,
     owner: c.ownerName ? { display_name: c.ownerName } : null,
     snapshot_id: c.revision ?? undefined,

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -7,6 +7,7 @@ import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 import type { MediaTrack, MediaCollection, ProviderId, PlaybackItemRef } from '@/types/domain';
 import { toSavedPlaylistId } from '@/constants/playlist';
 import { logLibrary } from '@/lib/debugLog';
+import { buildAlbumCoverMap, selectMosaicCovers } from '@/utils/mosaicSelection';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -321,6 +322,13 @@ export async function listSavedPlaylists(
           collection.name, filePaths[i], data ? 'loaded' : 'null', data?.tracks?.length ?? -1);
         if (data) {
           collection.trackCount = data.tracks.length;
+          const albumMap = buildAlbumCoverMap(data.tracks);
+          if (albumMap.size >= 2) {
+            collection.mosaicImageUrls = selectMosaicCovers(albumMap, collection.id);
+          } else if (albumMap.size === 1) {
+            const singleCover = albumMap.values().next().value;
+            if (singleCover?.coverUrl) collection.imageUrl = singleCover.coverUrl;
+          }
         }
       } catch (err) {
         logLibrary('listSavedPlaylists: "%s" failed to load: %o', collection.name, err);

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -71,6 +71,8 @@ export interface MediaCollection {
   revision?: string | null;
   /** Release date string (e.g. "2023", "2023-05-17") for sorting. */
   releaseDate?: string;
+  /** Multiple cover image URLs for mosaic thumbnails (multi-album playlists). */
+  mosaicImageUrls?: string[];
 }
 
 /**

--- a/src/utils/__tests__/mosaicSelection.test.ts
+++ b/src/utils/__tests__/mosaicSelection.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { selectMosaicCovers, buildAlbumCoverMap } from '../mosaicSelection';
+
+describe('selectMosaicCovers', () => {
+  it('returns empty array when no albums have covers', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: '', trackCount: 5 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toEqual([]);
+  });
+
+  it('returns single URL for one album with cover', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: 'https://art/a.jpg', trackCount: 5 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toEqual(['https://art/a.jpg']);
+  });
+
+  it('returns 2 URLs for 2 albums sorted by track count', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: 'https://art/a.jpg', trackCount: 3 });
+    map.set('album-b', { coverUrl: 'https://art/b.jpg', trackCount: 7 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toEqual(['https://art/b.jpg', 'https://art/a.jpg']);
+  });
+
+  it('returns 2 URLs for 3 albums taking the top 2 by track count', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: 'https://art/a.jpg', trackCount: 2 });
+    map.set('album-b', { coverUrl: 'https://art/b.jpg', trackCount: 10 });
+    map.set('album-c', { coverUrl: 'https://art/c.jpg', trackCount: 5 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toEqual(['https://art/b.jpg', 'https://art/c.jpg']);
+  });
+
+  it('returns 4 URLs for 4+ albums via weighted random', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: 'https://art/a.jpg', trackCount: 10 });
+    map.set('album-b', { coverUrl: 'https://art/b.jpg', trackCount: 8 });
+    map.set('album-c', { coverUrl: 'https://art/c.jpg', trackCount: 6 });
+    map.set('album-d', { coverUrl: 'https://art/d.jpg', trackCount: 4 });
+    map.set('album-e', { coverUrl: 'https://art/e.jpg', trackCount: 2 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toHaveLength(4);
+    const unique = new Set(result);
+    expect(unique.size).toBe(4);
+    for (const url of result) {
+      expect(url).toMatch(/^https:\/\/art\/[a-e]\.jpg$/);
+    }
+  });
+
+  it('produces stable results for the same playlist ID', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    for (let i = 0; i < 10; i++) {
+      map.set(`album-${i}`, { coverUrl: `https://art/${i}.jpg`, trackCount: i + 1 });
+    }
+
+    // #when
+    const result1 = selectMosaicCovers(map, 'stable-test');
+    const result2 = selectMosaicCovers(map, 'stable-test');
+
+    // #then
+    expect(result1).toEqual(result2);
+  });
+
+  it('produces different results for different playlist IDs', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    for (let i = 0; i < 20; i++) {
+      map.set(`album-${i}`, { coverUrl: `https://art/${i}.jpg`, trackCount: 5 });
+    }
+
+    // #when
+    const result1 = selectMosaicCovers(map, 'playlist-alpha');
+    const result2 = selectMosaicCovers(map, 'playlist-beta');
+
+    // #then
+    expect(result1).not.toEqual(result2);
+  });
+
+  it('skips albums with empty cover URLs', () => {
+    const map = new Map<string, { coverUrl: string; trackCount: number }>();
+    map.set('album-a', { coverUrl: 'https://art/a.jpg', trackCount: 5 });
+    map.set('album-b', { coverUrl: '', trackCount: 10 });
+    map.set('album-c', { coverUrl: 'https://art/c.jpg', trackCount: 3 });
+
+    // #when
+    const result = selectMosaicCovers(map, 'playlist-1');
+
+    // #then
+    expect(result).toEqual(['https://art/a.jpg', 'https://art/c.jpg']);
+  });
+});
+
+describe('buildAlbumCoverMap', () => {
+  it('groups tracks by albumId and counts them', () => {
+    // #given
+    const tracks = [
+      { album: 'Album A', albumId: 'a1', image: 'https://art/a.jpg' },
+      { album: 'Album A', albumId: 'a1', image: 'https://art/a.jpg' },
+      { album: 'Album B', albumId: 'b1', image: 'https://art/b.jpg' },
+    ];
+
+    // #when
+    const map = buildAlbumCoverMap(tracks);
+
+    // #then
+    expect(map.size).toBe(2);
+    expect(map.get('a1')).toEqual({ coverUrl: 'https://art/a.jpg', trackCount: 2 });
+    expect(map.get('b1')).toEqual({ coverUrl: 'https://art/b.jpg', trackCount: 1 });
+  });
+
+  it('falls back to album name when albumId is missing', () => {
+    // #given
+    const tracks = [
+      { album: 'Album X', image: 'https://art/x.jpg' },
+      { album: 'Album X', image: 'https://art/x.jpg' },
+    ];
+
+    // #when
+    const map = buildAlbumCoverMap(tracks);
+
+    // #then
+    expect(map.size).toBe(1);
+    expect(map.get('Album X')?.trackCount).toBe(2);
+  });
+
+  it('uses first available image for an album', () => {
+    // #given
+    const tracks = [
+      { album: 'Album A', albumId: 'a1' },
+      { album: 'Album A', albumId: 'a1', image: 'https://art/a.jpg' },
+    ];
+
+    // #when
+    const map = buildAlbumCoverMap(tracks);
+
+    // #then
+    expect(map.get('a1')?.coverUrl).toBe('https://art/a.jpg');
+  });
+});

--- a/src/utils/mosaicSelection.ts
+++ b/src/utils/mosaicSelection.ts
@@ -1,0 +1,90 @@
+interface AlbumCoverInfo {
+  coverUrl: string;
+  trackCount: number;
+}
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1664525 + 1013904223) | 0;
+    return (state >>> 0) / 0x100000000;
+  };
+}
+
+function weightedPick(
+  albums: AlbumCoverInfo[],
+  rng: () => number,
+  exclude: Set<number>,
+): number {
+  let totalWeight = 0;
+  for (let i = 0; i < albums.length; i++) {
+    if (!exclude.has(i)) totalWeight += albums[i].trackCount;
+  }
+  if (totalWeight === 0) return -1;
+
+  let target = rng() * totalWeight;
+  for (let i = 0; i < albums.length; i++) {
+    if (exclude.has(i)) continue;
+    target -= albums[i].trackCount;
+    if (target <= 0) return i;
+  }
+  return albums.length - 1;
+}
+
+export function selectMosaicCovers(
+  tracksByAlbum: Map<string, { coverUrl: string; trackCount: number }>,
+  playlistId: string,
+): string[] {
+  const albums: AlbumCoverInfo[] = [];
+  for (const entry of tracksByAlbum.values()) {
+    if (entry.coverUrl) albums.push(entry);
+  }
+
+  if (albums.length === 0) return [];
+  if (albums.length === 1) return [albums[0].coverUrl];
+
+  if (albums.length <= 3) {
+    const sorted = [...albums].sort((a, b) => b.trackCount - a.trackCount);
+    return [sorted[0].coverUrl, sorted[1].coverUrl];
+  }
+
+  const seed = hashString(playlistId);
+  const rng = seededRandom(seed);
+  const picked: string[] = [];
+  const excluded = new Set<number>();
+
+  for (let i = 0; i < 4 && excluded.size < albums.length; i++) {
+    const idx = weightedPick(albums, rng, excluded);
+    if (idx === -1) break;
+    picked.push(albums[idx].coverUrl);
+    excluded.add(idx);
+  }
+
+  return picked;
+}
+
+export function buildAlbumCoverMap(
+  tracks: { album?: string; albumId?: string; image?: string }[],
+): Map<string, { coverUrl: string; trackCount: number }> {
+  const map = new Map<string, { coverUrl: string; trackCount: number }>();
+  for (const track of tracks) {
+    const key = track.albumId ?? track.album ?? '';
+    if (!key) continue;
+    const existing = map.get(key);
+    if (existing) {
+      existing.trackCount++;
+      if (!existing.coverUrl && track.image) existing.coverUrl = track.image;
+    } else {
+      map.set(key, { coverUrl: track.image ?? '', trackCount: 1 });
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

- Dropbox saved playlists spanning 2+ albums now display a 2x2 CSS grid mosaic of album cover art instead of a music emoji
- Weighted random album selection seeded by playlist ID ensures stable but content-aware mosaics
- Fallback rules: 4+ covers pick 4, 2-3 use diagonal pairing, 1 goes full-bleed, 0 keeps emoji

Closes #700

## Test plan

- [ ] Verify Dropbox saved playlist with 4+ albums shows 4 distinct covers in 2x2 grid
- [ ] Verify playlist with 2-3 albums shows diagonal pattern (A/B/B/A)
- [ ] Verify single-album playlist shows full-bleed cover
- [ ] Verify playlist with no covers still shows music emoji
- [ ] Verify mosaic appears in library grid view, list view, and PinRing
- [ ] Verify Spotify playlists are unaffected
- [ ] Run `npm run test:run` — 879 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)