### PR TITLE
feat: add Resume label to ResumeCard on initial load

### DIFF
--- a/src/components/QuickAccessPanel/ResumeCard.tsx
+++ b/src/components/QuickAccessPanel/ResumeCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import {
+  ResumeLabel,
   ResumeCardRoot,
   ResumeArt,
   ResumeText,
@@ -15,24 +16,27 @@ interface ResumeCardProps {
 }
 
 const ResumeCard: React.FC<ResumeCardProps> = ({ session, onResume }) => (
-  <ResumeCardRoot onClick={onResume} aria-label={`Resume: ${session.trackTitle ?? session.collectionName}`}>
-    <ResumeArt>
-      {session.trackImage ? (
-        <img src={session.trackImage} alt={session.collectionName} loading="lazy" />
-      ) : (
-        <span style={{ fontSize: '1.2rem' }}>♪</span>
-      )}
-    </ResumeArt>
-    <ResumeText>
-      <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
-      <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
-    </ResumeText>
-    <ResumePlayButton aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="currentColor">
-        <path d="M8 5v14l11-7z" />
-      </svg>
-    </ResumePlayButton>
-  </ResumeCardRoot>
+  <>
+    <ResumeLabel>Pick up where you left off</ResumeLabel>
+    <ResumeCardRoot onClick={onResume} aria-label={`Resume: ${session.trackTitle ?? session.collectionName}`}>
+      <ResumeArt>
+        {session.trackImage ? (
+          <img src={session.trackImage} alt={session.collectionName} loading="lazy" />
+        ) : (
+          <span style={{ fontSize: '1.2rem' }}>♪</span>
+        )}
+      </ResumeArt>
+      <ResumeText>
+        <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
+        <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
+      </ResumeText>
+      <ResumePlayButton aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      </ResumePlayButton>
+    </ResumeCardRoot>
+  </>
 );
 
 export default ResumeCard;

--- a/src/components/QuickAccessPanel/styled.ts
+++ b/src/components/QuickAccessPanel/styled.ts
@@ -23,6 +23,14 @@ export const PanelRoot = styled.div`
   animation: ${fadeIn} 0.25s ease-out;
 `;
 
+export const ResumeLabel = styled.div`
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.medium};
+  color: rgba(255, 255, 255, 0.5);
+  padding: ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.xs};
+  flex-shrink: 0;
+`;
+
 export const ResumeCardRoot = styled.button`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Adds a "Pick up where you left off" label above the ResumeCard component
- Styled with muted text (`rgba(255,255,255,0.5)`) using existing theme tokens
- Visible in both QAP and LibraryDrawer contexts

Closes #787

## Test plan
- [ ] Verify label appears above ResumeCard on initial load (library browser)
- [ ] Verify label appears in QAP when enabled
- [ ] Verify styling is subtle and doesn't dominate the card