### PR TITLE
fix: spread zen mode overlay buttons and scale size with album art

### DIFF
--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -178,7 +178,7 @@ function AlbumArtQuickSwapBack({
   };
 
   return (
-    <BacksideRoot>
+    <BacksideRoot onClick={(e) => e.stopPropagation()}>
       <BlurredBg $image={currentTrack?.image} />
       <DarkOverlay />
       <CloseButton aria-label="Close menu" onClick={(e) => { e.stopPropagation(); onClose(); }}>×</CloseButton>

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { resolveZenZone } from '@/constants/zenAnimation';
 import styled from 'styled-components';
 import { CardContent } from '@/components/styled';
 import AlbumArt from '@/components/AlbumArt';
@@ -117,7 +116,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   } = useVisualEffectsState();
 
   const [isFlipped, setIsFlipped] = useState(false);
-  const [hoveredZone, setHoveredZone] = useState<'left' | 'center' | 'right' | null>(null);
   const [isHovered, setIsHovered] = useState(false);
   const flipContainerRef = useRef<HTMLDivElement>(null);
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
@@ -140,31 +138,20 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
     onFlipToggle: toggleFlip,
   });
 
-  const handleClick = useCallback((e: React.MouseEvent) => {
+  const handlePlayPause = useCallback(() => {
+    if (isPlaying) {
+      onPause();
+    } else {
+      onPlay();
+    }
+  }, [isPlaying, onPlay, onPause]);
+
+  const handleClick = useCallback((_e: React.MouseEvent) => {
     if (zenTouchActive || (zenModeEnabled && isFlipped)) {
       return;
     }
-    if (zenModeEnabled) {
-      const container = albumArtContainerRef.current;
-      if (!container) return;
-      const rect = container.getBoundingClientRect();
-      const zone = resolveZenZone(e.clientX, e.clientY, rect);
-      if (zone === null) return;
-      if (zone === 'left') {
-        onPrevious();
-      } else if (zone === 'right') {
-        onNext();
-      } else {
-        if (isPlaying) {
-          onPause();
-        } else {
-          onPlay();
-        }
-      }
-    } else {
-      toggleFlip();
-    }
-  }, [zenTouchActive, zenModeEnabled, isFlipped, isPlaying, onPlay, onPause, onNext, onPrevious, toggleFlip]);
+    toggleFlip();
+  }, [zenTouchActive, zenModeEnabled, isFlipped, toggleFlip]);
 
   const handleRetryAlbumArt = useCallback(async () => {
     const providerId = currentTrackProvider ?? currentTrack?.provider;
@@ -212,7 +199,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
 
   useEffect(() => {
     if (!zenModeEnabled) {
-      setHoveredZone(null);
       setIsHovered(false);
     }
   }, [zenModeEnabled]);
@@ -304,7 +290,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
             onLongPress={toggleFlip}
             zenTouchHandlers={zenTouchActive ? zenTouchGestures : undefined}
             albumArtContainerRef={albumArtContainerRef}
-            onZoneHover={setHoveredZone}
             zenModeEnabled={zenModeEnabled}
             hasPointerInput={hasPointerInput}
           >
@@ -353,8 +338,10 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           </GestureLayer>
           <ZenClickZoneOverlay
             isPlaying={isPlaying}
-            hoveredZone={hoveredZone}
             visible={zenModeEnabled && hasPointerInput && !zenTouchActive && !isFlipped}
+            onPrevious={onPrevious}
+            onNext={onNext}
+            onPlayPause={handlePlayPause}
           />
           <ZenLikeOverlay
             isLiked={isLiked}

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -8,6 +8,7 @@ import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
 import { useColorContext } from '@/contexts/ColorContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useProfilingContext } from '@/contexts/ProfilingContext';
+import type { VisualizerStyle } from '@/types/visualizer';
 import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useVolume } from '@/hooks/useVolume';
@@ -124,7 +125,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const {
     visualEffectsEnabled,
     setVisualEffectsEnabled,
-    setBackgroundVisualizerEnabled,
+    backgroundVisualizerStyle,
+    setBackgroundVisualizerStyle,
     setTranslucenceEnabled,
     showVisualEffects,
     setShowVisualEffects,
@@ -164,9 +166,13 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
     }
   }, [visualEffectsEnabled, setVisualEffectsEnabled, restoreGlowSettings]);
 
