### PR TITLE
feat: add Quick Access Panel toggle to settings panel

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -352,6 +352,8 @@ const AudioPlayerComponent = () => {
                 onProfilerToggle={() => {}}
                 visualizerDebugEnabled={false}
                 onVisualizerDebugToggle={() => {}}
+                qapEnabled={false}
+                onQapToggle={() => {}}
               />
             </Suspense>
             <Suspense fallback={null}>

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -17,6 +17,7 @@ import { clearCacheWithOptions } from '@/services/cache/libraryCache';
 import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/VisualEffectsMenu';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState } from '@/types/radio';
 import { LoadingCard, ZenControlsWrapper, ZenControlsInner } from './styled';
@@ -135,6 +136,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const { enabled: profilerEnabled, toggle: profilerToggle } = useProfilingContext();
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
+  const [qapEnabled, setQapEnabled] = useQapEnabled();
 
   const settingsHasBeenOpenedRef = useRef(false);
   if (showVisualEffects) settingsHasBeenOpenedRef.current = true;
@@ -345,6 +347,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
             onProfilerToggle={handleProfilerToggle}
             visualizerDebugEnabled={visualizerDebugEnabled}
             onVisualizerDebugToggle={handleVisualizerDebugToggle}
+            qapEnabled={qapEnabled}
+            onQapToggle={() => setQapEnabled(!qapEnabled)}
           />
         </Suspense>
       )}

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -44,6 +44,8 @@ interface AppSettingsMenuProps {
   onProfilerToggle: () => void;
   visualizerDebugEnabled: boolean;
   onVisualizerDebugToggle: () => void;
+  qapEnabled: boolean;
+  onQapToggle: () => void;
 }
 
 const arePropsEqual = (
@@ -53,7 +55,8 @@ const arePropsEqual = (
   if (
     prevProps.isOpen !== nextProps.isOpen ||
     prevProps.profilerEnabled !== nextProps.profilerEnabled ||
-    prevProps.visualizerDebugEnabled !== nextProps.visualizerDebugEnabled
+    prevProps.visualizerDebugEnabled !== nextProps.visualizerDebugEnabled ||
+    prevProps.qapEnabled !== nextProps.qapEnabled
   ) {
     return false;
   }
@@ -68,7 +71,9 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
   profilerEnabled,
   onProfilerToggle,
   visualizerDebugEnabled,
-  onVisualizerDebugToggle
+  onVisualizerDebugToggle,
+  qapEnabled,
+  onQapToggle,
 }) => {
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizingContext();
   const { enabledProviderIds, registry } = useProviderContext();
@@ -136,6 +141,23 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
           ))}
 
           <CollapsibleSection title="Advanced">
+            <ControlGroup>
+              <ControlLabel>Quick Access Panel</ControlLabel>
+              <OptionButtonGroup>
+                <OptionButton
+                  $isActive={qapEnabled}
+                  onClick={onQapToggle}
+                >
+                  On
+                </OptionButton>
+                <OptionButton
+                  $isActive={!qapEnabled}
+                  onClick={onQapToggle}
+                >
+                  Off
+                </OptionButton>
+              </OptionButtonGroup>
+            </ControlGroup>
             <ControlGroup>
               <ControlLabel>Clear Library Cache</ControlLabel>
               {clearState === 'confirming' ? (

--- a/src/components/__tests__/VisualEffectsMenu.test.tsx
+++ b/src/components/__tests__/VisualEffectsMenu.test.tsx
@@ -71,6 +71,8 @@ describe('AppSettingsMenu', () => {
     onProfilerToggle: vi.fn(),
     visualizerDebugEnabled: false,
     onVisualizerDebugToggle: vi.fn(),
+    qapEnabled: false,
+    onQapToggle: vi.fn(),
   };
 
   beforeEach(() => {
@@ -171,7 +173,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[0]);
+      fireEvent.click(onButtons[1]);
 
       // #then
       expect(onProfilerToggle).toHaveBeenCalled();
@@ -189,7 +191,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[1]);
+      fireEvent.click(onButtons[2]);
 
       // #then
       expect(onVisualizerDebugToggle).toHaveBeenCalled();


### PR DESCRIPTION
## What

Adds an On/Off toggle for the Quick Access Panel to the settings drawer (gear icon). Toggling immediately updates the idle view.

Closes #766