### PR TITLE
enhance: reduce default visualization speed (#711)

### DIFF
--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -361,8 +361,8 @@ function QuickEffectsRow({
               <SubLabel>Speed</SubLabel>
               <OptionButtonGroup>
                 <OptionButton $isActive={backgroundVisualizerSpeed === 0.5} onClick={() => onBackgroundVisualizerSpeedChange(0.5)}>Slower</OptionButton>
-                <OptionButton $isActive={backgroundVisualizerSpeed === 1.0} onClick={() => onBackgroundVisualizerSpeedChange(1.0)}>Normal</OptionButton>
-                <OptionButton $isActive={backgroundVisualizerSpeed === 2.0} onClick={() => onBackgroundVisualizerSpeedChange(2.0)}>Faster</OptionButton>
+                <OptionButton $isActive={backgroundVisualizerSpeed === 0.7} onClick={() => onBackgroundVisualizerSpeedChange(0.7)}>Normal</OptionButton>
+                <OptionButton $isActive={backgroundVisualizerSpeed === 1.2} onClick={() => onBackgroundVisualizerSpeedChange(1.2)}>Faster</OptionButton>
               </OptionButtonGroup>
             </SubSettingRow>
           )}

--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -40,7 +40,7 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.BG_VISUALIZER_ENABLED, true);
   const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>(STORAGE_KEYS.BG_VISUALIZER_STYLE, 'fireflies');
   const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_INTENSITY, 40);
-  const [backgroundVisualizerSpeed, setBackgroundVisualizerSpeed] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_SPEED, 1.0);
+  const [backgroundVisualizerSpeed, setBackgroundVisualizerSpeed] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_SPEED, 0.7);
   const [accentColorBackgroundPreferred, setAccentColorBackgroundPreferred] = useLocalStorage<boolean>(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED, false);
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
   const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.TRANSLUCENCE_ENABLED, false);


### PR DESCRIPTION
## Summary
- Reduce Normal speed multiplier from 1.0 to 0.7
- Reduce Faster speed multiplier from 2.0 to 1.2
- Keep Slower at 0.5 (unchanged)
- Update default to match new Normal value

Closes #711