-  const handleBackgroundVisualizerToggle = useCallback(() => {
-    setBackgroundVisualizerEnabled(prev => !prev);
-  }, [setBackgroundVisualizerEnabled]);
+  const VISUALIZER_CYCLE: VisualizerStyle[] = ['fireflies', 'comet', 'wave', 'grid'];
+
+  const handleCycleVisualizerStyle = useCallback(() => {
+    const currentIndex = VISUALIZER_CYCLE.indexOf(backgroundVisualizerStyle);
+    const nextIndex = (currentIndex + 1) % VISUALIZER_CYCLE.length;
+    setBackgroundVisualizerStyle(VISUALIZER_CYCLE[nextIndex]);
+  }, [backgroundVisualizerStyle, setBackgroundVisualizerStyle]);
 
   const handleTranslucenceToggle = useCallback(() => {
     setTranslucenceEnabled(prev => !prev);
@@ -254,7 +260,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
     onCloseQueue: onCloseQueue,
     onToggleVisualEffectsMenu: handleToggleVisualEffectsMenu,
     onCloseVisualEffects: handleEscapeClose,
-    onToggleBackgroundVisualizer: handleBackgroundVisualizerToggle,
+    onCycleVisualizerStyle: handleCycleVisualizerStyle,
     onToggleGlow: handleGlowToggle,
     onToggleTranslucence: handleTranslucenceToggle,
     onMute: handleMuteToggle,

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-type Zone = 'left' | 'center' | 'right';
-
 interface ZenClickZoneOverlayProps {
   isPlaying: boolean;
-  hoveredZone: Zone | null;
   visible: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+  onPlayPause: () => void;
 }
 
 const Overlay = styled.div`
@@ -18,40 +18,36 @@ const Overlay = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8%;
   container-type: size;
 `;
 
-const ZoneDiv = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$hovered'].includes(prop),
-})<{ $hovered: boolean }>`
+const IconButton = styled.button`
+  pointer-events: auto;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  border-radius: 50%;
+  width: 112px;
+  height: 112px;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  padding: 0;
 
