### PR TITLE
feat: update idle routing to skip QAP when qapEnabled is false

### DIFF
--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from '../components/styled';
 import { flexColumn, cardBase } from '../styles/utils';
 import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
 
 const PlaylistSelection = React.lazy(() => import('./PlaylistSelection'));
@@ -187,7 +188,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
-  const [showLibrary, setShowLibrary] = useState(false);
+  const [qapEnabled] = useQapEnabled();
+  const [showLibrary, setShowLibrary] = useState(!qapEnabled);
 
   const handleConnectClick = useCallback(() => {
     activeDescriptor?.auth.beginLogin();


### PR DESCRIPTION
## What

When `qapEnabled` is `false` (the default), the idle state renders `PlaylistSelection` directly instead of `QuickAccessPanel`.

## Why

Makes library browser the default idle view for all users. QAP users (`qapEnabled=true`) are unaffected.

Closes #764