### PR TITLE
cleanup(visualizers): remove unused onColorChange callback

### DIFF
--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -166,24 +166,6 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     [g]
   );
 
-  const handleColorChange = useCallback(
-    (states: GridWaveState[], color: string): void => {
-      const state = states[0];
-      if (!state) return;
-      const spacing = state.width < 768 ? g.spacingMobile : g.spacing;
-      const cols = Math.ceil(state.width / spacing) + 1;
-      const rows = Math.ceil(state.height / spacing) + 1;
-      const centerX = (cols - 1) * spacing / 2;
-      state.particles.forEach(particle => {
-        const edgeFactor = Math.abs(particle.baseX - centerX) / Math.max(1, centerX);
-        const depthFactor = particle.gridY / Math.max(1, rows - 1);
-        const intensityFactor = edgeFactor * g.edgeIntensity + depthFactor * (1 - g.edgeIntensity);
-        particle.color = generateColorVariant(color, 0.3 + intensityFactor * 0.5);
-      });
-    },
-    [g]
-  );
-
   const canvasRef = useCanvasVisualizer<GridWaveState>({
     accentColor,
     isPlaying,
@@ -192,7 +174,6 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     initializeItems,
     updateItems,
     renderItems,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -120,12 +120,6 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     });
   }, []);
 
-  const handleColorChange = useCallback((particles: Particle[], color: string) => {
-    particles.forEach(particle => {
-      particle.color = generateColorVariant(color, Math.random() * 0.5 + 0.3);
-    });
-  }, []);
-
   const canvasRef = useCanvasVisualizer<Particle>({
     accentColor,
     isPlaying,
@@ -134,7 +128,6 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     initializeItems: initializeParticles,
     updateItems: updateParticles,
     renderItems: renderParticles,
-    onColorChange: handleColorChange
   });
 
   return (

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -227,12 +227,6 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     }
   }, [t]);
 
-  const handleColorChange = useCallback((particles: TrailParticle[], color: string) => {
-    particles.forEach(particle => {
-      particle.color = generateColorVariant(color, Math.random() * 0.5 + 0.3);
-    });
-  }, []);
-
   const canvasRef = useCanvasVisualizer<TrailParticle>({
     accentColor,
     isPlaying,
@@ -241,7 +235,6 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     initializeItems: initializeParticles,
     updateItems: updateParticles,
     renderItems: renderParticles,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -117,17 +117,6 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
     []
   );
 
-  const handleColorChange = useCallback(
-    (waves: Wave[], color: string): void => {
-      const count = waves.length;
-      waves.forEach((wave, i) => {
-        const layerRatio = i / Math.max(1, count - 1);
-        wave.color = generateColorVariant(color, 0.2 + layerRatio * 0.6);
-      });
-    },
-    []
-  );
-
   const canvasRef = useCanvasVisualizer<Wave>({
     accentColor,
     isPlaying,
@@ -136,7 +125,6 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
     initializeItems,
     updateItems,
     renderItems,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/hooks/useCanvasVisualizer.ts
+++ b/src/hooks/useCanvasVisualizer.ts
@@ -21,12 +21,6 @@ interface UseCanvasVisualizerProps<T> {
    * Render items to the canvas
    */
   renderItems: (ctx: CanvasRenderingContext2D, items: T[], width: number, height: number, intensity: number) => void;
-  /**
-   * Update item colors when accent color changes. 
-   * This runs in addition to re-initialization to ensure immediate feedback without full reset if desired,
-   * though currently the hook re-initializes on color change by default due to dependency.
-   */
-  onColorChange: (items: T[], color: string) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `onColorChange` was declared in `UseCanvasVisualizerProps<T>` with a JSDoc describing it as an optimization for updating colors without full re-initialization
- All four visualizer components (`ParticleVisualizer`, `TrailVisualizer`, `GridWaveVisualizer`, `WaveVisualizer`) passed a `handleColorChange` callback, but the hook never destructured or called it
- Color changes on `accentColor` were already handled by the `useEffect` re-initializing all items — making `onColorChange` permanently dead code

## Changes

- Removed `onColorChange` prop from `UseCanvasVisualizerProps<T>` interface in `useCanvasVisualizer.ts`
- Removed all four `handleColorChange` callback definitions and their corresponding `onColorChange` prop usages from the visualizer components

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — 947 tests pass

Closes #833