-  .zone-icon {
-    opacity: ${({ $hovered }) => ($hovered ? 1 : 0)};
-    transition: opacity 150ms ease;
-    background: rgba(0, 0, 0, 0.4);
-    border-radius: 50%;
-    width: 16cqw;
-    height: 16cqw;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  &:hover {
+    opacity: 1;
   }
 `;
 
-const LeftZone = styled(ZoneDiv)`
-  width: 25%;
-`;
-
-const CenterZone = styled(ZoneDiv)`
-  width: 50%;
-`;
-
-const RightZone = styled(ZoneDiv)`
-  width: 25%;
+const CenterIconButton = styled(IconButton)`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 `;
 
 const Icon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -62,37 +58,42 @@ const Icon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.memo(({
   isPlaying,
-  hoveredZone,
   visible,
+  onPrevious,
+  onNext,
+  onPlayPause,
 }) => {
   if (!visible) return null;
 
   return (
     <Overlay>
-      <LeftZone $hovered={hoveredZone === 'left'}>
-        <div className="zone-icon">
-          <Icon>
-            <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
-          </Icon>
-        </div>
-      </LeftZone>
-      <CenterZone $hovered={hoveredZone === 'center'}>
-        <div className="zone-icon">
-          <Icon>
-            {isPlaying
-              ? <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
-              : <path d="M8 5v14l11-7z" />
-            }
-          </Icon>
-        </div>
-      </CenterZone>
-      <RightZone $hovered={hoveredZone === 'right'}>
-        <div className="zone-icon">
-          <Icon>
-            <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
-          </Icon>
-        </div>
-      </RightZone>
+      <IconButton
+        onClick={(e) => { e.stopPropagation(); onPrevious(); }}
+        aria-label="Previous track"
+      >
+        <Icon>
+          <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
+        </Icon>
+      </IconButton>
+      <CenterIconButton
+        onClick={(e) => { e.stopPropagation(); onPlayPause(); }}
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+      >
+        <Icon>
+          {isPlaying
+            ? <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+            : <path d="M8 5v14l11-7z" />
+          }
+        </Icon>
+      </CenterIconButton>
+      <IconButton
+        onClick={(e) => { e.stopPropagation(); onNext(); }}
+        aria-label="Next track"
+      >
+        <Icon>
+          <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+        </Icon>
+      </IconButton>
     </Overlay>
   );
 });

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -20,7 +20,7 @@ const Overlay = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 0 8%;
+  padding: 0 2%;
   container-type: size;
 `;
 
@@ -29,8 +29,8 @@ const IconButton = styled.button`
   background: rgba(0, 0, 0, 0.4);
   border: none;
   border-radius: 50%;
-  width: 224px;
-  height: 224px;
+  width: 30cqmin;
+  height: 30cqmin;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -29,8 +29,8 @@ const IconButton = styled.button`
   background: rgba(0, 0, 0, 0.4);
   border: none;
   border-radius: 50%;
-  width: 112px;
-  height: 112px;
+  width: 224px;
+  height: 224px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsIntegration.test.tsx
@@ -104,7 +104,7 @@ describe('Keyboard Shortcuts Integration', () => {
       onCloseQueue: vi.fn(),
       onToggleVisualEffectsMenu: vi.fn(),
       onCloseVisualEffects: vi.fn(),
-      onToggleBackgroundVisualizer: vi.fn(),
+      onCycleVisualizerStyle: vi.fn(),
       onToggleGlow: vi.fn(),
       onMute: vi.fn(),
       onToggleLike: vi.fn(),
@@ -123,7 +123,7 @@ describe('Keyboard Shortcuts Integration', () => {
       { key: 'KeyM', handler: handlers.onMute },
       { key: 'KeyK', handler: handlers.onToggleLike },
       { key: 'KeyG', handler: handlers.onToggleGlow },
-      { key: 'KeyV', handler: handlers.onToggleBackgroundVisualizer },
+      { key: 'KeyV', handler: handlers.onCycleVisualizerStyle },
       { key: 'KeyS', handler: handlers.onToggleShuffle, shift: false },
     ];
 

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -130,12 +130,12 @@ describe('useKeyboardShortcuts', () => {
     addEventListenerSpy.mockRestore();
   });
 
-  it('should call onToggleBackgroundVisualizer when KeyV is pressed', () => {
+  it('should call onCycleVisualizerStyle when KeyV is pressed', () => {
     // #given
-    const onToggleBackgroundVisualizer = vi.fn();
+    const onCycleVisualizerStyle = vi.fn();
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
-    renderHook(() => useKeyboardShortcuts({ onToggleBackgroundVisualizer }));
+    renderHook(() => useKeyboardShortcuts({ onCycleVisualizerStyle }));
 
     const handler = addEventListenerSpy.mock.calls[0][1] as EventListener;
     const event = createKeyboardEvent('KeyV');
@@ -144,7 +144,7 @@ describe('useKeyboardShortcuts', () => {
     handler(event);
 
     // #then
-    expect(onToggleBackgroundVisualizer).toHaveBeenCalled();
+    expect(onCycleVisualizerStyle).toHaveBeenCalled();
     addEventListenerSpy.mockRestore();
   });
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -12,7 +12,7 @@ interface KeyboardShortcutHandlers {
   onCloseQueue?: () => void;
   onToggleVisualEffectsMenu?: () => void;
   onCloseVisualEffects?: () => void;
-  onToggleBackgroundVisualizer?: () => void;
+  onCycleVisualizerStyle?: () => void;
   onToggleGlow?: () => void;
   onToggleTranslucence?: () => void;
   onToggleHelp?: () => void;
@@ -45,7 +45,7 @@ export const useKeyboardShortcuts = (
     onCloseQueue,
     onToggleVisualEffectsMenu,
     onCloseVisualEffects,
-    onToggleBackgroundVisualizer,
+    onCycleVisualizerStyle,
     onToggleGlow,
     onToggleTranslucence,
     onToggleHelp,
@@ -92,7 +92,7 @@ export const useKeyboardShortcuts = (
         case 'KeyV':
           if (!event.ctrlKey && !event.metaKey) {
             event.preventDefault();
-            onToggleBackgroundVisualizer?.();
+            onCycleVisualizerStyle?.();
           }
           break;
 
@@ -199,7 +199,7 @@ export const useKeyboardShortcuts = (
     onCloseQueue,
     onToggleVisualEffectsMenu,
     onCloseVisualEffects,
-    onToggleBackgroundVisualizer,
+    onCycleVisualizerStyle,
     onToggleGlow,
     onToggleTranslucence,
     onToggleHelp,


### PR DESCRIPTION
## Summary

- Same refactor as #745 (ZenClickZoneOverlay → real buttons, padding 8%→2%, visualizer cycle, stopPropagation fix)
- Additionally: button size changes from fixed `224px` to `30cqmin` so buttons scale proportionally with the album art container

## Test plan

- [ ] Zen mode on desktop/mobile: prev/next/play-pause buttons appear, work, and scale with album art
- [ ] V key cycles visualizer styles (fireflies → comet → wave → grid → fireflies)
- [ ] Flip menu click doesn't bleed through
- [ ] No TypeScript errors: `npx tsc -b --noEmit`
- [ ] Tests pass: `npm run test:run`

Closes #744