### PR TITLE
fix: prevent Spotify resume playback from being cancelled

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -230,18 +230,10 @@ const AudioPlayerComponent = () => {
     // without this, usePlaybackSubscription may overwrite resolvedIdx with a
     // stale provider track index before the new track's ID is confirmed.
     expectedTrackIdRef.current = queueTracks[resolvedIdx]?.id ?? null;
-    await handlers.playTrack(resolvedIdx);
 
-    if (savedPositionMs && savedPositionMs > 0) {
-      const drivingProviderId = playbackProviderRef.current;
-      if (drivingProviderId) {
-        const { providerRegistry } = await import('@/providers/registry');
-        const descriptor = providerRegistry.get(drivingProviderId);
-        // savedPositionMs is already in milliseconds (sourced from state.playbackPosition / positionMs)
-        descriptor?.playback.seek(savedPositionMs).catch(() => {});
-      }
-    }
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, expectedTrackIdRef, handlers, playbackProviderRef]);
+    const positionMs = savedPositionMs && savedPositionMs > 0 ? savedPositionMs : undefined;
+    await handlers.playTrack(resolvedIdx, false, positionMs ? { positionMs } : undefined);
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, expectedTrackIdRef, handlers]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/hooks/__tests__/useSpotifyPlayback.test.ts
+++ b/src/hooks/__tests__/useSpotifyPlayback.test.ts
@@ -93,7 +93,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
     expect(setCurrentTrackIndex).toHaveBeenCalledWith(1);
   });
 
