### PR TITLE
test(settings): add persistence layer tests

### DIFF
--- a/src/contexts/__tests__/VisualEffectsContext.test.tsx
+++ b/src/contexts/__tests__/VisualEffectsContext.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { VisualEffectsProvider, useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  isProfilingEnabled: () => false,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <VisualEffectsProvider>{children}</VisualEffectsProvider>;
+}
+
+describe('VisualEffectsContext', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+    vi.mocked(window.localStorage.removeItem).mockClear();
+    vi.mocked(window.localStorage.setItem).mockClear();
+  });
+
+  describe('visualizer style migration', () => {
+    it("migrates 'particles' to 'fireflies' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'particles';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'fireflies',
+      );
+    });
+
+    it("migrates 'trail' to 'comet' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'trail';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'comet',
+      );
+    });
+
+    it("migrates 'geometric' to 'fireflies' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'geometric';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'fireflies',
+      );
+    });
+
+    it("leaves a valid style unchanged — 'fireflies' is not remapped", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return '"fireflies"';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then — setItem should only have been called for ALBUM_FILTERS removal, not for BG_VISUALIZER_STYLE
+      const styleSetCalls = vi.mocked(window.localStorage.setItem).mock.calls.filter(
+        ([key]) => key === STORAGE_KEYS.BG_VISUALIZER_STYLE,
+      );
+      expect(styleSetCalls).toHaveLength(0);
+    });
+
+    it("leaves a valid style unchanged — 'comet' is not remapped", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return '"comet"';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      const styleSetCalls = vi.mocked(window.localStorage.setItem).mock.calls.filter(
+        ([key]) => key === STORAGE_KEYS.BG_VISUALIZER_STYLE,
+      );
+      expect(styleSetCalls).toHaveLength(0);
+    });
+  });
+
+  describe('context defaults', () => {
+    it('exposes default backgroundVisualizerStyle of fireflies when no value is stored', () => {
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.backgroundVisualizerStyle).toBe('fireflies');
+    });
+
+    it('exposes default visualEffectsEnabled of true', () => {
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.visualEffectsEnabled).toBe(true);
+    });
+
+    it('disables accentColorBackgroundEnabled when visualEffectsEnabled is false', () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.VISUAL_EFFECTS_ENABLED) return 'false';
+        if (key === STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED) return 'true';
+        return null;
+      });
+
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.accentColorBackgroundEnabled).toBe(false);
+    });
+
+    it('sets accentColorBackgroundEnabled based on preference when visual effects are on', () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.VISUAL_EFFECTS_ENABLED) return 'true';
+        if (key === STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED) return 'true';
+        return null;
+      });
+
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.accentColorBackgroundEnabled).toBe(true);
+    });
+  });
+
+  describe('setters', () => {
+    it('updates backgroundVisualizerStyle and persists to localStorage', () => {
+      // #given
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #when
+      act(() => {
+        result.current.setBackgroundVisualizerStyle('wave');
+      });
+
+      // #then
+      expect(result.current.backgroundVisualizerStyle).toBe('wave');
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        expect.stringContaining('wave'),
+      );
+    });
+
+    it('updates zenModeEnabled and persists to localStorage', () => {
+      // #given
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #when
+      act(() => {
+        result.current.setZenModeEnabled(true);
+      });
+
+      // #then
+      expect(result.current.zenModeEnabled).toBe(true);
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ZEN_MODE_ENABLED,
+        'true',
+      );
+    });
+  });
+
+  describe('useVisualEffectsContext guard', () => {
+    it('throws when used outside VisualEffectsProvider', () => {
+      // #when / #then
+      expect(() => renderHook(() => useVisualEffectsContext())).toThrow(
+        'useVisualEffectsContext must be used within VisualEffectsProvider',
+      );
+    });
+  });
+});

--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -1,168 +1,142 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useLocalStorage } from '../useLocalStorage';
-
-// Mock localStorage since it's not available in all test environments
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-
-  return {
-    getItem: (key: string) => store[key] || null,
-    setItem: (key: string, value: string) => {
-      store[key] = value.toString();
-    },
-    removeItem: (key: string) => {
-      delete store[key];
-    },
-    clear: () => {
-      store = {};
-    }
-  };
-})();
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 describe('useLocalStorage', () => {
   beforeEach(() => {
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-      writable: true
-    });
-    localStorageMock.clear();
-    vi.clearAllMocks();
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
   });
 
