### PR TITLE
fix: restore correct track and position on session resume

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -51,7 +51,7 @@ const ScreenReaderAnnouncement = styled.div`
 `;
 
 const AudioPlayerComponent = () => {
-  const { state, handlers, radio, currentPlaybackProviderRef: playbackProviderRef, mediaTracksRef } = usePlayerLogic();
+  const { state, handlers, radio, currentPlaybackProviderRef: playbackProviderRef, mediaTracksRef, expectedTrackIdRef } = usePlayerLogic();
   const { debugActive, handleActivatorTap } = useDebugActivator();
   const { accentColor } = useColorContext();
   const {
@@ -213,7 +213,7 @@ const AudioPlayerComponent = () => {
 
   const handleResume = useCallback(async () => {
     if (!lastSession?.queueTracks?.length) return;
-    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPosition } = lastSession;
+    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPositionMs } = lastSession;
     const targetIdx = trackId
       ? queueTracks.findIndex(t => t.id === trackId)
       : Math.min(trackIndex, queueTracks.length - 1);
@@ -226,17 +226,22 @@ const AudioPlayerComponent = () => {
     // the right track before React re-renders. Required for iOS Safari, which
     // blocks audio.play() called outside the synchronous user-gesture call stack.
     mediaTracksRef.current = queueTracks;
+    // Guard the playback subscription against index-sync racing during load:
+    // without this, usePlaybackSubscription may overwrite resolvedIdx with a
+    // stale provider track index before the new track's ID is confirmed.
+    expectedTrackIdRef.current = queueTracks[resolvedIdx]?.id ?? null;
     await handlers.playTrack(resolvedIdx);
 
-    if (savedPosition && savedPosition > 0) {
+    if (savedPositionMs && savedPositionMs > 0) {
       const drivingProviderId = playbackProviderRef.current;
       if (drivingProviderId) {
         const { providerRegistry } = await import('@/providers/registry');
         const descriptor = providerRegistry.get(drivingProviderId);
-        descriptor?.playback.seek(savedPosition * 1000).catch(() => {});
+        // savedPositionMs is already in milliseconds (sourced from state.playbackPosition / positionMs)
+        descriptor?.playback.seek(savedPositionMs).catch(() => {});
       }
     }
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, handlers, playbackProviderRef]);
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, expectedTrackIdRef, handlers, playbackProviderRef]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -346,5 +346,6 @@ export function usePlayerLogic() {
     setTracks,
     setOriginalTracks,
     currentPlaybackProviderRef: drivingProviderRef,
+    expectedTrackIdRef,
   };
 }

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -67,7 +67,7 @@ export function useSessionPersistence(
       return;
     }
 
-    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+    logSession('save effect fired — collectionId=%s, provider=%s, trackIndex=%d, position=%dms, queueLength=%d',
       collectionId, collectionProvider, currentTrackIndex, Math.floor(playbackPosition), tracks.length
     );
 
@@ -76,7 +76,7 @@ export function useSessionPersistence(
     debounceTimerRef.current = setTimeout(() => {
       const snapshot = snapshotRef.current;
       if (!snapshot) return;
-      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, position=%ds, queueLength=%d',
+      logSession('saving session — collectionId=%s, provider=%s, trackIndex=%d, position=%dms, queueLength=%d',
         snapshot.collectionId, snapshot.collectionProvider, snapshot.trackIndex, Math.floor(snapshot.playbackPosition ?? 0), snapshot.queueTracks?.length
       );
       saveSession(snapshot);
@@ -95,7 +95,7 @@ export function useSessionPersistence(
     periodicTimerRef.current = setInterval(() => {
       const snapshot = snapshotRef.current;
       if (!snapshot) return;
-      logSession('periodic save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      logSession('periodic save — position=%dms', Math.floor(snapshot.playbackPosition ?? 0));
       saveSession(snapshot);
     }, PERIODIC_SAVE_INTERVAL_MS);
 
@@ -109,7 +109,7 @@ export function useSessionPersistence(
     const handleBeforeUnload = () => {
       const snapshot = snapshotRef.current;
       if (!snapshot) return;
-      logSession('beforeunload save — position=%ds', Math.floor(snapshot.playbackPosition ?? 0));
+      logSession('beforeunload save — position=%dms', Math.floor(snapshot.playbackPosition ?? 0));
       saveSession(snapshot);
     };
 

--- a/src/services/__tests__/sessionPersistence.test.ts
+++ b/src/services/__tests__/sessionPersistence.test.ts
@@ -103,6 +103,32 @@ describe('sessionPersistence', () => {
     });
   });
 
+  describe('playbackPosition unit contract', () => {
+    it('stores playbackPosition as milliseconds (not seconds)', () => {
+      // #given — a typical position of 2 minutes 30 seconds = 150,000 ms
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 150_000 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then — value must come back unchanged (milliseconds, not multiplied/divided)
+      expect(loaded?.playbackPosition).toBe(150_000);
+    });
+
+    it('stores sub-second playbackPosition accurately', () => {
+      // #given — position at 500 ms
+      const snapshot: SessionSnapshot = { ...baseSnapshot, playbackPosition: 500 };
+
+      // #when
+      saveSession(snapshot);
+      const loaded = loadSession();
+
+      // #then
+      expect(loaded?.playbackPosition).toBe(500);
+    });
+  });
+
   describe('clearSession', () => {
     it('removes persisted session', () => {
       // #given

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -15,7 +15,7 @@ export interface SessionSnapshot {
   trackArtist?: string;
   trackImage?: string;
   savedAt?: number;
-  /** Playback position in seconds at the time the session was saved. */
+  /** Playback position in milliseconds at the time the session was saved. */
   playbackPosition?: number;
 }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `handleResume` that caused the wrong track to play and playback position to not be restored after a session resume.

**Bug 1 — Wrong track plays (index race)**

`handleResume` did not set `expectedTrackIdRef` before calling `playTrack`. While the new track was loading, `usePlaybackSubscription` would receive a provider state event with the previous session's track ID, look it up in the new queue, and overwrite `currentTrackIndex` with a stale value — advancing to the wrong track.

Fix: set `expectedTrackIdRef.current` to the target track's ID before calling `playTrack`, mirroring what `handleNext`/`handlePrevious` already do.

**Bug 2 — Position not restored (unit mismatch)**

`playbackPosition` in `SessionSnapshot` is stored in **milliseconds** (sourced from `state.playbackPosition → positionMs`). The seek call was `descriptor.playback.seek(savedPosition * 1000)` — multiplying ms by 1000, seeking ~1000× past the correct position. Providers clamp out-of-range seeks to track end, so the track immediately reported near-zero `timeRemaining`, triggering `useAutoAdvance` to advance to the next track.

Fix: pass `savedPositionMs` directly to `seek()` without the ×1000 multiplier. Also corrects the `SessionSnapshot` JSDoc and debug log format strings (`%ds` → `%dms`).

## Test plan

- [ ] Verify `src/services/__tests__/sessionPersistence.test.ts` — new `playbackPosition unit contract` suite passes (2 new tests confirming ms-level round-trip)
- [ ] Manual: play a track to ~2:30, close/reload, click Resume — should resume the same track at ~2:30
- [ ] Manual: play a track near the end (~last 5s), close/reload, click Resume — should resume the same track near the end (not advance to the next one)
- [ ] Manual: session with `trackId` set correctly resolves to the right queue index by ID

Closes #799