### PR TITLE
fix: prevent drawer flash on first player load

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -82,6 +82,9 @@ const DrawerContent = styled.div`
 `;
 
 const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode }: LibraryDrawerProps) {
+  const hasBeenOpenedRef = useRef(false);
+  if (isOpen) hasBeenOpenedRef.current = true;
+
   const [isRefreshing, setIsRefreshing] = useState(false);
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -124,6 +127,8 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
   });
 
   const effectiveDragOffset = isOpen && isDragging ? dragOffset : 0;
+
+  if (!hasBeenOpenedRef.current) return null;
 
   return createPortal(
     <>

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -165,7 +165,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
 
   return (
     <>
-      <Suspense fallback={<QueueLoadingFallback />}>
+      <Suspense fallback={showQueue ? <QueueLoadingFallback /> : null}>
         {isMobile ? (
           <ProfiledComponent id="QueueBottomSheet">
             <QueueBottomSheet

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState, useCallback } from 'react';
+import React, { Suspense, lazy, useState, useCallback, useRef } from 'react';
 import { useTheme } from 'styled-components';
 import { CardContent } from '@/components/styled';
 import SpotifyPlayerControls from '@/components/SpotifyPlayerControls';
@@ -133,6 +133,9 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const { enabled: profilerEnabled, toggle: profilerToggle } = useProfilingContext();
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
+
+  const settingsHasBeenOpenedRef = useRef(false);
+  if (showVisualEffects) settingsHasBeenOpenedRef.current = true;
 
   const [showHelp, setShowHelp] = useState(false);
   const toggleHelp = useCallback(() => setShowHelp(prev => !prev), []);
@@ -325,17 +328,19 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
           onFlipToggle={onFlipToggle}
         />
       </ProfiledComponent>
-      <Suspense fallback={<VisualEffectsLoadingFallback />}>
-        <VisualEffectsMenu
-          isOpen={showVisualEffects}
-          onClose={handleCloseVisualEffects}
-          onClearCache={handleClearCache}
-          profilerEnabled={profilerEnabled}
-          onProfilerToggle={handleProfilerToggle}
-          visualizerDebugEnabled={visualizerDebugEnabled}
-          onVisualizerDebugToggle={handleVisualizerDebugToggle}
-        />
-      </Suspense>
+      {settingsHasBeenOpenedRef.current && (
+        <Suspense fallback={<VisualEffectsLoadingFallback />}>
+          <VisualEffectsMenu
+            isOpen={showVisualEffects}
+            onClose={handleCloseVisualEffects}
+            onClearCache={handleClearCache}
+            profilerEnabled={profilerEnabled}
+            onProfilerToggle={handleProfilerToggle}
+            visualizerDebugEnabled={visualizerDebugEnabled}
+            onVisualizerDebugToggle={handleVisualizerDebugToggle}
+          />
+        </Suspense>
+      )}
       <Suspense fallback={null}>
         <KeyboardShortcutsHelp isOpen={showHelp} onClose={closeHelp} />
       </Suspense>

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, memo } from 'react';
+import React, { Suspense, memo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { useVerticalSwipeGesture } from '@/hooks/useVerticalSwipeGesture';
@@ -136,6 +136,9 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
   onSaveQueue,
   canSaveQueue,
 }) {
+  const hasBeenOpenedRef = useRef(false);
+  if (isOpen) hasBeenOpenedRef.current = true;
+
   const { ref: headerRef, isDragging, dragOffset } = useVerticalSwipeGesture({
     onSwipeDown: onClose,
     threshold: 80,
@@ -143,6 +146,8 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
   });
 
   const effectiveDragOffset = isOpen && isDragging ? dragOffset : 0;
+
+  if (!hasBeenOpenedRef.current) return null;
 
   return createPortal(
     <>

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, memo, useMemo } from 'react';
+import React, { Suspense, memo, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
@@ -220,6 +220,9 @@ const QueueDrawer = memo<QueueDrawerProps>(({
   onSaveQueue,
   canSaveQueue,
 }) => {
+  const hasBeenOpenedRef = useRef(false);
+  if (isOpen) hasBeenOpenedRef.current = true;
+
   // Get responsive sizing information
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizingContext();
 
@@ -229,6 +232,9 @@ const QueueDrawer = memo<QueueDrawerProps>(({
     if (isTablet) return Math.min(viewport.width * 0.4, parseInt(theme.drawer.widths.tablet));
     return Math.min(viewport.width * 0.3, parseInt(theme.drawer.widths.desktop));
   }, [viewport.width, isMobile, isTablet]);
+
+  if (!hasBeenOpenedRef.current) return null;
+
   return createPortal(
     <>
       <QueueOverlay


### PR DESCRIPTION
## Summary

- Drawers (queue, library, settings) were rendering into the DOM on mount with CSS transitions, causing a brief visible flash before the closed state applied
- Added `hasBeenOpenedRef` guards to `QueueDrawer`, `QueueBottomSheet`, `LibraryDrawer`, and the `VisualEffectsMenu` Suspense boundary so they don't render until explicitly opened for the first time
- Made the queue `Suspense` fallback conditional on `showQueue` to prevent the loading placeholder panel from flashing on the right side

## Test plan

- [ ] Load the player for the first time after selecting a playlist — no drawer should flash on the right or top of the screen
- [ ] Open and close the queue drawer — should animate normally
- [ ] Open and close the library drawer — should animate normally
- [ ] Open and close the settings menu — should animate normally
- [ ] All 878 tests pass, zero type errors

Closes #696