### PR TITLE
fix(queue-drawer): use transient props and 100dvh

### DIFF
--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -8,20 +8,18 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
 
-const QueueDrawerContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['isOpen', 'width', 'transitionDuration', 'transitionEasing'].includes(prop),
-}) <{ isOpen: boolean; width: number; transitionDuration: number; transitionEasing: string }>`
+const QueueDrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $transitionDuration: number; $transitionEasing: string }>`
   position: fixed;
   top: 0;
   right: 0;
-  width: ${({ width }) => width}px;
-  height: 100vh;
+  width: ${({ $width }) => $width}px;
+  height: 100dvh;
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(${theme.drawer.backdropBlur});
   border-left: 1px solid ${theme.colors.popover.border};
-  transform: translateX(${props => props.isOpen ? '0' : '100%'});
-  transition: transform ${({ transitionDuration }) => transitionDuration}ms ${({ transitionEasing }) => transitionEasing},
-            width ${({ transitionDuration }) => transitionDuration}ms ${({ transitionEasing }) => transitionEasing};
+  transform: translateX(${props => props.$isOpen ? '0' : '100%'});
+  transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
+            width ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
   z-index: ${theme.zIndex.modal};
   overflow-y: auto;
   padding: ${theme.spacing.md};
@@ -69,18 +67,16 @@ const QueueContent = styled.div`
   }
 `;
 
-const QueueOverlay = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['isOpen'].includes(prop),
-}) <{ isOpen: boolean }>`
+const QueueOverlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   background: ${theme.colors.overlay.light};
   backdrop-filter: blur(2px);
-  opacity: ${props => props.isOpen ? 1 : 0};
-  visibility: ${props => props.isOpen ? 'visible' : 'hidden'};
+  opacity: ${props => props.$isOpen ? 1 : 0};
+  visibility: ${props => props.$isOpen ? 'visible' : 'hidden'};
   transition: all ${theme.drawer.transitionDuration}ms ${theme.drawer.transitionEasing};
   z-index: ${theme.zIndex.overlay};
 `;
