### PR TITLE
cleanup(visualizers): remove dead interface and unused props

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -60,7 +60,6 @@ const AudioPlayerComponent = () => {
     backgroundVisualizerIntensity,
     backgroundVisualizerSpeed,
     accentColorBackgroundEnabled,
-    zenModeEnabled,
     showVisualEffects,
     setShowVisualEffects,
   } = useVisualEffectsContext();
@@ -351,8 +350,6 @@ const AudioPlayerComponent = () => {
             speed={backgroundVisualizerSpeed}
             accentColor={accentColor}
             isPlaying={state.isPlaying}
-            playbackPosition={state.playbackPosition}
-            zenMode={zenModeEnabled}
           />
         </ProfiledComponent>
         {renderContent()}

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -20,8 +20,6 @@ interface BackgroundVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
   /** When style is 'comet', the trail head is constrained to this rect so it appears to come from the album art */
   albumArtBounds?: AlbumArtBounds | null;
 }
@@ -51,7 +49,6 @@ const VisualizerContainer = styled.div`
  * - intensity: Visualizer intensity (0-100)
  * - accentColor: Current track's accent color
  * - isPlaying: Whether music is currently playing
- * - playbackPosition: Current playback position in milliseconds (optional)
  */
 const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   enabled,
@@ -60,8 +57,6 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   speed,
   accentColor,
   isPlaying,
-  playbackPosition,
-  zenMode,
   albumArtBounds,
 }) => {
   const VisualizerComponent = useMemo(() => {
@@ -92,8 +87,6 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
         speed={speed ?? 1.0}
         accentColor={accentColor}
         isPlaying={isPlaying}
-        playbackPosition={playbackPosition}
-        zenMode={zenMode}
         {...(style === 'comet' && albumArtBounds != null ? { albumArtBounds } : {})}
       />
     </VisualizerContainer>

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -8,8 +8,6 @@ interface GridWaveVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface GridParticle {

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -8,8 +8,6 @@ interface ParticleVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface Particle {

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -15,8 +15,6 @@ interface TrailVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
   /** When set, the trail head (ship) stays inside this rect so the trail appears to come from the album art */
   albumArtBounds?: AlbumArtBounds | null;
 }

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -8,8 +8,6 @@ interface WaveVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface Wave {

--- a/src/types/visualizer.d.ts
+++ b/src/types/visualizer.d.ts
@@ -11,12 +11,3 @@ export type VisualizerStyle =
   | 'wave'
   | 'grid';
 
-interface VisualizerConfig {
-  particleCount?: number;
-  animationSpeed?: number;
-  colorVariation?: number;
-  barCount?: number;
-  shapeCount?: number;
-  layerCount?: number;
-}
-


### PR DESCRIPTION
Closes #834
Closes #835

## Changes

- **#834**: Removed the `VisualizerConfig` interface from `src/types/visualizer.d.ts` — it declared six optional properties (`particleCount`, `animationSpeed`, `colorVariation`, `barCount`, `shapeCount`, `layerCount`) but was never referenced anywhere in the codebase.

- **#835**: Removed `playbackPosition?` and `zenMode?` from all four visualizer component interfaces (`ParticleVisualizerProps`, `TrailVisualizerProps`, `WaveVisualizerProps`, `GridWaveVisualizerProps`). All four components declared these props but none of the implementations ever destructured or consumed them. Cleaned up the corresponding pass-through in `BackgroundVisualizerProps` and its render site, and removed the now-unused `zenModeEnabled` destructure in `AudioPlayer`.

## Verification

- `npx tsc -b --noEmit` — clean
- `npm run build` — clean (exit 0)
- `npm run test:run` — 937 tests across 74 files, all passing