### PR TITLE
feat: persist playback position and seek on session resume

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -94,6 +94,7 @@ const AudioPlayerComponent = () => {
     currentTrack?.name,
     currentTrack?.artists,
     currentTrack?.image,
+    state.playbackPosition,
   );
 
   const handleAlbumPlay = useCallback((albumId: string) => {
@@ -183,9 +184,9 @@ const AudioPlayerComponent = () => {
     setShowVisualEffects(false);
   }, [setShowVisualEffects]);
 
-  const handleResume = useCallback(() => {
+  const handleResume = useCallback(async () => {
     if (!lastSession?.queueTracks?.length) return;
-    const { queueTracks, trackId, trackIndex, collectionId } = lastSession;
+    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPosition } = lastSession;
     const targetIdx = trackId
       ? queueTracks.findIndex(t => t.id === trackId)
       : Math.min(trackIndex, queueTracks.length - 1);
@@ -198,8 +199,17 @@ const AudioPlayerComponent = () => {
     // the right track before React re-renders. Required for iOS Safari, which
     // blocks audio.play() called outside the synchronous user-gesture call stack.
     mediaTracksRef.current = queueTracks;
-    handlers.playTrack(resolvedIdx);
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers]);
+    await handlers.playTrack(resolvedIdx);
+
+    if (savedPosition && savedPosition > 0) {
+      const drivingProviderId = playbackProviderRef.current;
+      if (drivingProviderId) {
+        const { providerRegistry } = await import('@/providers/registry');
+        const descriptor = providerRegistry.get(drivingProviderId);
+        descriptor?.playback.seek(savedPosition * 1000).catch(() => {});
+      }
+    }
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers, playbackProviderRef]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -1,10 +1,11 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { saveSession, loadSession } from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { logSession } from '@/lib/debugLog';
 
 const DEBOUNCE_MS = 1000;
+const PERIODIC_SAVE_INTERVAL_MS = 20_000;
 
 export function useSessionPersistence(
   collectionId: string | null,
@@ -16,10 +17,16 @@ export function useSessionPersistence(
   trackTitle: string | undefined,
   trackArtist: string | undefined,
   trackImage: string | undefined,
+  playbackPosition: number,
 ): { lastSession: SessionSnapshot | null } {
   const [lastSession, setLastSession] = useState<SessionSnapshot | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const hasLoadedRef = useRef(false);
+
+  // Keep a ref to the latest snapshot data so beforeunload and interval can
+  // access current values without capturing stale closure state.
+  const snapshotRef = useRef<SessionSnapshot | null>(null);
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
@@ -32,40 +39,85 @@ export function useSessionPersistence(
     setLastSession(loaded);
   }, []);
 
+  const buildSnapshot = useCallback((): SessionSnapshot | null => {
+    if (!collectionId || tracks.length === 0) return null;
+    return {
+      collectionId,
+      collectionName,
+      collectionProvider,
+      trackIndex: currentTrackIndex,
+      trackId,
+      queueTracks: tracks,
+      trackTitle,
+      trackArtist,
+      trackImage,
+      playbackPosition,
+    };
+  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
+
+  // Keep snapshotRef in sync so event-driven saves (beforeunload, interval) are always fresh.
+  useEffect(() => {
+    snapshotRef.current = buildSnapshot();
+  }, [buildSnapshot]);
+
+  // Debounced save on any state change.
   useEffect(() => {
     if (!collectionId || tracks.length === 0) {
       logSession('skipping save — no collectionId or empty tracks');
       return;
     }
 
-    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, queueLength=%d',
-      collectionId, collectionProvider, currentTrackIndex, tracks.length
+    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+      collectionId, collectionProvider, currentTrackIndex, Math.floor(playbackPosition), tracks.length
     );
 
     if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
 
     debounceTimerRef.current = setTimeout(() => {
-      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, queueLength=%d',
-        collectionId, collectionProvider, currentTrackIndex, tracks.length
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+        snapshot.collectionId, snapshot.collectionProvider, snapshot.trackIndex, Math.floor(snapshot.playbackPosition ?? 0), snapshot.queueTracks?.length
       );
-      saveSession({
-        collectionId,
-        collectionName,
-        collectionProvider,
-        trackIndex: currentTrackIndex,
-        trackId,
-        queueTracks: tracks,
-        trackTitle,
-        trackArtist,
-        trackImage,
-      });
+      saveSession(snapshot);
       logSession('save complete');
     }, DEBOUNCE_MS);
 
     return () => {
       if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
     };
-  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage]);
+  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
+
+  // Periodic save every 20 seconds during active playback.
+  useEffect(() => {
+    if (periodicTimerRef.current !== null) clearInterval(periodicTimerRef.current);
+
+    periodicTimerRef.current = setInterval(() => {
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('periodic save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      saveSession(snapshot);
+    }, PERIODIC_SAVE_INTERVAL_MS);
+
+    return () => {
+      if (periodicTimerRef.current !== null) clearInterval(periodicTimerRef.current);
+    };
+  }, []);
+
+  // Save on tab close / page unload.
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('beforeunload save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      saveSession(snapshot);
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
 
   return { lastSession };
 }

--- a/src/services/__tests__/sessionPersistence.test.ts
+++ b/src/services/__tests__/sessionPersistence.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveSession, loadSession, clearSession } from '../sessionPersistence';
+import type { SessionSnapshot } from '../sessionPersistence';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+const baseSnapshot: SessionSnapshot = {
+  collectionId: 'col-1',
+  collectionName: 'Test Album',
+  trackIndex: 2,
+  trackId: 'track-abc',
+  trackTitle: 'My Track',
+  trackArtist: 'Artist Name',
+};
+
+describe('sessionPersistence', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+    localStorageMock.clear();
+  });
+
+  describe('saveSession / loadSession', () => {
+    it('persists and restores playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 42.5 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBe(42.5);
+    });
+
+    it('loads session with undefined playbackPosition when not saved', () => {
+      // #given
+      saveSession(baseSnapshot);
+
+      // #when
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBeUndefined();
+    });
+
+    it('persists zero playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 0 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBe(0);
+    });
+
+    it('sets savedAt timestamp on save', () => {
+      // #given
+      const before = Date.now();
+
+      // #when
+      saveSession(baseSnapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.savedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it('returns null when nothing is saved', () => {
+      // #when
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded).toBeNull();
+    });
+
+    it('round-trips all core fields including playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = {
+        ...baseSnapshot,
+        collectionProvider: 'spotify',
+        playbackPosition: 123.456,
+      };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.collectionId).toBe('col-1');
+      expect(loaded?.trackIndex).toBe(2);
+      expect(loaded?.collectionProvider).toBe('spotify');
+      expect(loaded?.playbackPosition).toBe(123.456);
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes persisted session', () => {
+      // #given
+      saveSession({ ...baseSnapshot, playbackPosition: 10 });
+
+      // #when
+      clearSession();
+
+      // #then
+      expect(loadSession()).toBeNull();
+    });
+  });
+});

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -15,6 +15,8 @@ export interface SessionSnapshot {
   trackArtist?: string;
   trackImage?: string;
   savedAt?: number;
+  /** Playback position in seconds at the time the session was saved. */
+  playbackPosition?: number;
 }
 
 /** Strip Dropbox image URLs — presigned and large. playbackRef is a permanent path, keep it. */


### PR DESCRIPTION
## Summary

- Adds `playbackPosition` (in seconds) to `SessionSnapshot` — fully backward-compatible; old sessions without the field resume from the start as before
- `useSessionPersistence` now accepts `playbackPosition` and saves it on every debounced change, every 20 s via a periodic interval, and immediately on `beforeunload`
- A `snapshotRef` keeps interval/beforeunload writers always in sync with the freshest position without stale closures
- `handleResume` in `AudioPlayer` awaits `playTrack()` then calls `descriptor.playback.seek(savedPosition * 1000)` on the driving provider — works for both Spotify (`seek()` via REST API) and Dropbox (HTML5 `audio.currentTime`)

## Test plan

- [x] `npm run test:run` — 891 tests pass (69 test files)
- [x] `npx tsc -b --noEmit` — no type errors
- [x] New unit tests in `src/services/__tests__/sessionPersistence.test.ts` cover round-trip persistence of `playbackPosition`, zero value, and undefined when absent

Closes #788