### PR TITLE
Release: unified pin limit

### DIFF
--- a/src/components/PlaylistSelection/AlbumGrid.tsx
+++ b/src/components/PlaylistSelection/AlbumGrid.tsx
@@ -101,7 +101,7 @@ export const AlbumGrid: React.FC = React.memo(function AlbumGrid() {
           $isPinned={pinned}
           $disabled={!canPinMoreAlbums && !pinned}
           onClick={(e) => onPinAlbumClick(album.id, e)}
-          title={pinned ? 'Unpin' : (canPinMoreAlbums ? 'Pin to top' : 'Pin limit reached (8)')}
+          title={pinned ? 'Unpin' : (canPinMoreAlbums ? 'Pin to top' : 'Pin limit reached (12)')}
           aria-label={pinned ? `Unpin ${album.name}` : `Pin ${album.name} to top`}
         >
           <PinIcon filled={pinned} />

--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -102,7 +102,7 @@ const LikedSongsCard: React.FC<LikedSongsCardProps> = React.memo(function LikedS
       $isPinned={likedSongsPinned}
       $disabled={!canPinMorePlaylists && !likedSongsPinned}
       onClick={(e) => onPinPlaylistClick(LIKED_SONGS_ID, e)}
-      title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
+      title={likedSongsPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (12)')}
       aria-label={likedSongsPinned ? 'Unpin Liked Songs' : 'Pin Liked Songs to top'}
     >
       <PinIcon filled={likedSongsPinned} />

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -119,7 +119,7 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
           $isPinned={pinned}
           $disabled={!canPinMorePlaylists && !pinned}
           onClick={(e) => onPinPlaylistClick(playlist.id, e)}
-          title={pinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (8)')}
+          title={pinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (12)')}
           aria-label={pinned ? `Unpin ${playlist.name}` : `Pin ${playlist.name} to top`}
         >
           <PinIcon filled={pinned} />

--- a/src/components/QuickAccessPanel/PinRing.tsx
+++ b/src/components/QuickAccessPanel/PinRing.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import type { PlaylistInfo, AlbumInfo } from '@/services/spotify';
 import type { ProviderId } from '@/types/domain';
+import { MAX_PINS } from '@/services/settings/pinnedItemsStorage';
 import { getLikedSongsGradient } from '@/components/PlaylistSelection/utils';
 import { useLongPress } from '@/hooks/useLongPress';
 import { MosaicThumbnail } from '../MosaicThumbnail';
@@ -102,10 +103,10 @@ const PinRing: React.FC<PinRingProps> = ({
   const items: GridSatelliteItem[] = [
     ...filteredPlaylists.map(p => ({ kind: 'playlist' as const, item: p })),
     ...filteredAlbums.map(a => ({ kind: 'album' as const, item: a })),
-  ].slice(0, 12);
+  ];
 
   const showHint = items.length === 0;
-  const ghostCount = Math.max(0, 12 - items.length);
+  const ghostCount = Math.max(0, MAX_PINS - items.length);
 
   const gradient = getLikedSongsGradient(
     activeProviderIds.length === 1 ? activeProviderIds[0] : 'unified',

--- a/src/contexts/PinnedItemsContext.tsx
+++ b/src/contexts/PinnedItemsContext.tsx
@@ -62,24 +62,25 @@ export function PinnedItemsProvider({ children }: { children: React.ReactNode })
 
   const togglePinPlaylist = useCallback((id: string) => {
     setPinnedPlaylistIds(prev => {
-      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : prev.length >= MAX_PINS ? prev : [...prev, id];
+      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : prev.length + pinnedAlbumIds.length >= MAX_PINS ? prev : [...prev, id];
       setPins(UNIFIED_PROVIDER, 'playlists', next).catch(err => console.warn('[PinnedItemsContext] pin write failed:', err));
       getPreferencesSync()?.schedulePush();
       return next;
     });
-  }, []);
+  }, [pinnedAlbumIds]);
 
   const togglePinAlbum = useCallback((id: string) => {
     setPinnedAlbumIds(prev => {
-      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : prev.length >= MAX_PINS ? prev : [...prev, id];
+      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : pinnedPlaylistIds.length + prev.length >= MAX_PINS ? prev : [...prev, id];
       setPins(UNIFIED_PROVIDER, 'albums', next).catch(err => console.warn('[PinnedItemsContext] pin write failed:', err));
       getPreferencesSync()?.schedulePush();
       return next;
     });
-  }, []);
+  }, [pinnedPlaylistIds]);
 
-  const canPinMorePlaylists = pinnedPlaylistIds.length < MAX_PINS;
-  const canPinMoreAlbums = pinnedAlbumIds.length < MAX_PINS;
+  const totalPinned = pinnedPlaylistIds.length + pinnedAlbumIds.length;
+  const canPinMorePlaylists = totalPinned < MAX_PINS;
+  const canPinMoreAlbums = totalPinned < MAX_PINS;
 
   const value = useMemo<PinnedItemsContextValue>(() => ({
     pinnedPlaylistIds,

--- a/src/hooks/__tests__/usePinnedItems.test.ts
+++ b/src/hooks/__tests__/usePinnedItems.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/services/settings/pinnedItemsStorage', () => ({
   getPins: vi.fn().mockResolvedValue([]),
   setPins: vi.fn().mockResolvedValue(undefined),
   migratePinsFromLocalStorage: vi.fn().mockResolvedValue(undefined),
-  MAX_PINS: 8,
+  MAX_PINS: 12,
   UNIFIED_PROVIDER: '_unified',
   PINS_CHANGED_EVENT: 'vorbis-pins-changed',
 }));
@@ -92,23 +92,23 @@ describe('usePinnedItems', () => {
     expect(setPins).toHaveBeenCalledWith('_unified', 'playlists', ['p2']);
   });
 
-  it('should not pin beyond 8 playlists', async () => {
-    // #given - initialize with max playlists (8)
+  it('should not pin beyond 12 playlists', async () => {
+    // #given - initialize with max playlists (12)
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']) : Promise.resolve([])
+        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']));
+    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']));
 
     // #when - attempt to pin another playlist
     act(() => {
-      result.current.togglePinPlaylist('p9');
+      result.current.togglePinPlaylist('p13');
     });
 
     // #then
-    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']);
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']);
     expect(result.current.canPinMorePlaylists).toBe(false);
   });
 
@@ -150,23 +150,23 @@ describe('usePinnedItems', () => {
     expect(setPins).toHaveBeenCalledWith('_unified', 'albums', ['a2']);
   });
 
-  it('should not pin beyond 8 albums', async () => {
-    // #given - initialize with max albums (8)
+  it('should not pin beyond 12 albums', async () => {
+    // #given - initialize with max albums (12)
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'albums' ? Promise.resolve(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']) : Promise.resolve([])
+        type === 'albums' ? Promise.resolve(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']));
+    await waitFor(() => expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12']));
 
     // #when - attempt to pin another album
     act(() => {
-      result.current.togglePinAlbum('a9');
+      result.current.togglePinAlbum('a13');
     });
 
     // #then
-    expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8']);
+    expect(result.current.pinnedAlbumIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12']);
     expect(result.current.canPinMoreAlbums).toBe(false);
   });
 
@@ -179,7 +179,7 @@ describe('usePinnedItems', () => {
     expect(result.current.canPinMorePlaylists).toBe(true);
     expect(result.current.canPinMoreAlbums).toBe(true);
 
-    // #when - pin 7 playlists
+    // #when - pin 11 playlists
     act(() => {
       result.current.togglePinPlaylist('p1');
       result.current.togglePinPlaylist('p2');
@@ -188,14 +188,18 @@ describe('usePinnedItems', () => {
       result.current.togglePinPlaylist('p5');
       result.current.togglePinPlaylist('p6');
       result.current.togglePinPlaylist('p7');
+      result.current.togglePinPlaylist('p8');
+      result.current.togglePinPlaylist('p9');
+      result.current.togglePinPlaylist('p10');
+      result.current.togglePinPlaylist('p11');
     });
 
     // #then - still have capacity
     expect(result.current.canPinMorePlaylists).toBe(true);
 
-    // #when - pin 8th playlist
+    // #when - pin 12th playlist
     act(() => {
-      result.current.togglePinPlaylist('p8');
+      result.current.togglePinPlaylist('p12');
     });
 
     // #then - at max capacity
@@ -229,11 +233,11 @@ describe('usePinnedItems', () => {
     // #given - initialize with max playlists
     (getPins as ReturnType<typeof vi.fn>).mockImplementation(
       (_provider: string, type: string) =>
-        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']) : Promise.resolve([])
+        type === 'playlists' ? Promise.resolve(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']) : Promise.resolve([])
     );
     const { result } = renderHook(() => usePinnedItems(), { wrapper });
 
-    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']));
+    await waitFor(() => expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']));
 
     // #when - unpin one while at max
     act(() => {
@@ -241,7 +245,7 @@ describe('usePinnedItems', () => {
     });
 
     // #then
-    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']);
+    expect(result.current.pinnedPlaylistIds).toEqual(['p1', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10', 'p11', 'p12']);
     expect(result.current.canPinMorePlaylists).toBe(true);
   });
 

--- a/src/services/settings/pinnedItemsStorage.ts
+++ b/src/services/settings/pinnedItemsStorage.ts
@@ -7,7 +7,7 @@
 import { STORE_NAMES, settingsGet, settingsPut, settingsClearStore } from './settingsDb';
 import { STORAGE_KEYS } from '@/constants/storage';
 
-export const MAX_PINS = 8;
+export const MAX_PINS = 12;
 
 /** Event dispatched when pins are updated externally (e.g. Dropbox sync). */
 export const PINS_CHANGED_EVENT = 'vorbis-pins-changed';


### PR DESCRIPTION
## Summary
- Unified the pin limit to 12 total across playlists and albums (was 8 per type = 16 max, but QAP grid only shows 12)
- Pin toggles now check combined count instead of per-type count
- Removed the redundant `.slice(0, 12)` in PinRing — limit is now enforced at add time

## Issues addressed
- Closes #734

## PRs included
- #735 — refactor: unify pin limit to 12 across playlists and albums

## Test plan
- [ ] Pin 12 items in any mix of playlists/albums — 13th attempt is blocked
- [ ] Pin button tooltip shows "Pin limit reached (12)" when at limit
- [ ] QAP displays all pinned items up to 12
- [ ] Run `npm run test:run`