### PR TITLE
refactor(spotify): consolidate retry and backoff constants

### DIFF
--- a/src/constants/spotify.ts
+++ b/src/constants/spotify.ts
@@ -1,0 +1,20 @@
+/**
+ * Spotify API, SDK, and playback constants
+ * Shared across provider and service implementations
+ */
+
+// Retry and backoff behavior
+export const SPOTIFY_MAX_RETRIES = 5;
+export const SPOTIFY_BASE_BACKOFF_MS = 1000;
+export const SPOTIFY_TRANSFER_RETRY_COUNT = 2;
+
+// Rate limiting
+export const SPOTIFY_RATE_LIMIT_WAIT_S = 5;
+
+// SDK loading
+export const SPOTIFY_SDK_LOAD_TIMEOUT_MS = 10000;
+
+// Playback timing
+export const SPOTIFY_RESUME_TIMEOUT_MS = 3000;
+export const SPOTIFY_INITIAL_RETRY_DELAY_MS = 300;
+export const SPOTIFY_INITIAL_VOLUME = 0.5;

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -8,6 +8,7 @@ import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/typ
 import { spotifyPlayer } from '@/services/spotifyPlayer';
 import { spotifyAuth } from '@/services/spotify';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
+import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { spotifyQueueSync } from './spotifyQueueSync';
 import { logSpotify } from '@/lib/debugLog';
@@ -27,9 +28,6 @@ function mapPlaybackState(state: SpotifyPlaybackState | null): PlaybackState | n
       : null,
   };
 }
-
-const MAX_PLAY_RETRIES = 5;
-const BASE_RETRY_BACKOFF_MS = 1000;
 
 export class SpotifyPlaybackAdapter implements PlaybackProvider {
   readonly providerId: ProviderId = 'spotify';
@@ -140,7 +138,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         throw new AuthExpiredError('spotify');
       }
 
-      if (retryCount >= MAX_PLAY_RETRIES) {
+      if (retryCount >= SPOTIFY_MAX_RETRIES) {
         throw error;
       }
 
@@ -149,8 +147,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1], 10) : 0;
         const backoffMs = retryAfterSec > 0
           ? retryAfterSec * 1000
-          : BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
-        logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
+          : SPOTIFY_BASE_BACKOFF_MS * Math.pow(2, retryCount);
+        logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, SPOTIFY_MAX_RETRIES, backoffMs);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
@@ -161,8 +159,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         }
 
         this.playbackSessionActive = false;
-        const backoffMs = BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
-        logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
+        const backoffMs = SPOTIFY_BASE_BACKOFF_MS * Math.pow(2, retryCount);
+        logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, SPOTIFY_MAX_RETRIES, backoffMs);
         await spotifyPlayer.transferPlaybackToDevice(true);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         await spotifyPlayer.ensureDeviceIsActive(3, 1000);

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -1,4 +1,5 @@
 import type { PaginatedResponse } from './types';
+import { SPOTIFY_RATE_LIMIT_WAIT_S } from '@/constants/spotify';
 
 // =============================================================================
 // Rate Limiting & Request Deduplication
@@ -28,8 +29,8 @@ function isRateLimited(): boolean {
 function handleRateLimitResponse(response: Response): void {
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
-    const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : 5;
-    const waitMs = (isNaN(waitSeconds) ? 5 : Math.max(waitSeconds, 1)) * 1000;
+    const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : SPOTIFY_RATE_LIMIT_WAIT_S;
+    const waitMs = (isNaN(waitSeconds) ? SPOTIFY_RATE_LIMIT_WAIT_S : Math.max(waitSeconds, 1)) * 1000;
     rateLimitedUntil = Date.now() + waitMs;
     console.warn(`[spotify] 429 rate-limited — backing off for ${waitMs}ms`);
   }

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -1,5 +1,11 @@
 import { spotifyAuth } from './spotify';
 import { logSpotify } from '@/lib/debugLog';
+import {
+  SPOTIFY_MAX_RETRIES,
+  SPOTIFY_INITIAL_RETRY_DELAY_MS,
+  SPOTIFY_INITIAL_VOLUME,
+  SPOTIFY_RESUME_TIMEOUT_MS,
+} from '@/constants/spotify';
 import { getHMRState, saveHMRState, loadSpotifySDK } from './spotifyPlayerSdk';
 import {
   apiPlayTrack,
@@ -69,7 +75,7 @@ class SpotifyPlayerService {
           spotifyAuth.redirectToAuth();
         });
       },
