### PR TITLE
feat: show liked heart indicator on queue track rows

### DIFF
--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -17,6 +17,7 @@ import {
   TrackName,
   TrackArtist,
   Duration,
+  LikedIndicator,
   DragHandle,
   RemoveButton,
   SwipeableWrapper,
@@ -156,7 +157,7 @@ function useQueueItemContextMenu(
       : []),
   ];
 
-  return { menu, closeMenu, handleContextMenu, longPressHandlers, options };
+  return { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack };
 }
 
 export const SortableQueueItem = memo<QueueItemProps>(({
@@ -199,7 +200,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index]);
 
-  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack } = useQueueItemContextMenu(
     track, index, isSelected, onSelect, onRemove, onPlayNext
   );
 
@@ -248,6 +249,12 @@ export const SortableQueueItem = memo<QueueItemProps>(({
           {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
         </Duration>
 
+        {canSaveTrack && isLiked && (
+          <LikedIndicator aria-label="Liked">
+            <HeartIcon filled />
+          </LikedIndicator>
+        )}
+
         {isEditMode && onRemove && !isSelected && (
           <RemoveButton onClick={handleRemoveClick} aria-label={`Remove ${track.name}`}>
             <RemoveIcon />
@@ -294,7 +301,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index, reset]);
 
-  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack } = useQueueItemContextMenu(
     track, index, isSelected, onSelect, onRemove, onPlayNext
   );
 
@@ -337,6 +344,12 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
           <Duration isSelected={isSelected}>
             {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
           </Duration>
+
+          {canSaveTrack && isLiked && (
+            <LikedIndicator aria-label="Liked">
+              <HeartIcon filled />
+            </LikedIndicator>
+          )}
         </QueueListItem>
 
         {menu && (
@@ -399,6 +412,12 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             <Duration isSelected={isSelected}>
               {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
             </Duration>
+
+            {canSaveTrack && isLiked && (
+              <LikedIndicator aria-label="Liked">
+                <HeartIcon filled />
+              </LikedIndicator>
+            )}
           </QueueListItem>
         </SwipeableContent>
       </SwipeableWrapper>

--- a/src/components/QueueTrackList.styled.ts
+++ b/src/components/QueueTrackList.styled.ts
@@ -157,6 +157,15 @@ export const Duration = styled.span.withConfig({
   flex-shrink: 0;
 `;
 
+export const LikedIndicator = styled.span`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  color: var(--accent-color);
+  opacity: 0.85;
+  line-height: 1;
+`;
+
 export const DragHandle = styled.div`
   flex-shrink: 0;
   cursor: grab;

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -1,8 +1,9 @@
 import { memo, useRef, useEffect, useCallback, useState } from 'react';
-import type { MediaTrack } from '@/types/domain';
+import type { MediaTrack, ProviderId } from '@/types/domain';
 import { formatDuration } from '@/utils/formatDuration';
 import { Avatar } from '../components/styled';
 import ProviderIcon from './ProviderIcon';
+import { useLikeTrack } from '@/hooks/useLikeTrack';
 import {
   DndContext,
   closestCenter,
@@ -35,7 +36,33 @@ import {
   TrackName,
   TrackArtist,
   Duration,
+  LikedIndicator,
 } from './QueueTrackList.styled';
+
+const FilledHeartIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    width="12"
+    height="12"
+  >
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
+const TrackLikedIndicator = memo(({ trackId, provider }: { trackId: string; provider?: ProviderId }) => {
+  const { isLiked, canSaveTrack } = useLikeTrack(trackId, provider);
+  if (!canSaveTrack || !isLiked) return null;
+  return (
+    <LikedIndicator aria-label="Liked">
+      <FilledHeartIcon />
+    </LikedIndicator>
+  );
+});
 
 interface QueueTrackListProps {
   tracks: MediaTrack[];
@@ -272,6 +299,8 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   <Duration isSelected={index === currentTrackIndex}>
                     {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
                   </Duration>
+
+                  <TrackLikedIndicator trackId={track.id} provider={track.provider} />
                 </QueueListItem>
               ))}
             </QueueListItems>


### PR DESCRIPTION
## Summary

- Renders a small filled heart icon next to the duration of liked tracks in the queue view (`QueueTrackList` / `QueueTrackItem`)
- Passive indicator only — no toggle or click interaction
- Reuses the existing `HeartIcon` component and `useLikeTrack` hook already in `QueueTrackItem.tsx`
- Respects the `canSaveTrack` capability flag, so the indicator only appears for providers that support saved tracks (Spotify, Dropbox)
- Covers all three queue render paths: `SortableQueueItem`, `SwipeableQueueItem`, and the read-only fallback path in `QueueTrackList`

## Test plan

- [ ] TypeScript compiles clean (`npx tsc -b --noEmit`)
- [ ] All 884 existing tests pass (`npm run test:run`)
- [ ] Load a queue with liked Spotify tracks — filled heart appears next to the track duration
- [ ] Load a queue with liked Dropbox tracks — same behaviour
- [ ] Unlike a track via the context menu heart — indicator disappears from the row
- [ ] Un-liked tracks show no indicator
- [ ] Providers without `hasSaveTrack` (if any) show no indicator

Closes #782