### PR TITLE
cleanup(icons): remove inline size override from VisualEffectsIcon

### DIFF
--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -5,14 +5,7 @@ export const QueueIcon = () => (
 );
 
 export const VisualEffectsIcon = () => (
-  <svg
-    viewBox="0 0 24 24"
-    style={{ display: 'block' }}
-    width="1.5rem"
-    height="1.5rem"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       fill="currentColor"
       fillRule="evenodd"


### PR DESCRIPTION
Closes #828

Normalize `VisualEffectsIcon` to match sibling icon patterns — remove inline `width`, `height`, and `style` props.

The parent `ControlButton` in `BottomBar` already handles sizing via CSS for all other icons in the same file (`QueueIcon`, `BackToLibraryIcon`, `ZenModeIcon`, `ShuffleIcon`, `RadioIcon`, `QuickAccessPanelIcon`). `VisualEffectsIcon` was the only outlier with hardcoded `width="1.5rem"`, `height="1.5rem"`, and `style={{ display: 'block' }}`.