### PR TITLE
fix: restore artist browse from TrackInfoPopover to open library (#713)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -142,7 +142,7 @@ const AudioPlayerComponent = () => {
     onNext: handlers.handleNext,
     onPrevious: handlers.handlePrevious,
     onTrackSelect: handlers.playTrack,
-    onOpenLibraryDrawer: handleOpenQuickAccessPanel,
+    onOpenLibraryDrawer: handlers.handleOpenLibraryDrawer,
     onCloseLibraryDrawer: handlers.handleCloseLibraryDrawer,
     onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
     onPlaylistSelect: handlePlaylistSelect,


### PR DESCRIPTION
## Summary
- Fixes regression where clicking 'Browse albums by [Artist]' opened Quick Access Panel instead of the library drawer
- Restores original behavior: opens library filtered to the artist

Closes #713