### PR TITLE
feat: limit zen control hit targets to icon circles (#737)

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { resolveZenZone } from '@/constants/zenAnimation';
 import styled from 'styled-components';
 import { CardContent } from '@/components/styled';
 import AlbumArt from '@/components/AlbumArt';
@@ -117,7 +116,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   } = useVisualEffectsState();
 
   const [isFlipped, setIsFlipped] = useState(false);
-  const [hoveredZone, setHoveredZone] = useState<'left' | 'center' | 'right' | null>(null);
   const [isHovered, setIsHovered] = useState(false);
   const flipContainerRef = useRef<HTMLDivElement>(null);
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
@@ -140,31 +138,20 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     onFlipToggle: toggleFlip,
   });
 
-  const handleClick = useCallback((e: React.MouseEvent) => {
+  const handlePlayPause = useCallback(() => {
+    if (isPlaying) {
+      onPause();
+    } else {
+      onPlay();
+    }
+  }, [isPlaying, onPlay, onPause]);
+
+  const handleClick = useCallback((_e: React.MouseEvent) => {
     if (zenTouchActive || (zenModeEnabled && isFlipped)) {
       return;
     }
-    if (zenModeEnabled) {
-      const container = albumArtContainerRef.current;
-      if (!container) return;
-      const rect = container.getBoundingClientRect();
-      const zone = resolveZenZone(e.clientX, e.clientY, rect);
-      if (zone === null) return;
-      if (zone === 'left') {
-        onPrevious();
-      } else if (zone === 'right') {
-        onNext();
-      } else {
-        if (isPlaying) {
-          onPause();
-        } else {
-          onPlay();
-        }
-      }
-    } else {
-      toggleFlip();
-    }
-  }, [zenTouchActive, zenModeEnabled, isFlipped, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
+    toggleFlip();
+  }, [zenTouchActive, zenModeEnabled, isFlipped, toggleFlip]);
 
   const handleRetryAlbumArt = useCallback(async () => {
     const providerId = currentTrackProvider ?? currentTrack?.provider;
@@ -212,7 +199,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
 
   useEffect(() => {
     if (!zenModeEnabled) {
-      setHoveredZone(null);
       setIsHovered(false);
     }
   }, [zenModeEnabled]);
@@ -304,7 +290,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
             onLongPress={toggleFlip}
             zenTouchHandlers={zenTouchActive ? zenTouchGestures : undefined}
             albumArtContainerRef={albumArtContainerRef}
-            onZoneHover={setHoveredZone}
             zenModeEnabled={zenModeEnabled}
             hasPointerInput={hasPointerInput}
           >
@@ -353,8 +338,10 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           </GestureLayer>
           <ZenClickZoneOverlay
             isPlaying={isPlaying}
-            hoveredZone={hoveredZone}
             visible={zenModeEnabled && hasPointerInput && !zenTouchActive && !isFlipped}
+            onPrevious={onPrevious}
+            onNext={onNext}
+            onPlayPause={handlePlayPause}
           />
           <ZenLikeOverlay
             isLiked={isLiked}

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-type Zone = 'left' | 'center' | 'right';
-
 interface ZenClickZoneOverlayProps {
   isPlaying: boolean;
-  hoveredZone: Zone | null;
   visible: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+  onPlayPause: () => void;
 }
 
 const Overlay = styled.div`
@@ -18,40 +18,36 @@ const Overlay = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12%;
   container-type: size;
 `;
 
-const ZoneDiv = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$hovered'].includes(prop),
-})<{ $hovered: boolean }>`
+const IconButton = styled.button`
+  pointer-events: auto;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  border-radius: 50%;
+  width: 56px;
+  height: 56px;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  padding: 0;
 
-  .zone-icon {
-    opacity: ${({ $hovered }) => ($hovered ? 1 : 0)};
-    transition: opacity 150ms ease;
-    background: rgba(0, 0, 0, 0.4);
-    border-radius: 50%;
-    width: 16cqw;
-    height: 16cqw;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  &:hover {
+    opacity: 1;
   }
 `;
 
-const LeftZone = styled(ZoneDiv)`
-  width: 25%;
-`;
-
-const CenterZone = styled(ZoneDiv)`
-  width: 50%;
-`;
-
-const RightZone = styled(ZoneDiv)`
-  width: 25%;
+const CenterIconButton = styled(IconButton)`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 `;
 
 const Icon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -62,37 +58,42 @@ const Icon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.memo(({
   isPlaying,
-  hoveredZone,
   visible,
+  onPrevious,
+  onNext,
+  onPlayPause,
 }) => {
   if (!visible) return null;
 
   return (
     <Overlay>
-      <LeftZone $hovered={hoveredZone === 'left'}>
-        <div className="zone-icon">
-          <Icon>
-            <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
-          </Icon>
-        </div>
-      </LeftZone>
-      <CenterZone $hovered={hoveredZone === 'center'}>
-        <div className="zone-icon">
-          <Icon>
-            {isPlaying
-              ? <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
-              : <path d="M8 5v14l11-7z" />
-            }
-          </Icon>
-        </div>
-      </CenterZone>
-      <RightZone $hovered={hoveredZone === 'right'}>
-        <div className="zone-icon">
-          <Icon>
-            <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
-          </Icon>
-        </div>
-      </RightZone>
+      <IconButton
+        onClick={(e) => { e.stopPropagation(); onPrevious(); }}
+        aria-label="Previous track"
+      >
+        <Icon>
+          <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
+        </Icon>
+      </IconButton>
+      <CenterIconButton
+        onClick={(e) => { e.stopPropagation(); onPlayPause(); }}
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+      >
+        <Icon>
+          {isPlaying
+            ? <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+            : <path d="M8 5v14l11-7z" />
+          }
+        </Icon>
+      </CenterIconButton>
+      <IconButton
+        onClick={(e) => { e.stopPropagation(); onNext(); }}
+        aria-label="Next track"
+      >
+        <Icon>
+          <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+        </Icon>
+      </IconButton>
     </Overlay>
   );
 });


### PR DESCRIPTION
## Summary
- Zen control icons (prev/next/play-pause) now own their own click handlers with ~56px circular hit areas
- Clicking album art outside any icon falls through to toggle the flip menu
- Like button overlay and mobile zen touch gestures unchanged

Closes #737