### PR TITLE
enhance: redistribute grid visualizer intensity to left/right edges (#687)

### DIFF
--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -59,17 +59,21 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
       const cols = Math.ceil(width / spacing) + 1;
       const rows = Math.ceil(height / spacing) + 1;
 
+      const centerX = (cols - 1) * spacing / 2;
       const particles: GridParticle[] = [];
       for (let row = 0; row < rows; row++) {
         for (let col = 0; col < cols; col++) {
+          const x = col * spacing;
+          const edgeFactor = Math.abs(x - centerX) / Math.max(1, centerX);
           const depthFactor = row / Math.max(1, rows - 1);
+          const intensityFactor = edgeFactor * g.edgeIntensity + depthFactor * (1 - g.edgeIntensity);
           particles.push({
             gridX: col,
             gridY: row,
-            baseX: col * spacing,
+            baseX: x,
             baseY: row * spacing,
-            baseRadius: g.baseRadius * (0.7 + depthFactor * 0.6),
-            color: generateColorVariant(baseColor, 0.3 + depthFactor * 0.5),
+            baseRadius: g.baseRadius * (0.7 + intensityFactor * 0.6),
+            color: generateColorVariant(baseColor, 0.3 + intensityFactor * 0.5),
           });
         }
       }
@@ -123,6 +127,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
       const intensityScale = Math.max(0.3, intensityValue / 60);
       const amplitude = g.amplitudeBase * Math.min(width, height) * intensityScale;
       const rows = Math.ceil(height / g.spacing) + 1;
+      const centerX = width / 2;
 
       state.particles.forEach(particle => {
         let displacement = 0;
@@ -135,8 +140,10 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
         const normalizedDisp = (displacement + 1) / 2;
         const yOffset = displacement * amplitude;
 
+        const edgeFactor = Math.abs(particle.baseX - centerX) / Math.max(1, centerX);
         const depthFactor = particle.gridY / Math.max(1, rows - 1);
-        const perspectiveScale = 1.0 - g.perspectiveStrength * (1.0 - depthFactor);
+        const spatialFactor = edgeFactor * g.edgeIntensity + depthFactor * (1 - g.edgeIntensity);
+        const perspectiveScale = 1.0 - g.perspectiveStrength * (1.0 - spatialFactor);
 
         const radius = Math.max(0.5, particle.baseRadius * (1 + normalizedDisp * g.radiusWaveScale) * perspectiveScale);
         const opacity = Math.max(0.05, Math.min(1.0,
@@ -164,10 +171,14 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     (states: GridWaveState[], color: string): void => {
       const state = states[0];
       if (!state) return;
+      const cols = Math.ceil(state.width / g.spacing) + 1;
       const rows = Math.ceil(state.height / g.spacing) + 1;
+      const centerX = (cols - 1) * g.spacing / 2;
       state.particles.forEach(particle => {
+        const edgeFactor = Math.abs(particle.baseX - centerX) / Math.max(1, centerX);
         const depthFactor = particle.gridY / Math.max(1, rows - 1);
-        particle.color = generateColorVariant(color, 0.3 + depthFactor * 0.5);
+        const intensityFactor = edgeFactor * g.edgeIntensity + depthFactor * (1 - g.edgeIntensity);
+        particle.color = generateColorVariant(color, 0.3 + intensityFactor * 0.5);
       });
     },
     [g]

--- a/src/constants/visualizerDebugConfig.ts
+++ b/src/constants/visualizerDebugConfig.ts
@@ -63,6 +63,7 @@ export interface GridWaveVisualizerConfig {
   frequencyBase: number;
   frequencySpread: number;
   perspectiveStrength: number;
+  edgeIntensity: number;
   baseRadius: number;
   radiusWaveScale: number;
   opacityBase: number;
@@ -154,7 +155,8 @@ const DEFAULT_GRID_WAVE: GridWaveVisualizerConfig = {
   amplitudeBase: 0.12,
   frequencyBase: 0.005,
   frequencySpread: 0.003,
-  perspectiveStrength: 0.4,
+  perspectiveStrength: 0.12,
+  edgeIntensity: 0.7,
   baseRadius: 2.5,
   radiusWaveScale: 1.2,
   opacityBase: 0.25,


### PR DESCRIPTION
## Summary

- Replaces the bottom-heavy vertical depth perspective in `GridWaveVisualizer` with a horizontal edge-intensity model
- Largest, brightest particles now concentrate in the left and right quartiles of the screen, creating a visual "frame" around the album art
- The center horizontal band is kept subtle so it doesn't compete with the album art or get hidden by the bottom bar

## Changes

- **`src/components/visualizers/GridWaveVisualizer.tsx`**: Introduces `edgeFactor` (distance from horizontal center, 0→1) in `initializeItems`, `renderItems`, and `handleColorChange`. `spatialFactor` blends `edgeFactor` (weighted by `edgeIntensity`) with `depthFactor` (weighted by `1 - edgeIntensity`) to drive particle radius, color variation, and perspective scale.
- **`src/constants/visualizerDebugConfig.ts`**: Adds `edgeIntensity: 0.7` to `GridWaveVisualizerConfig` and `DEFAULT_GRID_WAVE`; reduces `perspectiveStrength` default from `0.4` → `0.12` to flatten the top-to-bottom gradient.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] TypeScript clean (`npx tsc -b --noEmit`)
- [ ] All 878 tests pass (`npm run test:run`)
- [ ] Visually verify: most intense particles appear on left/right edges, center is calmer, bottom bar no longer hides the best particles
- [ ] Verify wave displacement animation still works across all intensity levels

Closes #687