### PR TITLE
feat: add Play Liked and Queue Liked to collection context menu

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -136,6 +136,31 @@ const AudioPlayerComponent = () => {
     [handlers, setShowQueue],
   );
 
+  const handlePlayLikedTracks = useCallback(
+    async (likedTracks: import('@/types/domain').MediaTrack[], collectionId: string, collectionName: string, provider?: import('@/types/domain').ProviderId) => {
+      collectionNameRef.current = collectionName;
+      collectionProviderRef.current = provider;
+      await handlers.playTracksDirectly(likedTracks, collectionId, provider);
+    },
+    [handlers],
+  );
+
+  const handleQueueLikedTracks = useCallback(
+    (likedTracks: import('@/types/domain').MediaTrack[], collectionName?: string) => {
+      const result = handlers.queueTracksDirectly(likedTracks, collectionName);
+      if (result && result.added > 0) {
+        const title = result.collectionName?.trim();
+        const label = title ? `"${title}"` : 'this collection';
+        setQapToast({
+          message: `Added ${result.added} liked ${result.added === 1 ? 'track' : 'tracks'} from ${label} to your`,
+          actionLabel: 'queue',
+          onAction: () => { setShowQueue(true); setQapToast(null); },
+        });
+      }
+    },
+    [handlers, setShowQueue],
+  );
+
   const playbackHandlers = useMemo(() => ({
     onPlay: handlers.handlePlay,
     onPause: handlers.handlePause,
@@ -147,6 +172,8 @@ const AudioPlayerComponent = () => {
     onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
     onPlaylistSelect: handlePlaylistSelect,
     onAddToQueue: handlers.handleAddToQueue,
+    onPlayLikedTracks: handlePlayLikedTracks,
+    onQueueLikedTracks: handleQueueLikedTracks,
     onAlbumPlay: handleAlbumPlay,
     onBackToLibrary: handleOpenQuickAccessPanel,
     onStartRadio: handlers.handleStartRadio,
@@ -241,6 +268,8 @@ const AudioPlayerComponent = () => {
               tracks={tracks}
               onPlaylistSelect={handlePlaylistSelect}
               onAddToQueue={handleAddToQueueFromPanel}
+              onPlayLikedTracks={handlePlayLikedTracks}
+              onQueueLikedTracks={handleQueueLikedTracks}
               lastSession={lastSession}
               onResume={handleResume}
             />
@@ -362,6 +391,8 @@ const AudioPlayerComponent = () => {
                 onClose={handlers.handleCloseLibraryDrawer}
                 onPlaylistSelect={handlePlaylistSelect}
                 onAddToQueue={handleAddToQueueFromPanel}
+                onPlayLikedTracks={handlePlayLikedTracks}
+                onQueueLikedTracks={handleQueueLikedTracks}
                 lastSession={lastSession}
                 onResume={handleResume}
               />

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -13,7 +13,7 @@ import {
 import PlaylistSelection from './PlaylistSelection';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 const REFRESH_SPINNER_MIN_MS = 1500;
@@ -27,6 +27,8 @@ interface LibraryDrawerProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   initialSearchQuery?: string;
   initialViewMode?: 'playlists' | 'albums';
   lastSession?: SessionSnapshot | null;
@@ -85,7 +87,7 @@ const DrawerContent = styled.div`
   padding-top: env(safe-area-inset-top, 0px);
 `;
 
-const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode, lastSession, onResume }: LibraryDrawerProps) {
+const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, initialSearchQuery, initialViewMode, lastSession, onResume }: LibraryDrawerProps) {
   const hasBeenOpenedRef = useRef(false);
   if (isOpen) hasBeenOpenedRef.current = true;
 
@@ -151,6 +153,8 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
               <PlaylistSelection
                 onPlaylistSelect={handlePlaylistSelectWrapper}
                 onAddToQueue={onAddToQueue}
+                onPlayLikedTracks={onPlayLikedTracks}
+                onQueueLikedTracks={onQueueLikedTracks}
                 inDrawer
                 initialSearchQuery={initialSearchQuery}
                 initialViewMode={initialViewMode}

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -48,6 +48,8 @@ interface DrawerOrchestratorProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   onTrackSelect: (index: number) => void;
   onRemoveFromQueue?: (index: number) => void;
   onReorderQueue?: (fromIndex: number, toIndex: number) => void;
@@ -71,6 +73,8 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
   onCloseLibraryDrawer,
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   onTrackSelect,
   onRemoveFromQueue,
   onReorderQueue,
@@ -208,6 +212,8 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
           onClose={handleCloseLibrary}
           onPlaylistSelect={onPlaylistSelect}
           onAddToQueue={handleAddToQueueWithToast}
+          onPlayLikedTracks={onPlayLikedTracks}
+          onQueueLikedTracks={onQueueLikedTracks}
           initialSearchQuery={librarySearchQuery}
           initialViewMode={libraryViewMode}
         />

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -26,6 +26,8 @@ export interface PlaybackHandlers {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   onAlbumPlay: (albumId: string, albumName: string) => void;
   onBackToLibrary: () => void;
   onStartRadio?: () => void;
@@ -241,6 +243,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
         onCloseLibraryDrawer={handleCloseLibraryDrawer}
         onPlaylistSelect={handlers.onPlaylistSelect}
         onAddToQueue={handlers.onAddToQueue}
+        onPlayLikedTracks={handlers.onPlayLikedTracks}
+        onQueueLikedTracks={handlers.onQueueLikedTracks}
         onTrackSelect={handlers.onTrackSelect}
         onRemoveFromQueue={handlers.onRemoveFromQueue}
         onReorderQueue={handlers.onReorderQueue}

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -173,6 +173,8 @@ interface PlayerStateRendererProps {
   tracks: MediaTrack[];
   onPlaylistSelect: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
   onAddToQueue: (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => void;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: import('@/types/domain').ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   lastSession: SessionSnapshot | null;
   onResume: () => void;
 }
@@ -184,6 +186,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   tracks,
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   lastSession,
   onResume,
 }) => {
@@ -278,6 +282,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
         }>
           <PlaylistSelection
             onPlaylistSelect={handlePlaylistSelectWrapped}
+            onPlayLikedTracks={onPlayLikedTracks}
+            onQueueLikedTracks={onQueueLikedTracks}
             footer={lastSession && onResume ? (
               <ResumeCard session={lastSession} onResume={onResume} />
             ) : undefined}

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -15,7 +15,7 @@ import { usePinnedItems } from '../../hooks/usePinnedItems';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { logQueue } from '@/lib/debugLog';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import {
   Container,
@@ -36,6 +36,8 @@ interface PlaylistSelectionProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   /** When true, uses compact layout for drawer context (no centering, fills available space) */
   inDrawer?: boolean;
   /** Ref for swipe-to-close gesture zone (search/filters area only, not the scrollable list) */
@@ -55,6 +57,8 @@ interface PlaylistSelectionProps {
 const PlaylistSelection = React.memo(function PlaylistSelection({
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   inDrawer = false,
   swipeZoneRef,
   initialSearchQuery,
@@ -107,6 +111,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   } = useItemActions({
     onPlaylistSelect,
     onAddToQueue,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
     activeDescriptor: activeDescriptor ?? null,
     getDescriptor,
     removeCollection,

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
-import { LIKED_SONGS_ID, isAlbumId, isSavedPlaylistId, extractPlaylistPath } from '@/constants/playlist';
+import { LIKED_SONGS_ID, isAlbumId, isSavedPlaylistId, extractPlaylistPath, resolvePlaylistRef } from '@/constants/playlist';
 import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { toAlbumPlaylistId } from '@/constants/playlist';
 import TrackInfoPopover, {
@@ -14,6 +14,7 @@ import TrackInfoPopover, {
   AddToLibraryIcon,
   RemoveFromLibraryIcon,
   AddToQueueIcon,
+  HeartIcon,
   TrashIcon,
   ICON_MAP,
 } from '../controls/TrackInfoPopover';
@@ -33,14 +34,36 @@ type PlaylistPopoverState = {
 interface UseItemActionsProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue?: (playlistId: string, playlistName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   activeDescriptor: ProviderDescriptor | null;
   getDescriptor: (id: ProviderId) => ProviderDescriptor | undefined;
   removeCollection: (id: string) => void;
 }
 
+async function fetchLikedTracksForCollection(
+  collectionId: string,
+  descriptor: ProviderDescriptor,
+): Promise<MediaTrack[]> {
+  const providerId = descriptor.id;
+  const { id, kind } = resolvePlaylistRef(collectionId, providerId);
+  const collectionRef = { provider: providerId, kind, id } as const;
+  const allTracks = await descriptor.catalog.listTracks(collectionRef);
+
+  if (!descriptor.catalog.isTrackSaved) return [];
+
+  const savedResults = await Promise.all(
+    allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false))
+  );
+
+  return allTracks.filter((_, i) => savedResults[i]);
+}
+
 export function useItemActions({
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   activeDescriptor,
   getDescriptor,
   removeCollection,
@@ -49,6 +72,7 @@ export function useItemActions({
   const [playlistPopover, setPlaylistPopover] = useState<PlaylistPopoverState>(null);
   const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string; provider?: ProviderId } | null>(null);
+  const [likedLoading, setLikedLoading] = useState(false);
 
   useEffect(() => {
     if (!albumPopover) {
@@ -98,6 +122,10 @@ export function useItemActions({
   const buildPlaylistPopoverOptions = useCallback(() => {
     if (!playlistPopover) return [];
     const playlist = playlistPopover.playlist;
+    const provider = playlist.provider ?? activeDescriptor?.id;
+    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
+    const canSaveTrack = descriptor?.capabilities.hasSaveTrack && !!descriptor.catalog.isTrackSaved;
+
     const options: Array<{ label: string; icon: React.ReactNode; onClick: () => void }> = [
       {
         label: `Play ${playlist.name}`,
@@ -114,8 +142,44 @@ export function useItemActions({
       });
     }
 
-    const provider = playlist.provider ?? activeDescriptor?.id;
-    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
+    if (canSaveTrack && onPlayLikedTracks && descriptor) {
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Play Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(playlist.id, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                return onPlayLikedTracks(likedTracks, playlist.id, playlist.name, playlist.provider);
+              }
+            })
+            .catch((err) => { console.error('[PlayLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
+    if (canSaveTrack && onQueueLikedTracks && descriptor) {
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Queue Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(playlist.id, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                onQueueLikedTracks(likedTracks, playlist.name);
+              }
+            })
+            .catch((err) => { console.error('[QueueLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
     const canDelete = descriptor?.capabilities.hasDeleteCollection &&
       descriptor.catalog.deleteCollection &&
       playlist.id !== LIKED_SONGS_ID &&
@@ -130,7 +194,7 @@ export function useItemActions({
     }
 
     return options;
-  }, [playlistPopover, onPlaylistSelect, onAddToQueue, activeDescriptor, getDescriptor]);
+  }, [playlistPopover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading]);
 
   const closeAlbumPopover = useCallback(() => {
     setAlbumPopover(null);
@@ -143,6 +207,8 @@ export function useItemActions({
     const capabilities = descriptor?.capabilities;
     const catalog = descriptor?.catalog;
     const ExternalIcon = descriptor?.getExternalUrl ? DiscogsIcon : SpotifyIcon;
+    const canSaveTrack = capabilities?.hasSaveTrack && !!catalog?.isTrackSaved;
+
     const options: Array<{ label: string; icon: React.ReactNode; onClick: () => void }> = [
       {
         label: `Play ${album.name}`,
@@ -156,6 +222,46 @@ export function useItemActions({
         label: 'Add to Queue',
         icon: React.createElement(AddToQueueIcon),
         onClick: () => onAddToQueue(toAlbumPlaylistId(album.id), album.name, album.provider),
+      });
+    }
+
+    if (canSaveTrack && onPlayLikedTracks && descriptor) {
+      const albumCollectionId = toAlbumPlaylistId(album.id);
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Play Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(albumCollectionId, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                return onPlayLikedTracks(likedTracks, albumCollectionId, album.name, album.provider);
+              }
+            })
+            .catch((err) => { console.error('[PlayLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
+    if (canSaveTrack && onQueueLikedTracks && descriptor) {
+      const albumCollectionId = toAlbumPlaylistId(album.id);
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Queue Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(albumCollectionId, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                onQueueLikedTracks(likedTracks, album.name);
+              }
+            })
+            .catch((err) => { console.error('[QueueLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
       });
     }
 
@@ -217,7 +323,7 @@ export function useItemActions({
     }
 
     return options;
-  }, [albumPopover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue]);
+  }, [albumPopover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -176,6 +176,12 @@ export const AddToQueueIcon = () => (
   </svg>
 );
 
+export const HeartIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
 export const ICON_MAP: Record<string, React.FC> = {
   discogs: DiscogsIcon,
   musicbrainz: MusicBrainzIcon,

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -25,6 +25,7 @@ interface UseCollectionLoaderProps {
 
 interface UseCollectionLoaderReturn {
   loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
+  playTracksDirectly: (tracks: MediaTrack[], collectionId: string, provider?: ProviderId) => Promise<number>;
 }
 
 export function useCollectionLoader({
@@ -206,7 +207,53 @@ export function useCollectionLoader({
     ]
   );
 
+  const playTracksDirectly = useCallback(
+    async (tracks: MediaTrack[], collectionId: string, provider?: ProviderId): Promise<number> => {
+      if (radioStateIsActive) stopRadioBase();
+
+      const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
+      const targetProviderId = provider ?? activeDescriptor?.id;
+
+      if (targetDescriptor && activeDescriptor && activeDescriptor.id !== targetDescriptor.id) {
+        activeDescriptor.playback.pause().catch(() => {});
+      }
+
+      setError(null);
+      setIsLoading(true);
+      setSelectedPlaylistId(collectionId);
+      mediaTracksRef.current = [];
+
+      if (tracks.length === 0) {
+        setTracks([]);
+        setOriginalTracks([]);
+        setCurrentTrackIndex(0);
+        setIsLoading(false);
+        return 0;
+      }
+
+      applyTracks(tracks);
+
+      if (targetProviderId) {
+        drivingProviderRef.current = targetProviderId;
+        if (targetProviderId !== activeDescriptor?.id) {
+          setActiveProviderId(targetProviderId);
+        }
+      }
+
+      queueSnapshot('Direct tracks loaded', tracks, mediaTracksRef.current.length, 0);
+      await playTrack(0);
+      return tracks.length;
+    },
+    [
+      radioStateIsActive, stopRadioBase, getDescriptor, activeDescriptor,
+      setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef,
+      setTracks, setOriginalTracks, setCurrentTrackIndex,
+      applyTracks, drivingProviderRef, setActiveProviderId, playTrack,
+    ]
+  );
+
   return {
     loadCollection,
+    playTracksDirectly,
   };
 }

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -117,7 +117,7 @@ export function usePlayerLogic() {
   });
 
   // Initialize collection loader
-  const { loadCollection } = useCollectionLoader({
+  const { loadCollection, playTracksDirectly } = useCollectionLoader({
     trackOps,
     activeDescriptor,
     getDescriptor,
@@ -271,7 +271,7 @@ export function usePlayerLogic() {
   }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowQueue, setShowVisualEffects]);
 
   // Initialize queue management handlers
-  const { handleAddToQueue, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
+  const { handleAddToQueue, queueTracksDirectly, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
     trackOps,
     tracks,
     currentTrackIndex,
@@ -287,7 +287,9 @@ export function usePlayerLogic() {
   const handlers = useMemo(
     () => ({
       loadCollection,
+      playTracksDirectly,
       handleAddToQueue,
+      queueTracksDirectly,
       handlePlay,
       handlePause,
       handleNext,
@@ -302,7 +304,9 @@ export function usePlayerLogic() {
     }),
     [
       loadCollection,
+      playTracksDirectly,
       handleAddToQueue,
+      queueTracksDirectly,
       handlePlay,
       handlePause,
       handleNext,

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -25,6 +25,7 @@ interface UseQueueManagementProps {
 
 interface UseQueueManagementReturn {
   handleAddToQueue: (playlistId: string, collectionName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  queueTracksDirectly: (tracks: MediaTrack[], collectionName?: string) => AddToQueueResult | null;
   handleRemoveFromQueue: (index: number) => void;
   handleReorderQueue: (fromIndex: number, toIndex: number) => void;
 }
@@ -183,8 +184,32 @@ export function useQueueManagement({
     [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex]
   );
 
+  const queueTracksDirectly = useCallback(
+    (newTracks: MediaTrack[], collectionName?: string): AddToQueueResult | null => {
+      if (newTracks.length === 0) return null;
+
+      const existingIds = new Set(tracksRef.current.map((t) => t.id));
+      const uniqueNewTracks = newTracks.filter((t) => !existingIds.has(t.id));
+
+      if (uniqueNewTracks.length === 0) return null;
+
+      logQueue(
+        'queueTracksDirectly — appending %d tracks. Before: tracks=%d, mediaRef=%d',
+        uniqueNewTracks.length,
+        tracksRef.current.length,
+        mediaTracksRef.current.length,
+      );
+      mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
+      setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+      setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+      return { added: uniqueNewTracks.length, collectionName };
+    },
+    [mediaTracksRef, setOriginalTracks, setTracks]
+  );
+
   return {
     handleAddToQueue,
+    queueTracksDirectly,
     handleRemoveFromQueue,
     handleReorderQueue,
   };


### PR DESCRIPTION
## Summary
- Adds "Play Liked" and "Queue Liked" actions to album/playlist context menus
- Fetches collection tracks, filters through `checkTrackSaved` batch API, then plays or queues only liked tracks
- New `playTracksDirectly` and `queueTracksDirectly` methods in collection loader and queue management hooks
- Works for both Spotify and Dropbox providers
- Options only shown when provider supports `hasSaveTrack`

Closes #781

## Test plan
- [ ] Right-click/long-press a collection → verify "Play Liked" and "Queue Liked" appear
- [ ] Play Liked with a collection containing liked tracks → only liked tracks play
- [ ] Queue Liked appends only liked tracks to existing queue
- [ ] Options hidden for providers without save track capability
- [ ] Loading state shown while checking liked status