-  afterEach(() => {
-    localStorageMock.clear();
-  });
-
-  it('should initialize with the provided initial value when localStorage is empty', () => {
+  it('returns the initial value when localStorage has no entry for the key', () => {
+    // #when
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
-    const [value] = result.current;
-    expect(value).toBe('initial');
+
+    // #then
+    expect(result.current[0]).toBe('initial');
   });
 
-  it('should read value from localStorage on initialization', () => {
-    localStorageMock.setItem('test-key', JSON.stringify('stored-value'));
+  it('returns the stored value when localStorage has data for the key', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify('stored-value'));
+
+    // #when
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
-    const [value] = result.current;
-    expect(value).toBe('stored-value');
+
+    // #then
+    expect(result.current[0]).toBe('stored-value');
   });
 
-  it('should update localStorage when value changes', () => {
+  it('writes to localStorage when setValue is called with a direct value', () => {
     // #given
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
 
-    // #when - update value to 'updated'
+    // #when
     act(() => {
-      const [, setValue] = result.current;
-      setValue('updated');
+      result.current[1]('updated');
     });
 
     // #then
-    const storedValue = localStorageMock.getItem('test-key');
-    expect(storedValue).toBe(JSON.stringify('updated'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('test-key', JSON.stringify('updated'));
+    expect(result.current[0]).toBe('updated');
   });
 
-  it('should support function updates like useState', () => {
+  it('writes to localStorage when setValue is called with an updater function', () => {
     // #given
+    vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(10));
     const { result } = renderHook(() => useLocalStorage('counter', 0));
 
-    // #when - increment counter using function update
+    // #when
     act(() => {
-      const [, setValue] = result.current;
-      setValue(prev => prev + 1);
+      result.current[1]((prev) => prev + 5);
     });
 
     // #then
-    expect(result.current[0]).toBe(1);
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('counter', JSON.stringify(15));
+    expect(result.current[0]).toBe(15);
   });
 
-  it('should handle complex objects', () => {
+  it('falls back to the initial value and warns when stored JSON is malformed', () => {
     // #given
-    const initialObj = { name: 'test', values: [1, 2, 3] };
-    const { result } = renderHook(() => useLocalStorage('obj-key', initialObj));
+    vi.mocked(window.localStorage.getItem).mockReturnValue('not-valid-json{{');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    // #when - update object to new values
-    act(() => {
-      const [, setValue] = result.current;
-      setValue({ name: 'updated', values: [4, 5, 6] });
-    });
-
-    // #then
-    const [value] = result.current;
-    expect(value).toEqual({ name: 'updated', values: [4, 5, 6] });
-    expect(localStorageMock.getItem('obj-key')).toBe(JSON.stringify({ name: 'updated', values: [4, 5, 6] }));
-  });
-
-  it('should handle JSON parse errors gracefully', () => {
-    // #given - store invalid JSON
-    localStorageMock.setItem('bad-json', 'not-valid-json');
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    // #when - initialize with bad JSON key
+    // #when
     const { result } = renderHook(() => useLocalStorage('bad-json', 'fallback'));
-    const [value] = result.current;
 
     // #then
-    expect(value).toBe('fallback');
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(result.current[0]).toBe('fallback');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bad-json'), expect.anything());
 
-    consoleSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
-  it('should handle localStorage quota exceeded gracefully', () => {
-    // #given - mock failing localStorage and console
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('warns and still updates React state when localStorage.setItem throws', () => {
+    // #given
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useLocalStorage('test-key', 'original'));
 
-    const failingStorage = {
-      getItem: (key: string) => localStorageMock.getItem(key),
-      setItem: () => {
-        throw new Error('QuotaExceededError');
-      },
-      removeItem: (key: string) => localStorageMock.removeItem(key),
-      clear: () => localStorageMock.clear()
-    };
-
-    Object.defineProperty(window, 'localStorage', {
-      value: failingStorage,
-      writable: true
+    // #when
+    act(() => {
+      result.current[1]('new-value');
     });
 
+    // #then
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('test-key'), expect.anything());
+    expect(result.current[0]).toBe('new-value');
+
+    warnSpy.mockRestore();
+  });
+
+  it('syncs state from a StorageEvent fired by another tab', () => {
+    // #given
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
 
-    // #when - attempt to set value when storage is full
-    try {
-      act(() => {
-        const [, setValue] = result.current;
-        setValue('new-value');
-      });
-    } catch {
-      // Expected error from React boundary
-    }
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'test-key',
+          newValue: JSON.stringify('from-other-tab'),
+        }),
+      );
+    });
 
     // #then
-    expect(consoleSpy).toHaveBeenCalled();
-
-    // Restore original localStorage
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-      writable: true
-    });
-    consoleSpy.mockRestore();
-    errorSpy.mockRestore();
+    expect(result.current[0]).toBe('from-other-tab');
   });
 
-  it('should handle different data types', () => {
-    // #given - initialize hooks with various data types
-    const { result: stringResult } = renderHook(() => useLocalStorage('string', 'hello'));
-    const { result: numberResult } = renderHook(() => useLocalStorage('number', 42));
-    const { result: booleanResult } = renderHook(() => useLocalStorage('boolean', true));
-    const { result: arrayResult } = renderHook(() => useLocalStorage('array', [1, 2, 3]));
+  it('ignores StorageEvents for unrelated keys', () => {
+    // #given
+    const { result } = renderHook(() => useLocalStorage('test-key', 'original'));
 
-    // #then - verify each type is preserved
-    expect(stringResult.current[0]).toBe('hello');
-    expect(numberResult.current[0]).toBe(42);
-    expect(booleanResult.current[0]).toBe(true);
-    expect(arrayResult.current[0]).toEqual([1, 2, 3]);
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'other-key',
+          newValue: JSON.stringify('should-not-apply'),
+        }),
+      );
+    });
+
+    // #then
+    expect(result.current[0]).toBe('original');
+  });
+
+  it('removes the storage event listener when the hook unmounts', () => {
+    // #given
+    const removeListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useLocalStorage('test-key', 0));
+
+    // #when
+    unmount();
+
+    // #then
+    expect(removeListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+    removeListenerSpy.mockRestore();
   });
 });

--- a/src/services/settings/__tests__/settingsDb.test.ts
+++ b/src/services/settings/__tests__/settingsDb.test.ts
@@ -1,0 +1,138 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  settingsGet,
+  settingsPut,
+  settingsClearStore,
+  initSettingsDb,
+  STORE_NAMES,
+  _settingsDbTesting,
+} from '@/services/settings/settingsDb';
+
+async function resetDb(): Promise<void> {
+  await initSettingsDb();
+
+  const { db, fallbackStores } = _settingsDbTesting;
+  fallbackStores[STORE_NAMES.PINS].clear();
+
+  if (db) {
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_NAMES.PINS, 'readwrite');
+      tx.objectStore(STORE_NAMES.PINS).clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    });
+  }
+
+  _settingsDbTesting.reset();
+}
+
+describe('settingsDb (IDB happy path)', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it('returns undefined for a key that has never been stored', async () => {
+    // #when
+    const result = await settingsGet(STORE_NAMES.PINS, 'missing-key');
+
+    // #then
+    expect(result).toBeUndefined();
+  });
+
+  it('round-trips a value: settingsPut then settingsGet returns the stored record', async () => {
+    // #given
+    const record = { key: 'pin-1', ids: ['a', 'b', 'c'] };
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, record);
+    const result = await settingsGet<typeof record>(STORE_NAMES.PINS, 'pin-1');
+
+    // #then
+    expect(result).toEqual(record);
+  });
+
+  it('overwrites an existing record when settingsPut is called with the same key', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['old'] });
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['new'] });
+    const result = await settingsGet<{ key: string; ids: string[] }>(STORE_NAMES.PINS, 'pin-1');
+
+    // #then
+    expect(result?.ids).toEqual(['new']);
+  });
+
+  it('clears all records in the store after settingsClearStore', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['a'] });
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-2', ids: ['b'] });
+
+    // #when
+    await settingsClearStore(STORE_NAMES.PINS);
+
+    // #then
+    expect(await settingsGet(STORE_NAMES.PINS, 'pin-1')).toBeUndefined();
+    expect(await settingsGet(STORE_NAMES.PINS, 'pin-2')).toBeUndefined();
+  });
+});
+
+describe('settingsDb (in-memory fallback mode)', () => {
+  beforeEach(async () => {
+    await resetDb();
+    _settingsDbTesting.reset();
+    // Force fallback mode by making initSettingsDb think IDB is missing
+    Object.defineProperty(_settingsDbTesting, 'fallbackMode', {
+      get() { return true; },
+      configurable: true,
+    });
+    // Bypass the normal init by patching the module-level flag via reset + manual state
+    // The cleanest way is to reset and then simulate fallback via the testing helper
+    _settingsDbTesting.reset();
+    // Patch indexedDB to force the error path on next init
+    const originalIndexedDB = globalThis.indexedDB;
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    await initSettingsDb();
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: originalIndexedDB,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('returns undefined for a missing key in fallback mode', async () => {
+    // #when
+    const result = await settingsGet(STORE_NAMES.PINS, 'nonexistent');
+
+    // #then
+    expect(result).toBeUndefined();
+  });
+
+  it('round-trips a value using the in-memory store when IDB is unavailable', async () => {
+    // #given
+    const record = { key: 'fallback-pin', ids: ['x', 'y'] };
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, record);
+    const result = await settingsGet<typeof record>(STORE_NAMES.PINS, 'fallback-pin');
+
+    // #then
+    expect(result).toEqual(record);
+  });
+
+  it('clears the in-memory store when settingsClearStore is called in fallback mode', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'fb-1', ids: ['a'] });
+
+    // #when
+    await settingsClearStore(STORE_NAMES.PINS);
+
+    // #then
+    expect(await settingsGet(STORE_NAMES.PINS, 'fb-1')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #818

Add test coverage for the settings persistence layer:

- **useLocalStorage** (`src/hooks/__tests__/useLocalStorage.test.ts`): rewrites the existing test file to use the project's `vi.fn()` mock pattern from `setup.ts`; adds StorageEvent tab-sync, JSON parse error fallback, localStorage write error (quota exceeded), and listener cleanup tests
- **settingsDb** (`src/services/settings/__tests__/settingsDb.test.ts`): IDB happy-path tests (get missing key, put/get round-trip, overwrite, clearStore) and in-memory fallback mode tests (triggered by temporarily removing `globalThis.indexedDB`)
- **VisualEffectsContext** (`src/contexts/__tests__/VisualEffectsContext.test.tsx`): migration tests (`particles`→`fireflies`, `trail`→`comet`, `geometric`→`fireflies`), valid-style no-op tests (`fireflies` and `comet` unchanged), default value tests, setter-persistence tests, and provider guard test

All 937 tests pass (was 917 before this PR).