### PR TITLE
Release: QAP opt-in, liked tracks features, queue indicators, session position

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ AppContainer (flexCenter, min-height: 100dvh)
 - **`100dvh`** throughout to handle iOS address bar changes
 - **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
 - **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle **queue** (up) and **library** (down) drawers (`QueueDrawer` / `QueueBottomSheet` vs `LibraryDrawer`)
+- **Idle/home view** — when no track is loaded, `PlayerStateRenderer` shows the library browser (`PlaylistSelection`) by default. The Quick Access Panel (QAP) is opt-in: toggled via the "Quick Access Panel" On/Off control in the settings panel (gear icon, `VisualEffectsMenu`). The preference is stored under the `vorbis-player-qap-enabled` localStorage key (default `false`) via `useQapEnabled()`. `PlayerStateRenderer` initializes `showLibrary` to `!qapEnabled` and routes accordingly.
+- **ResumeCard** — `LibraryDrawer` accepts `lastSession` and `onResume` props and renders a `ResumeCard` at the bottom of the drawer, allowing users to resume a previous session regardless of whether QAP is enabled.
 - **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout
 - **Zen mode overlays** (`ZenClickZoneOverlay`, `ZenLikeOverlay`): hover-activated on desktop (pointer devices only), hidden when flip menu is open (`isFlipped`), with vertical dead zones (top/bottom 20% of album art ignored). Mobile zen uses touch gestures instead (`useZenTouchGestures`). BottomBar in zen mode shows via grip pill tap with tap-outside-to-dismiss backdrop.
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -94,6 +94,7 @@ const AudioPlayerComponent = () => {
     currentTrack?.name,
     currentTrack?.artists,
     currentTrack?.image,
+    state.playbackPosition,
   );
 
   const handleAlbumPlay = useCallback((albumId: string) => {
@@ -183,9 +184,9 @@ const AudioPlayerComponent = () => {
     setShowVisualEffects(false);
   }, [setShowVisualEffects]);
 
-  const handleResume = useCallback(() => {
+  const handleResume = useCallback(async () => {
     if (!lastSession?.queueTracks?.length) return;
-    const { queueTracks, trackId, trackIndex, collectionId } = lastSession;
+    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPosition } = lastSession;
     const targetIdx = trackId
       ? queueTracks.findIndex(t => t.id === trackId)
       : Math.min(trackIndex, queueTracks.length - 1);
@@ -198,8 +199,17 @@ const AudioPlayerComponent = () => {
     // the right track before React re-renders. Required for iOS Safari, which
     // blocks audio.play() called outside the synchronous user-gesture call stack.
     mediaTracksRef.current = queueTracks;
-    handlers.playTrack(resolvedIdx);
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers]);
+    await handlers.playTrack(resolvedIdx);
+
+    if (savedPosition && savedPosition > 0) {
+      const drivingProviderId = playbackProviderRef.current;
+      if (drivingProviderId) {
+        const { providerRegistry } = await import('@/providers/registry');
+        const descriptor = providerRegistry.get(drivingProviderId);
+        descriptor?.playback.seek(savedPosition * 1000).catch(() => {});
+      }
+    }
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers, playbackProviderRef]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -137,6 +137,31 @@ const AudioPlayerComponent = () => {
     [handlers, setShowQueue],
   );
 
+  const handlePlayLikedTracks = useCallback(
+    async (likedTracks: import('@/types/domain').MediaTrack[], collectionId: string, collectionName: string, provider?: import('@/types/domain').ProviderId) => {
+      collectionNameRef.current = collectionName;
+      collectionProviderRef.current = provider;
+      await handlers.playTracksDirectly(likedTracks, collectionId, provider);
+    },
+    [handlers],
+  );
+
+  const handleQueueLikedTracks = useCallback(
+    (likedTracks: import('@/types/domain').MediaTrack[], collectionName?: string) => {
+      const result = handlers.queueTracksDirectly(likedTracks, collectionName);
+      if (result && result.added > 0) {
+        const title = result.collectionName?.trim();
+        const label = title ? `"${title}"` : 'this collection';
+        setQapToast({
+          message: `Added ${result.added} liked ${result.added === 1 ? 'track' : 'tracks'} from ${label} to your`,
+          actionLabel: 'queue',
+          onAction: () => { setShowQueue(true); setQapToast(null); },
+        });
+      }
+    },
+    [handlers, setShowQueue],
+  );
+
   const playbackHandlers = useMemo(() => ({
     onPlay: handlers.handlePlay,
     onPause: handlers.handlePause,
@@ -148,6 +173,8 @@ const AudioPlayerComponent = () => {
     onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
     onPlaylistSelect: handlePlaylistSelect,
     onAddToQueue: handlers.handleAddToQueue,
+    onPlayLikedTracks: handlePlayLikedTracks,
+    onQueueLikedTracks: handleQueueLikedTracks,
     onAlbumPlay: handleAlbumPlay,
     onBackToLibrary: handleOpenQuickAccessPanel,
     onStartRadio: handlers.handleStartRadio,
@@ -251,6 +278,8 @@ const AudioPlayerComponent = () => {
               tracks={tracks}
               onPlaylistSelect={handlePlaylistSelect}
               onAddToQueue={handleAddToQueueFromPanel}
+              onPlayLikedTracks={handlePlayLikedTracks}
+              onQueueLikedTracks={handleQueueLikedTracks}
               lastSession={lastSession}
               onResume={handleResume}
             />
@@ -372,6 +401,8 @@ const AudioPlayerComponent = () => {
                 onClose={handlers.handleCloseLibraryDrawer}
                 onPlaylistSelect={handlePlaylistSelect}
                 onAddToQueue={handleAddToQueueFromPanel}
+                onPlayLikedTracks={handlePlayLikedTracks}
+                onQueueLikedTracks={handleQueueLikedTracks}
                 lastSession={lastSession}
                 onResume={handleResume}
               />

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -362,6 +362,8 @@ const AudioPlayerComponent = () => {
                 onClose={handlers.handleCloseLibraryDrawer}
                 onPlaylistSelect={handlePlaylistSelect}
                 onAddToQueue={handleAddToQueueFromPanel}
+                lastSession={lastSession}
+                onResume={handleResume}
               />
             </Suspense>
           </>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -352,6 +352,8 @@ const AudioPlayerComponent = () => {
                 onProfilerToggle={() => {}}
                 visualizerDebugEnabled={false}
                 onVisualizerDebugToggle={() => {}}
+                qapEnabled={false}
+                onQapToggle={() => {}}
               />
             </Suspense>
             <Suspense fallback={null}>

--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -4,6 +4,7 @@ import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBac
 import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import {
   VisualEffectsIcon,
   BackToLibraryIcon,
@@ -50,6 +51,7 @@ const BottomBar = React.memo(function BottomBar({
   onOpenQuickAccessPanel,
 }: BottomBarProps) {
   const { isMobile, isTablet, isTouchDevice } = usePlayerSizingContext();
+  const [qapEnabled] = useQapEnabled();
   const [barVisible, setBarVisible] = useState(!zenModeEnabled);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const isHoveringRef = useRef(false);
@@ -175,7 +177,7 @@ const BottomBar = React.memo(function BottomBar({
             </ControlButton>
           )}
 
-          {onOpenQuickAccessPanel && (
+          {qapEnabled && onOpenQuickAccessPanel && (
             <ControlButton
               $isMobile={isMobile}
               $isTablet={isTablet}

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -11,8 +11,10 @@ import {
   DRAWER_TRANSITION_EASING
 } from './styled';
 import PlaylistSelection from './PlaylistSelection';
+import ResumeCard from './QuickAccessPanel/ResumeCard';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
 import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 const REFRESH_SPINNER_MIN_MS = 1500;
 
@@ -27,6 +29,8 @@ interface LibraryDrawerProps {
   ) => Promise<AddToQueueResult | null>;
   initialSearchQuery?: string;
   initialViewMode?: 'playlists' | 'albums';
+  lastSession?: SessionSnapshot | null;
+  onResume?: () => void;
 }
 
 const DrawerContainer = styled.div.withConfig({
@@ -81,7 +85,7 @@ const DrawerContent = styled.div`
   padding-top: env(safe-area-inset-top, 0px);
 `;
 
-const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode }: LibraryDrawerProps) {
+const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode, lastSession, onResume }: LibraryDrawerProps) {
   const hasBeenOpenedRef = useRef(false);
   if (isOpen) hasBeenOpenedRef.current = true;
 
@@ -153,6 +157,9 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
                 onLibraryRefresh={handleRefresh}
                 isLibraryRefreshing={isRefreshing}
               />
+              {lastSession && onResume && (
+                <ResumeCard session={lastSession} onResume={onResume} />
+              )}
             </DrawerContent>
             <SwipeHandle
               ref={handleRef}

--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -13,7 +13,7 @@ import {
 import PlaylistSelection from './PlaylistSelection';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 const REFRESH_SPINNER_MIN_MS = 1500;
@@ -27,6 +27,8 @@ interface LibraryDrawerProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   initialSearchQuery?: string;
   initialViewMode?: 'playlists' | 'albums';
   lastSession?: SessionSnapshot | null;
@@ -85,7 +87,7 @@ const DrawerContent = styled.div`
   padding-top: env(safe-area-inset-top, 0px);
 `;
 
-const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, initialSearchQuery, initialViewMode, lastSession, onResume }: LibraryDrawerProps) {
+const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, initialSearchQuery, initialViewMode, lastSession, onResume }: LibraryDrawerProps) {
   const hasBeenOpenedRef = useRef(false);
   if (isOpen) hasBeenOpenedRef.current = true;
 
@@ -151,6 +153,8 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
               <PlaylistSelection
                 onPlaylistSelect={handlePlaylistSelectWrapper}
                 onAddToQueue={onAddToQueue}
+                onPlayLikedTracks={onPlayLikedTracks}
+                onQueueLikedTracks={onQueueLikedTracks}
                 inDrawer
                 initialSearchQuery={initialSearchQuery}
                 initialViewMode={initialViewMode}

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -48,6 +48,8 @@ interface DrawerOrchestratorProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   onTrackSelect: (index: number) => void;
   onRemoveFromQueue?: (index: number) => void;
   onReorderQueue?: (fromIndex: number, toIndex: number) => void;
@@ -71,6 +73,8 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
   onCloseLibraryDrawer,
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   onTrackSelect,
   onRemoveFromQueue,
   onReorderQueue,
@@ -208,6 +212,8 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
           onClose={handleCloseLibrary}
           onPlaylistSelect={onPlaylistSelect}
           onAddToQueue={handleAddToQueueWithToast}
+          onPlayLikedTracks={onPlayLikedTracks}
+          onQueueLikedTracks={onQueueLikedTracks}
           initialSearchQuery={librarySearchQuery}
           initialViewMode={libraryViewMode}
         />

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -17,6 +17,7 @@ import { clearCacheWithOptions } from '@/services/cache/libraryCache';
 import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/VisualEffectsMenu';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState } from '@/types/radio';
 import { LoadingCard, ZenControlsWrapper, ZenControlsInner } from './styled';
@@ -135,6 +136,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const { enabled: profilerEnabled, toggle: profilerToggle } = useProfilingContext();
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
+  const [qapEnabled, setQapEnabled] = useQapEnabled();
 
   const settingsHasBeenOpenedRef = useRef(false);
   if (showVisualEffects) settingsHasBeenOpenedRef.current = true;
@@ -345,6 +347,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
             onProfilerToggle={handleProfilerToggle}
             visualizerDebugEnabled={visualizerDebugEnabled}
             onVisualizerDebugToggle={handleVisualizerDebugToggle}
+            qapEnabled={qapEnabled}
+            onQapToggle={() => setQapEnabled(!qapEnabled)}
           />
         </Suspense>
       )}

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -237,15 +237,16 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   }, [showLibraryDrawer, showQueue, onShowQueue, onCloseQueue, onCloseLibraryDrawer]);
 
   const handleArrowDown = useCallback(() => {
+    const openPanel = qapEnabled ? onOpenQuickAccessPanel : onOpenLibraryDrawer;
     if (showQueue) {
       onCloseQueue();
-      onOpenQuickAccessPanel?.();
+      openPanel?.();
     } else if (showLibraryDrawer) {
       onCloseLibraryDrawer();
     } else {
-      onOpenQuickAccessPanel?.();
+      openPanel?.();
     }
-  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenQuickAccessPanel, onCloseLibraryDrawer]);
+  }, [showQueue, showLibraryDrawer, onCloseQueue, onOpenQuickAccessPanel, onOpenLibraryDrawer, onCloseLibraryDrawer, qapEnabled]);
 
   const handleVolumeUp = useCallback(() => {
     setVolumeLevel(Math.min(100, (volume ?? 50) + 5));

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
@@ -73,6 +74,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
 
   const [librarySearchQuery, setLibrarySearchQuery] = useState<string | undefined>(undefined);
   const [libraryViewMode, setLibraryViewMode] = useState<'playlists' | 'albums' | undefined>(undefined);
+  const [qapEnabled] = useQapEnabled();
 
   const controlsRef = useRef<HTMLDivElement>(null);
   const stableControlsHeightRef = useRef<number>(220);
@@ -155,12 +157,14 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
   const handleSwipeDown = useCallback(() => {
     if (showLibraryDrawer) {
       handlers.onCloseLibraryDrawer();
+    } else if (!qapEnabled) {
+      handleOpenLibraryDrawer();
     } else if (handlers.onOpenQuickAccessPanel) {
       handlers.onOpenQuickAccessPanel();
     } else {
       handleOpenLibraryDrawer();
     }
-  }, [showLibraryDrawer, handlers, handleOpenLibraryDrawer]);
+  }, [showLibraryDrawer, handlers, handleOpenLibraryDrawer, qapEnabled]);
 
   const handleLibrarySearchQueryReset = useCallback(() => setLibrarySearchQuery(undefined), []);
   const handleLibraryViewModeReset = useCallback(() => setLibraryViewMode(undefined), []);

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -26,6 +26,8 @@ export interface PlaybackHandlers {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   onAlbumPlay: (albumId: string, albumName: string) => void;
   onBackToLibrary: () => void;
   onStartRadio?: () => void;
@@ -241,6 +243,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
         onCloseLibraryDrawer={handleCloseLibraryDrawer}
         onPlaylistSelect={handlers.onPlaylistSelect}
         onAddToQueue={handlers.onAddToQueue}
+        onPlayLikedTracks={handlers.onPlayLikedTracks}
+        onQueueLikedTracks={handlers.onQueueLikedTracks}
         onTrackSelect={handlers.onTrackSelect}
         onRemoveFromQueue={handlers.onRemoveFromQueue}
         onReorderQueue={handlers.onReorderQueue}

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from '../components/styled';
 import { flexColumn, cardBase } from '../styles/utils';
 import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
 
 const PlaylistSelection = React.lazy(() => import('./PlaylistSelection'));
@@ -187,7 +188,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
-  const [showLibrary, setShowLibrary] = useState(false);
+  const [qapEnabled] = useQapEnabled();
+  const [showLibrary, setShowLibrary] = useState(!qapEnabled);
 
   const handleConnectClick = useCallback(() => {
     activeDescriptor?.auth.beginLogin();

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -10,6 +10,7 @@ import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
+import ResumeCard from './QuickAccessPanel/ResumeCard';
 
 const PlaylistSelection = React.lazy(() => import('./PlaylistSelection'));
 
@@ -275,7 +276,12 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
             </LoadingContainer>
           </LoadingCard>
         }>
-          <PlaylistSelection onPlaylistSelect={handlePlaylistSelectWrapped} />
+          <PlaylistSelection
+            onPlaylistSelect={handlePlaylistSelectWrapped}
+            footer={lastSession && onResume ? (
+              <ResumeCard session={lastSession} onResume={onResume} />
+            ) : undefined}
+          />
         </Suspense>
       );
     }

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -173,6 +173,8 @@ interface PlayerStateRendererProps {
   tracks: MediaTrack[];
   onPlaylistSelect: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
   onAddToQueue: (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => void;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: import('@/types/domain').ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   lastSession: SessionSnapshot | null;
   onResume: () => void;
 }
@@ -184,6 +186,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   tracks,
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   lastSession,
   onResume,
 }) => {
@@ -278,6 +282,8 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
         }>
           <PlaylistSelection
             onPlaylistSelect={handlePlaylistSelectWrapped}
+            onPlayLikedTracks={onPlayLikedTracks}
+            onQueueLikedTracks={onQueueLikedTracks}
             footer={lastSession && onResume ? (
               <ResumeCard session={lastSession} onResume={onResume} />
             ) : undefined}

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -48,6 +48,8 @@ interface PlaylistSelectionProps {
   onLibraryRefresh?: () => void;
   /** Drawer-only: controls the refresh spinner */
   isLibraryRefreshing?: boolean;
+  /** Optional element rendered below the grid inside the card */
+  footer?: React.ReactNode;
 }
 
 const PlaylistSelection = React.memo(function PlaylistSelection({
@@ -58,7 +60,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   initialSearchQuery,
   initialViewMode,
   onLibraryRefresh,
-  isLibraryRefreshing
+  isLibraryRefreshing,
+  footer,
 }: PlaylistSelectionProps): JSX.Element {
   const { activeDescriptor, hasMultipleProviders, enabledProviderIds, getDescriptor } = useProviderContext();
   const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
@@ -304,6 +307,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
             {playlistPopoverPortal}
             {confirmDeletePortal}
           </CardContent>
+          {footer}
         </SelectionCard>
       </Container>
     </LibraryProvider>

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -15,7 +15,7 @@ import { usePinnedItems } from '../../hooks/usePinnedItems';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { logQueue } from '@/lib/debugLog';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import {
   Container,
@@ -36,6 +36,8 @@ interface PlaylistSelectionProps {
     playlistName?: string,
     provider?: ProviderId,
   ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   /** When true, uses compact layout for drawer context (no centering, fills available space) */
   inDrawer?: boolean;
   /** Ref for swipe-to-close gesture zone (search/filters area only, not the scrollable list) */
@@ -55,6 +57,8 @@ interface PlaylistSelectionProps {
 const PlaylistSelection = React.memo(function PlaylistSelection({
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   inDrawer = false,
   swipeZoneRef,
   initialSearchQuery,
@@ -107,6 +111,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   } = useItemActions({
     onPlaylistSelect,
     onAddToQueue,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
     activeDescriptor: activeDescriptor ?? null,
     getDescriptor,
     removeCollection,

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
-import type { AddToQueueResult, ProviderId } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
-import { LIKED_SONGS_ID, isAlbumId, isSavedPlaylistId, extractPlaylistPath } from '@/constants/playlist';
+import { LIKED_SONGS_ID, isAlbumId, isSavedPlaylistId, extractPlaylistPath, resolvePlaylistRef } from '@/constants/playlist';
 import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { toAlbumPlaylistId } from '@/constants/playlist';
 import TrackInfoPopover, {
@@ -14,6 +14,7 @@ import TrackInfoPopover, {
   AddToLibraryIcon,
   RemoveFromLibraryIcon,
   AddToQueueIcon,
+  HeartIcon,
   TrashIcon,
   ICON_MAP,
 } from '../controls/TrackInfoPopover';
@@ -33,14 +34,36 @@ type PlaylistPopoverState = {
 interface UseItemActionsProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue?: (playlistId: string, playlistName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   activeDescriptor: ProviderDescriptor | null;
   getDescriptor: (id: ProviderId) => ProviderDescriptor | undefined;
   removeCollection: (id: string) => void;
 }
 
+async function fetchLikedTracksForCollection(
+  collectionId: string,
+  descriptor: ProviderDescriptor,
+): Promise<MediaTrack[]> {
+  const providerId = descriptor.id;
+  const { id, kind } = resolvePlaylistRef(collectionId, providerId);
+  const collectionRef = { provider: providerId, kind, id } as const;
+  const allTracks = await descriptor.catalog.listTracks(collectionRef);
+
+  if (!descriptor.catalog.isTrackSaved) return [];
+
+  const savedResults = await Promise.all(
+    allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false))
+  );
+
+  return allTracks.filter((_, i) => savedResults[i]);
+}
+
 export function useItemActions({
   onPlaylistSelect,
   onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
   activeDescriptor,
   getDescriptor,
   removeCollection,
@@ -49,6 +72,7 @@ export function useItemActions({
   const [playlistPopover, setPlaylistPopover] = useState<PlaylistPopoverState>(null);
   const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string; provider?: ProviderId } | null>(null);
+  const [likedLoading, setLikedLoading] = useState(false);
 
   useEffect(() => {
     if (!albumPopover) {
@@ -98,6 +122,10 @@ export function useItemActions({
   const buildPlaylistPopoverOptions = useCallback(() => {
     if (!playlistPopover) return [];
     const playlist = playlistPopover.playlist;
+    const provider = playlist.provider ?? activeDescriptor?.id;
+    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
+    const canSaveTrack = descriptor?.capabilities.hasSaveTrack && !!descriptor.catalog.isTrackSaved;
+
     const options: Array<{ label: string; icon: React.ReactNode; onClick: () => void }> = [
       {
         label: `Play ${playlist.name}`,
@@ -114,8 +142,44 @@ export function useItemActions({
       });
     }
 
-    const provider = playlist.provider ?? activeDescriptor?.id;
-    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
+    if (canSaveTrack && onPlayLikedTracks && descriptor) {
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Play Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(playlist.id, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                return onPlayLikedTracks(likedTracks, playlist.id, playlist.name, playlist.provider);
+              }
+            })
+            .catch((err) => { console.error('[PlayLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
+    if (canSaveTrack && onQueueLikedTracks && descriptor) {
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Queue Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(playlist.id, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                onQueueLikedTracks(likedTracks, playlist.name);
+              }
+            })
+            .catch((err) => { console.error('[QueueLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
     const canDelete = descriptor?.capabilities.hasDeleteCollection &&
       descriptor.catalog.deleteCollection &&
       playlist.id !== LIKED_SONGS_ID &&
@@ -130,7 +194,7 @@ export function useItemActions({
     }
 
     return options;
-  }, [playlistPopover, onPlaylistSelect, onAddToQueue, activeDescriptor, getDescriptor]);
+  }, [playlistPopover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading]);
 
   const closeAlbumPopover = useCallback(() => {
     setAlbumPopover(null);
@@ -143,6 +207,8 @@ export function useItemActions({
     const capabilities = descriptor?.capabilities;
     const catalog = descriptor?.catalog;
     const ExternalIcon = descriptor?.getExternalUrl ? DiscogsIcon : SpotifyIcon;
+    const canSaveTrack = capabilities?.hasSaveTrack && !!catalog?.isTrackSaved;
+
     const options: Array<{ label: string; icon: React.ReactNode; onClick: () => void }> = [
       {
         label: `Play ${album.name}`,
@@ -156,6 +222,46 @@ export function useItemActions({
         label: 'Add to Queue',
         icon: React.createElement(AddToQueueIcon),
         onClick: () => onAddToQueue(toAlbumPlaylistId(album.id), album.name, album.provider),
+      });
+    }
+
+    if (canSaveTrack && onPlayLikedTracks && descriptor) {
+      const albumCollectionId = toAlbumPlaylistId(album.id);
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Play Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(albumCollectionId, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                return onPlayLikedTracks(likedTracks, albumCollectionId, album.name, album.provider);
+              }
+            })
+            .catch((err) => { console.error('[PlayLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
+      });
+    }
+
+    if (canSaveTrack && onQueueLikedTracks && descriptor) {
+      const albumCollectionId = toAlbumPlaylistId(album.id);
+      options.push({
+        label: likedLoading ? 'Loading…' : 'Queue Liked',
+        icon: React.createElement(HeartIcon),
+        onClick: () => {
+          if (likedLoading) return;
+          setLikedLoading(true);
+          fetchLikedTracksForCollection(albumCollectionId, descriptor)
+            .then((likedTracks) => {
+              if (likedTracks.length > 0) {
+                onQueueLikedTracks(likedTracks, album.name);
+              }
+            })
+            .catch((err) => { console.error('[QueueLiked] Failed:', err); })
+            .finally(() => { setLikedLoading(false); });
+        },
       });
     }
 
@@ -217,7 +323,7 @@ export function useItemActions({
     }
 
     return options;
-  }, [albumPopover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue]);
+  }, [albumPopover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -17,6 +17,7 @@ import {
   TrackName,
   TrackArtist,
   Duration,
+  LikedIndicator,
   DragHandle,
   RemoveButton,
   SwipeableWrapper,
@@ -156,7 +157,7 @@ function useQueueItemContextMenu(
       : []),
   ];
 
-  return { menu, closeMenu, handleContextMenu, longPressHandlers, options };
+  return { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack };
 }
 
 export const SortableQueueItem = memo<QueueItemProps>(({
@@ -199,7 +200,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index]);
 
-  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack } = useQueueItemContextMenu(
     track, index, isSelected, onSelect, onRemove, onPlayNext
   );
 
@@ -248,6 +249,12 @@ export const SortableQueueItem = memo<QueueItemProps>(({
           {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
         </Duration>
 
+        {canSaveTrack && isLiked && (
+          <LikedIndicator aria-label="Liked">
+            <HeartIcon filled />
+          </LikedIndicator>
+        )}
+
         {isEditMode && onRemove && !isSelected && (
           <RemoveButton onClick={handleRemoveClick} aria-label={`Remove ${track.name}`}>
             <RemoveIcon />
@@ -294,7 +301,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
     onRemove?.(index);
   }, [onRemove, index, reset]);
 
-  const { menu, closeMenu, handleContextMenu, longPressHandlers, options } = useQueueItemContextMenu(
+  const { menu, closeMenu, handleContextMenu, longPressHandlers, options, isLiked, canSaveTrack } = useQueueItemContextMenu(
     track, index, isSelected, onSelect, onRemove, onPlayNext
   );
 
@@ -337,6 +344,12 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
           <Duration isSelected={isSelected}>
             {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
           </Duration>
+
+          {canSaveTrack && isLiked && (
+            <LikedIndicator aria-label="Liked">
+              <HeartIcon filled />
+            </LikedIndicator>
+          )}
         </QueueListItem>
 
         {menu && (
@@ -399,6 +412,12 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             <Duration isSelected={isSelected}>
               {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
             </Duration>
+
+            {canSaveTrack && isLiked && (
+              <LikedIndicator aria-label="Liked">
+                <HeartIcon filled />
+              </LikedIndicator>
+            )}
           </QueueListItem>
         </SwipeableContent>
       </SwipeableWrapper>

--- a/src/components/QueueTrackList.styled.ts
+++ b/src/components/QueueTrackList.styled.ts
@@ -157,6 +157,15 @@ export const Duration = styled.span.withConfig({
   flex-shrink: 0;
 `;
 
+export const LikedIndicator = styled.span`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  color: var(--accent-color);
+  opacity: 0.85;
+  line-height: 1;
+`;
+
 export const DragHandle = styled.div`
   flex-shrink: 0;
   cursor: grab;

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -1,8 +1,9 @@
 import { memo, useRef, useEffect, useCallback, useState } from 'react';
-import type { MediaTrack } from '@/types/domain';
+import type { MediaTrack, ProviderId } from '@/types/domain';
 import { formatDuration } from '@/utils/formatDuration';
 import { Avatar } from '../components/styled';
 import ProviderIcon from './ProviderIcon';
+import { useLikeTrack } from '@/hooks/useLikeTrack';
 import {
   DndContext,
   closestCenter,
@@ -35,7 +36,33 @@ import {
   TrackName,
   TrackArtist,
   Duration,
+  LikedIndicator,
 } from './QueueTrackList.styled';
+
+const FilledHeartIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    width="12"
+    height="12"
+  >
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
+const TrackLikedIndicator = memo(({ trackId, provider }: { trackId: string; provider?: ProviderId }) => {
+  const { isLiked, canSaveTrack } = useLikeTrack(trackId, provider);
+  if (!canSaveTrack || !isLiked) return null;
+  return (
+    <LikedIndicator aria-label="Liked">
+      <FilledHeartIcon />
+    </LikedIndicator>
+  );
+});
 
 interface QueueTrackListProps {
   tracks: MediaTrack[];
@@ -272,6 +299,8 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   <Duration isSelected={index === currentTrackIndex}>
                     {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
                   </Duration>
+
+                  <TrackLikedIndicator trackId={track.id} provider={track.provider} />
                 </QueueListItem>
               ))}
             </QueueListItems>

--- a/src/components/QuickAccessPanel/ResumeCard.tsx
+++ b/src/components/QuickAccessPanel/ResumeCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import {
+  ResumeLabel,
   ResumeCardRoot,
   ResumeArt,
   ResumeText,
@@ -15,24 +16,27 @@ interface ResumeCardProps {
 }
 
 const ResumeCard: React.FC<ResumeCardProps> = ({ session, onResume }) => (
-  <ResumeCardRoot onClick={onResume} aria-label={`Resume: ${session.trackTitle ?? session.collectionName}`}>
-    <ResumeArt>
-      {session.trackImage ? (
-        <img src={session.trackImage} alt={session.collectionName} loading="lazy" />
-      ) : (
-        <span style={{ fontSize: '1.2rem' }}>♪</span>
-      )}
-    </ResumeArt>
-    <ResumeText>
-      <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
-      <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
-    </ResumeText>
-    <ResumePlayButton aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="currentColor">
-        <path d="M8 5v14l11-7z" />
-      </svg>
-    </ResumePlayButton>
-  </ResumeCardRoot>
+  <>
+    <ResumeLabel>Pick up where you left off</ResumeLabel>
+    <ResumeCardRoot onClick={onResume} aria-label={`Resume: ${session.trackTitle ?? session.collectionName}`}>
+      <ResumeArt>
+        {session.trackImage ? (
+          <img src={session.trackImage} alt={session.collectionName} loading="lazy" />
+        ) : (
+          <span style={{ fontSize: '1.2rem' }}>♪</span>
+        )}
+      </ResumeArt>
+      <ResumeText>
+        <ResumeTrackName>{session.trackTitle ?? session.collectionName}</ResumeTrackName>
+        <ResumeCollectionName>{session.collectionName}</ResumeCollectionName>
+      </ResumeText>
+      <ResumePlayButton aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      </ResumePlayButton>
+    </ResumeCardRoot>
+  </>
 );
 
 export default ResumeCard;

--- a/src/components/QuickAccessPanel/styled.ts
+++ b/src/components/QuickAccessPanel/styled.ts
@@ -23,6 +23,14 @@ export const PanelRoot = styled.div`
   animation: ${fadeIn} 0.25s ease-out;
 `;
 
+export const ResumeLabel = styled.div`
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.medium};
+  color: rgba(255, 255, 255, 0.5);
+  padding: ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.xs};
+  flex-shrink: 0;
+`;
+
 export const ResumeCardRoot = styled.button`
   display: flex;
   align-items: center;

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -140,24 +140,25 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
             <ProviderDataSection key={p.id} providerName={p.name} catalog={p.catalog} />
           ))}
 
+          <ControlGroup>
+            <ControlLabel>Quick Access Panel</ControlLabel>
+            <OptionButtonGroup>
+              <OptionButton
+                $isActive={qapEnabled}
+                onClick={onQapToggle}
+              >
+                On
+              </OptionButton>
+              <OptionButton
+                $isActive={!qapEnabled}
+                onClick={onQapToggle}
+              >
+                Off
+              </OptionButton>
+            </OptionButtonGroup>
+          </ControlGroup>
+
           <CollapsibleSection title="Advanced">
-            <ControlGroup>
-              <ControlLabel>Quick Access Panel</ControlLabel>
-              <OptionButtonGroup>
-                <OptionButton
-                  $isActive={qapEnabled}
-                  onClick={onQapToggle}
-                >
-                  On
-                </OptionButton>
-                <OptionButton
-                  $isActive={!qapEnabled}
-                  onClick={onQapToggle}
-                >
-                  Off
-                </OptionButton>
-              </OptionButtonGroup>
-            </ControlGroup>
             <ControlGroup>
               <ControlLabel>Clear Library Cache</ControlLabel>
               {clearState === 'confirming' ? (

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -136,10 +136,6 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
 
           <NativeQueueSyncSection />
 
-          {dataProviders.map((p) => (
-            <ProviderDataSection key={p.id} providerName={p.name} catalog={p.catalog} />
-          ))}
-
           <ControlGroup>
             <ControlLabel>Quick Access Panel</ControlLabel>
             <OptionButtonGroup>
@@ -243,6 +239,9 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
                 </OptionButton>
               </OptionButtonGroup>
             </ControlGroup>
+            {dataProviders.map((p) => (
+              <ProviderDataSection key={p.id} providerName={p.name} catalog={p.catalog} />
+            ))}
           </CollapsibleSection>
         </DrawerContent>
       </DrawerContainer>

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -44,6 +44,8 @@ interface AppSettingsMenuProps {
   onProfilerToggle: () => void;
   visualizerDebugEnabled: boolean;
   onVisualizerDebugToggle: () => void;
+  qapEnabled: boolean;
+  onQapToggle: () => void;
 }
 
 const arePropsEqual = (
@@ -53,7 +55,8 @@ const arePropsEqual = (
   if (
     prevProps.isOpen !== nextProps.isOpen ||
     prevProps.profilerEnabled !== nextProps.profilerEnabled ||
-    prevProps.visualizerDebugEnabled !== nextProps.visualizerDebugEnabled
+    prevProps.visualizerDebugEnabled !== nextProps.visualizerDebugEnabled ||
+    prevProps.qapEnabled !== nextProps.qapEnabled
   ) {
     return false;
   }
@@ -68,7 +71,9 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
   profilerEnabled,
   onProfilerToggle,
   visualizerDebugEnabled,
-  onVisualizerDebugToggle
+  onVisualizerDebugToggle,
+  qapEnabled,
+  onQapToggle,
 }) => {
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizingContext();
   const { enabledProviderIds, registry } = useProviderContext();
@@ -136,6 +141,23 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
           ))}
 
           <CollapsibleSection title="Advanced">
+            <ControlGroup>
+              <ControlLabel>Quick Access Panel</ControlLabel>
+              <OptionButtonGroup>
+                <OptionButton
+                  $isActive={qapEnabled}
+                  onClick={onQapToggle}
+                >
+                  On
+                </OptionButton>
+                <OptionButton
+                  $isActive={!qapEnabled}
+                  onClick={onQapToggle}
+                >
+                  Off
+                </OptionButton>
+              </OptionButtonGroup>
+            </ControlGroup>
             <ControlGroup>
               <ControlLabel>Clear Library Cache</ControlLabel>
               {clearState === 'confirming' ? (

--- a/src/components/__tests__/LibraryDrawer.test.tsx
+++ b/src/components/__tests__/LibraryDrawer.test.tsx
@@ -1,0 +1,215 @@
+import React, { Suspense } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import LibraryDrawer from '../LibraryDrawer';
+
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  PlayerSizingProvider: ({ children }: { children: React.ReactNode }) => children,
+  usePlayerSizingContext: vi.fn(() => ({
+    viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    hasPointerInput: true,
+    dimensions: { width: 600, height: 600 },
+  })),
+}));
+
+vi.mock('@/components/PlaylistSelection', () => ({
+  default: ({ onPlaylistSelect }: { onPlaylistSelect: (id: string, name: string) => void }) => (
+    <div data-testid="playlist-selection">
+      <button onClick={() => onPlaylistSelect('pl-1', 'Mock Playlist')}>Mock Playlist</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: vi.fn(() => ({
+    playlists: [],
+    albums: [],
+    likedSongsCount: 0,
+    likedSongsPerProvider: [],
+    isInitialLoadComplete: true,
+    isSyncing: false,
+    lastSyncTimestamp: Date.now(),
+    syncError: null,
+    refreshNow: vi.fn(),
+  })),
+  LIBRARY_REFRESH_EVENT: 'vorbis-library-refresh',
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <Suspense fallback={<div>Loading...</div>}>
+      {children}
+    </Suspense>
+  </ThemeProvider>
+);
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onPlaylistSelect: vi.fn(),
+};
+
+describe('LibraryDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('header removal', () => {
+    it('does not render a "Library" title text', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByText('Library')).toBeNull();
+    });
+
+    it('does not render a "Browse and select" subtitle', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByText(/browse and select/i)).toBeNull();
+    });
+
+    it('does not render a LibraryDrawerHeader element', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(document.querySelector('[data-testid="library-drawer-header"]')).toBeNull();
+    });
+  });
+
+  describe('layout and content', () => {
+    it('renders PlaylistSelection inside the drawer when open', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByTestId('playlist-selection')).toBeTruthy();
+    });
+
+    it('renders the grip pill swipe handle when open', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByRole('button', { name: /swipe up or tap to close library/i })).toBeTruthy();
+    });
+
+    it('renders as a dialog with aria-label "Library selection"', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByRole('dialog', { name: /library selection/i })).toBeTruthy();
+    });
+  });
+
+  describe('closed state', () => {
+    it('does not render content when isOpen is false and drawer has never been opened', () => {
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} isOpen={false} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByTestId('playlist-selection')).toBeNull();
+      expect(screen.queryByRole('button', { name: /swipe up or tap to close library/i })).toBeNull();
+    });
+
+    it('hides content (pointer-events none) when closed after previously being open', () => {
+      // #given
+      const { rerender } = render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} isOpen={true} />
+        </Wrapper>
+      );
+      expect(screen.getByTestId('playlist-selection')).toBeTruthy();
+
+      // #when
+      rerender(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} isOpen={false} />
+        </Wrapper>
+      );
+
+      // #then
+      const dialog = screen.queryByRole('dialog', { name: /library selection/i });
+      expect(dialog).toBeTruthy();
+      expect(screen.queryByTestId('playlist-selection')).toBeNull();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClose when the overlay is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} onClose={onClose} />
+        </Wrapper>
+      );
+
+      // #when
+      const overlay = document.body.querySelector('[aria-hidden="true"]');
+      if (overlay) fireEvent.click(overlay);
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when the swipe handle is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} onClose={onClose} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: /swipe up or tap to close library/i }));
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/__tests__/LibraryDrawer.test.tsx
+++ b/src/components/__tests__/LibraryDrawer.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { theme } from '@/styles/theme';
 import LibraryDrawer from '../LibraryDrawer';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
@@ -175,6 +176,113 @@ describe('LibraryDrawer', () => {
       const dialog = screen.queryByRole('dialog', { name: /library selection/i });
       expect(dialog).toBeTruthy();
       expect(screen.queryByTestId('playlist-selection')).toBeNull();
+    });
+  });
+
+  describe('ResumeCard integration', () => {
+    const makeSession = (overrides?: Partial<SessionSnapshot>): SessionSnapshot => ({
+      collectionId: 'col-1',
+      collectionName: 'My Album',
+      trackIndex: 0,
+      trackTitle: 'Test Track',
+      trackArtist: 'Test Artist',
+      trackImage: undefined,
+      savedAt: Date.now(),
+      ...overrides,
+    });
+
+    it('renders ResumeCard when lastSession and onResume are both provided', () => {
+      // #given
+      const session = makeSession();
+      const onResume = vi.fn();
+
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} lastSession={session} onResume={onResume} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByRole('button', { name: /Resume: Test Track/i })).toBeTruthy();
+    });
+
+    it('does not render ResumeCard when lastSession is null', () => {
+      // #given
+      const onResume = vi.fn();
+
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} lastSession={null} onResume={onResume} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByRole('button', { name: /Resume:/i })).toBeNull();
+    });
+
+    it('does not render ResumeCard when lastSession is undefined', () => {
+      // #given
+      const onResume = vi.fn();
+
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} onResume={onResume} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByRole('button', { name: /Resume:/i })).toBeNull();
+    });
+
+    it('does not render ResumeCard when onResume is not provided', () => {
+      // #given
+      const session = makeSession();
+
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} lastSession={session} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.queryByRole('button', { name: /Resume:/i })).toBeNull();
+    });
+
+    it('calls onResume when the ResumeCard is clicked', () => {
+      // #given
+      const session = makeSession();
+      const onResume = vi.fn();
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} lastSession={session} onResume={onResume} />
+        </Wrapper>
+      );
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: /Resume: Test Track/i }));
+
+      // #then
+      expect(onResume).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to collectionName in aria-label when trackTitle is absent', () => {
+      // #given
+      const session = makeSession({ trackTitle: undefined });
+      const onResume = vi.fn();
+
+      // #when
+      render(
+        <Wrapper>
+          <LibraryDrawer {...defaultProps} lastSession={session} onResume={onResume} />
+        </Wrapper>
+      );
+
+      // #then
+      expect(screen.getByRole('button', { name: /Resume: My Album/i })).toBeTruthy();
     });
   });
 

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import PlayerStateRenderer from '../PlayerStateRenderer';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
+
+vi.mock('@/hooks/useQapEnabled', () => ({
+  useQapEnabled: vi.fn(),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    activeDescriptor: {
+      id: 'spotify',
+      name: 'Spotify',
+      capabilities: { hasSaveTrack: true, hasExternalLink: true },
+    },
+  })),
+}));
+
+vi.mock('../PlaylistSelection', () => ({
+  default: () => <div data-testid="playlist-selection">PlaylistSelection</div>,
+}));
+
+vi.mock('../QuickAccessPanel', () => ({
+  default: () => <div data-testid="quick-access-panel">QuickAccessPanel</div>,
+}));
+
+const mockUseQapEnabled = vi.mocked(useQapEnabled);
+
+const defaultProps = {
+  isLoading: false,
+  error: null,
+  selectedPlaylistId: null,
+  tracks: [],
+  onPlaylistSelect: vi.fn(),
+  onAddToQueue: vi.fn(),
+  lastSession: null,
+  onResume: vi.fn(),
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('PlayerStateRenderer idle routing based on qapEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders PlaylistSelection when qapEnabled is false (default)', async () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
+  });
+
+  it('does not render QuickAccessPanel when qapEnabled is false (default)', async () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders QuickAccessPanel when qapEnabled is true', () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+  });
+
+  it('does not render PlaylistSelection when qapEnabled is true', () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/VisualEffectsMenu.test.tsx
+++ b/src/components/__tests__/VisualEffectsMenu.test.tsx
@@ -71,6 +71,8 @@ describe('AppSettingsMenu', () => {
     onProfilerToggle: vi.fn(),
     visualizerDebugEnabled: false,
     onVisualizerDebugToggle: vi.fn(),
+    qapEnabled: false,
+    onQapToggle: vi.fn(),
   };
 
   beforeEach(() => {
@@ -171,7 +173,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[0]);
+      fireEvent.click(onButtons[1]);
 
       // #then
       expect(onProfilerToggle).toHaveBeenCalled();
@@ -189,7 +191,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[1]);
+      fireEvent.click(onButtons[2]);
 
       // #then
       expect(onVisualizerDebugToggle).toHaveBeenCalled();

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -176,6 +176,12 @@ export const AddToQueueIcon = () => (
   </svg>
 );
 
+export const HeartIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
 export const ICON_MAP: Record<string, React.FC> = {
   discogs: DiscogsIcon,
   musicbrainz: MusicBrainzIcon,

--- a/src/hooks/__tests__/useQapEnabled.test.ts
+++ b/src/hooks/__tests__/useQapEnabled.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQapEnabled } from '../useQapEnabled';
+
+describe('useQapEnabled', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('defaults to false when localStorage is empty', () => {
+    // #when
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #then
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('can be set to true', () => {
+    // #given
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('persists to localStorage under the correct key', () => {
+    // #given
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'vorbis-player-qap-enabled',
+      'true'
+    );
+  });
+
+  it('reads initial value from localStorage', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === 'vorbis-player-qap-enabled') return 'true';
+      return null;
+    });
+
+    // #when
+    const { result } = renderHook(() => useQapEnabled());
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -25,6 +25,7 @@ interface UseCollectionLoaderProps {
 
 interface UseCollectionLoaderReturn {
   loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
+  playTracksDirectly: (tracks: MediaTrack[], collectionId: string, provider?: ProviderId) => Promise<number>;
 }
 
 export function useCollectionLoader({
@@ -206,7 +207,53 @@ export function useCollectionLoader({
     ]
   );
 
+  const playTracksDirectly = useCallback(
+    async (tracks: MediaTrack[], collectionId: string, provider?: ProviderId): Promise<number> => {
+      if (radioStateIsActive) stopRadioBase();
+
+      const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
+      const targetProviderId = provider ?? activeDescriptor?.id;
+
+      if (targetDescriptor && activeDescriptor && activeDescriptor.id !== targetDescriptor.id) {
+        activeDescriptor.playback.pause().catch(() => {});
+      }
+
+      setError(null);
+      setIsLoading(true);
+      setSelectedPlaylistId(collectionId);
+      mediaTracksRef.current = [];
+
+      if (tracks.length === 0) {
+        setTracks([]);
+        setOriginalTracks([]);
+        setCurrentTrackIndex(0);
+        setIsLoading(false);
+        return 0;
+      }
+
+      applyTracks(tracks);
+
+      if (targetProviderId) {
+        drivingProviderRef.current = targetProviderId;
+        if (targetProviderId !== activeDescriptor?.id) {
+          setActiveProviderId(targetProviderId);
+        }
+      }
+
+      queueSnapshot('Direct tracks loaded', tracks, mediaTracksRef.current.length, 0);
+      await playTrack(0);
+      return tracks.length;
+    },
+    [
+      radioStateIsActive, stopRadioBase, getDescriptor, activeDescriptor,
+      setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef,
+      setTracks, setOriginalTracks, setCurrentTrackIndex,
+      applyTracks, drivingProviderRef, setActiveProviderId, playTrack,
+    ]
+  );
+
   return {
     loadCollection,
+    playTracksDirectly,
   };
 }

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -117,7 +117,7 @@ export function usePlayerLogic() {
   });
 
   // Initialize collection loader
-  const { loadCollection } = useCollectionLoader({
+  const { loadCollection, playTracksDirectly } = useCollectionLoader({
     trackOps,
     activeDescriptor,
     getDescriptor,
@@ -271,7 +271,7 @@ export function usePlayerLogic() {
   }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowQueue, setShowVisualEffects]);
 
   // Initialize queue management handlers
-  const { handleAddToQueue, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
+  const { handleAddToQueue, queueTracksDirectly, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
     trackOps,
     tracks,
     currentTrackIndex,
@@ -287,7 +287,9 @@ export function usePlayerLogic() {
   const handlers = useMemo(
     () => ({
       loadCollection,
+      playTracksDirectly,
       handleAddToQueue,
+      queueTracksDirectly,
       handlePlay,
       handlePause,
       handleNext,
@@ -302,7 +304,9 @@ export function usePlayerLogic() {
     }),
     [
       loadCollection,
+      playTracksDirectly,
       handleAddToQueue,
+      queueTracksDirectly,
       handlePlay,
       handlePause,
       handleNext,

--- a/src/hooks/useQapEnabled.ts
+++ b/src/hooks/useQapEnabled.ts
@@ -1,0 +1,5 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export const useQapEnabled = (): [boolean, (value: boolean) => void] => {
+  return useLocalStorage<boolean>('vorbis-player-qap-enabled', false);
+};

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -25,6 +25,7 @@ interface UseQueueManagementProps {
 
 interface UseQueueManagementReturn {
   handleAddToQueue: (playlistId: string, collectionName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  queueTracksDirectly: (tracks: MediaTrack[], collectionName?: string) => AddToQueueResult | null;
   handleRemoveFromQueue: (index: number) => void;
   handleReorderQueue: (fromIndex: number, toIndex: number) => void;
 }
@@ -183,8 +184,32 @@ export function useQueueManagement({
     [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex]
   );
 
+  const queueTracksDirectly = useCallback(
+    (newTracks: MediaTrack[], collectionName?: string): AddToQueueResult | null => {
+      if (newTracks.length === 0) return null;
+
+      const existingIds = new Set(tracksRef.current.map((t) => t.id));
+      const uniqueNewTracks = newTracks.filter((t) => !existingIds.has(t.id));
+
+      if (uniqueNewTracks.length === 0) return null;
+
+      logQueue(
+        'queueTracksDirectly — appending %d tracks. Before: tracks=%d, mediaRef=%d',
+        uniqueNewTracks.length,
+        tracksRef.current.length,
+        mediaTracksRef.current.length,
+      );
+      mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
+      setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+      setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+      return { added: uniqueNewTracks.length, collectionName };
+    },
+    [mediaTracksRef, setOriginalTracks, setTracks]
+  );
+
   return {
     handleAddToQueue,
+    queueTracksDirectly,
     handleRemoveFromQueue,
     handleReorderQueue,
   };

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -1,10 +1,11 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { saveSession, loadSession } from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { logSession } from '@/lib/debugLog';
 
 const DEBOUNCE_MS = 1000;
+const PERIODIC_SAVE_INTERVAL_MS = 20_000;
 
 export function useSessionPersistence(
   collectionId: string | null,
@@ -16,10 +17,16 @@ export function useSessionPersistence(
   trackTitle: string | undefined,
   trackArtist: string | undefined,
   trackImage: string | undefined,
+  playbackPosition: number,
 ): { lastSession: SessionSnapshot | null } {
   const [lastSession, setLastSession] = useState<SessionSnapshot | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const hasLoadedRef = useRef(false);
+
+  // Keep a ref to the latest snapshot data so beforeunload and interval can
+  // access current values without capturing stale closure state.
+  const snapshotRef = useRef<SessionSnapshot | null>(null);
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
@@ -32,40 +39,85 @@ export function useSessionPersistence(
     setLastSession(loaded);
   }, []);
 
+  const buildSnapshot = useCallback((): SessionSnapshot | null => {
+    if (!collectionId || tracks.length === 0) return null;
+    return {
+      collectionId,
+      collectionName,
+      collectionProvider,
+      trackIndex: currentTrackIndex,
+      trackId,
+      queueTracks: tracks,
+      trackTitle,
+      trackArtist,
+      trackImage,
+      playbackPosition,
+    };
+  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
+
+  // Keep snapshotRef in sync so event-driven saves (beforeunload, interval) are always fresh.
+  useEffect(() => {
+    snapshotRef.current = buildSnapshot();
+  }, [buildSnapshot]);
+
+  // Debounced save on any state change.
   useEffect(() => {
     if (!collectionId || tracks.length === 0) {
       logSession('skipping save — no collectionId or empty tracks');
       return;
     }
 
-    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, queueLength=%d',
-      collectionId, collectionProvider, currentTrackIndex, tracks.length
+    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+      collectionId, collectionProvider, currentTrackIndex, Math.floor(playbackPosition), tracks.length
     );
 
     if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
 
     debounceTimerRef.current = setTimeout(() => {
-      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, queueLength=%d',
-        collectionId, collectionProvider, currentTrackIndex, tracks.length
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+        snapshot.collectionId, snapshot.collectionProvider, snapshot.trackIndex, Math.floor(snapshot.playbackPosition ?? 0), snapshot.queueTracks?.length
       );
-      saveSession({
-        collectionId,
-        collectionName,
-        collectionProvider,
-        trackIndex: currentTrackIndex,
-        trackId,
-        queueTracks: tracks,
-        trackTitle,
-        trackArtist,
-        trackImage,
-      });
+      saveSession(snapshot);
       logSession('save complete');
     }, DEBOUNCE_MS);
 
     return () => {
       if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
     };
-  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage]);
+  }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
+
+  // Periodic save every 20 seconds during active playback.
+  useEffect(() => {
+    if (periodicTimerRef.current !== null) clearInterval(periodicTimerRef.current);
+
+    periodicTimerRef.current = setInterval(() => {
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('periodic save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      saveSession(snapshot);
+    }, PERIODIC_SAVE_INTERVAL_MS);
+
+    return () => {
+      if (periodicTimerRef.current !== null) clearInterval(periodicTimerRef.current);
+    };
+  }, []);
+
+  // Save on tab close / page unload.
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const snapshot = snapshotRef.current;
+      if (!snapshot) return;
+      logSession('beforeunload save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      saveSession(snapshot);
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
 
   return { lastSession };
 }

--- a/src/services/__tests__/sessionPersistence.test.ts
+++ b/src/services/__tests__/sessionPersistence.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveSession, loadSession, clearSession } from '../sessionPersistence';
+import type { SessionSnapshot } from '../sessionPersistence';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+const baseSnapshot: SessionSnapshot = {
+  collectionId: 'col-1',
+  collectionName: 'Test Album',
+  trackIndex: 2,
+  trackId: 'track-abc',
+  trackTitle: 'My Track',
+  trackArtist: 'Artist Name',
+};
+
+describe('sessionPersistence', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+    localStorageMock.clear();
+  });
+
+  describe('saveSession / loadSession', () => {
+    it('persists and restores playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 42.5 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBe(42.5);
+    });
+
+    it('loads session with undefined playbackPosition when not saved', () => {
+      // #given
+      saveSession(baseSnapshot);
+
+      // #when
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBeUndefined();
+    });
+
+    it('persists zero playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 0 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBe(0);
+    });
+
+    it('sets savedAt timestamp on save', () => {
+      // #given
+      const before = Date.now();
+
+      // #when
+      saveSession(baseSnapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.savedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it('returns null when nothing is saved', () => {
+      // #when
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded).toBeNull();
+    });
+
+    it('round-trips all core fields including playbackPosition', () => {
+      // #given
+      const snapshot: SessionSnapshot = {
+        ...baseSnapshot,
+        collectionProvider: 'spotify',
+        playbackPosition: 123.456,
+      };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.collectionId).toBe('col-1');
+      expect(loaded?.trackIndex).toBe(2);
+      expect(loaded?.collectionProvider).toBe('spotify');
+      expect(loaded?.playbackPosition).toBe(123.456);
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes persisted session', () => {
+      // #given
+      saveSession({ ...baseSnapshot, playbackPosition: 10 });
+
+      // #when
+      clearSession();
+
+      // #then
+      expect(loadSession()).toBeNull();
+    });
+  });
+});

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -15,6 +15,8 @@ export interface SessionSnapshot {
   trackArtist?: string;
   trackImage?: string;
   savedAt?: number;
+  /** Playback position in seconds at the time the session was saved. */
+  playbackPosition?: number;
 }
 
 /** Strip Dropbox image URLs — presigned and large. playbackRef is a permanent path, keep it. */


### PR DESCRIPTION
## Summary
- **QAP opt-in**: Quick Access Panel is now opt-in (default off), library browser is the default idle view (#772, #774, #775, #776, #778, #777, #780, #779, #785, #786)
- **Play/Queue Liked**: New "Play Liked" and "Queue Liked" actions in collection context menus (#792)
- **Queue heart indicators**: Liked tracks show a small heart icon in queue view (#789)
- **Session position persistence**: Playback position is saved and restored on session resume (#790)
- **ResumeCard label**: "Pick up where you left off" heading added to ResumeCard (#791)
- **Library drawer header removal**: Recovered vertical space by removing misleading header (#773)

## PRs included
- #772 feat: add qapEnabled preference hook (default false)
- #773 test: verify library drawer layout after header removal
- #774 feat: update idle routing to skip QAP when qapEnabled is false
- #775 feat: add ResumeCard to LibraryDrawer when last session exists
- #776 feat: add Quick Access Panel toggle to settings panel
- #777 test: ResumeCard visibility in LibraryDrawer
- #778 test: preference persistence and idle routing for qapEnabled
- #779 docs: update README and CLAUDE.md for QAP opt-in change
- #780 fix: QAP opt-in wiring — keyboard routing, settings visibility, ResumeCard
- #785 fix: hide QAP button in bottom bar when qapEnabled is false
- #786 refactor: move Dropbox data settings into Advanced section
- #789 feat: show liked heart indicator on queue track rows
- #790 feat: persist playback position and seek on session resume
- #791 feat: add Resume label to ResumeCard
- #792 feat: add Play Liked and Queue Liked to collection context menu

## Test plan
- [ ] Fresh load defaults to library browser (not QAP)
- [ ] Settings toggle enables QAP; idle view switches accordingly
- [ ] ResumeCard appears in both library drawer and QAP with "Pick up where you left off" label
- [ ] Play a track, close tab, reopen — resumes at saved position
- [ ] Queue shows heart icons on liked tracks
- [ ] Collection context menu shows Play Liked / Queue Liked options
- [ ] Keyboard shortcuts (Q, L, ↑, ↓) route correctly based on QAP setting