### PR TITLE
fix: prevent flip menu dismiss when clicking controls

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -160,6 +160,7 @@ function AlbumArtQuickSwapBack({
   onRetryAlbumArt,
 }: AlbumArtQuickSwapBackProps) {
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const controlsRef = useRef<HTMLDivElement>(null);
 
   const handlePointerDown = (e: React.PointerEvent) => {
     pointerStartRef.current = { x: e.clientX, y: e.clientY };
@@ -170,7 +171,10 @@ function AlbumArtQuickSwapBack({
     const dx = Math.abs(e.clientX - pointerStartRef.current.x);
     const dy = Math.abs(e.clientY - pointerStartRef.current.y);
     pointerStartRef.current = null;
-    if (dx < 10 && dy < 10) onClose();
+    if (dx < 10 && dy < 10) {
+      if (controlsRef.current?.contains(e.target as Node)) return;
+      onClose();
+    }
   };
 
   return (
@@ -181,7 +185,7 @@ function AlbumArtQuickSwapBack({
 
       <Content onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
         {!isMobile && <Title>Visual Effects</Title>}
-        <div onClick={(e) => e.stopPropagation()}>
+        <div ref={controlsRef} onClick={(e) => e.stopPropagation()}>
         <QuickEffectsRow
           currentTrack={currentTrack}
           accentColor={accentColor}


### PR DESCRIPTION
## What
- Skip `onClose` in the flip menu's `pointerUp` handler when the tap target is inside the controls wrapper
- Added a `controlsRef` to the interactive controls div so the handler can distinguish control taps from background taps

## Why
Clicking any option in the flip menu (toggling glow, changing visualizer speed, etc.) was dismissing the menu immediately — the `Content` div's `pointerUp` handler called `onClose()` on every tap, even on interactive controls. The existing `stopPropagation` wrapper only blocked `click` events, not `pointerup`.

## Test plan
- [ ] Open flip menu, toggle any setting (glow, visualizer, speed) — menu stays open
- [ ] Tap empty space on the flip menu background — menu dismisses
- [ ] Click outside the flip menu entirely — menu dismisses
- [ ] Verify on mobile: same behavior with touch events