### PR TITLE
fix: flip menu scrollable on mobile — translucence now reachable

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -64,10 +64,18 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   height: 100%;
   padding: ${theme.spacing.lg};
+  padding-top: ${theme.spacing.xl};
   box-sizing: border-box;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Title = styled.div`


### PR DESCRIPTION
## Summary
- Made the flip menu (visual effects backside panel) scrollable on mobile so all sections are reachable
- The Translucence toggle at the bottom was previously clipped when the Visualizer section's Speed sub-setting pushed content past the panel bounds
- Changed `Content` container from `justify-content: center` to `flex-start` with `overflow-y: auto` and hidden scrollbar

Closes #698

## Test plan
- [ ] Open on a mobile viewport (~300-350px album art size)
- [ ] Flip to the visual effects menu
- [ ] Verify all four sections (Color, Glow, Visualizer, Translucent) are visible or reachable by scrolling
- [ ] Enable Glow and Visualizer to expand sub-settings, verify Translucent is still reachable
- [ ] Verify desktop layout is unaffected