### PR TITLE
feat: redesign ResumeCard as mini now-playing banner

### DIFF
--- a/src/components/QuickAccessPanel/ResumeCard.tsx
+++ b/src/components/QuickAccessPanel/ResumeCard.tsx
@@ -6,7 +6,7 @@ import {
   ResumeText,
   ResumeTrackName,
   ResumeCollectionName,
-  ResumeLabel,
+  ResumePlayButton,
 } from './styled';
 
 interface ResumeCardProps {
@@ -27,7 +27,11 @@ const ResumeCard: React.FC<ResumeCardProps> = ({ session, onResume }) => (
       <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
       <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
     </ResumeText>
-    <ResumeLabel>Resume</ResumeLabel>
+    <ResumePlayButton aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M8 5v14l11-7z" />
+      </svg>
+    </ResumePlayButton>
   </ResumeCardRoot>
 );
 

--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -116,15 +116,15 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
         </ChipsSection>
       )}
 
-      {lastSession && lastSession.collectionId && (
-        <ResumeCard session={lastSession} onResume={onResume} />
-      )}
-
       <BrowseSection>
         <BrowseButton onClick={onBrowseLibrary}>
           Browse Library →
         </BrowseButton>
       </BrowseSection>
+
+      {lastSession && lastSession.collectionId && (
+        <ResumeCard session={lastSession} onResume={onResume} />
+      )}
     </PanelRoot>
   );
 };

--- a/src/components/QuickAccessPanel/styled.ts
+++ b/src/components/QuickAccessPanel/styled.ts
@@ -48,9 +48,9 @@ export const ResumeCardRoot = styled.button`
 `;
 
 export const ResumeArt = styled.div`
-  width: 40px;
-  height: 40px;
-  border-radius: ${theme.borderRadius.md};
+  width: 52px;
+  height: 52px;
+  border-radius: ${theme.borderRadius.lg};
   overflow: hidden;
   flex-shrink: 0;
   background: ${theme.colors.control.background};
@@ -72,7 +72,7 @@ export const ResumeText = styled.div`
 
 export const ResumeTrackName = styled.div`
   color: ${theme.colors.white};
-  font-size: ${theme.fontSize.sm};
+  font-size: ${theme.fontSize.base};
   font-weight: ${theme.fontWeight.medium};
   white-space: nowrap;
   overflow: hidden;
@@ -87,14 +87,21 @@ export const ResumeCollectionName = styled.div`
   text-overflow: ellipsis;
 `;
 
-export const ResumeLabel = styled.div`
-  color: ${theme.colors.muted.foreground};
-  font-size: ${theme.fontSize.xs};
-  font-weight: ${theme.fontWeight.medium};
-  flex-shrink: 0;
-  padding: ${theme.spacing.xs} ${theme.spacing.sm};
-  border: 1px solid ${theme.colors.borderSubtle};
+export const ResumePlayButton = styled.div`
+  width: 34px;
+  height: 34px;
   border-radius: ${theme.borderRadius.full};
+  background: rgba(255, 255, 255, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: ${theme.colors.white};
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
 `;
 
 export const GridSection = styled.div`


### PR DESCRIPTION
## Summary

- Move `ResumeCard` below `BrowseSection` so it appears at the bottom of the QuickAccessPanel
- Increase album art thumbnail from 40px → 52px with slightly rounder border radius (`lg`)
- Increase track name font size from `sm` (14px) → `base` (16px) for better legibility
- Replace the "Resume" pill label with a 34px circular play button (rgba white background, white ▶ icon)

## Changed files

- `src/components/QuickAccessPanel/index.tsx` — reorder layout
- `src/components/QuickAccessPanel/ResumeCard.tsx` — swap `ResumeLabel` for `ResumePlayButton`
- `src/components/QuickAccessPanel/styled.ts` — update art size, font size, replace `ResumeLabel` with `ResumePlayButton`

## Test plan

- [x] TypeScript check passes (`npx tsc -b --noEmit`)
- [x] All 878 tests pass (`npm run test:run`)

Closes #751