### PR TITLE
Release: PlaylistSelection polish — derived state, memoization, cleanup

### DIFF
--- a/src/components/PlaylistSelection/LibraryControls.tsx
+++ b/src/components/PlaylistSelection/LibraryControls.tsx
@@ -9,6 +9,7 @@ import {
   RefreshButton,
   ClearButton,
 } from './styled';
+import { RefreshIcon } from './utils';
 
 interface LibraryControlsProps {
   inDrawer: boolean;
@@ -25,15 +26,6 @@ interface LibraryControlsProps {
   onLibraryRefresh?: () => void;
   isLibraryRefreshing?: boolean;
 }
-
-const RefreshIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
 
 export function LibraryControls({
   inDrawer,

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -6,6 +6,7 @@ import { PlaylistGrid } from './PlaylistGrid';
 import { AlbumGrid } from './AlbumGrid';
 import { LibraryControls } from './LibraryControls';
 import { useLibraryContext } from './LibraryContext';
+import { RefreshIcon } from './utils';
 import {
   TabSpinner,
   TabsContainer,
@@ -118,12 +119,7 @@ export function LibraryMainContent(): React.JSX.Element {
                   aria-label="Refresh library"
                   title="Refresh library"
                 >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
+                  <RefreshIcon />
                 </DrawerRefreshButton>
               )}
             </DrawerBottomActions>

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import * as React from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { CardContent } from '../styled';
@@ -81,9 +81,7 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     removeCollection,
   } = useLibrarySync();
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   const {
     viewMode,
@@ -174,31 +172,25 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   const pinnedAlbums = albumLibraryView.pinned;
   const unpinnedAlbums = albumLibraryView.unpinned;
 
-  useEffect(() => {
-    if (!isInitialLoadComplete) return;
+  const isAuthenticated = useMemo(
+    () =>
+      enabledProviderIds.some(id => getDescriptor(id)?.auth.isAuthenticated()) ||
+      (activeDescriptor?.auth.isAuthenticated() ?? false),
+    [activeDescriptor, enabledProviderIds, getDescriptor]
+  );
+
+  const isLoading = false;
+
+  const libraryError = useMemo(() => {
+    if (!isInitialLoadComplete) return null;
     if (playlists.length === 0 && albums.length === 0 && likedSongsCount === 0) {
       const providerName = activeDescriptor?.name ?? 'your music service';
-      setError(
-        `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`
-      );
-    } else {
-      setError(null);
+      return `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`;
     }
+    return null;
   }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount, activeDescriptor]);
 
-  useEffect(() => {
-    const hasAuth = enabledProviderIds.some(id => {
-      const desc = getDescriptor(id);
-      return desc?.auth.isAuthenticated();
-    }) || activeDescriptor?.auth.isAuthenticated();
-    if (hasAuth) {
-      setIsAuthenticated(true);
-      setIsLoading(false);
-    } else {
-      setIsAuthenticated(false);
-      setIsLoading(false);
-    }
-  }, [activeDescriptor, enabledProviderIds, getDescriptor]);
+  const error = loginError ?? libraryError;
 
   function handlePlaylistClick(playlist: PlaylistInfo): void {
     logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
@@ -233,59 +225,100 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
   const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
 
-  const libraryContextValue: LibraryContextValue = {
-    inDrawer,
-    swipeZoneRef,
-    viewMode,
-    setViewMode,
-    searchQuery,
-    setSearchQuery,
-    playlistSort,
-    setPlaylistSort,
-    albumSort,
-    setAlbumSort,
-    artistFilter,
-    setArtistFilter,
-    providerFilters,
-    setProviderFilters,
-    handleProviderToggle,
-    hasActiveFilters,
-    albums,
-    isInitialLoadComplete,
-    showProviderBadges,
-    enabledProviderIds,
-    likedSongsPerProvider,
-    likedSongsCount,
-    isLikedSongsSyncing,
-    isUnifiedLikedActive,
-    unifiedLikedCount,
-    pinnedPlaylists,
-    unpinnedPlaylists,
-    pinnedAlbums,
-    unpinnedAlbums,
-    isPlaylistPinned,
-    canPinMorePlaylists,
-    isAlbumPinned,
-    canPinMoreAlbums,
-    activeDescriptor: activeDescriptor ?? null,
-    onPlaylistClick: handlePlaylistClick,
-    onPlaylistContextMenu: handlePlaylistContextMenu,
-    onPinPlaylistClick: handlePinPlaylistClick,
-    onLikedSongsClick: handleLikedSongsClick,
-    onAlbumClick: handleAlbumClick,
-    onAlbumContextMenu: handleAlbumContextMenu,
-    onPinAlbumClick: handlePinAlbumClick,
-    onArtistClick: handleArtistClick,
-    onLibraryRefresh,
-    isLibraryRefreshing,
-  };
+  const libraryContextValue: LibraryContextValue = useMemo(
+    () => ({
+      inDrawer,
+      swipeZoneRef,
+      viewMode,
+      setViewMode,
+      searchQuery,
+      setSearchQuery,
+      playlistSort,
+      setPlaylistSort,
+      albumSort,
+      setAlbumSort,
+      artistFilter,
+      setArtistFilter,
+      providerFilters,
+      setProviderFilters,
+      handleProviderToggle,
+      hasActiveFilters,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      activeDescriptor: activeDescriptor ?? null,
+      onPlaylistClick: handlePlaylistClick,
+      onPlaylistContextMenu: handlePlaylistContextMenu,
+      onPinPlaylistClick: handlePinPlaylistClick,
+      onLikedSongsClick: handleLikedSongsClick,
+      onAlbumClick: handleAlbumClick,
+      onAlbumContextMenu: handleAlbumContextMenu,
+      onPinAlbumClick: handlePinAlbumClick,
+      onArtistClick: handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    }),
+    [
+      inDrawer,
+      swipeZoneRef,
+      viewMode,
+      searchQuery,
+      playlistSort,
+      albumSort,
+      artistFilter,
+      providerFilters,
+      hasActiveFilters,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      activeDescriptor,
+      handlePlaylistClick,
+      handlePlaylistContextMenu,
+      handlePinPlaylistClick,
+      handleLikedSongsClick,
+      handleAlbumClick,
+      handleAlbumContextMenu,
+      handlePinAlbumClick,
+      handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    ]
+  );
 
   const statusContentProps = {
     isLoading,
     isAuthenticated,
     error,
     activeDescriptor: activeDescriptor ?? null,
-    setError,
+    setError: setLoginError,
   };
 
   if (inDrawer) {

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -370,21 +370,8 @@ export function useItemActions({
   }) : null;
 
   return {
-    albumPopover,
-    setAlbumPopover,
-    playlistPopover,
-    setPlaylistPopover,
-    albumSaved,
-    deleteTarget,
-    setDeleteTarget,
     handlePlaylistContextMenu,
     handleAlbumContextMenu,
-    closePlaylistPopover,
-    buildPlaylistPopoverOptions,
-    closeAlbumPopover,
-    buildAlbumPopoverOptions,
-    handleDeleteConfirm,
-    handleDeleteClose,
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,

--- a/src/components/PlaylistSelection/utils.tsx
+++ b/src/components/PlaylistSelection/utils.tsx
@@ -61,6 +61,15 @@ export const PinIcon: React.FC<{ filled?: boolean }> = ({ filled = false }) => (
   </svg>
 );
 
+export const RefreshIcon: React.FC = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path d="M21 2v6h-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 12a9 9 0 0 1 15.36-6.36L21 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 22v-6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M21 12a9 9 0 0 1-15.36 6.36L3 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
 /** Shared hook for lazy-loading images via IntersectionObserver */
 function useLazyImage(
   images: { url: string; width: number | null; height: number | null }[],


### PR DESCRIPTION
## Summary
- **Derived state**: replaced 3 useState+useEffect sync patterns with computed values in PlaylistSelection (#806, closes #802, #803)
- **Context memoization**: wrapped LibraryContext value in useMemo to prevent cascade re-renders (#806)
- **Hook API trim**: removed 14 unused return values from useItemActions (#808, closes #804)
- **Icon dedup**: extracted duplicated refresh SVG to shared RefreshIcon component (#807, closes #805)

## PRs included
- #806 refactor: replace derived useState with computed values and memoize context
- #807 refactor: extract duplicated refresh SVG to shared RefreshIcon
- #808 refactor: trim unused return values from useItemActions

## Test plan
- [ ] Library browser loads and displays playlists/albums correctly
- [ ] Search, sort, filter all work
- [ ] Context menu (Play, Queue, Play Liked, Queue Liked) functions
- [ ] No visual regressions in library drawer or idle view