### PR TITLE
cleanup(controls): remove dead conditional branches in ControlButton

### DIFF
--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -158,32 +158,12 @@ export const ControlButton = styled.button.withConfig({
   cursor: pointer;
   touch-action: manipulation; /* Remove 300ms tap delay on iOS */
   transition: all 0.2s ease;
-  padding: ${({ $isMobile, $isTablet, $compact, theme }) => {
-    if ($compact) return theme.spacing.sm;
-    if ($isMobile) return theme.spacing.sm;
-    if ($isTablet) return theme.spacing.sm;
-    return theme.spacing.sm;
-  }};
-  border-radius: ${({ $isMobile, $isTablet, $compact, theme }) => {
-    if ($compact) return theme.borderRadius.md;
-    if ($isMobile) return theme.borderRadius.md;
-    if ($isTablet) return theme.borderRadius.md;
-    return theme.borderRadius.md;
-  }};
+  padding: ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
 
   svg {
-    width: ${({ $isMobile, $isTablet, $compact }) => {
-    if ($compact) return '1.5rem';
-    if ($isMobile) return '1.5rem';
-    if ($isTablet) return '1.5rem';
-    return '1.5rem';
-  }};
-    height: ${({ $isMobile, $isTablet, $compact }) => {
-    if ($compact) return '1.5rem';
-    if ($isMobile) return '1.5rem';
-    if ($isTablet) return '1.5rem';
-    return '1.5rem';
-  }};
+    width: 1.5rem;
+    height: 1.5rem;
     fill: currentColor;
   }
 


### PR DESCRIPTION
Closes #819

The `ControlButton` styled component had four conditional blocks (padding, border-radius, SVG width, SVG height) where every branch returned the same value. Replaced each with the single static value.

No visual change — output is identical.