@@ -238,15 +234,15 @@ const QueueDrawer = memo<QueueDrawerProps>(({
   return createPortal(
     <>
       <QueueOverlay
-        isOpen={isOpen}
+        $isOpen={isOpen}
         onClick={onClose}
       />
 
       <QueueDrawerContainer
-        isOpen={isOpen}
-        width={drawerWidth}
-        transitionDuration={transitionDuration}
-        transitionEasing={transitionEasing}
+        $isOpen={isOpen}
+        $width={drawerWidth}
+        $transitionDuration={transitionDuration}
+        $transitionEasing={transitionEasing}
       >
         <QueueHeader>
           <div>

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -210,7 +210,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         ref={itemRef}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
-        isSelected={isSelected}
+        $isSelected={isSelected}
         {...longPressHandlers}
         {...(isEditMode && onRemove ? { ...attributes, ...listeners } : {})}
         style={isEditMode && onRemove ? { cursor: isDragging ? 'grabbing' : 'grab', touchAction: 'none' } : undefined}
@@ -237,15 +237,15 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         </AlbumArtContainer>
 
         <TrackInfo>
-          <TrackName isSelected={isSelected}>
+          <TrackName $isSelected={isSelected}>
             {track.name}
           </TrackName>
-          <TrackArtist isSelected={isSelected}>
+          <TrackArtist $isSelected={isSelected}>
             {track.artists}
           </TrackArtist>
         </TrackInfo>
 
-        <Duration isSelected={isSelected}>
+        <Duration $isSelected={isSelected}>
           {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
         </Duration>
 
@@ -314,7 +314,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             if (!isEditMode) onSelect(index);
           }}
           onContextMenu={handleContextMenu}
-          isSelected={isSelected}
+          $isSelected={isSelected}
           {...longPressHandlers}
         >
           <AlbumArtContainer>
@@ -333,15 +333,15 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
           </AlbumArtContainer>
 
           <TrackInfo>
-            <TrackName isSelected={isSelected}>
+            <TrackName $isSelected={isSelected}>
               {track.name}
             </TrackName>
-            <TrackArtist isSelected={isSelected}>
+            <TrackArtist $isSelected={isSelected}>
               {track.artists}
             </TrackArtist>
           </TrackInfo>
 
-          <Duration isSelected={isSelected}>
+          <Duration $isSelected={isSelected}>
             {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
           </Duration>
 
@@ -383,7 +383,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             ref={itemRef}
             onClick={() => !isRevealed && !isEditMode && onSelect(index)}
             onContextMenu={handleContextMenu}
-            isSelected={isSelected}
+            $isSelected={isSelected}
             {...longPressHandlers}
           >
             <AlbumArtContainer>
@@ -401,15 +401,15 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             </AlbumArtContainer>
 
             <TrackInfo>
-              <TrackName isSelected={isSelected}>
+              <TrackName $isSelected={isSelected}>
                 {track.name}
               </TrackName>
-              <TrackArtist isSelected={isSelected}>
+              <TrackArtist $isSelected={isSelected}>
                 {track.artists}
               </TrackArtist>
             </TrackInfo>
 
-            <Duration isSelected={isSelected}>
+            <Duration $isSelected={isSelected}>
               {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
             </Duration>
 

--- a/src/components/QueueTrackList.styled.ts
+++ b/src/components/QueueTrackList.styled.ts
@@ -78,9 +78,7 @@ export const QueueListItems = styled.div`
   gap: ${({ theme }) => theme.spacing.sm};
 `;
 
-export const QueueListItem = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const QueueListItem = styled.div<{ $isSelected: boolean }>`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spacing.sm};
@@ -90,7 +88,7 @@ export const QueueListItem = styled.div.withConfig({
   transition: background 0.2s ease, border-color 0.2s ease;
   border: 1px solid transparent;
 
-  ${({ theme, isSelected }) => isSelected ? `
+  ${({ theme, $isSelected }) => $isSelected ? `
     background: color-mix(in srgb, var(--accent-color) 20%, transparent);
     border-color: var(--accent-color);
   ` : `
@@ -121,13 +119,11 @@ export const TrackInfo = styled.div`
   min-width: 0;
 `;
 
-export const TrackName = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const TrackName = styled.div<{ $isSelected: boolean }>`
   font-weight: ${({ theme }) => theme.fontWeight.semibold};
   font-size: ${({ theme }) => theme.fontSize.base};
   line-height: 1.25;
-  color: ${({ isSelected, theme }) => isSelected ? theme.colors.white : '#f5f5f5'};
+  color: ${({ $isSelected, theme }) => $isSelected ? theme.colors.white : '#f5f5f5'};
 
   /* Allow up to 2 lines with ellipsis on overflow */
   display: -webkit-box;
@@ -137,23 +133,19 @@ export const TrackName = styled.div.withConfig({
   word-break: break-word;
 `;
 
-export const TrackArtist = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const TrackArtist = styled.div<{ $isSelected: boolean }>`
   font-size: ${({ theme }) => theme.fontSize.sm};
   margin-top: ${({ theme }) => theme.spacing.xs};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: ${({ isSelected, theme }) => isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
+  color: ${({ $isSelected, theme }) => $isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
 `;
 
-export const Duration = styled.span.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const Duration = styled.span<{ $isSelected: boolean }>`
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-family: monospace;
-  color: ${({ isSelected, theme }) => isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
+  color: ${({ $isSelected, theme }) => $isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
   flex-shrink: 0;
 `;
 

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -260,7 +260,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   key={`${track.name}-${track.id}`}
                   ref={index === currentTrackIndex ? currentTrackRef : undefined}
                   onClick={() => onTrackSelect(index)}
-                  isSelected={index === currentTrackIndex}
+                  $isSelected={index === currentTrackIndex}
                 >
                   <AlbumArtContainer>
                     <Avatar
@@ -288,15 +288,15 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   </AlbumArtContainer>
 
                   <TrackInfo>
-                    <TrackName isSelected={index === currentTrackIndex}>
+                    <TrackName $isSelected={index === currentTrackIndex}>
                       {track.name}
                     </TrackName>
-                    <TrackArtist isSelected={index === currentTrackIndex}>
+                    <TrackArtist $isSelected={index === currentTrackIndex}>
                       {track.artists}
                     </TrackArtist>
                   </TrackInfo>
 
-                  <Duration isSelected={index === currentTrackIndex}>
+                  <Duration $isSelected={index === currentTrackIndex}>
                     {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
                   </Duration>
 


### PR DESCRIPTION
Closes #842
Closes #844

## Changes

- Convert `QueueDrawerContainer` and `QueueOverlay` styled components from non-transient props (`isOpen`, `width`, `transitionDuration`, `transitionEasing`) to `$`-prefixed transient props, removing `shouldForwardProp` workarounds — eliminates React DOM attribute warnings
- Replace `100vh` with `100dvh` in `QueueDrawerContainer` and `QueueOverlay` to prevent mobile viewport bouncing on iOS address bar changes
- Convert `QueueListItem`, `TrackName`, `TrackArtist`, `Duration` in `QueueTrackList.styled.ts` from `isSelected` to `$isSelected` transient prop
- Update all JSX usage sites in `QueueTrackItem.tsx` and `QueueTrackList.tsx`