### PR TITLE
fix: iOS first-track autoplay blocked by broken user-gesture chain

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -183,8 +183,6 @@ const AudioPlayerComponent = () => {
     setShowVisualEffects(false);
   }, [setShowVisualEffects]);
 
-  const pendingPlayRef = useRef<{ trackId?: string; trackIndex: number } | null>(null);
-
   const handleResume = useCallback(() => {
     if (!lastSession?.queueTracks?.length) return;
     const { queueTracks, trackId, trackIndex, collectionId } = lastSession;
@@ -196,16 +194,12 @@ const AudioPlayerComponent = () => {
     setOriginalTracks(queueTracks);
     setSelectedPlaylistId(collectionId);
     setCurrentTrackIndex(resolvedIdx);
-    pendingPlayRef.current = { trackId, trackIndex: resolvedIdx };
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex]);
-
-  useEffect(() => {
-    if (tracks.length === 0 || !pendingPlayRef.current) return;
-    const { trackId, trackIndex } = pendingPlayRef.current;
-    pendingPlayRef.current = null;
-    const idx = trackId ? tracks.findIndex(t => t.id === trackId) : -1;
-    handlers.playTrack(idx >= 0 ? idx : Math.min(trackIndex, tracks.length - 1));
-  }, [tracks, handlers]);
+    // Update the imperative tracks mirror synchronously so playTrack can resolve
+    // the right track before React re-renders. Required for iOS Safari, which
+    // blocks audio.play() called outside the synchronous user-gesture call stack.
+    mediaTracksRef.current = queueTracks;
+    handlers.playTrack(resolvedIdx);
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -27,40 +27,53 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.catalog = catalog;
   }
 
-  async initialize(): Promise<void> {
-    if (!this.audio) {
-      this.audio = new Audio();
-      this.audio.preload = 'auto';
+  private ensureAudio(): void {
+    if (this.audio) return;
+    this.audio = new Audio();
+    this.audio.preload = 'auto';
 
-      this.audio.addEventListener('play', () => this.notifyListeners());
-      this.audio.addEventListener('pause', () => this.notifyListeners());
-      this.audio.addEventListener('ended', () => this.notifyListeners());
-      this.audio.addEventListener('timeupdate', () => this.notifyListeners());
-      this.audio.addEventListener('loadedmetadata', () => {
-        const dur = this.audio!.duration;
-        if (!isNaN(dur) && dur > 0 && this.currentTrack) {
-          const durationMs = Math.floor(dur * 1000);
-          this.pendingDurationMs = durationMs;
-          putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
-        }
-        this.notifyListeners();
-      });
-      this.audio.addEventListener('error', () => {
-        const mediaError = this.audio?.error;
-        this.pendingError = {
-          code: mediaError?.code ?? 0,
-          message: mediaError?.message || `MediaError code ${mediaError?.code ?? 0}`,
-        };
-        console.error('[DropboxPlayback] Audio error:', mediaError);
-        this.notifyListeners();
-      });
-    }
+    this.audio.addEventListener('play', () => this.notifyListeners());
+    this.audio.addEventListener('pause', () => this.notifyListeners());
+    this.audio.addEventListener('ended', () => this.notifyListeners());
+    this.audio.addEventListener('timeupdate', () => this.notifyListeners());
+    this.audio.addEventListener('loadedmetadata', () => {
+      const dur = this.audio!.duration;
+      if (!isNaN(dur) && dur > 0 && this.currentTrack) {
+        const durationMs = Math.floor(dur * 1000);
+        this.pendingDurationMs = durationMs;
+        putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
+      }
+      this.notifyListeners();
+    });
+    this.audio.addEventListener('error', () => {
+      const mediaError = this.audio?.error;
+      this.pendingError = {
+        code: mediaError?.code ?? 0,
+        message: mediaError?.message || `MediaError code ${mediaError?.code ?? 0}`,
+      };
+      console.error('[DropboxPlayback] Audio error:', mediaError);
+      this.notifyListeners();
+    });
+  }
+
+  async initialize(): Promise<void> {
+    this.ensureAudio();
   }
 
   async playTrack(track: MediaTrack): Promise<void> {
-    if (!this.audio) await this.initialize();
+    this.ensureAudio();
 
     const dropboxPath = track.playbackRef.ref;
+
+    // iOS Safari requires audio.play() to be called within the synchronous
+    // user-gesture call stack to register this element as user-activated.
+    // Calling it here (before any await) ensures the subsequent async play()
+    // — after the Dropbox URL fetch — succeeds on iOS even though the
+    // network request breaks the gesture activation window.
+    if (this.audio!.paused) {
+      this.audio!.play().catch(() => {});
+    }
+
     const streamUrl = await this.catalog.getTemporaryLink(dropboxPath);
 
     this.currentTrack = track;
@@ -68,6 +81,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.hydrateAlbumArtFromCache(track);
     this.pendingMetadataUpdate = null;
     this.pendingDurationMs = null;
+    this.audio!.pause();
     this.audio!.src = streamUrl;
     await this.audio!.play();
 


### PR DESCRIPTION
## Summary

- Fix iOS autoplay regression where Dropbox tracks never auto-played after session resume or collection load (#762)
- Extract synchronous `ensureAudio()` helper in `DropboxPlaybackAdapter` so `audio.play()` fires before any async work, keeping it inside iOS Safari's user-gesture activation window
- Remove `pendingPlayRef` + `useEffect` deferred-play pattern in `AudioPlayer.handleResume` — play is now called directly within the click handler

## PRs included

- #762 fix: iOS first-track autoplay blocked by broken user-gesture chain

## Test plan

- [ ] Open on iPhone (Dropbox provider) — tap Resume, track should play immediately
- [ ] Select a new collection from library — first track should auto-play
- [ ] Verify desktop playback unaffected (no regression)