### PR TITLE
fix: QAP opt-in wiring — keyboard routing, settings visibility, ResumeCard

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -362,6 +362,8 @@ const AudioPlayerComponent = () => {
                 onClose={handlers.handleCloseLibraryDrawer}
                 onPlaylistSelect={handlePlaylistSelect}
                 onAddToQueue={handleAddToQueueFromPanel}
+                lastSession={lastSession}
+                onResume={handleResume}
               />
             </Suspense>
           </>

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -237,15 +237,16 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   }, [showLibraryDrawer, showQueue, onShowQueue, onCloseQueue, onCloseLibraryDrawer]);
 
   const handleArrowDown = useCallback(() => {
+    const openPanel = qapEnabled ? onOpenQuickAccessPanel : onOpenLibraryDrawer;
     if (showQueue) {
       onCloseQueue();
-      onOpenQuickAccessPanel?.();
+      openPanel?.();
     } else if (showLibraryDrawer) {
       onCloseLibraryDrawer();
     } else {
-      onOpenQuickAccessPanel?.();
+      openPanel?.();
     }
-  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenQuickAccessPanel, onCloseLibraryDrawer]);
+  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenQuickAccessPanel, onOpenLibraryDrawer, onCloseLibraryDrawer, qapEnabled]);
 
   const handleVolumeUp = useCallback(() => {
     setVolumeLevel(Math.min(100, (volume ?? 50) + 5));

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
@@ -73,6 +74,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
 
   const [librarySearchQuery, setLibrarySearchQuery] = useState<string | undefined>(undefined);
   const [libraryViewMode, setLibraryViewMode] = useState<'playlists' | 'albums' | undefined>(undefined);
+  const [qapEnabled] = useQapEnabled();
 
   const controlsRef = useRef<HTMLDivElement>(null);
   const stableControlsHeightRef = useRef<number>(220);
@@ -155,12 +157,14 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
   const handleSwipeDown = useCallback(() => {
     if (showLibraryDrawer) {
       handlers.onCloseLibraryDrawer();
+    } else if (!qapEnabled) {
+      handleOpenLibraryDrawer();
     } else if (handlers.onOpenQuickAccessPanel) {
       handlers.onOpenQuickAccessPanel();
     } else {
       handleOpenLibraryDrawer();
     }
-  }, [showLibraryDrawer, handlers, handleOpenLibraryDrawer]);
+  }, [showLibraryDrawer, handlers, handleOpenLibraryDrawer, qapEnabled]);
 
   const handleLibrarySearchQueryReset = useCallback(() => setLibrarySearchQuery(undefined), []);
   const handleLibraryViewModeReset = useCallback(() => setLibraryViewMode(undefined), []);

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -10,6 +10,7 @@ import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
+import ResumeCard from './QuickAccessPanel/ResumeCard';
 
 const PlaylistSelection = React.lazy(() => import('./PlaylistSelection'));
 
@@ -275,7 +276,12 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
             </LoadingContainer>
           </LoadingCard>
         }>
-          <PlaylistSelection onPlaylistSelect={handlePlaylistSelectWrapped} />
+          <PlaylistSelection
+            onPlaylistSelect={handlePlaylistSelectWrapped}
+            footer={lastSession && onResume ? (
+              <ResumeCard session={lastSession} onResume={onResume} />
+            ) : undefined}
+          />
         </Suspense>
       );
     }

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -48,6 +48,8 @@ interface PlaylistSelectionProps {
   onLibraryRefresh?: () => void;
   /** Drawer-only: controls the refresh spinner */
   isLibraryRefreshing?: boolean;
+  /** Optional element rendered below the grid inside the card */
+  footer?: React.ReactNode;
 }
 
 const PlaylistSelection = React.memo(function PlaylistSelection({
@@ -58,7 +60,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   initialSearchQuery,
   initialViewMode,
   onLibraryRefresh,
-  isLibraryRefreshing
+  isLibraryRefreshing,
+  footer,
 }: PlaylistSelectionProps): JSX.Element {
   const { activeDescriptor, hasMultipleProviders, enabledProviderIds, getDescriptor } = useProviderContext();
   const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
@@ -304,6 +307,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
             {playlistPopoverPortal}
             {confirmDeletePortal}
           </CardContent>
+          {footer}
         </SelectionCard>
       </Container>
     </LibraryProvider>

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -140,24 +140,25 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
             <ProviderDataSection key={p.id} providerName={p.name} catalog={p.catalog} />
           ))}
 
+          <ControlGroup>
+            <ControlLabel>Quick Access Panel</ControlLabel>
+            <OptionButtonGroup>
+              <OptionButton
+                $isActive={qapEnabled}
+                onClick={onQapToggle}
+              >
+                On
+              </OptionButton>
+              <OptionButton
+                $isActive={!qapEnabled}
+                onClick={onQapToggle}
+              >
+                Off
+              </OptionButton>
+            </OptionButtonGroup>
+          </ControlGroup>
+
           <CollapsibleSection title="Advanced">
-            <ControlGroup>
-              <ControlLabel>Quick Access Panel</ControlLabel>
-              <OptionButtonGroup>
-                <OptionButton
-                  $isActive={qapEnabled}
-                  onClick={onQapToggle}
-                >
-                  On
-                </OptionButton>
-                <OptionButton
-                  $isActive={!qapEnabled}
-                  onClick={onQapToggle}
-                >
-                  Off
-                </OptionButton>
-              </OptionButtonGroup>
-            </ControlGroup>
             <ControlGroup>
               <ControlLabel>Clear Library Cache</ControlLabel>
               {clearState === 'confirming' ? (


### PR DESCRIPTION
## Summary

- Move QAP toggle out of collapsed "Advanced" section so it's immediately visible in settings
- Route ↓/L keyboard shortcut and swipe-down gesture to library drawer (not QAP) when `qapEnabled=false`
- Wire `lastSession`/`onResume` into `LibraryDrawer` in `AudioPlayer.tsx`
- Add `footer` prop to `PlaylistSelection` and render `ResumeCard` inside the `SelectionCard` when a previous session exists — sits below the grid naturally

## Test plan

- [ ] Open settings (gear icon) — QAP toggle visible without expanding Advanced
- [ ] Toggle QAP off → press ↓ or L → library drawer opens (not QAP)
- [ ] Toggle QAP on → press ↓ or L → QAP opens as before
- [ ] Reload with QAP off and a saved session → ResumeCard appears below playlist grid
- [ ] Tap ResumeCard → previous session resumes
- [ ] All 908 tests pass