### PR TITLE
Release: fix Spotify resume and live position saves

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -230,18 +230,10 @@ const AudioPlayerComponent = () => {
     // without this, usePlaybackSubscription may overwrite resolvedIdx with a
     // stale provider track index before the new track's ID is confirmed.
     expectedTrackIdRef.current = queueTracks[resolvedIdx]?.id ?? null;
-    await handlers.playTrack(resolvedIdx);
 
-    if (savedPositionMs && savedPositionMs > 0) {
-      const drivingProviderId = playbackProviderRef.current;
-      if (drivingProviderId) {
-        const { providerRegistry } = await import('@/providers/registry');
-        const descriptor = providerRegistry.get(drivingProviderId);
-        // savedPositionMs is already in milliseconds (sourced from state.playbackPosition / positionMs)
-        descriptor?.playback.seek(savedPositionMs).catch(() => {});
-      }
-    }
-  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, expectedTrackIdRef, handlers, playbackProviderRef]);
+    const positionMs = savedPositionMs && savedPositionMs > 0 ? savedPositionMs : undefined;
+    await handlers.playTrack(resolvedIdx, false, positionMs ? { positionMs } : undefined);
+  }, [lastSession, setTracks, setOriginalTracks, setSelectedPlaylistId, setCurrentTrackIndex, mediaTracksRef, expectedTrackIdRef, handlers]);
 
   const handleClearCache = useCallback(async (options: ClearCacheOptions) => {
     const { clearCacheWithOptions } = await import('@/services/cache/libraryCache');

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -84,6 +84,15 @@ const AudioPlayerComponent = () => {
   const collectionNameRef = useRef<string>('');
   const collectionProviderRef = useRef<import('@/types/domain').ProviderId | undefined>(undefined);
 
+  const getLivePosition = useCallback(async (): Promise<number | null> => {
+    const drivingId = playbackProviderRef.current;
+    if (!drivingId) return null;
+    const { providerRegistry } = await import('@/providers/registry');
+    const descriptor = providerRegistry.get(drivingId);
+    const ps = await descriptor?.playback.getState();
+    return ps?.positionMs ?? null;
+  }, [playbackProviderRef]);
+
   const { lastSession } = useSessionPersistence(
     selectedPlaylistId,
     collectionNameRef.current,
@@ -95,6 +104,7 @@ const AudioPlayerComponent = () => {
     currentTrack?.artists,
     currentTrack?.image,
     state.playbackPosition,
+    getLivePosition,
   );
 
   const handleAlbumPlay = useCallback((albumId: string) => {

--- a/src/hooks/__tests__/useSpotifyPlayback.test.ts
+++ b/src/hooks/__tests__/useSpotifyPlayback.test.ts
@@ -93,7 +93,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
     expect(setCurrentTrackIndex).toHaveBeenCalledWith(1);
   });
 
@@ -134,7 +134,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then — recursive call plays track at index 1
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
   });
 
   it('skips to next track on generic error when skipOnError is true', async () => {
@@ -155,7 +155,7 @@ describe('useProviderPlayback', () => {
     });
 
     // #then
-    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1]);
+    expect(mockPlayTrack).toHaveBeenCalledWith(mediaTracks[1], undefined);
   });
 
   it('prefetches the next track after successful playback', async () => {

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -35,7 +35,7 @@ export const useProviderPlayback = ({
     }
   }, []);
 
-  const playTrack = useCallback(async (index: number, skipOnError = false) => {
+  const playTrack = useCallback(async (index: number, skipOnError = false, options?: { positionMs?: number }) => {
     const tracks = mediaTracksRef.current;
     const mediaTrack = tracks[index];
     const trackProvider = resolveTrackProvider(mediaTrack);
@@ -72,7 +72,7 @@ export const useProviderPlayback = ({
     }
 
     try {
-      await descriptor.playback.playTrack(mediaTrack);
+      await descriptor.playback.playTrack(mediaTrack, options);
       setCurrentTrackIndex(index);
 
       const nextIndex = (index + 1) % tracks.length;

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -5,7 +5,7 @@ import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { logSession } from '@/lib/debugLog';
 
 const DEBOUNCE_MS = 1000;
-const PERIODIC_SAVE_INTERVAL_MS = 20_000;
+const PERIODIC_SAVE_INTERVAL_MS = 10_000;
 
 export function useSessionPersistence(
   collectionId: string | null,
@@ -18,6 +18,7 @@ export function useSessionPersistence(
   trackArtist: string | undefined,
   trackImage: string | undefined,
   playbackPosition: number,
+  getLivePosition?: () => Promise<number | null>,
 ): { lastSession: SessionSnapshot | null } {
   const [lastSession, setLastSession] = useState<SessionSnapshot | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -88,13 +89,19 @@ export function useSessionPersistence(
     };
   }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
 
-  // Periodic save every 20 seconds during active playback.
+  const getLivePositionRef = useRef(getLivePosition);
+  getLivePositionRef.current = getLivePosition;
+
   useEffect(() => {
     if (periodicTimerRef.current !== null) clearInterval(periodicTimerRef.current);
 
-    periodicTimerRef.current = setInterval(() => {
+    periodicTimerRef.current = setInterval(async () => {
       const snapshot = snapshotRef.current;
       if (!snapshot) return;
+
+      const livePos = await getLivePositionRef.current?.();
+      if (livePos != null) snapshot.playbackPosition = livePos;
+
       logSession('periodic save — position=%dms', Math.floor(snapshot.playbackPosition ?? 0));
       saveSession(snapshot);
     }, PERIODIC_SAVE_INTERVAL_MS);

--- a/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
+++ b/src/providers/__tests__/spotifyPlaybackAdapter.test.ts
@@ -79,7 +79,7 @@ describe('SpotifyPlaybackAdapter', () => {
     expect(spotifyPlayer.initialize).toHaveBeenCalledTimes(1);
     expect(spotifyPlayer.transferPlaybackToDevice).toHaveBeenCalledTimes(1);
     expect(spotifyPlayer.ensureDeviceIsActive).toHaveBeenCalledTimes(1);
-    expect(spotifyPlayer.playTrack).toHaveBeenCalledWith('spotify:track:abc123', undefined);
+    expect(spotifyPlayer.playTrack).toHaveBeenCalledWith('spotify:track:abc123', undefined, undefined);
   });
 
   it('times out if SDK never becomes ready', async () => {

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -60,7 +60,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.ensureAudio();
   }
 
-  async playTrack(track: MediaTrack): Promise<void> {
+  async playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void> {
     this.ensureAudio();
 
     const dropboxPath = track.playbackRef.ref;
@@ -84,6 +84,10 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.audio!.pause();
     this.audio!.src = streamUrl;
     await this.audio!.play();
+
+    if (options?.positionMs) {
+      this.audio!.currentTime = options.positionMs / 1000;
+    }
 
     this.startUpdateInterval();
     this.enrichMetadataInBackground(track, streamUrl);

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -75,11 +75,12 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     await spotifyPlayer.initialize();
   }
 
-  async playTrack(track: MediaTrack): Promise<void> {
+  async playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void> {
     const uri = track.playbackRef.ref;
+    const startPositionMs = options?.positionMs;
 
     // If Spotify's SDK already natively advanced to this track, skip the API call entirely.
-    if (this.playbackSessionActive) {
+    if (this.playbackSessionActive && !startPositionMs) {
       const state = await spotifyPlayer.getCurrentState();
       if (state?.track_window?.current_track?.uri === uri && !state.paused) {
         logSpotify('Spotify already playing requested track natively, skipping API call');
@@ -95,7 +96,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
     const upcomingUris = this.pendingUpcomingUris ?? undefined;
 
-    await this.playWithRetry(uri, track.name, upcomingUris);
+    await this.playWithRetry(uri, track.name, upcomingUris, 0, startPositionMs);
     this.playbackSessionActive = true;
 
     const activateDevice = async () => {
@@ -128,9 +129,10 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     trackName: string,
     upcomingUris?: string[],
     retryCount = 0,
+    positionMs?: number,
   ): Promise<void> {
     try {
-      await spotifyPlayer.playTrack(uri, upcomingUris);
+      await spotifyPlayer.playTrack(uri, upcomingUris, positionMs);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
@@ -150,7 +152,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
           : BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
         logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
-        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1);
+        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
       if (message.includes('403')) {
@@ -164,7 +166,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         await spotifyPlayer.transferPlaybackToDevice(true);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         await spotifyPlayer.ensureDeviceIsActive(3, 1000);
-        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1);
+        return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
       throw error;

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -106,12 +106,12 @@ class SpotifyPlayerService {
     this.saveState();
   }
 
-  async playTrack(uri: string, upcomingUris?: string[]): Promise<void> {
+  async playTrack(uri: string, upcomingUris?: string[], positionMs?: number): Promise<void> {
     if (!this.deviceId || !this.isReady) {
       throw new Error('Spotify player not ready');
     }
     this.lastPlayTrackTime = Date.now();
-    await apiPlayTrack(this.deviceId, uri, upcomingUris);
+    await apiPlayTrack(this.deviceId, uri, upcomingUris, positionMs);
   }
 
   async playContext(contextUri: string, offsetPosition?: number): Promise<void> {

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -5,15 +5,16 @@ export async function apiPlayTrack(
   deviceId: string,
   uri: string,
   upcomingUris?: string[],
+  positionMs?: number,
 ): Promise<void> {
   const token = await spotifyAuth.ensureValidToken();
   const uris = upcomingUris?.length ? [uri, ...upcomingUris] : [uri];
 
-  logSpotify('Web API play track deviceId=%s queueSize=%d', deviceId, uris.length);
+  logSpotify('Web API play track deviceId=%s queueSize=%d positionMs=%s', deviceId, uris.length, positionMs ?? 0);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
-    body: JSON.stringify({ uris, position_ms: 0 }),
+    body: JSON.stringify({ uris, position_ms: positionMs ?? 0 }),
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${token}`

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -66,8 +66,8 @@ export interface CatalogProvider {
 export interface PlaybackProvider {
   readonly providerId: ProviderId;
   initialize(): Promise<void>;
-  /** Play a single track by ref. */
-  playTrack(track: MediaTrack): Promise<void>;
+  /** Play a single track by ref, optionally starting from a position. */
+  playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void>;
   /** Play a collection from optional offset (e.g. playlist from index). */
   playCollection?(collectionRef: CollectionRef, options?: { offset?: number }): Promise<void>;
   pause(): Promise<void>;


### PR DESCRIPTION
## Summary
- **Spotify resume fix**: threaded `positionMs` through the entire play chain so Spotify's `/me/player/play` API receives position atomically — no separate seek, no race (#810)
- **Live position saves**: periodic session save now queries the driving provider's `getState()` for accurate positionMs instead of relying on stale React state; interval reduced from 20s to 10s

## PRs included
- #810 fix: prevent Spotify resume playback from being cancelled by seek race
- Direct commit: fix: query live playback position for periodic session saves

## Test plan
- [ ] Spotify: play a track, close tab, reopen → resumes correct track at saved position
- [ ] Spotify: play for 30s+ past a resume point, refresh → position is within ~10s of where you were
- [ ] Dropbox: resume still works correctly
- [ ] Auto-advance still works normally during playback