@@ -134,7 +134,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then — recursive call plays track at index 1
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
   });
 
   it('skips to next track on generic error when skipOnError is true', async () => {
@@ -155,7 +155,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
   });
 
   it('prefetches the next track after successful playback', async () => {

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -35,7 +35,7 @@ export const useProviderPlayback = ({
     }
   }, []);
 
-  const playTrack = useCallback(async (index: number, skipOnError = false) => {
+  const playTrack = useCallback(async (index: number, skipOnError = false, options?: { positionMs?: number }) => {
     const tracks = mediaTracksRef.current;
     const mediaTrack = tracks[index];
     const trackProvider = resolveTrackProvider(mediaTrack);
@@ -72,7 +72,7 @@ export const useProviderPlayback = ({
     }
 
     try {
-      await descriptor.playback.playTrack(mediaTrack);
+      await descriptor.playback.playTrack(mediaTrack, options);
       setCurrentTrackIndex(index);
 
       const nextIndex = (index + 1) % tracks.length;

--- a/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
+++ b/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
@@ -79,7 +79,7 @@ describe('SpotifyPlaybackAdapter', () => {
     expect(spotifyPlayer.initialize).toHaveBeenCalledTimes(1);
     expect(spotifyPlayer.transferPlaybackToDevice).toHaveBeenCalledTimes(1);
     expect(spotifyPlayer.ensureDeviceIsActive).toHaveBeenCalledTimes(1);
-    expect(spotifyPlayer.playTrack).toHaveBeenCalledWith('spotify:track:abc123', undefined);
+    expect(spotifyPlayer.playTrack).toHaveBeenCalledWith('spotify:track:abc123', undefined, undefined);
   });
 
   it('times out if SDK never becomes ready', async () => {

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -60,7 +60,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.ensureAudio();
   }
 
-  async playTrack(track: MediaTrack): Promise<void> {
+  async playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void> {
     this.ensureAudio();
 
     const dropboxPath = track.playbackRef.ref;
@@ -84,6 +84,10 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.audio!.pause();
     this.audio!.src = streamUrl;
     await this.audio!.play();
+
+    if (options?.positionMs) {
+      this.audio!.currentTime = options.positionMs / 1000;
+    }
 
     this.startUpdateInterval();
     this.enrichMetadataInBackground(track, streamUrl);

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -75,11 +75,12 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     await spotifyPlayer.initialize();
   }
 
-  async playTrack(track: MediaTrack): Promise<void> {
+  async playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void> {
     const uri = track.playbackRef.ref;
+    const startPositionMs = options?.positionMs;
 
     // If Spotify's SDK already natively advanced to this track, skip the API call entirely.
-    if (this.playbackSessionActive) {
+    if (this.playbackSessionActive && !startPositionMs) {
       const state = await spotifyPlayer.getCurrentState();
       if (state?.track_window?.current_track?.uri === uri && !state.paused) {
         logSpotify('Spotify already playing requested track natively, skipping API call');
@@ -95,7 +96,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
     const upcomingUris = this.pendingUpcomingUris ?? undefined;
 
-    await this.playWithRetry(uri, track.name, upcomingUris);
+    await this.playWithRetry(uri, track.name, upcomingUris, 0, startPositionMs);
     this.playbackSessionActive = true;
 
     const activateDevice = async () => {
@@ -128,9 +129,10 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     trackName: string,
     upcomingUris?: string[],
     retryCount = 0,
+    positionMs?: number,
   ): Promise<void> {
     try {
-      await spotifyPlayer.playTrack(uri, upcomingUris);
+      await spotifyPlayer.playTrack(uri, upcomingUris, positionMs);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
@@ -150,7 +152,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
           : BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
         logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
-        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1);
+        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
       if (message.includes('403')) {
@@ -164,7 +166,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         await spotifyPlayer.transferPlaybackToDevice(true);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         await spotifyPlayer.ensureDeviceIsActive(3, 1000);
-        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1);
+        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
       throw error;

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -106,12 +106,12 @@ class SpotifyPlayerService {
     this.saveState();
   }
 
-  async playTrack(uri: string, upcomingUris?: string[]): Promise<void> {
+  async playTrack(uri: string, upcomingUris?: string[], positionMs?: number): Promise<void> {
     if (!this.deviceId || !this.isReady) {
       throw new Error('Spotify player not ready');
     }
     this.lastPlayTrackTime = Date.now();
-    await apiPlayTrack(this.deviceId, uri, upcomingUris);
+    await apiPlayTrack(this.deviceId, uri, upcomingUris, positionMs);
   }
 
   async playContext(contextUri: string, offsetPosition?: number): Promise<void> {

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -5,15 +5,16 @@ export async function apiPlayTrack(
   deviceId: string,
   uri: string,
   upcomingUris?: string[],
+  positionMs?: number,
 ): Promise<void> {
   const token = await spotifyAuth.ensureValidToken();
   const uris = upcomingUris?.length ? [uri, ...upcomingUris] : [uri];
 
-  logSpotify('Web API play track deviceId=%s queueSize=%d', deviceId, uris.length);
+  logSpotify('Web API play track deviceId=%s queueSize=%d positionMs=%s', deviceId, uris.length, positionMs ?? 0);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
-    body: JSON.stringify({ uris, position_ms: 0 }),
+    body: JSON.stringify({ uris, position_ms: positionMs ?? 0 }),
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${token}`

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -66,8 +66,8 @@ export interface CatalogProvider {
 export interface PlaybackProvider {
   readonly providerId: ProviderId;
   initialize(): Promise<void>;
-  /** Play a single track by ref. */
-  playTrack(track: MediaTrack): Promise<void>;
+  /** Play a single track by ref, optionally starting from a position. */
+  playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void>;
   /** Play a collection from optional offset (e.g. playlist from index). */
   playCollection?(collectionRef: CollectionRef, options?: { offset?: number }): Promise<void>;
   pause(): Promise<void>;


### PR DESCRIPTION
## Summary

When resuming a Spotify session, playback would start briefly (~1 second) then stop. Dropbox resume worked fine.

**Root cause:** `handleResume` issued a separate `seek()` API call immediately after the `playTrack()` call resolved. The Spotify SDK fires intermediate paused states during the seek operation, and nothing in the flow resumed playback afterward — the `waitForPlaybackOrResume` listener had already settled from an earlier state event.

**Fix:** Pass `positionMs` through the entire play chain so the Spotify Web API `/me/player/play` endpoint receives `position_ms` in the same request as the track URI. This is an atomic operation — no separate seek, no race condition.

## Changes

- Add optional `positionMs` to `PlaybackProvider.playTrack` interface
- Thread `positionMs` through `SpotifyPlaybackAdapter` → `spotifyPlayer` → `apiPlayTrack` to set `position_ms` in the play API call
- Thread `positionMs` through `DropboxPlaybackAdapter` (seeks after play start)
- Thread `positionMs` through `useProviderPlayback.playTrack` via options param
- Update `handleResume` to pass saved position via `playTrack` options instead of a separate seek call
- Update test assertions for the new parameter

## Test plan

- [ ] Resume a Spotify session — track should play from saved position without stopping
- [ ] Resume a Dropbox session — should still work as before
- [ ] Normal play (non-resume) for both providers — unchanged behavior
- [ ] `npm run test:run` passes (917/917)
- [ ] `npx tsc -b --noEmit` clean