### PR TITLE
feat: add qapEnabled preference hook (default false)

### DIFF
--- a/src/hooks/__tests__/useQapEnabled.test.ts
+++ b/src/hooks/__tests__/useQapEnabled.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQapEnabled } from '../useQapEnabled';
+
+describe('useQapEnabled', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('defaults to false when localStorage is empty', () => {
+    // #when
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #then
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('can be set to true', () => {
+    // #given
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('persists to localStorage under the correct key', () => {
+    // #given
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'vorbis-player-qap-enabled',
+      'true'
+    );
+  });
+
+  it('reads initial value from localStorage', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === 'vorbis-player-qap-enabled') return 'true';
+      return null;
+    });
+
+    // #when
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/src/hooks/useQapEnabled.ts
+++ b/src/hooks/useQapEnabled.ts
@@ -1,0 +1,5 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export const useQapEnabled = (): [boolean, (value: boolean) => void] => {
+  return useLocalStorage<boolean>('vorbis-player-qap-enabled', false);
+};


### PR DESCRIPTION
## What

Add `useQapEnabled` hook backed by localStorage with default `false`.

## Why

Foundation for the QAP opt-in feature (#770). The value controls whether the Quick Access Panel or the library browser is shown as the idle/home screen.

Closes #763