### PR TITLE
fix: move ResumeCard above Browse Library button in QuickAccessPanel

### DIFF
--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -83,10 +83,6 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
 
   return (
     <PanelRoot>
-      {lastSession && lastSession.collectionId && (
-        <ResumeCard session={lastSession} onResume={onResume} />
-      )}
-
       <PinRing
         pinnedPlaylists={pinnedPlaylists}
         pinnedAlbums={pinnedAlbums}
@@ -118,6 +114,10 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
             })}
           </ChipRow>
         </ChipsSection>
+      )}
+
+      {lastSession && lastSession.collectionId && (
+        <ResumeCard session={lastSession} onResume={onResume} />
       )}
 
       <BrowseSection>


### PR DESCRIPTION
Moves `ResumeCard` from the top of the `QuickAccessPanel` flex column to just above the Browse Library button, so it's no longer hidden behind the phone status bar, notch, or Dynamic Island on mobile.

New order: PinRing → ChipsSection → ResumeCard → Browse Library

Closes #749