### PR TITLE
feat: double size of zen mode player control overlay buttons

### DIFF
--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -29,8 +29,8 @@ const IconButton = styled.button`
   background: rgba(0, 0, 0, 0.4);
   border: none;
   border-radius: 50%;
-  width: 112px;
-  height: 112px;
+  width: 224px;
+  height: 224px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Doubles the width and height of the zen mode player controls overlay buttons from 112px to 224px. Since border-radius is 50%, the circular radius doubles automatically.

Closes #742

Generated with [Claude Code](https://claude.ai/code)