### PR TITLE
feat: reroute swipe-down and ↓/L keyboard to open QAP (#727)

### DIFF
--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -78,6 +78,7 @@ interface PlayerControlsSectionProps {
   onCloseQueue: () => void;
   onOpenLibraryDrawer: () => void;
   onCloseLibraryDrawer: () => void;
+  onOpenQuickAccessPanel?: () => void;
   onZenModeToggle: () => void;
   isRadioAvailable?: boolean;
   onStartRadio?: () => void;
@@ -107,6 +108,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   onCloseQueue,
   onOpenLibraryDrawer,
   onCloseLibraryDrawer,
+  onOpenQuickAccessPanel,
   onZenModeToggle,
   isRadioAvailable,
   onStartRadio,
@@ -231,13 +233,13 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const handleArrowDown = useCallback(() => {
     if (showQueue) {
       onCloseQueue();
-      onOpenLibraryDrawer();
+      onOpenQuickAccessPanel?.();
     } else if (showLibraryDrawer) {
       onCloseLibraryDrawer();
     } else {
-      onOpenLibraryDrawer();
+      onOpenQuickAccessPanel?.();
     }
-  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenLibraryDrawer, onCloseLibraryDrawer]);
+  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenQuickAccessPanel, onCloseLibraryDrawer]);
 
   const handleVolumeUp = useCallback(() => {
     setVolumeLevel(Math.min(100, (volume ?? 50) + 5));
@@ -264,7 +266,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
     onToggleShuffle: handleShuffleToggle,
     onToggleHelp: toggleHelp,
     onShowQueue: handleArrowUp,
-    onOpenLibraryDrawer: handleArrowDown,
+    onOpenLibraryDrawer: onOpenLibraryDrawer,
+    onOpenQuickAccessPanel: handleArrowDown,
     onToggleZenMode: onZenModeToggle,
   }, { prefersPointerInput: hasPointerInput });
 

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -220,6 +220,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
             onCloseQueue={handleCloseQueue}
             onOpenLibraryDrawer={handleOpenLibraryDrawer}
             onCloseLibraryDrawer={handleCloseLibraryDrawer}
+            onOpenQuickAccessPanel={handlers.onOpenQuickAccessPanel}
             onZenModeToggle={handleZenModeToggle}
             isRadioAvailable={isRadioAvailable}
             onStartRadio={handlers.onStartRadio}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -26,6 +26,8 @@ interface KeyboardShortcutHandlers {
   onShowQueue?: () => void;
   /** Open library drawer (desktop: ArrowDown) */
   onOpenLibraryDrawer?: () => void;
+  /** Open quick access panel (desktop: ArrowDown / L) */
+  onOpenQuickAccessPanel?: () => void;
   /** Toggle zen mode */
   onToggleZenMode?: () => void;
 }
@@ -55,6 +57,7 @@ export const useKeyboardShortcuts = (
     onCloseMobileMenu,
     onShowQueue,
     onOpenLibraryDrawer,
+    onOpenQuickAccessPanel,
     onToggleZenMode,
   } = handlers;
 
@@ -140,7 +143,7 @@ export const useKeyboardShortcuts = (
         case 'KeyL':
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
-            onOpenLibraryDrawer?.();
+            onOpenQuickAccessPanel?.();
           }
           break;
 
@@ -176,9 +179,9 @@ export const useKeyboardShortcuts = (
           break;
 
         case 'ArrowDown':
-          if (prefersPointerInput && onOpenLibraryDrawer) {
+          if (prefersPointerInput && onOpenQuickAccessPanel) {
             event.preventDefault();
-            onOpenLibraryDrawer();
+            onOpenQuickAccessPanel();
           } else if (onVolumeDown) {
             event.preventDefault();
             onVolumeDown();
@@ -208,6 +211,7 @@ export const useKeyboardShortcuts = (
     onCloseMobileMenu,
     onShowQueue,
     onOpenLibraryDrawer,
+    onOpenQuickAccessPanel,
     onToggleZenMode,
     prefersPointerInput,
   ]);


### PR DESCRIPTION
## Summary
- Swipe down on album art now opens QAP instead of library drawer
- Keyboard ↓ and L now open QAP instead of library drawer
- onOpenLibraryDrawer unchanged — artist browse context menu still goes directly to library

Closes #727