### PR TITLE
fix: gate DevBugFAB behind localStorage flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { logApp } from '@/lib/debugLog';
 import { DevBugProvider } from '@/contexts/DevBugContext';
 import { DevBugFAB } from '@/components/DevBug';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { STORAGE_KEYS } from '@/constants/storage';
 
 /**
  * Cleanup function to remove deprecated localStorage keys
@@ -93,7 +94,7 @@ function App() {
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isPopupCallback, setIsPopupCallback] = useState(false);
-  const [devbugEnabled] = useLocalStorage('vorbis-player-devbug', false);
+  const [devbugEnabled] = useLocalStorage(STORAGE_KEYS.DEVBUG_ENABLED, false);
 
   useEffect(() => {
     // Clean up deprecated localStorage keys on app initialization

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { AUTH_COMPLETE_EVENT } from '@/constants/events';
 import { logApp } from '@/lib/debugLog';
 import { DevBugProvider } from '@/contexts/DevBugContext';
 import { DevBugFAB } from '@/components/DevBug';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 /**
  * Cleanup function to remove deprecated localStorage keys
@@ -92,6 +93,7 @@ function App() {
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isPopupCallback, setIsPopupCallback] = useState(false);
+  const [devbugEnabled] = useLocalStorage('vorbis-player-devbug', false);
 
   useEffect(() => {
     // Clean up deprecated localStorage keys on app initialization
@@ -223,7 +225,7 @@ function App() {
     return (
       <DevBugProvider>
         {player}
-        <DevBugFAB />
+        {devbugEnabled && <DevBugFAB />}
       </DevBugProvider>
     );
   }

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -61,4 +61,5 @@ export const STORAGE_KEYS = {
   PROFILING: 'vorbis-player-profiling',
   DEBUG_OVERLAY: 'vorbis-player-debug-overlay',
   VISUALIZER_DEBUG_OVERRIDES: 'vorbis-player-visualizer-debug-overrides',
+  DEVBUG_ENABLED: 'vorbis-player-devbug',
 } as const;


### PR DESCRIPTION
## What
- Reads `vorbis-player-devbug` from localStorage via `useLocalStorage`
- `DevBugFAB` only renders when that flag is `true`
- Default value is `false`, so the FAB is hidden for all users unless explicitly opted in

## Why
Prevents the DevBug FAB from appearing in production for regular users. Developers can enable it locally by setting `localStorage.setItem('vorbis-player-devbug', 'true')`.

## Test plan
- [ ] Open app in browser — DevBugFAB should not appear
- [ ] Run `localStorage.setItem('vorbis-player-devbug', 'true')` in DevTools console and reload — FAB should appear
- [ ] Remove the key and reload — FAB should be gone again