-      volume: 0.5
+      volume: SPOTIFY_INITIAL_VOLUME
     });
 
     this.player.addListener('ready', ({ device_id }: { device_id: string }) => {
@@ -261,7 +267,7 @@ class SpotifyPlayerService {
     }
   }
 
-  async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 300): Promise<boolean> {
+  async ensureDeviceIsActive(maxRetries = SPOTIFY_MAX_RETRIES, initialDelayMs = SPOTIFY_INITIAL_RETRY_DELAY_MS): Promise<boolean> {
     if (this.isReady && Date.now() - this.lastDeviceActiveAt < SpotifyPlayerService.DEVICE_ACTIVE_TTL_MS) {
       return true;
     }
@@ -274,7 +280,7 @@ class SpotifyPlayerService {
     return active;
   }
 
-  waitForPlaybackOrResume(activateDevice: () => Promise<void>, timeoutMs = 3000): void {
+  waitForPlaybackOrResume(activateDevice: () => Promise<void>, timeoutMs = SPOTIFY_RESUME_TIMEOUT_MS): void {
     let settled = false;
     let unsub: (() => void) | null = null;
 

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -1,4 +1,5 @@
 import { spotifyAuth } from './spotify';
+import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 
 export async function apiPlayTrack(
@@ -143,7 +144,7 @@ export async function apiTransferPlayback(
   const body = JSON.stringify({ device_ids: [deviceId], play: false });
   const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < SPOTIFY_TRANSFER_RETRY_COUNT; attempt++) {
     try {
       const response = await fetch('https://api.spotify.com/v1/me/player', {
         method: 'PUT',

--- a/src/services/spotifyPlayerSdk.ts
+++ b/src/services/spotifyPlayerSdk.ts
@@ -1,3 +1,4 @@
+import { SPOTIFY_SDK_LOAD_TIMEOUT_MS } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 
 interface HMRPlayerState {
@@ -43,7 +44,7 @@ export function loadSpotifySDK(pendingRef: { current: Promise<void> | null }): P
     const timeout = setTimeout(() => {
       pendingRef.current = null;
       reject(new Error('Spotify SDK failed to load within timeout'));
-    }, 10000);
+    }, SPOTIFY_SDK_LOAD_TIMEOUT_MS);
 
     window.onSpotifyWebPlaybackSDKReady = () => {
       clearTimeout(timeout);


### PR DESCRIPTION
Consolidates Spotify retry/backoff constants into a single shared module.

## Changes

- Create `src/constants/spotify.ts` with shared constants:
  - `SPOTIFY_MAX_RETRIES` (5)
  - `SPOTIFY_BASE_BACKOFF_MS` (1000)
  - `SPOTIFY_TRANSFER_RETRY_COUNT` (2)
  - `SPOTIFY_RATE_LIMIT_WAIT_S` (5)
  - `SPOTIFY_SDK_LOAD_TIMEOUT_MS` (10000)
  - `SPOTIFY_RESUME_TIMEOUT_MS` (3000)
  - `SPOTIFY_INITIAL_RETRY_DELAY_MS` (300)
  - `SPOTIFY_INITIAL_VOLUME` (0.5)

- Update files to use the new constants:
  - `spotifyPlaybackAdapter.ts`
  - `spotifyPlayerPlayback.ts`
  - `api.ts`
  - `spotifyPlayer.ts`
  - `spotifyPlayerSdk.ts`

Closes #854