### PR TITLE
docs: tidy codebase — session resume, liked tracks, branch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet
 - **Playlists & Albums** — Browse, search, sort, filter, and pin your **library** collections (not the same as the playback queue)
-- **Unified Liked Songs** — Merge liked tracks from connected providers into one queue
+- **Unified Liked Songs** — Merge liked tracks from connected providers into one queue; "Play Liked" and "Queue Liked" filter any collection to just your favorites
 - **Track Radio** — Generate a one-shot radio playlist from the current track (Last.fm-powered matching)
 - **Visual Effects** — Dynamic glow, configurable album art filters, accent color backgrounds
 - **Background Visualizers** — Animated particle and geometric visualizer backgrounds
@@ -35,6 +35,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 - **Swipe Gestures** — Swipe to change tracks, open the queue, or browse the library
 - **Keyboard Shortcuts** — Context-aware controls with device-specific behavior
 - **Responsive Design** — Fluid layout from mobile phones to ultra-wide desktops
+- **Session Resume** — Pick up where you left off — playback position, queue, and track are restored on reopen
 - **Instant Startup** — IndexedDB-based library cache with background sync
 
 ## Quick Start

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,7 +114,7 @@ Guidelines:
 
 ## Git Workflow
 
-- Feature branches from main: `feature/name`, `fix/name`
+- Feature branches from `develop`: `feature/name`, `fix/name`
 - Atomic commits with conventional format (`feat:`, `fix:`, `refactor:`, etc.)
 - Reference issue numbers in commit messages
 - Run `npm run test:run` and `npm run build` before pushing

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,6 +43,14 @@ On mobile and tablet:
 - **Swipe up** on album art to toggle the queue drawer
 - **Swipe down** on album art to toggle the library drawer
 
+## Home Screen & Quick Access Panel
+
+By default, the player opens to the **library browser** when no track is loaded. An optional **Quick Access Panel (QAP)** can be enabled in the settings panel (gear icon) under "Quick Access Panel" — it shows pinned collections and liked songs as a home screen.
+
+### Session Resume
+
+When a previous session exists, a **ResumeCard** ("Pick up where you left off") appears at the bottom of the library drawer (or inside the QAP if enabled). Tapping it restores your queue, track, and exact playback position.
+
 ## Library
 
 The library drawer supports:
@@ -51,8 +59,9 @@ The library drawer supports:
 - **Sort** — Sort by recently added, name, artist, or release date
 - **Filter** — Filter albums by decade or by artist (click artist name in album grid)
 - **View Modes** — Toggle between Playlists and Albums tabs
-- **Pinning** — Pin up to 4 playlists and 4 albums to the top of their tabs
+- **Pinning** — Pin up to 12 playlists and 12 albums to the top of their tabs
 - **Liked Songs** — Special entry with shuffle indicator
+- **Play Liked / Queue Liked** — Long-press or right-click a collection to play or queue only your liked tracks from it
 
 ## Provider Selection
 


### PR DESCRIPTION
## Summary
- Add Session Resume and expanded Liked Songs features to README
- Add QAP opt-in, ResumeCard, and Play/Queue Liked sections to user guide
- Fix contributing.md to reference `develop` instead of `main` for feature branches
- Deleted 13 stale remote branches (worktree-agent-*, orphaned feature branches)

## Test plan
- [ ] Verify README features list reads correctly
- [ ] Verify user guide QAP/resume section is accurate