### PR TITLE
fix: flip menu scroll and compact layout on mobile

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import styled from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import type { VisualizerStyle } from '@/types/visualizer';
@@ -66,8 +67,8 @@ const Content = styled.div`
   align-items: center;
   justify-content: flex-start;
   height: 100%;
-  padding: ${theme.spacing.lg};
-  padding-top: ${theme.spacing.xl};
+  padding: ${theme.spacing.sm};
+  padding-top: ${theme.spacing.lg};
   box-sizing: border-box;
   overflow-y: auto;
   scrollbar-width: none;
@@ -84,7 +85,7 @@ const Title = styled.div`
   color: rgba(255, 255, 255, 0.7);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: ${theme.spacing.md};
+  margin-bottom: ${theme.spacing.xs};
 `;
 
 const CloseButton = styled.button`
@@ -166,13 +167,27 @@ function AlbumArtQuickSwapBack({
   onClose,
   onRetryAlbumArt,
 }: AlbumArtQuickSwapBackProps) {
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    pointerStartRef.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (!pointerStartRef.current) return;
+    const dx = Math.abs(e.clientX - pointerStartRef.current.x);
+    const dy = Math.abs(e.clientY - pointerStartRef.current.y);
+    pointerStartRef.current = null;
+    if (dx < 10 && dy < 10) onClose();
+  };
+
   return (
     <BacksideRoot>
       <BlurredBg $image={currentTrack?.image} />
       <DarkOverlay />
       <CloseButton aria-label="Close menu" onClick={(e) => { e.stopPropagation(); onClose(); }}>×</CloseButton>
 
-      <Content onClick={onClose}>
+      <Content onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
         <Title>Visual Effects</Title>
         <div onClick={(e) => e.stopPropagation()}>
         <QuickEffectsRow

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -40,9 +40,9 @@ const QuickRow = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: ${theme.spacing.sm};
+  gap: ${theme.spacing.xs};
   width: 100%;
-  margin-top: ${theme.spacing.xs};
+  margin-top: 2px;
 `;
 
 const RowLine = styled.div`
@@ -127,10 +127,10 @@ const SectionCard = styled.div`
   width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: ${theme.borderRadius.lg};
-  padding: 8px 10px;
+  padding: 6px 8px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 `;
 
 const SectionHeader = styled.div`
@@ -151,14 +151,14 @@ const SubSettings = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
+  gap: 3px;
 `;
 
 const SubSettingRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: ${theme.spacing.sm};
+  gap: ${theme.spacing.xs};
   flex-wrap: wrap;
 `;
 


### PR DESCRIPTION
## Summary
- Replace `onClick={onClose}` on flip menu `Content` with pointer-based tap detection (`onPointerDown`/`onPointerUp` with 10px movement threshold) so scrolling no longer triggers close
- Compact vertical spacing throughout `QuickEffectsRow` and `AlbumArtQuickSwapBack` so more sections fit without scrolling

Closes #706