### PR TITLE
fix: clamp zen overlay button size to prevent overflow at large art

### DIFF
--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -20,7 +20,7 @@ const Overlay = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 0 8%;
+  padding: 0 2%;
   container-type: size;
 `;
 
@@ -29,8 +29,8 @@ const IconButton = styled.button`
   background: rgba(0, 0, 0, 0.4);
   border: none;
   border-radius: 50%;
-  width: 224px;
-  height: 224px;
+  width: clamp(72px, 20cqmin, 224px);
+  height: clamp(72px, 20cqmin, 224px);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## What
- Replace hardcoded `224px` button size with `clamp(72px, 20cqmin, 224px)` so buttons scale with album art on small viewports without growing unbounded on large ones
- Reduce overlay side padding from `8%` to `2%` to keep prev/next buttons closer to the album art edges

## Why
The `224px` hardcoded size was too large at small viewport widths (e.g. narrow desktop windows), where the album art can be as small as ~280px — causing the three buttons to nearly overlap. The `30cqmin` value from the previous fix over-corrected in the other direction, producing 200px+ buttons on wide viewports (1440×900 → 210px buttons on a 700px art square).

`clamp(72px, 20cqmin, 224px)` gives a floor of 72px (safe minimum with ~26px clearance between adjacent buttons), scales proportionally with art size in the middle range, and caps at 224px for very large art.

## Test plan
- [ ] Zen mode on a narrow window (~500px wide): buttons should be visibly smaller than album art, no overlap with center play button
- [ ] Zen mode on a wide desktop (1440×900+): buttons should be large but not dominate the album art
- [ ] Hover on prev/next/play in zen mode: each button appears independently with correct opacity transition