### PR TITLE
refactor(bottom-bar): polish for clarity and consistency

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '../icons/QuickActionIcons';
 
 const AUTOHIDE_DELAY = 1000;
+const noop = () => {};
 
 interface BottomBarProps {
   zenModeEnabled?: boolean;
@@ -143,8 +144,8 @@ const BottomBar = React.memo(function BottomBar({
           <VolumeControl
             isMuted={isMuted}
             volume={volume}
-            onClick={onMuteToggle ?? (() => {})}
-            onVolumeChange={onVolumeChange ?? (() => {})}
+            onClick={onMuteToggle ?? noop}
+            onVolumeChange={onVolumeChange ?? noop}
             isMobile={isMobile}
             isTablet={isTablet}
           />

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 import { ZEN_BAR_DURATION } from '@/constants/zenAnimation';
 
 export const BOTTOM_BAR_HEIGHT = 60;
 
 export const BottomBarContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$hidden'].includes(prop),
+  shouldForwardProp: (prop) => prop !== '$hidden',
 })<{ $hidden?: boolean }>`
   position: fixed;
   bottom: 0;
@@ -28,12 +27,12 @@ export const BottomBarInner = styled.div`
   align-items: center;
   justify-content: center;
   gap: ${({ theme }) => theme.spacing.xs};
-  padding: ${({ theme }) => theme.spacing.xs} ${theme.spacing.md};
+  padding: ${({ theme }) => `${theme.spacing.xs} ${theme.spacing.md}`};
   height: ${BOTTOM_BAR_HEIGHT}px;
 `;
 
 export const ZenGripPill = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$visible'].includes(prop),
+  shouldForwardProp: (prop) => prop !== '$visible',
 })<{ $visible: boolean }>`
   width: 36px;
   height: 4px;
@@ -55,13 +54,13 @@ export const ZenTriggerZone = styled.div`
   left: 0;
   right: 0;
   height: 48px;
-  z-index: ${Number(theme.zIndex.mobileMenu) - 1};
+  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 1};
   background: transparent;
 `;
 
 export const ZenBackdrop = styled.div`
   position: fixed;
   inset: 0;
-  z-index: ${Number(theme.zIndex.mobileMenu) - 2};
+  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 2};
   background: transparent;
 `;

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -44,6 +44,7 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
     isMobile: false,
     isTablet: false,
     isDesktop: true,
+    isTouchDevice: false,
     hasPointerInput: true,
     viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
     dimensions: { width: 600, height: 600 },


### PR DESCRIPTION
## Summary

- **Removed unused bare `theme` import** from `styled.ts` — all theme access now goes through the styled-components theme prop, eliminating the inconsistency of mixing bare imports with prop-based access
- **Simplified `shouldForwardProp`** on `BottomBarContainer` and `ZenGripPill` from `!['$prop'].includes(prop)` to direct `prop !== '$prop'` equality checks
- **Fixed inconsistent padding interpolation** in `BottomBarInner` where the horizontal padding used a bare theme import while vertical used the prop pattern
- **Converted `ZenTriggerZone` and `ZenBackdrop` z-index** from bare theme import to theme prop access for consistency
- **Stabilized noop fallback callbacks** with a module-level `noop` constant, avoiding new function allocations on every render that would defeat `React.memo`
- **Added missing `isTouchDevice`** to the `PlayerSizingContext` mock in tests, matching the shape the component destructures

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc -b --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] All 917 tests pass (`npm run test:run`)
- [x] No visual/behavioral changes — polish only