### PR TITLE
Release: QAP fixes, ResumeCard redesign, DevBugFAB flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import { AUTH_COMPLETE_EVENT } from '@/constants/events';
 import { logApp } from '@/lib/debugLog';
 import { DevBugProvider } from '@/contexts/DevBugContext';
 import { DevBugFAB } from '@/components/DevBug';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { STORAGE_KEYS } from '@/constants/storage';
 
 /**
  * Cleanup function to remove deprecated localStorage keys
@@ -92,6 +94,7 @@ function App() {
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isPopupCallback, setIsPopupCallback] = useState(false);
+  const [devbugEnabled] = useLocalStorage(STORAGE_KEYS.DEVBUG_ENABLED, false);
 
   useEffect(() => {
     // Clean up deprecated localStorage keys on app initialization
@@ -223,7 +226,7 @@ function App() {
     return (
       <DevBugProvider>
         {player}
-        <DevBugFAB />
+        {devbugEnabled && <DevBugFAB />}
       </DevBugProvider>
     );
   }

--- a/src/components/QuickAccessPanel/ResumeCard.tsx
+++ b/src/components/QuickAccessPanel/ResumeCard.tsx
@@ -6,7 +6,7 @@ import {
   ResumeText,
   ResumeTrackName,
   ResumeCollectionName,
-  ResumeLabel,
+  ResumePlayButton,
 } from './styled';
 
 interface ResumeCardProps {
@@ -27,7 +27,11 @@ const ResumeCard: React.FC<ResumeCardProps> = ({ session, onResume }) => (
       <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
       <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
     </ResumeText>
-    <ResumeLabel>Resume</ResumeLabel>
+    <ResumePlayButton aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M8 5v14l11-7z" />
+      </svg>
+    </ResumePlayButton>
   </ResumeCardRoot>
 );
 

--- a/src/components/QuickAccessPanel/__tests__/QuickAccessPanel.test.tsx
+++ b/src/components/QuickAccessPanel/__tests__/QuickAccessPanel.test.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import QuickAccessPanel from '../index';
+import type { ProviderId } from '@/types/domain';
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(),
+}));
+
+vi.mock('@/contexts/PinnedItemsContext', () => ({
+  usePinnedItemsContext: vi.fn(),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(),
+}));
+
+vi.mock('@/hooks/useLongPress', () => ({
+  useLongPress: vi.fn(() => ({
+    onPointerDown: vi.fn(),
+    onPointerUp: vi.fn(),
+    onPointerCancel: vi.fn(),
+  })),
+}));
+
+vi.mock('@/components/ProviderIcon', () => ({
+  default: ({ provider }: { provider: string }) => <span data-testid={`provider-icon-${provider}`} />,
+}));
+
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
+import { usePinnedItemsContext } from '@/contexts/PinnedItemsContext';
+import { useProviderContext } from '@/contexts/ProviderContext';
+
+const mockUseLibrarySync = vi.mocked(useLibrarySync);
+const mockUseUnifiedLikedTracks = vi.mocked(useUnifiedLikedTracks);
+const mockUsePinnedItemsContext = vi.mocked(usePinnedItemsContext);
+const mockUseProviderContext = vi.mocked(useProviderContext);
+
+function setupProviderContext(connectedProviderIds: ProviderId[]) {
+  mockUseProviderContext.mockReturnValue({
+    connectedProviderIds,
+    getDescriptor: (id: ProviderId) => ({
+      id,
+      name: id === 'spotify' ? 'Spotify' : 'Dropbox',
+      capabilities: { hasSaveTrack: true, hasExternalLink: true, hasLikedCollection: true },
+      auth: { providerId: id, isAuthenticated: vi.fn(() => true), getAccessToken: vi.fn(), beginLogin: vi.fn(), handleCallback: vi.fn(), logout: vi.fn() },
+      catalog: { providerId: id, listCollections: vi.fn(), listTracks: vi.fn() },
+      playback: { providerId: id, initialize: vi.fn(), playTrack: vi.fn(), pause: vi.fn(), resume: vi.fn(), seek: vi.fn(), next: vi.fn(), previous: vi.fn(), setVolume: vi.fn(), getState: vi.fn(), subscribe: vi.fn(() => vi.fn()), getLastPlayTime: vi.fn() },
+    }),
+    enabledProviderIds: connectedProviderIds,
+    activeDescriptor: null,
+    storedProviderId: null,
+    setActiveProviderId: vi.fn(),
+    toggleProvider: vi.fn(),
+    isProviderEnabled: vi.fn(),
+    allProviders: [],
+    setProviderSwitchInterceptor: vi.fn(),
+    needsProviderSelection: false,
+    fallthroughNotification: null,
+    dismissFallthroughNotification: vi.fn(),
+    authRevision: 0,
+  } as ReturnType<typeof useProviderContext>);
+}
+
+function setupLibrarySync(likedSongsPerProvider: { provider: ProviderId; count: number }[]) {
+  mockUseLibrarySync.mockReturnValue({
+    playlists: [],
+    albums: [],
+    likedSongsCount: likedSongsPerProvider.reduce((s, e) => s + e.count, 0),
+    likedSongsPerProvider,
+    isInitialLoadComplete: true,
+    isSyncing: false,
+    lastSyncTimestamp: null,
+    syncError: null,
+    refreshNow: vi.fn(),
+    removeCollection: vi.fn(),
+  } as ReturnType<typeof useLibrarySync>);
+}
+
+function setupUnifiedLiked(isUnifiedLikedActive: boolean, totalCount: number) {
+  mockUseUnifiedLikedTracks.mockReturnValue({
+    isUnifiedLikedActive,
+    totalCount,
+    unifiedTracks: [],
+    isLoading: false,
+  } as ReturnType<typeof useUnifiedLikedTracks>);
+}
+
+function renderPanel() {
+  mockUsePinnedItemsContext.mockReturnValue({
+    pinnedPlaylistIds: [],
+    pinnedAlbumIds: [],
+    togglePlaylistPin: vi.fn(),
+    toggleAlbumPin: vi.fn(),
+    isPlaylistPinned: vi.fn(() => false),
+    isAlbumPinned: vi.fn(() => false),
+    canPinMorePlaylists: true,
+    canPinMoreAlbums: true,
+  } as ReturnType<typeof usePinnedItemsContext>);
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <QuickAccessPanel
+        onPlaylistSelect={vi.fn()}
+        onAddToQueue={vi.fn()}
+        onBrowseLibrary={vi.fn()}
+        lastSession={null}
+        onResume={vi.fn()}
+      />
+    </ThemeProvider>
+  );
+}
+
+function getLikedCount(): number {
+  const el = screen.getByLabelText(/Liked Songs/);
+  const match = el.getAttribute('aria-label')?.match(/\((\d+)\)/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+describe('QuickAccessPanel effectiveLikedCount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('unified liked active + all providers visible (no filter chip selected)', () => {
+    it('shows the unified total count', () => {
+      // #given
+      setupProviderContext(['spotify', 'dropbox']);
+      setupLibrarySync([
+        { provider: 'spotify', count: 100 },
+        { provider: 'dropbox', count: 50 },
+      ]);
+      setupUnifiedLiked(true, 150);
+
+      // #when
+      renderPanel();
+
+      // #then
+      expect(getLikedCount()).toBe(150);
+    });
+  });
+
+  describe('unified liked active + one provider filter chip selected', () => {
+    it('shows the single-provider count (not unified) when filtered to one provider', () => {
+      // #given
+      setupProviderContext(['spotify', 'dropbox']);
+      setupLibrarySync([
+        { provider: 'spotify', count: 100 },
+        { provider: 'dropbox', count: 50 },
+      ]);
+      setupUnifiedLiked(true, 150);
+
+      // #when
+      renderPanel();
+      const spotifyChip = screen.getByText('Spotify');
+      fireEvent.click(spotifyChip);
+
+      // #then
+      expect(getLikedCount()).toBe(100);
+    });
+  });
+
+  describe('unified liked inactive + provider filter active', () => {
+    it('shows the sum of filtered per-provider counts', () => {
+      // #given
+      setupProviderContext(['spotify', 'dropbox']);
+      setupLibrarySync([
+        { provider: 'spotify', count: 100 },
+        { provider: 'dropbox', count: 50 },
+      ]);
+      setupUnifiedLiked(false, 0);
+
+      // #when
+      renderPanel();
+      const dropboxChip = screen.getByText('Dropbox');
+      fireEvent.click(dropboxChip);
+
+      // #then
+      expect(getLikedCount()).toBe(50);
+    });
+
+    it('shows the total count when no filter chip is active', () => {
+      // #given
+      setupProviderContext(['spotify', 'dropbox']);
+      setupLibrarySync([
+        { provider: 'spotify', count: 100 },
+        { provider: 'dropbox', count: 50 },
+      ]);
+      setupUnifiedLiked(false, 0);
+
+      // #when
+      renderPanel();
+
+      // #then
+      expect(getLikedCount()).toBe(150);
+    });
+  });
+
+  describe('no providers connected (single provider)', () => {
+    it('shows the single provider count when only one provider is connected', () => {
+      // #given
+      setupProviderContext(['spotify']);
+      setupLibrarySync([{ provider: 'spotify', count: 75 }]);
+      setupUnifiedLiked(false, 0);
+
+      // #when
+      renderPanel();
+
+      // #then — one provider, unified inactive: shows 75
+      expect(getLikedCount()).toBe(75);
+    });
+  });
+
+  describe('unified liked active + filter chip selects both providers', () => {
+    it('shows unified count when both provider chips are individually toggled back on', () => {
+      // #given
+      setupProviderContext(['spotify', 'dropbox']);
+      setupLibrarySync([
+        { provider: 'spotify', count: 100 },
+        { provider: 'dropbox', count: 50 },
+      ]);
+      setupUnifiedLiked(true, 150);
+
+      // #when
+      renderPanel();
+      const spotifyChip = screen.getByText('Spotify');
+      fireEvent.click(spotifyChip);
+      fireEvent.click(spotifyChip);
+
+      // #then
+      expect(getLikedCount()).toBe(150);
+    });
+  });
+});

--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -116,15 +116,15 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
         </ChipsSection>
       )}
 
-      {lastSession && lastSession.collectionId && (
-        <ResumeCard session={lastSession} onResume={onResume} />
-      )}
-
       <BrowseSection>
         <BrowseButton onClick={onBrowseLibrary}>
           Browse Library →
         </BrowseButton>
       </BrowseSection>
+
+      {lastSession && lastSession.collectionId && (
+        <ResumeCard session={lastSession} onResume={onResume} />
+      )}
     </PanelRoot>
   );
 };

--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -35,7 +35,7 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
 }) => {
   const { pinnedPlaylistIds, pinnedAlbumIds } = usePinnedItemsContext();
   const { connectedProviderIds, getDescriptor } = useProviderContext();
-  const { playlists, albums, likedSongsCount, likedSongsPerProvider } = useLibrarySync();
+  const { playlists, albums, likedSongsPerProvider } = useLibrarySync();
   const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
 
   const [activeProviderIds, setActiveProviderIds] = useState<ProviderId[]>([]);
@@ -65,7 +65,14 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
       .sort((a, b) => pinnedAlbumIds.indexOf(a.id) - pinnedAlbumIds.indexOf(b.id));
   }, [albums, pinnedAlbumIds]);
 
-  const effectiveLikedCount = isUnifiedLikedActive ? unifiedLikedCount : likedSongsCount;
+  const filteredLikedSongsPerProvider = activeProviderIds.length > 0
+    ? likedSongsPerProvider.filter(e => activeProviderIds.includes(e.provider))
+    : likedSongsPerProvider;
+
+  const shouldShowUnified = isUnifiedLikedActive && filteredLikedSongsPerProvider.length !== 1;
+  const effectiveLikedCount = shouldShowUnified
+    ? unifiedLikedCount
+    : filteredLikedSongsPerProvider.reduce((sum, e) => sum + e.count, 0);
 
   const handleLoadCollection = (id: string, name: string, provider?: ProviderId) => {
     onPlaylistSelect(id, name, provider);

--- a/src/components/QuickAccessPanel/styled.ts
+++ b/src/components/QuickAccessPanel/styled.ts
@@ -48,9 +48,9 @@ export const ResumeCardRoot = styled.button`
 `;
 
 export const ResumeArt = styled.div`
-  width: 40px;
-  height: 40px;
-  border-radius: ${theme.borderRadius.md};
+  width: 52px;
+  height: 52px;
+  border-radius: ${theme.borderRadius.lg};
   overflow: hidden;
   flex-shrink: 0;
   background: ${theme.colors.control.background};
@@ -72,7 +72,7 @@ export const ResumeText = styled.div`
 
 export const ResumeTrackName = styled.div`
   color: ${theme.colors.white};
-  font-size: ${theme.fontSize.sm};
+  font-size: ${theme.fontSize.base};
   font-weight: ${theme.fontWeight.medium};
   white-space: nowrap;
   overflow: hidden;
@@ -87,14 +87,21 @@ export const ResumeCollectionName = styled.div`
   text-overflow: ellipsis;
 `;
 
-export const ResumeLabel = styled.div`
-  color: ${theme.colors.muted.foreground};
-  font-size: ${theme.fontSize.xs};
-  font-weight: ${theme.fontWeight.medium};
-  flex-shrink: 0;
-  padding: ${theme.spacing.xs} ${theme.spacing.sm};
-  border: 1px solid ${theme.colors.borderSubtle};
+export const ResumePlayButton = styled.div`
+  width: 34px;
+  height: 34px;
   border-radius: ${theme.borderRadius.full};
+  background: rgba(255, 255, 255, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: ${theme.colors.white};
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
 `;
 
 export const GridSection = styled.div`

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -61,4 +61,5 @@ export const STORAGE_KEYS = {
   PROFILING: 'vorbis-player-profiling',
   DEBUG_OVERLAY: 'vorbis-player-debug-overlay',
   VISUALIZER_DEBUG_OVERRIDES: 'vorbis-player-visualizer-debug-overrides',
+  DEVBUG_ENABLED: 'vorbis-player-devbug',
 } as const;


### PR DESCRIPTION
## Summary

- **#755** fix: QAP liked songs count now respects provider filter chips — mirrors PlaylistGrid logic, adds unit tests
- **#754** fix: gate DevBugFAB behind `vorbis-player-devbug` localStorage flag (off by default in production)
- **#752** feat: redesign ResumeCard as mini now-playing banner (52px art, larger text, circular play button)

## PRs included

- #755 fix: QAP liked songs count respects provider filter chips
- #754 fix: gate DevBugFAB behind localStorage flag
- #752 feat: redesign ResumeCard as mini now-playing banner

## Test plan

- [ ] QAP Liked Songs count updates when switching provider filter chips (Spotify-only, Dropbox-only, all)
- [ ] DevBugFAB does not appear on fresh load; appears after `localStorage.setItem('vorbis-player-devbug', 'true')` + reload
- [ ] ResumeCard displays as mini banner with circular play button when a session exists
- [ ] Resume button triggers playback of the previous session