### PR TITLE
docs: add background visualizer reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,19 @@ Queue state lives in `TrackContext` (`tracks`, `originalTracks`, `currentTrackIn
 
 **Queue change notification**: `usePlayerLogic` calls `descriptor.playback.onQueueChanged?(tracks, currentTrackIndex)` whenever `tracks` or `currentTrackIndex` change, allowing providers with native queue sync (Spotify) to stay aligned.
 
+### Background Visualizers
+
+Four animated background styles, selectable via the flip menu's Speed/Style controls. All share a `speed` prop (multiplier from `VisualEffectsContext`) and per-visualizer tuning in `src/constants/visualizerDebugConfig.ts`.
+
+| Style key | Component | Description |
+|-----------|-----------|-------------|
+| `fireflies` | `ParticleVisualizer` | Drifting particles with pulsing opacity |
+| `comet` | `TrailVisualizer` | Ships leaving fading particle trails |
+| `wave` | `WaveVisualizer` | Layered sine waves spread vertically |
+| `grid` | `GridWaveVisualizer` | Dot grid distorted by traveling waves |
+
+Type: `VisualizerStyle` in `src/types/visualizer.d.ts`. Components in `src/components/visualizers/`.
+
 ### Debug logging (optional)
 
 Debug logging uses the [`debug`](https://www.npmjs.com/package/debug) package via `src/lib/debugLog.ts` with namespace `vorbis:*`. See `docs/troubleshooting.md` for usage.


### PR DESCRIPTION
## What
- Added a Background Visualizers section to CLAUDE.md architecture docs
- Maps each style key (`fireflies`, `comet`, `wave`, `grid`) to its component and describes what it does

## Why
AI agents working on visualizer issues had no reference for what visualizers exist or where config lives — they had to explore the directory each time.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub