### PR TITLE
fix: update default VFX settings to fireflies with translucence

### DIFF
--- a/src/contexts/VisualEffectsContext.tsx
+++ b/src/contexts/VisualEffectsContext.tsx
@@ -38,12 +38,12 @@ export function VisualEffectsProvider({ children }: { children: React.ReactNode 
   const [visualEffectsEnabled, setVisualEffectsEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED, true);
   const [perAlbumGlow, setPerAlbumGlow] = useLocalStorage<Record<string, { intensity: number; rate: number }>>(STORAGE_KEYS.PER_ALBUM_GLOW, {});
   const [backgroundVisualizerEnabled, setBackgroundVisualizerEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.BG_VISUALIZER_ENABLED, true);
-  const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>(STORAGE_KEYS.BG_VISUALIZER_STYLE, 'wave');
+  const [backgroundVisualizerStyle, setBackgroundVisualizerStyle] = useLocalStorage<VisualizerStyle>(STORAGE_KEYS.BG_VISUALIZER_STYLE, 'fireflies');
   const [backgroundVisualizerIntensity, setBackgroundVisualizerIntensity] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_INTENSITY, 40);
-  const [backgroundVisualizerSpeed, setBackgroundVisualizerSpeed] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_SPEED, 0.7);
+  const [backgroundVisualizerSpeed, setBackgroundVisualizerSpeed] = useLocalStorage<number>(STORAGE_KEYS.BG_VISUALIZER_SPEED, 1.0);
   const [accentColorBackgroundPreferred, setAccentColorBackgroundPreferred] = useLocalStorage<boolean>(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED, false);
   const [accentColorBackgroundEnabled, setAccentColorBackgroundEnabled] = useState<boolean>(false);
-  const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.TRANSLUCENCE_ENABLED, false);
+  const [translucenceEnabled, setTranslucenceEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.TRANSLUCENCE_ENABLED, true);
   const [translucenceOpacity, setTranslucenceOpacity] = useLocalStorage<number>(STORAGE_KEYS.TRANSLUCENCE_OPACITY, 0.8);
   const [zenModeEnabled, setZenModeEnabled] = useLocalStorage<boolean>(STORAGE_KEYS.ZEN_MODE_ENABLED, false);
   const [showVisualEffects, setShowVisualEffects] = useState<boolean>(false);


### PR DESCRIPTION
## Summary

Updates the default visual effects settings for new users to use the fireflies visualizer with translucence enabled and normal speed.

- Visualizer style: fireflies (was wave)
- Speed: 1.0 (was 0.7)
- Translucence: ON (was OFF)
- Intensity: 40 (normal) - unchanged
- Glow: OFF - unchanged

Existing users with saved preferences are not affected — only the fallback defaults change.

Closes #794