### PR TITLE
docs(features): add player controls and album art guides

### DIFF
--- a/docs/features/album-art.md
+++ b/docs/features/album-art.md
@@ -1,0 +1,343 @@
+# Album Art System
+
+## Overview
+
+The album art system handles display, color extraction, accent color propagation, the flip menu (visual effects controls on the back of album art), gesture recognition, and responsive sizing. Album art is also the primary gesture target for opening drawers and zen mode interactions.
+
+## File Map
+
+| File | Role |
+|------|------|
+| `src/components/AlbumArt.tsx` | Core display component; glow, translucence, image processing |
+| `src/components/AlbumArtQuickSwapBack.tsx` | Flip menu back face; hosts `QuickEffectsRow` |
+| `src/components/AccentColorBackground.tsx` | Full-viewport gradient tinted by accent color |
+| `src/components/AccentColorGlowOverlay.tsx` | Per-art glow overlay with breathing animation |
+| `src/components/PlayerContent/AlbumArtSection.tsx` | Composition layer: art + flip + zen overlays + gestures |
+| `src/components/PlayerContent/GestureLayer.tsx` | Swipe/click/long-press routing; merges touch + pointer handlers |
+| `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons |
+| `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button |
+| `src/components/PlayerContent/styled.tsx` | `FlipInner`, `ClickableAlbumArtContainer`, zen track info styled components |
+| `src/hooks/useAccentColor.ts` | Auto-extract color on track change; manages override lifecycle |
+| `src/hooks/usePlayerSizing.ts` | Viewport-aware dimensions, breakpoints, device detection |
+| `src/hooks/useImageProcessingWorker.ts` | Hook wrapping the web worker for accent-mask image processing |
+| `src/hooks/useZenTouchGestures.ts` | Touch gesture recognizer (single tap, double tap, long press) |
+| `src/hooks/useSwipeGesture.ts` | Horizontal swipe detection (next/prev track) |
+| `src/hooks/useVerticalSwipeGesture.ts` | Vertical swipe detection (queue up, library down) |
+| `src/utils/colorExtractor.ts` | Canvas-based dominant color extraction with LRU cache |
+| `src/utils/colorCache.ts` | LRU cache (100 entries) for extracted colors |
+| `src/utils/colorUtils.ts` | `hexToRgb`, `getRelativeLuminance`, `isLightColor`, `getContrastColor` |
+| `src/contexts/ColorContext.tsx` | Global accent color state, overrides, custom colors |
+| `src/workers/imageProcessor.worker.ts` | Web worker: pixel-level accent-mask processing |
+| `src/constants/zenAnimation.ts` | Zen mode animation timings and dead zone constants |
+
+## AlbumArt Component
+
+**Location:** `src/components/AlbumArt.tsx`
+
+### Props
+
+```ts
+interface AlbumArtProps {
+  currentTrack: MediaTrack | null;
+  objectPosition?: string;
+  accentColor?: string;
+  glowIntensity?: number;     // 95-125 range, controls glow spread
+  glowRate?: number;          // seconds per breathing cycle
+  glowEnabled?: boolean;
+  zenMode?: boolean;
+  translucenceEnabled?: boolean;
+  translucenceOpacity?: number;
+  onRetryAlbumArt?: () => void;
+}
+```
+
+### Rendering pipeline
+
+1. `AlbumArtContainer` sets the base box with CSS glow (see below)
+2. `AccentColorGlowOverlay` adds a blurred overlay for glow bleed
+3. Main image: either processed `canvasUrl` (accent-masked) or raw `currentTrack.image`
+4. If `glowIntensity === 0` or worker processing is incomplete, falls back to raw image
+5. Missing artwork shows "No image" placeholder with optional retry button
+
+### Glow system (box-shadow)
+
+Four visual states based on `glowEnabled` and `glowIntensity`:
+
+| State | Visual |
+|-------|--------|
+| `glowEnabled === false` | Subtle edge definition only (white border + depth shadow) |
+| `glowEnabled && glowIntensity > 0` | Animated breathing glow via `breatheBorderGlow` CSS animation. Three colored shadow layers with opacities derived from `glowIntensity`. Uses CSS custom properties `--glow-opacity` and `--glow-rate`. |
+| `glowEnabled && glowIntensity === 0` | Static full glow (no animation) |
+| No accent color | White glow fallback |
+
+The glow intensity range 95-125 is mapped to opacity coefficients via `t = (glowIntensity - 95) / (125 - 95)`.
+
+### Zen mode sizing
+
+In zen mode, `max-width` expands to fill viewport minus margins:
+- Desktop: `min(calc(100vw - 96px), calc(100dvh - 196px))`
+- Mobile (`<= theme.breakpoints.lg`): `min(calc(100vw - 32px), calc(100dvh - 120px))`
+
+Transition: 1000ms with 300ms enter delay, Material Design easing.
+
+### Image processing
+
+On track/accent color change, the component:
+1. Loads the image via `new Image()` with `crossOrigin = 'anonymous'`
+2. Draws to a canvas, extracts `ImageData`
+3. Sends to `processImage()` (web worker) with `maxDistance = 40`
+4. Worker masks pixels close to the accent color (makes them transparent)
+5. Result displayed as `canvas.toDataURL()`
+
+The processing spinner shows while the worker is active.
+
+### Custom equality check (arePropsEqual)
+
+The component uses a custom `React.memo` comparator that checks: `currentTrack.id`, `currentTrack.image`, `accentColor`, `glowIntensity`, `glowRate`, `glowEnabled`, `zenMode`, `translucenceEnabled`, `translucenceOpacity`, `onRetryAlbumArt`. This prevents unnecessary re-renders from parent state changes that don't affect album art.
+
+## The Flip Menu
+
+### Architecture
+
+Album art has a front (artwork) and back (visual effects controls). The flip is a CSS 3D transform (`rotateY(180deg)`) applied via `FlipInner` in `src/components/PlayerContent/styled.tsx`.
+
+### Flip state
+
+`isFlipped` state lives in `AlbumArtSection`. Toggled by:
+- Click on album art (when not in zen touch mode and not already flipped in zen)
+- Long press on album art (zen mode, pointer devices)
+- Long press gesture (zen mode, touch devices -- 500ms via `useZenTouchGestures`)
+
+Auto-closes when:
+- Track changes (`currentTrack.id` effect resets `isFlipped = false`)
+- Click outside the flip container (`mousedown` handler on `document`)
+- Explicit close button on the back face
+
+### Back face content (AlbumArtQuickSwapBack)
+
+**Location:** `src/components/AlbumArtQuickSwapBack.tsx`
+
+Renders over a blurred version of the album art (`filter: blur(20px)`) with a dark overlay. Contains:
+- Title "Visual Effects" (hidden on mobile)
+- `QuickEffectsRow` -- the actual controls (accent color picker, glow toggle/sliders, visualizer controls, translucence toggle)
+- Close button (top-right)
+- "Retry Artwork" button (when no image is available)
+- Tap-to-close on the background area (pointer up within 10px of pointer down, not on controls)
+
+The back face has `backface-visibility: hidden` and `transform: rotateY(180deg)` so it only appears when the container is flipped.
+
+### Click-outside dismissal
+
+An effect in `AlbumArtSection` adds a `mousedown` listener on `document` when `isFlipped === true`. Clicks outside `flipContainerRef` close the menu. Exception: clicks on `[data-eyedropper-overlay]` are ignored (color picker overlay).
+
+## Color Extraction
+
+**Location:** `src/utils/colorExtractor.ts`
+
+### extractDominantColor(imageUrl): Promise<ExtractedColor | null>
+
+1. Check LRU cache (`src/utils/colorCache.ts`, max 100 entries)
+2. Load image with `crossOrigin = 'anonymous'`
+3. Downscale to max 150px (either dimension)
+4. Sample every 4th pixel (stride 16 in RGBA array)
+5. Bucket into 8-unit color bins (32 shades per channel)
+6. Filter: `isGoodContrast` (lightness 40-85%) AND `isVibrant` (saturation >= 50%)
+7. Score: `pixelCount * (saturation/100) * (1 - |lightness - 50| / 50)`
+8. Return highest-scoring color as `{ hex, rgb, hsl }`
+
+Returns `null` if no color passes filters.
+
+### extractTopVibrantColors(imageUrl, count = 3): Promise<ExtractedColor[]>
+
+Same algorithm but returns up to `count` colors with a similarity filter: candidates within Euclidean RGB distance < 40 of an already-selected color are skipped.
+
+### ExtractedColor type
+
+```ts
+interface ExtractedColor {
+  hex: string;   // '#rrggbb'
+  rgb: string;   // 'rgb(r, g, b)'
+  hsl: string;   // 'hsl(h, s%, l%)'
+}
+```
+
+### Cache (colorCache.ts)
+
+Simple `Map<string, ExtractedColor | null>` with LRU eviction at 100 entries (deletes oldest key when full). Keyed by image URL.
+
+## Accent Color System
+
+### Flow
+
+```
+Track changes (currentTrack.id or currentTrack.image)
+  -> useAccentColor effect fires
+    -> if albumId has override in accentColorOverrides: use it
+    -> else: extractDominantColor(image) -> apply via requestIdleCallback + startTransition
+    -> fallback: theme.colors.accent (default teal)
+
+Accent color set via setAccentColor()
+  -> ColorContext propagates to all consumers
+  -> CSS custom property --accent-color updated on :root
+  -> CSS custom property --accent-contrast-color updated (via getContrastColor)
+```
+
+### ColorContext
+
+**Location:** `src/contexts/ColorContext.tsx`
+
+```ts
+interface ColorContextValue {
+  accentColor: string;
+  accentColorOverrides: Record<string, string>;   // albumId -> color, persisted in localStorage
+  customAccentColors: Record<string, string>;      // albumId -> eyedropper color, separate storage
+  setAccentColor: (color: string) => void;
+  setAccentColorOverrides: (...) => void;
+  handleSetAccentColorOverride: (albumId: string, color: string) => void;
+  handleRemoveAccentColorOverride: (albumId: string) => void;
+  handleResetAccentColorOverride: (albumId: string) => void;    // alias for remove
+  handleSetCustomAccentColor: (albumId: string, color: string) => void;
+  handleRemoveCustomAccentColor: (albumId: string) => void;
+}
+```
+
+Storage keys:
+- `accentColorOverrides`: `STORAGE_KEYS.ACCENT_COLOR_OVERRIDES` -- palette selections AND eyedropper picks
+- `customAccentColors`: `STORAGE_KEYS.CUSTOM_ACCENT_COLORS` -- eyedropper picks only (so palette clicks don't overwrite the custom swatch display)
+
+All override mutations schedule a Dropbox preferences push (`getPreferencesSync()?.schedulePush()`) for cross-device sync.
+
+### Override priority
+
+In `useAccentColor`:
+1. If `albumId` exists in `accentColorOverrides` -> use that color directly (no extraction)
+2. If album has image -> extract dominant color
+3. Fallback -> `theme.colors.accent`
+
+### Custom color handling in AlbumArtSection
+
+When user picks a custom color (eyedropper or palette):
+- `handleSetAccentColorOverride(albumId, color)` -- saves to overrides
+- `handleSetCustomAccentColor(albumId, color)` -- saves to custom colors store
+- `setAccentColor(color)` -- immediate visual update
+
+When user clears custom color (empty string):
+- Both overrides are removed
+- Accent color re-extracts from album art
+
+When user picks `'RESET_TO_DEFAULT'`:
+- Override is removed
+- Auto-extraction resumes on next track change
+
+## AccentColorBackground
+
+**Location:** `src/components/AccentColorBackground.tsx`
+
+A `position: fixed` full-viewport gradient that tints the background based on accent color. Uses `generateColorVariant()` for shifted hues. The gradient is subtle: 0x20 / 0x15 / 0x10 alpha at three stops.
+
+Renders nothing when `enabled === false`. Low z-index (0) so it sits behind all content.
+
+## Album Art as Gesture Target
+
+`AlbumArtSection` wraps art in `GestureLayer`, which composites multiple gesture recognizers.
+
+### GestureLayer
+
+**Location:** `src/components/PlayerContent/GestureLayer.tsx`
+
+Merges:
+- `useSwipeGesture` (horizontal: next/prev track) -- touch only
+- `useVerticalSwipeGesture` (vertical: swipe up = queue, swipe down = library) -- touch only, 80px threshold
+- `useLongPress` (zen mode long press to flip) -- zen + pointer only
+- `zenTouchHandlers` (from `useZenTouchGestures`) -- zen + touch only
+- Click handler (toggles flip, suppressed during swipe/animation)
+- Zone hover tracking for zen mode (pointer devices only)
+
+The component merges refs via `handleRef` callback to share a single DOM element between `albumArtContainerRef` and `drawerSwipeRef`.
+
+### Gesture priority
+
+When zen touch is active (`isTouchDevice && zenModeEnabled && !isFlipped`), the `zenTouchHandlers` from `useZenTouchGestures` override the normal click/long-press handlers. This enables the single-tap/double-tap/long-press gesture set.
+
+When zen mode is active with pointer input, `longPressHandlers` from `useLongPress` are active instead, allowing long press to open the flip menu.
+
+## Image Processing Worker
+
+**Location:** `src/workers/imageProcessor.worker.ts`
+
+### Purpose
+
+Processes album art pixels off the main thread. The primary operation masks pixels whose color is close to the accent color (making them transparent), creating a "glow bleed" effect where the accent color shows through the art.
+
+### Message protocol
+
+Request:
+```ts
+{ type: 'PROCESS_IMAGE', imageData: ImageData, accentColor: [r, g, b], maxDistance: number, requestId: number }
+```
+
+Response:
+```ts
+{ type: 'IMAGE_PROCESSED', processedImageData: ImageData, success: true, requestId: number }
+// or
+{ type: 'IMAGE_PROCESSING_ERROR', error: string, success: false, requestId: number }
+```
+
+### Algorithm
+
+For each pixel, compute Euclidean RGB distance from `accentColor`. If distance < `maxDistance` (default 40), reduce alpha proportionally: `alpha = alpha * (distance / maxDistance)`. Exact matches become fully transparent; pixels at the threshold retain full opacity.
+
+### Hook wrapper (useImageProcessingWorker)
+
+Not documented in detail here but provides `processImage(imageData, accentColor, maxDistance): Promise<ImageData>` that manages worker lifecycle and request IDs.
+
+## Responsive Sizing
+
+### usePlayerSizing
+
+**Location:** `src/hooks/usePlayerSizing.ts`
+
+Returns viewport-aware dimensions consumed by album art sizing:
+
+```ts
+interface UsePlayerSizingReturn {
+  dimensions: PlayerDimensions;
+  viewport: ViewportInfo;
+  isMobile: boolean;        // width < 700
+  isTablet: boolean;        // 700 <= width < 1024
+  isDesktop: boolean;       // width >= 1024
+  hasPointerInput: boolean; // pointer:fine OR hover:hover
+  isTouchDevice: boolean;   // !hasPointerInput
+  orientation: 'portrait' | 'landscape';
+  // ...additional sizing utilities
+}
+```
+
+### Album art max-width calculation
+
+In `AlbumArt.tsx`, `AlbumArtContainer` uses CSS `max-width`:
+- Normal mode: `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - 120px))`
+- Zen mode: `min(calc(100vw - 96px), calc(100dvh - 196px))`
+- Zen mode mobile: `min(calc(100vw - 32px), calc(100dvh - 120px))`
+
+The `aspect-ratio: 1` rule ensures square art. The `max-width` constraint is the sole sizing mechanism -- no explicit width or height is set.
+
+### AlbumArtSection bounds reporting
+
+`AlbumArtSection` optionally reports its DOM bounds via `onAlbumArtBoundsChange` callback, using a `ResizeObserver`. This is used by other components (e.g. zen overlays) to position elements relative to the art.
+
+## Invariants and Gotchas
+
+1. **crossOrigin is required**: Both `colorExtractor` and `AlbumArt` set `img.crossOrigin = 'anonymous'`. Without this, canvas `getImageData` throws a security error for cross-origin images (Spotify CDN, Dropbox thumbnails).
+
+2. **Flip auto-resets on track change**: The `isFlipped` state resets to `false` whenever `currentTrack.id` changes. This prevents showing stale back-face controls.
+
+3. **Custom colors vs overrides**: `customAccentColors` and `accentColorOverrides` are separate localStorage entries. Palette swatch selection writes to `accentColorOverrides` only. Eyedropper writes to both. This lets the flip menu display the user's last eyedropper pick even when they select a different palette swatch.
+
+4. **requestIdleCallback + startTransition**: Accent color application uses both to minimize jank. `requestIdleCallback` defers the work, `startTransition` marks it as non-urgent for React's concurrent scheduler. Falls back to immediate application if `requestIdleCallback` is unavailable.
+
+5. **Worker error handling**: If the web worker fails, `canvasUrl` stays `null` and the raw image displays. The "Component unmounted" error is explicitly ignored to prevent console noise during rapid track changes.
+
+6. **Eyedropper overlay exception**: Click-outside-to-close for the flip menu explicitly ignores clicks on `[data-eyedropper-overlay]` elements. Without this, opening the color picker would immediately close the flip menu.
+
+7. **isTouchDevice vs isMobile**: These are different. `isTouchDevice` is input-capability-based (CSS `pointer: coarse`). `isMobile` is viewport-width-based (`< 700px`). A large tablet is `isTouchDevice === true` but `isMobile === false`. Use `isTouchDevice` for interaction decisions, `isMobile`/`isTablet` for layout.

--- a/docs/features/player-controls.md
+++ b/docs/features/player-controls.md
@@ -1,0 +1,369 @@
+# Player Controls
+
+## Overview
+
+The player control system routes user actions (play, pause, next, previous) through a provider-agnostic dispatch layer. The central hook `usePlayerLogic` owns all control handlers and delegates playback to whichever provider is currently driving audio output.
+
+Key concept: **active provider** (selected for browsing/catalog) vs **driving provider** (currently outputting audio). In mixed queues these differ.
+
+## File Map
+
+| File | Role |
+|------|------|
+| `src/hooks/usePlayerLogic.ts` | Central orchestrator; assembles handlers, wires subscriptions, owns local playback state |
+| `src/hooks/useProviderPlayback.ts` | Resolves provider per track, handles cross-provider handoff, error recovery |
+| `src/hooks/usePlaybackSubscription.ts` | Subscribes to all provider state events, filters by driving provider, syncs React state |
+| `src/hooks/useAutoAdvance.ts` | Detects track-end signals, triggers `playTrack(nextIndex)` with cooldown guard |
+| `src/hooks/useKeyboardShortcuts.ts` | Keyboard event handler; device-aware (pointer vs touch) |
+| `src/hooks/useVolume.ts` | Volume + mute state; persisted via `useLocalStorage` |
+| `src/hooks/useZenTouchGestures.ts` | Touch gesture recognizer for zen mode (single tap, double tap, long press) |
+| `src/hooks/useCollectionLoader.ts` | Loads a collection into the queue and starts playback |
+| `src/hooks/useQueueManagement.ts` | Queue mutation: add, remove, reorder |
+| `src/hooks/useRadioSession.ts` | Radio generation session lifecycle |
+| `src/components/PlayerStateRenderer.tsx` | Idle/home view routing (QAP vs library browser) |
+| `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons over album art |
+| `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button (bottom-right of album art) |
+| `src/providers/errors.ts` | `AuthExpiredError`, `UnavailableTrackError` |
+| `src/types/providers.ts` | `PlaybackProvider` interface (line 66) |
+| `src/types/domain.ts` | `PlaybackState` interface (line 81) |
+
+## usePlayerLogic
+
+**Location:** `src/hooks/usePlayerLogic.ts`
+
+Central dispatch hub. Composes all sub-hooks and returns a structured API:
+
+```ts
+return {
+  state: { isLoading, error, selectedPlaylistId, tracks, showLibraryDrawer, isPlaying, playbackPosition },
+  handlers: {
+    loadCollection, playTracksDirectly, handleAddToQueue, queueTracksDirectly,
+    handlePlay, handlePause, handleNext, handlePrevious, playTrack,
+    handleOpenLibraryDrawer, handleCloseLibraryDrawer, handleBackToLibrary,
+    handleStartRadio, handleRemoveFromQueue, handleReorderQueue,
+  },
+  radio: { radioState, isRadioAvailable, stopRadio, authExpired, clearAuthExpired, isActive, radioProgress, dismissRadioProgress },
+  mediaTracksRef,         // imperative mirror of tracks[]
+  setTracks,
+  setOriginalTracks,
+  currentPlaybackProviderRef,  // ref to driving provider ID
+  expectedTrackIdRef,          // guards against stale provider index updates during transitions
+};
+```
+
+### Ref-based state pattern
+
+`tracksRef`, `currentTrackIndexRef`, and `expectedTrackIdRef` are `useRef` mirrors of their corresponding React state. This is intentional: the `usePlaybackSubscription` effect depends only on `activeDescriptor`, not on tracks/index. Without refs, every track change would tear down and recreate the provider subscription, triggering a `getState()` call that briefly resets `currentTrackIndex` to the old track.
+
+### handleNext / handlePrevious
+
+Both wrap around the queue circularly (`% tracks.length`). Before calling `playTrack`, they set `expectedTrackIdRef.current` to the target track's ID. This tells `usePlaybackSubscription` to ignore any stale provider index updates until the expected track arrives.
+
+### handlePlay / handlePause
+
+Route through `getDrivingProviderDescriptor()` -- resolves the driving provider (not the active provider). `handlePlay` calls `descriptor.playback.resume()`. `handlePause` calls `descriptor.playback.pause()`.
+
+### handleBackToLibrary
+
+Pauses playback, stops radio, clears all queue state (`tracks`, `originalTracks`, `mediaTracksRef`, `selectedPlaylistId`, `currentTrackIndex`), and closes drawers.
+
+### Queue change notification
+
+An effect watches `tracks` and `currentTrackIndex` and calls `descriptor.playback.onQueueChanged?.(tracks, currentTrackIndex)` on the driving provider. Spotify uses this to sync its native queue.
+
+## useProviderPlayback
+
+**Location:** `src/hooks/useProviderPlayback.ts`
+
+### Props
+
+```ts
+interface UseProviderPlaybackProps {
+  setCurrentTrackIndex: (index: number) => void;
+  activeDescriptor?: ProviderDescriptor | null;
+  mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  onAuthExpired?: (providerId: ProviderId) => void;
+}
+```
+
+### Provider resolution chain
+
+`resolveTrackProvider(mediaTrack)` returns the first defined value from:
+
+1. `mediaTrack.provider` -- per-track provider ID (set when track was loaded)
+2. `currentPlaybackProviderRef.current` -- last known driving provider
+3. `activeDescriptor.id` -- currently selected provider in UI
+
+### Cross-provider handoff
+
+`pausePreviousProvider(nextProvider)` checks if the driving provider is changing. If so, it pauses the old provider before updating `currentPlaybackProviderRef`.
+
+### playTrack(index, skipOnError?, options?)
+
+1. Read `mediaTracksRef.current[index]`
+2. Resolve provider via `resolveTrackProvider`
+3. `pausePreviousProvider(trackProvider)` -- handoff if needed
+4. Update `currentPlaybackProviderRef.current = trackProvider`
+5. Call `descriptor.playback.playTrack(mediaTrack, options)`
+6. On success: `setCurrentTrackIndex(index)`, then pre-warm next track via `prepareTrack?.(nextTrack)`
+7. On error: see Error Recovery below
+
+### Error recovery
+
+| Error type | Behavior |
+|-----------|----------|
+| `AuthExpiredError` | Calls `onAuthExpired(providerId)`, does NOT skip. UI shows re-auth prompt. |
+| `UnavailableTrackError` | Logs warning. If `skipOnError` and not at end of queue, schedules `playTrack(index + 1)` after 500ms. |
+| Generic error | Logs error. Same skip logic as `UnavailableTrackError`. |
+
+The 500ms delay before skip prevents rapid-fire skipping through consecutive unavailable tracks.
+
+## usePlaybackSubscription
+
+**Location:** `src/hooks/usePlaybackSubscription.ts`
+
+Subscribes to playback state events from ALL registered providers (not just the active one). Only processes events from the driving provider.
+
+### Subscription setup
+
+1. Subscribe to `activeDescriptor.playback.subscribe()`
+2. Iterate `providerRegistry.getAll()` and subscribe to every other provider
+3. Each callback passes `providerId` to `handleProviderStateChange`
+
+### Driving provider filter
+
+```ts
+const drivingProviderId = drivingProviderRef.current ?? activeProviderId;
+if (providerId !== drivingProviderId) return;
+```
+
+Events from non-driving providers are silently dropped.
+
+### State sync
+
+From each `PlaybackState`:
+- `setIsPlaying(state.isPlaying)`
+- `setPlaybackPosition(state.positionMs)`
+- If `state.currentTrackId` is present, find it in `tracksRef.current` and sync `currentTrackIndex`
+- If `state.trackMetadata` is present (Dropbox ID3 enrichment), merge into `tracks[trackIndex]`
+
+### expectedTrackIdRef guard
+
+During transitions (next/previous), `expectedTrackIdRef` is set to the target track ID. While non-null, provider index updates are ignored. When the expected track ID arrives, the ref is cleared and normal sync resumes. This prevents a brief flash of the old track's index being set by a stale provider event.
+
+### Visibility change handler
+
+On `visibilitychange` (tab returns to foreground):
+1. Clear `expectedTrackIdRef` (stale transition guards no longer relevant)
+2. Call `getState()` on the driving provider to resync all playback state
+
+### Dependency strategy (invariant)
+
+The effect depends only on `[activeDescriptor, setCurrentTrackIndex, setTracks]`. Tracks and index are read via refs. This prevents subscription teardown/recreation on every track change.
+
+## useAutoAdvance
+
+**Location:** `src/hooks/useAutoAdvance.ts`
+
+### Props
+
+```ts
+interface UseAutoAdvanceProps {
+  tracks: MediaTrack[];
+  currentTrackIndex: number;
+  playTrack: (index: number, skipOnError?: boolean) => void;
+  enabled?: boolean;          // default: true
+  endThreshold?: number;      // default: 2000ms
+  currentPlaybackProviderRef?: React.RefObject<ProviderId | null>;
+}
+```
+
+### End detection signals
+
+Two independent detection paths:
+
+1. **Near-end**: `timeRemaining <= endThreshold` OR `position >= duration - 1000` while still playing
+2. **Natural end**: `wasPlayingRef.current && isPaused && position === 0 && duration > 0` -- track was playing, is now paused at position 0
+
+### Cooldown guard (PLAY_COOLDOWN_MS = 5000)
+
+The natural-end signal has a cooldown: it checks `msSinceLastPlay > 5000` before advancing. Both Spotify SDK and HTML5 Audio briefly pause at position 0 during buffering, which would falsely trigger advance without this guard. The cooldown reads from `descriptor.playback.getLastPlayTime?.()` if available, falling back to `lastPlayInitiatedRef`.
+
+### Advance behavior
+
+`advanceToNext()` sets `hasEnded = true` and schedules a 100ms timeout. Inside the timeout:
+- If at end of queue (`currentIdx >= totalTracks - 1`): stop, do not wrap
+- Otherwise: `playTrack(currentIdx + 1, true)` with `skipOnError`
+
+The 100ms delay + computing `nextIndex` inside the timeout (not at schedule time) ensures shuffle toggles during the delay use fresh refs.
+
+### Reset on track/queue change
+
+`hasEnded` resets and pending advance timers are cancelled whenever `currentTrackIndex` or `tracks` changes. This prevents stale advance from playing the wrong track after shuffle toggle.
+
+### Subscription pattern
+
+Same as `usePlaybackSubscription`: subscribes to active provider + all others. Events from non-driving providers are only processed when `drivingProviderRef.current === descriptor.id`.
+
+## useKeyboardShortcuts
+
+**Location:** `src/hooks/useKeyboardShortcuts.ts`
+
+### Device detection
+
+Uses `prefersPointerInput` option (from `usePlayerSizing`), which checks CSS media queries `(pointer: fine)` and `(hover: hover)`. This is NOT viewport-based -- a high-resolution tablet with touch input is correctly identified as touch-only.
+
+### Key mappings
+
+| Code | Handler | Condition |
+|------|---------|-----------|
+| `Space` | `onPlayPause` | always |
+| `ArrowRight` | `onNext` | always |
+| `ArrowLeft` | `onPrevious` | always |
+| `ArrowUp` | `onShowQueue` | `prefersPointerInput` |
+| `ArrowUp` | `onVolumeUp` | NOT `prefersPointerInput` |
+| `ArrowDown` | `onOpenQuickAccessPanel` | `prefersPointerInput` |
+| `ArrowDown` | `onVolumeDown` | NOT `prefersPointerInput` |
+| `KeyQ` | `onShowQueue` | always (device-independent alternative) |
+| `KeyL` | `onOpenQuickAccessPanel` | always (device-independent alternative) |
+| `KeyV` | `onCycleVisualizerStyle` | no ctrl/meta |
+| `KeyS` | `onToggleShuffle` | no ctrl/meta, no shift |
+| `KeyS` + Shift | `onToggleVisualEffectsMenu` | no ctrl/meta |
+| `KeyG` | `onToggleGlow` | no ctrl/meta |
+| `KeyT` | `onToggleTranslucence` | no ctrl/meta |
+| `KeyZ` | `onToggleZenMode` | no ctrl/meta |
+| `KeyO` | (not wired -- effects menu uses `Shift+S`) | |
+| `KeyK` | `onToggleLike` | no ctrl/meta |
+| `KeyM` | `onMute` | always |
+| `Slash` | `onToggleHelp` | no ctrl/meta |
+| `Escape` | closes all menus | always |
+
+### Input guard
+
+Shortcuts are suppressed when the event target (via `composedPath()` for Shadow DOM) is `INPUT`, `TEXTAREA`, or `contentEditable`.
+
+## useVolume
+
+**Location:** `src/hooks/useVolume.ts`
+
+### State
+
+- `volume` (0-100): persisted via `useLocalStorage(STORAGE_KEYS.VOLUME, 50)`
+- `isMuted` (boolean): persisted via `useLocalStorage(STORAGE_KEYS.MUTED, false)`
+- `previousVolumeRef`: stores pre-mute volume for restore
+
+### Provider routing
+
+`getPlayingPlayback()` resolves the playback adapter for the currently playing provider:
+- If `currentTrackProvider` differs from `activeDescriptor.id`, looks up the track's provider via `providerRegistry`
+- Otherwise uses `activeDescriptor.playback`
+
+Volume changes call `playback.setVolume(value / 100)` -- the `PlaybackProvider` interface expects 0-1 range.
+
+### setVolumeLevel(newVolume)
+
+Clamps to 0-100, rounds, and auto-syncs mute state: setting volume to 0 enables mute, setting > 0 disables mute.
+
+## Zen Mode
+
+Zen mode hides player controls and expands album art to fill the viewport. Interaction differs by device type.
+
+### Desktop (pointer devices)
+
+`ZenClickZoneOverlay` renders three hover-activated circular buttons (prev, play/pause, next) over the album art. Buttons are transparent (`opacity: 0`) until hovered. The overlay uses `container-type: size` for responsive button sizing (`clamp(72px, 20cqmin, 224px)`).
+
+Visibility condition: `zenModeEnabled && hasPointerInput && !zenTouchActive && !isFlipped`
+
+`ZenLikeOverlay` renders a like heart button at bottom-right of album art. Appears on hover.
+
+Visibility condition: `zenModeEnabled && hasPointerInput && isHovered && !isFlipped`
+
+### Dead zones
+
+`resolveZenZone()` in `src/constants/zenAnimation.ts` maps cursor position to a zone. The top 20% and bottom 20% of album art are dead zones (return `null`). Within the active region:
+- Left 25%: `'left'` (previous)
+- Right 25%: `'right'` (next)
+- Center 50%: `'center'` (play/pause)
+
+Constants: `ZEN_DEAD_ZONE_TOP = 0.2`, `ZEN_DEAD_ZONE_BOTTOM = 0.8`, `ZEN_ZONE_LEFT_BOUNDARY = 0.25`, `ZEN_ZONE_RIGHT_BOUNDARY = 0.75`
+
+### Touch devices (useZenTouchGestures)
+
+**Location:** `src/hooks/useZenTouchGestures.ts`
+
+Uses pointer events (not touch events) for unified handling. Gesture mapping:
+
+| Gesture | Action |
+|---------|--------|
+| Single tap | Play/Pause (after 300ms double-tap window) |
+| Double tap | Like toggle |
+| Long press (500ms) | Flip menu toggle |
+
+Movement beyond 10px cancels long press. The hook returns `{ onPointerDown, onPointerUp, onPointerCancel, onPointerMove }`.
+
+Active condition in `AlbumArtSection`: `isTouchDevice && zenModeEnabled && !isFlipped`
+
+### BottomBar in zen mode
+
+BottomBar shows via grip pill tap with tap-outside-to-dismiss backdrop. (Handled elsewhere in BottomBar component, not in the hooks documented here.)
+
+### Zen animation constants
+
+From `src/constants/zenAnimation.ts`:
+- Art expand: 1000ms duration, 300ms enter delay
+- Controls fade: 300ms duration, 500ms exit delay
+- Art margins: 96px horizontal / 196px vertical (desktop), 32px / 120px (mobile)
+
+## PlayerStateRenderer
+
+**Location:** `src/components/PlayerStateRenderer.tsx`
+
+Renders the idle/home view when no track is loaded (`selectedPlaylistId === null || tracks.length === 0`).
+
+### View routing
+
+```
+qapEnabled (from useQapEnabled) ?
+  -> QuickAccessPanel (with browseLibrary callback)
+  : -> PlaylistSelection (lazy-loaded via React.lazy)
+```
+
+`showLibrary` state initializes to `!qapEnabled`. When the user selects a playlist from the library browser, `showLibrary` is set to `false` and the selection callback fires.
+
+### QAP preference
+
+Stored in `localStorage` under key `vorbis-player-qap-enabled` (default `false`). Toggled via the settings panel (`VisualEffectsMenu`). The `useQapEnabled()` hook wraps `useLocalStorage`.
+
+### Other states
+
+- **Loading**: Animated card with pulse icon and shimmer progress bar
+- **Auth error**: "Connect to {providerName}" card with login button
+- **Generic error**: Destructive alert with error message
+
+## Playback Flow (End to End)
+
+```
+User presses Next
+  -> usePlayerLogic.handleNext()
+    -> sets expectedTrackIdRef to target track ID
+    -> setCurrentTrackIndex(nextIndex)
+    -> useProviderPlayback.playTrack(nextIndex, skipOnError=true)
+      -> resolveTrackProvider(mediaTracksRef[nextIndex])
+      -> pausePreviousProvider(resolvedProvider)    // handoff if provider changed
+      -> currentPlaybackProviderRef.current = resolvedProvider
+      -> descriptor.playback.playTrack(mediaTrack)  // Spotify SDK or HTML5 Audio
+      -> on success: prepareTrack(nextTrack)         // pre-warm next
+      -> on error: skip or surface auth prompt
+
+Provider emits PlaybackState
+  -> usePlaybackSubscription receives event
+    -> filters by drivingProviderRef (ignores non-driving providers)
+    -> expectedTrackIdRef check (ignores stale events during transition)
+    -> syncs isPlaying, playbackPosition, currentTrackIndex to React state
+    -> merges trackMetadata if present
+
+Track nears end (timeRemaining <= 2000ms)
+  -> useAutoAdvance detects near-end signal
+    -> schedules advanceToNext after 100ms
+      -> playTrack(currentIdx + 1, skipOnError=true)
+```


### PR DESCRIPTION
AI agent feature guides for the player controls system and album art system.

## What's included

### `docs/features/player-controls.md`
- usePlayerLogic central dispatch, ref-based state pattern
- useProviderPlayback provider resolution chain and cross-provider handoff
- usePlaybackSubscription event filtering, expectedTrackIdRef guard, visibility resync
- useAutoAdvance end detection signals, cooldown guard, queue-end stop behavior
- useKeyboardShortcuts device-aware key mappings
- useVolume provider-routed volume control
- Zen mode overlays and touch gestures
- PlayerStateRenderer idle view routing
- End-to-end playback flow diagram

### `docs/features/album-art.md`
- AlbumArt component rendering pipeline and glow system
- Flip menu architecture (CSS 3D transform, auto-close, click-outside)
- Color extraction algorithm and LRU cache
- Accent color system: override priority, ColorContext, Dropbox sync
- AccentColorBackground gradient
- GestureLayer composition (swipe, click, long press, zen touch)
- Image processing web worker
- Responsive sizing strategy
- Invariants and gotchas (crossOrigin, custom colors vs overrides, isTouchDevice vs isMobile)