### PR TITLE
refactor(settings): extract useAsyncAction hook and feedback timeout constant

### DIFF
--- a/src/components/VisualEffectsMenu/ProviderDataSection.tsx
+++ b/src/components/VisualEffectsMenu/ProviderDataSection.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useCallback } from 'react';
 
 import type { CatalogProvider } from '@/types/providers';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
+import { useAsyncAction, FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
 
 import {
   ControlGroup,
@@ -11,36 +12,26 @@ import {
 import { CollapsibleSection } from './CollapsibleSection';
 
 export const ProviderDataSection = memo(({ providerName, catalog }: { providerName: string; catalog: CatalogProvider }) => {
-  const [artStatus, setArtStatus] = useState<'idle' | 'working' | 'done'>('idle');
-  const [likesStatus, setLikesStatus] = useState<'idle' | 'working' | 'done'>('idle');
   const [resultMessage, setResultMessage] = useState('');
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-
-  const artBusy = artStatus === 'working';
-  const likesBusy = likesStatus === 'working';
 
   const hasArtCache = !!catalog.clearArtCache;
   const hasRefreshArt = !!catalog.refreshArtCache;
   const hasLikesManagement = !!catalog.exportLikes && !!catalog.importLikes;
   const hasMetadataRefresh = !!catalog.refreshLikedMetadata;
 
-  const handleClearArt = async () => {
-    setArtStatus('working');
-    await catalog.clearArtCache?.();
-    setArtStatus('done');
-    setTimeout(() => setArtStatus('idle'), 1500);
-  };
+  const clearResultMessage = useCallback(() => setResultMessage(''), []);
 
-  const handleRefreshArt = async () => {
-    setArtStatus('working');
+  const clearArtFn = useCallback(async () => {
+    await catalog.clearArtCache?.();
+  }, [catalog]);
+
+  const refreshArtFn = useCallback(async () => {
     await catalog.refreshArtCache?.();
     window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
-    setArtStatus('done');
-    setTimeout(() => setArtStatus('idle'), 1500);
-  };
+  }, [catalog]);
 
-  const handleExport = async () => {
-    setLikesStatus('working');
+  const exportFn = useCallback(async () => {
     try {
       const json = await catalog.exportLikes!();
       const blob = new Blob([json], { type: 'application/json' });
@@ -54,28 +45,9 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
     } catch {
       setResultMessage('Export failed');
     }
-    setLikesStatus('done');
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 1500);
-  };
+  }, [catalog]);
 
-  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setLikesStatus('working');
-    try {
-      const json = await file.text();
-      const count = await catalog.importLikes!(json);
-      setResultMessage(`Imported ${count} tracks`);
-    } catch {
-      setResultMessage('Import failed');
-    }
-    setLikesStatus('done');
-    if (fileInputRef.current) fileInputRef.current.value = '';
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 2000);
-  };
-
-  const handleRefreshMetadata = async () => {
-    setLikesStatus('working');
+  const refreshMetadataFn = useCallback(async () => {
     try {
       const result = await catalog.refreshLikedMetadata!();
       const parts: string[] = [];
@@ -85,25 +57,48 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
     } catch {
       setResultMessage('Refresh failed');
     }
-    setLikesStatus('done');
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 2000);
-  };
+  }, [catalog]);
+
+  const [clearArtStatus, runClearArt] = useAsyncAction(clearArtFn);
+  const [refreshArtStatus, runRefreshArt] = useAsyncAction(refreshArtFn);
+  const [exportStatus, runExport] = useAsyncAction(exportFn, { onReset: clearResultMessage });
+  const [metadataStatus, runRefreshMetadata] = useAsyncAction(refreshMetadataFn, { onReset: clearResultMessage });
+  const [importStatus, setImportStatus] = useState<'idle' | 'working' | 'done'>('idle');
+
+  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportStatus('working');
+    try {
+      const json = await file.text();
+      const count = await catalog.importLikes!(json);
+      setResultMessage(`Imported ${count} tracks`);
+    } catch {
+      setResultMessage('Import failed');
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setImportStatus('done');
+    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, FEEDBACK_DISPLAY_MS);
+  }, [catalog]);
+
+  const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';
+  const likesBusy = exportStatus === 'working' || importStatus === 'working' || metadataStatus === 'working';
 
   return (
     <CollapsibleSection title={`${providerName} Data`}>
       {hasArtCache && (
         <ControlGroup>
           <ControlLabel>Clear cached art so it re-downloads on next library load</ControlLabel>
-          <ResetButton onClick={handleClearArt} disabled={artBusy}>
-            {artStatus === 'done' ? 'Cleared!' : artBusy ? 'Working...' : 'Clear Art Cache'}
+          <ResetButton onClick={runClearArt} disabled={artBusy}>
+            {clearArtStatus === 'done' ? 'Cleared!' : artBusy ? 'Working...' : 'Clear Art Cache'}
           </ResetButton>
         </ControlGroup>
       )}
       {hasRefreshArt && (
         <ControlGroup>
           <ControlLabel>Clear and immediately re-fetch fresh art in the background</ControlLabel>
-          <ResetButton onClick={handleRefreshArt} disabled={artBusy}>
-            {artStatus === 'done' ? 'Started!' : artBusy ? 'Working...' : 'Refresh Art'}
+          <ResetButton onClick={runRefreshArt} disabled={artBusy}>
+            {refreshArtStatus === 'done' ? 'Started!' : artBusy ? 'Working...' : 'Refresh Art'}
           </ResetButton>
         </ControlGroup>
       )}
@@ -111,8 +106,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
         <>
           <ControlGroup>
             <ControlLabel>Export liked songs to a JSON file for backup</ControlLabel>
-            <ResetButton onClick={handleExport} disabled={likesBusy}>
-              {likesStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working...' : 'Export Likes'}
+            <ResetButton onClick={runExport} disabled={likesBusy}>
+              {exportStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working...' : 'Export Likes'}
             </ResetButton>
           </ControlGroup>
           <ControlGroup>
@@ -125,7 +120,7 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
               style={{ display: 'none' }}
             />
             <ResetButton onClick={() => fileInputRef.current?.click()} disabled={likesBusy}>
-              {likesStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working...' : 'Import Likes'}
+              {importStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working...' : 'Import Likes'}
             </ResetButton>
           </ControlGroup>
         </>
@@ -133,8 +128,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       {hasMetadataRefresh && (
         <ControlGroup>
           <ControlLabel>Re-scan {providerName} to update metadata for liked tracks</ControlLabel>
-          <ResetButton onClick={handleRefreshMetadata} disabled={likesBusy}>
-            {likesStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning...' : 'Refresh Metadata'}
+          <ResetButton onClick={runRefreshMetadata} disabled={likesBusy}>
+            {metadataStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning...' : 'Refresh Metadata'}
           </ResetButton>
         </ControlGroup>
       )}

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -26,6 +26,8 @@ import {
   CacheCancelButton,
 } from './styled';
 
+import { FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
+
 import { MusicSourcesSection, NativeQueueSyncSection } from './SourcesSections';
 import { ProviderDataSection } from './ProviderDataSection';
 import { CollapsibleSection } from './CollapsibleSection';
@@ -110,7 +112,7 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
     setClearLikes(false);
     setClearPins(false);
     setClearAccentColors(false);
-    setTimeout(() => setClearState('idle'), 1500);
+    setTimeout(() => setClearState('idle'), FEEDBACK_DISPLAY_MS);
   }, [onClearCache, clearLikes, clearPins, clearAccentColors]);
 
   return createPortal(

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback, useRef } from 'react';
+
+export const FEEDBACK_DISPLAY_MS = 1500;
+
+type AsyncStatus = 'idle' | 'working' | 'done';
+
+export function useAsyncAction(
+  asyncFn: () => Promise<void>,
+  { resetMs = FEEDBACK_DISPLAY_MS, onReset }: { resetMs?: number; onReset?: () => void } = {},
+): [AsyncStatus, () => Promise<void>] {
+  const [status, setStatus] = useState<AsyncStatus>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const run = useCallback(async () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+    setStatus('working');
+    await asyncFn();
+    setStatus('done');
+    timerRef.current = setTimeout(() => {
+      setStatus('idle');
+      onReset?.();
+      timerRef.current = null;
+    }, resetMs);
+  }, [asyncFn, resetMs, onReset]);
+
+  return [status, run];
+}


### PR DESCRIPTION
Closes #815
Closes #816

## Summary

- Extract `useAsyncAction` hook to `src/hooks/useAsyncAction.ts` encapsulating the `idle → working → done → idle` state machine with configurable `resetMs` and an optional `onReset` callback
- Export `FEEDBACK_DISPLAY_MS = 1500` constant from the same module
- Refactor `ProviderDataSection.tsx` to use `useAsyncAction` for `clearArt`, `refreshArt`, `export`, and `refreshMetadata` handlers — eliminating four near-identical state machines and two duplicated status trackers
- Update `VisualEffectsMenu/index.tsx` cache-clear `setTimeout` to use `FEEDBACK_DISPLAY_MS` instead of a magic number

## Test plan

- [ ] `npx tsc -b --noEmit` — passes clean
- [ ] `npm run build` — builds successfully
- [ ] `npm run test:run` — 917 tests pass across 72 files
- [ ] Manually verify Clear Art Cache, Refresh Art, Export Likes, Import Likes, Refresh Metadata, and Clear Library Cache buttons still show Working… → feedback → reset cycle correctly