### PR TITLE
Release: feature guides, refactors, and bug fixes

### DIFF
--- a/.claude/rules/feature-guides.md
+++ b/.claude/rules/feature-guides.md
@@ -1,0 +1,15 @@
+# Feature Guides
+
+When working on a feature area, read the corresponding guide in `docs/features/` before making changes. These guides document architecture, invariants, gotchas, and cross-cutting concerns that aren't obvious from the code alone.
+
+| Working on... | Read |
+|---------------|------|
+| Background animations, canvas rendering, particle/wave/grid effects | `docs/features/visualizers.md` |
+| Glow, translucence, speed, AccentColorBackground, VisualEffectsContext | `docs/features/visual-effects.md` |
+| Track queue, shuffle, reorder, add/remove, TrackContext, TrackOperations | `docs/features/queue.md` |
+| LibraryDrawer, PlaylistSelection, browse, sort, filter, pinned items | `docs/features/library.md` |
+| Provider interfaces, Spotify/Dropbox adapters, auth, cross-provider handoff | `docs/features/providers.md` |
+| Play/pause/next/prev, keyboard shortcuts, zen mode, playback subscription | `docs/features/player-controls.md` |
+| Album art display, flip menu, color extraction, accent colors, sizing | `docs/features/album-art.md` |
+| Settings drawer, QAP toggle, localStorage keys, Dropbox preferences sync | `docs/features/settings.md` |
+| Performance profiler, debug overlays, visualizer debug panel, debug logging | `docs/features/profiler.md` |

--- a/docs/features/album-art.md
+++ b/docs/features/album-art.md
@@ -1,0 +1,343 @@
+# Album Art System
+
+## Overview
+
+The album art system handles display, color extraction, accent color propagation, the flip menu (visual effects controls on the back of album art), gesture recognition, and responsive sizing. Album art is also the primary gesture target for opening drawers and zen mode interactions.
+
+## File Map
+
+| File | Role |
+|------|------|
+| `src/components/AlbumArt.tsx` | Core display component; glow, translucence, image processing |
+| `src/components/AlbumArtQuickSwapBack.tsx` | Flip menu back face; hosts `QuickEffectsRow` |
+| `src/components/AccentColorBackground.tsx` | Full-viewport gradient tinted by accent color |
+| `src/components/AccentColorGlowOverlay.tsx` | Per-art glow overlay with breathing animation |
+| `src/components/PlayerContent/AlbumArtSection.tsx` | Composition layer: art + flip + zen overlays + gestures |
+| `src/components/PlayerContent/GestureLayer.tsx` | Swipe/click/long-press routing; merges touch + pointer handlers |
+| `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons |
+| `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button |
+| `src/components/PlayerContent/styled.tsx` | `FlipInner`, `ClickableAlbumArtContainer`, zen track info styled components |
+| `src/hooks/useAccentColor.ts` | Auto-extract color on track change; manages override lifecycle |
+| `src/hooks/usePlayerSizing.ts` | Viewport-aware dimensions, breakpoints, device detection |
+| `src/hooks/useImageProcessingWorker.ts` | Hook wrapping the web worker for accent-mask image processing |
+| `src/hooks/useZenTouchGestures.ts` | Touch gesture recognizer (single tap, double tap, long press) |
+| `src/hooks/useSwipeGesture.ts` | Horizontal swipe detection (next/prev track) |
+| `src/hooks/useVerticalSwipeGesture.ts` | Vertical swipe detection (queue up, library down) |
+| `src/utils/colorExtractor.ts` | Canvas-based dominant color extraction with LRU cache |
+| `src/utils/colorCache.ts` | LRU cache (100 entries) for extracted colors |
+| `src/utils/colorUtils.ts` | `hexToRgb`, `getRelativeLuminance`, `isLightColor`, `getContrastColor` |
+| `src/contexts/ColorContext.tsx` | Global accent color state, overrides, custom colors |
+| `src/workers/imageProcessor.worker.ts` | Web worker: pixel-level accent-mask processing |
+| `src/constants/zenAnimation.ts` | Zen mode animation timings and dead zone constants |
+
+## AlbumArt Component
+
+**Location:** `src/components/AlbumArt.tsx`
+
+### Props
+
+```ts
+interface AlbumArtProps {
+  currentTrack: MediaTrack | null;
+  objectPosition?: string;
+  accentColor?: string;
+  glowIntensity?: number;     // 95-125 range, controls glow spread
+  glowRate?: number;          // seconds per breathing cycle
+  glowEnabled?: boolean;
+  zenMode?: boolean;
+  translucenceEnabled?: boolean;
+  translucenceOpacity?: number;
+  onRetryAlbumArt?: () => void;
+}
+```
+
+### Rendering pipeline
+
+1. `AlbumArtContainer` sets the base box with CSS glow (see below)
+2. `AccentColorGlowOverlay` adds a blurred overlay for glow bleed
+3. Main image: either processed `canvasUrl` (accent-masked) or raw `currentTrack.image`
+4. If `glowIntensity === 0` or worker processing is incomplete, falls back to raw image
+5. Missing artwork shows "No image" placeholder with optional retry button
+
+### Glow system (box-shadow)
+
+Four visual states based on `glowEnabled` and `glowIntensity`:
+
+| State | Visual |
+|-------|--------|
+| `glowEnabled === false` | Subtle edge definition only (white border + depth shadow) |
+| `glowEnabled && glowIntensity > 0` | Animated breathing glow via `breatheBorderGlow` CSS animation. Three colored shadow layers with opacities derived from `glowIntensity`. Uses CSS custom properties `--glow-opacity` and `--glow-rate`. |
+| `glowEnabled && glowIntensity === 0` | Static full glow (no animation) |
+| No accent color | White glow fallback |
+
+The glow intensity range 95-125 is mapped to opacity coefficients via `t = (glowIntensity - 95) / (125 - 95)`.
+
+### Zen mode sizing
+
+In zen mode, `max-width` expands to fill viewport minus margins:
+- Desktop: `min(calc(100vw - 96px), calc(100dvh - 196px))`
+- Mobile (`<= theme.breakpoints.lg`): `min(calc(100vw - 32px), calc(100dvh - 120px))`
+
+Transition: 1000ms with 300ms enter delay, Material Design easing.
+
+### Image processing
+
+On track/accent color change, the component:
+1. Loads the image via `new Image()` with `crossOrigin = 'anonymous'`
+2. Draws to a canvas, extracts `ImageData`
+3. Sends to `processImage()` (web worker) with `maxDistance = 40`
+4. Worker masks pixels close to the accent color (makes them transparent)
+5. Result displayed as `canvas.toDataURL()`
+
+The processing spinner shows while the worker is active.
+
+### Custom equality check (arePropsEqual)
+
+The component uses a custom `React.memo` comparator that checks: `currentTrack.id`, `currentTrack.image`, `accentColor`, `glowIntensity`, `glowRate`, `glowEnabled`, `zenMode`, `translucenceEnabled`, `translucenceOpacity`, `onRetryAlbumArt`. This prevents unnecessary re-renders from parent state changes that don't affect album art.
+
+## The Flip Menu
+
+### Architecture
+
+Album art has a front (artwork) and back (visual effects controls). The flip is a CSS 3D transform (`rotateY(180deg)`) applied via `FlipInner` in `src/components/PlayerContent/styled.tsx`.
+
+### Flip state
+
+`isFlipped` state lives in `AlbumArtSection`. Toggled by:
+- Click on album art (when not in zen touch mode and not already flipped in zen)
+- Long press on album art (zen mode, pointer devices)
+- Long press gesture (zen mode, touch devices -- 500ms via `useZenTouchGestures`)
+
+Auto-closes when:
+- Track changes (`currentTrack.id` effect resets `isFlipped = false`)
+- Click outside the flip container (`mousedown` handler on `document`)
+- Explicit close button on the back face
+
+### Back face content (AlbumArtQuickSwapBack)
+
+**Location:** `src/components/AlbumArtQuickSwapBack.tsx`
+
+Renders over a blurred version of the album art (`filter: blur(20px)`) with a dark overlay. Contains:
+- Title "Visual Effects" (hidden on mobile)
+- `QuickEffectsRow` -- the actual controls (accent color picker, glow toggle/sliders, visualizer controls, translucence toggle)
+- Close button (top-right)
+- "Retry Artwork" button (when no image is available)
+- Tap-to-close on the background area (pointer up within 10px of pointer down, not on controls)
+
+The back face has `backface-visibility: hidden` and `transform: rotateY(180deg)` so it only appears when the container is flipped.
+
+### Click-outside dismissal
+
+An effect in `AlbumArtSection` adds a `mousedown` listener on `document` when `isFlipped === true`. Clicks outside `flipContainerRef` close the menu. Exception: clicks on `[data-eyedropper-overlay]` are ignored (color picker overlay).
+
+## Color Extraction
+
+**Location:** `src/utils/colorExtractor.ts`
+
+### extractDominantColor(imageUrl): Promise<ExtractedColor | null>
+
+1. Check LRU cache (`src/utils/colorCache.ts`, max 100 entries)
+2. Load image with `crossOrigin = 'anonymous'`
+3. Downscale to max 150px (either dimension)
+4. Sample every 4th pixel (stride 16 in RGBA array)
+5. Bucket into 8-unit color bins (32 shades per channel)
+6. Filter: `isGoodContrast` (lightness 40-85%) AND `isVibrant` (saturation >= 50%)
+7. Score: `pixelCount * (saturation/100) * (1 - |lightness - 50| / 50)`
+8. Return highest-scoring color as `{ hex, rgb, hsl }`
+
+Returns `null` if no color passes filters.
+
+### extractTopVibrantColors(imageUrl, count = 3): Promise<ExtractedColor[]>
+
+Same algorithm but returns up to `count` colors with a similarity filter: candidates within Euclidean RGB distance < 40 of an already-selected color are skipped.
+
+### ExtractedColor type
+
+```ts
+interface ExtractedColor {
+  hex: string;   // '#rrggbb'
+  rgb: string;   // 'rgb(r, g, b)'
+  hsl: string;   // 'hsl(h, s%, l%)'
+}
+```
+
+### Cache (colorCache.ts)
+
+Simple `Map<string, ExtractedColor | null>` with LRU eviction at 100 entries (deletes oldest key when full). Keyed by image URL.
+
+## Accent Color System
+
+### Flow
+
+```
+Track changes (currentTrack.id or currentTrack.image)
+  -> useAccentColor effect fires
+    -> if albumId has override in accentColorOverrides: use it
+    -> else: extractDominantColor(image) -> apply via requestIdleCallback + startTransition
+    -> fallback: theme.colors.accent (default teal)
+
+Accent color set via setAccentColor()
+  -> ColorContext propagates to all consumers
+  -> CSS custom property --accent-color updated on :root
+  -> CSS custom property --accent-contrast-color updated (via getContrastColor)
+```
+
+### ColorContext
+
+**Location:** `src/contexts/ColorContext.tsx`
+
+```ts
+interface ColorContextValue {
+  accentColor: string;
+  accentColorOverrides: Record<string, string>;   // albumId -> color, persisted in localStorage
+  customAccentColors: Record<string, string>;      // albumId -> eyedropper color, separate storage
+  setAccentColor: (color: string) => void;
+  setAccentColorOverrides: (...) => void;
+  handleSetAccentColorOverride: (albumId: string, color: string) => void;
+  handleRemoveAccentColorOverride: (albumId: string) => void;
+  handleResetAccentColorOverride: (albumId: string) => void;    // alias for remove
+  handleSetCustomAccentColor: (albumId: string, color: string) => void;
+  handleRemoveCustomAccentColor: (albumId: string) => void;
+}
+```
+
+Storage keys:
+- `accentColorOverrides`: `STORAGE_KEYS.ACCENT_COLOR_OVERRIDES` -- palette selections AND eyedropper picks
+- `customAccentColors`: `STORAGE_KEYS.CUSTOM_ACCENT_COLORS` -- eyedropper picks only (so palette clicks don't overwrite the custom swatch display)
+
+All override mutations schedule a Dropbox preferences push (`getPreferencesSync()?.schedulePush()`) for cross-device sync.
+
+### Override priority
+
+In `useAccentColor`:
+1. If `albumId` exists in `accentColorOverrides` -> use that color directly (no extraction)
+2. If album has image -> extract dominant color
+3. Fallback -> `theme.colors.accent`
+
+### Custom color handling in AlbumArtSection
+
+When user picks a custom color (eyedropper or palette):
+- `handleSetAccentColorOverride(albumId, color)` -- saves to overrides
+- `handleSetCustomAccentColor(albumId, color)` -- saves to custom colors store
+- `setAccentColor(color)` -- immediate visual update
+
+When user clears custom color (empty string):
+- Both overrides are removed
+- Accent color re-extracts from album art
+
+When user picks `'RESET_TO_DEFAULT'`:
+- Override is removed
+- Auto-extraction resumes on next track change
+
+## AccentColorBackground
+
+**Location:** `src/components/AccentColorBackground.tsx`
+
+A `position: fixed` full-viewport gradient that tints the background based on accent color. Uses `generateColorVariant()` for shifted hues. The gradient is subtle: 0x20 / 0x15 / 0x10 alpha at three stops.
+
+Renders nothing when `enabled === false`. Low z-index (0) so it sits behind all content.
+
+## Album Art as Gesture Target
+
+`AlbumArtSection` wraps art in `GestureLayer`, which composites multiple gesture recognizers.
+
+### GestureLayer
+
+**Location:** `src/components/PlayerContent/GestureLayer.tsx`
+
+Merges:
+- `useSwipeGesture` (horizontal: next/prev track) -- touch only
+- `useVerticalSwipeGesture` (vertical: swipe up = queue, swipe down = library) -- touch only, 80px threshold
+- `useLongPress` (zen mode long press to flip) -- zen + pointer only
+- `zenTouchHandlers` (from `useZenTouchGestures`) -- zen + touch only
+- Click handler (toggles flip, suppressed during swipe/animation)
+- Zone hover tracking for zen mode (pointer devices only)
+
+The component merges refs via `handleRef` callback to share a single DOM element between `albumArtContainerRef` and `drawerSwipeRef`.
+
+### Gesture priority
+
+When zen touch is active (`isTouchDevice && zenModeEnabled && !isFlipped`), the `zenTouchHandlers` from `useZenTouchGestures` override the normal click/long-press handlers. This enables the single-tap/double-tap/long-press gesture set.
+
+When zen mode is active with pointer input, `longPressHandlers` from `useLongPress` are active instead, allowing long press to open the flip menu.
+
+## Image Processing Worker
+
+**Location:** `src/workers/imageProcessor.worker.ts`
+
+### Purpose
+
+Processes album art pixels off the main thread. The primary operation masks pixels whose color is close to the accent color (making them transparent), creating a "glow bleed" effect where the accent color shows through the art.
+
+### Message protocol
+
+Request:
+```ts
+{ type: 'PROCESS_IMAGE', imageData: ImageData, accentColor: [r, g, b], maxDistance: number, requestId: number }
+```
+
+Response:
+```ts
+{ type: 'IMAGE_PROCESSED', processedImageData: ImageData, success: true, requestId: number }
+// or
+{ type: 'IMAGE_PROCESSING_ERROR', error: string, success: false, requestId: number }
+```
+
+### Algorithm
+
+For each pixel, compute Euclidean RGB distance from `accentColor`. If distance < `maxDistance` (default 40), reduce alpha proportionally: `alpha = alpha * (distance / maxDistance)`. Exact matches become fully transparent; pixels at the threshold retain full opacity.
+
+### Hook wrapper (useImageProcessingWorker)
+
+Not documented in detail here but provides `processImage(imageData, accentColor, maxDistance): Promise<ImageData>` that manages worker lifecycle and request IDs.
+
+## Responsive Sizing
+
+### usePlayerSizing
+
+**Location:** `src/hooks/usePlayerSizing.ts`
+
+Returns viewport-aware dimensions consumed by album art sizing:
+
+```ts
+interface UsePlayerSizingReturn {
+  dimensions: PlayerDimensions;
+  viewport: ViewportInfo;
+  isMobile: boolean;        // width < 700
+  isTablet: boolean;        // 700 <= width < 1024
+  isDesktop: boolean;       // width >= 1024
+  hasPointerInput: boolean; // pointer:fine OR hover:hover
+  isTouchDevice: boolean;   // !hasPointerInput
+  orientation: 'portrait' | 'landscape';
+  // ...additional sizing utilities
+}
+```
+
+### Album art max-width calculation
+
+In `AlbumArt.tsx`, `AlbumArtContainer` uses CSS `max-width`:
+- Normal mode: `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - 120px))`
+- Zen mode: `min(calc(100vw - 96px), calc(100dvh - 196px))`
+- Zen mode mobile: `min(calc(100vw - 32px), calc(100dvh - 120px))`
+
+The `aspect-ratio: 1` rule ensures square art. The `max-width` constraint is the sole sizing mechanism -- no explicit width or height is set.
+
+### AlbumArtSection bounds reporting
+
+`AlbumArtSection` optionally reports its DOM bounds via `onAlbumArtBoundsChange` callback, using a `ResizeObserver`. This is used by other components (e.g. zen overlays) to position elements relative to the art.
+
+## Invariants and Gotchas
+
+1. **crossOrigin is required**: Both `colorExtractor` and `AlbumArt` set `img.crossOrigin = 'anonymous'`. Without this, canvas `getImageData` throws a security error for cross-origin images (Spotify CDN, Dropbox thumbnails).
+
+2. **Flip auto-resets on track change**: The `isFlipped` state resets to `false` whenever `currentTrack.id` changes. This prevents showing stale back-face controls.
+
+3. **Custom colors vs overrides**: `customAccentColors` and `accentColorOverrides` are separate localStorage entries. Palette swatch selection writes to `accentColorOverrides` only. Eyedropper writes to both. This lets the flip menu display the user's last eyedropper pick even when they select a different palette swatch.
+
+4. **requestIdleCallback + startTransition**: Accent color application uses both to minimize jank. `requestIdleCallback` defers the work, `startTransition` marks it as non-urgent for React's concurrent scheduler. Falls back to immediate application if `requestIdleCallback` is unavailable.
+
+5. **Worker error handling**: If the web worker fails, `canvasUrl` stays `null` and the raw image displays. The "Component unmounted" error is explicitly ignored to prevent console noise during rapid track changes.
+
+6. **Eyedropper overlay exception**: Click-outside-to-close for the flip menu explicitly ignores clicks on `[data-eyedropper-overlay]` elements. Without this, opening the color picker would immediately close the flip menu.
+
+7. **isTouchDevice vs isMobile**: These are different. `isTouchDevice` is input-capability-based (CSS `pointer: coarse`). `isMobile` is viewport-width-based (`< 700px`). A large tablet is `isTouchDevice === true` but `isMobile === false`. Use `isTouchDevice` for interaction decisions, `isMobile`/`isTablet` for layout.

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -1,0 +1,300 @@
+# Library Browser System
+
+## Overview
+
+The library browser shows the user's music collections (playlists, albums, liked songs) across all connected providers. It appears in two contexts:
+
+1. **Idle/home view** -- rendered inline by `PlayerStateRenderer` when no track is loaded.
+2. **LibraryDrawer** -- a slide-down overlay accessible during playback via swipe-down on album art, `L` key, or `Down Arrow`.
+
+Both contexts render the same `PlaylistSelection` component. The difference is layout and dismissal behavior.
+
+## LibraryDrawer
+
+**File:** `src/components/LibraryDrawer.tsx`
+
+- Renders via `createPortal` to `document.body`.
+- Fixed position, slides down from top. Height: 85vh.
+- Swipe-to-dismiss via `useVerticalSwipeGesture` on a grip pill at the **bottom** of the drawer (swipe up to close, threshold: 80px).
+- Uses `hasBeenOpenedRef` to defer mount until first open.
+- Constrained to 700px width on desktop (`@media min-width: lg`), centered with auto margins and border-radius on bottom corners.
+- Only renders children when `isOpen` is true (conditional rendering, not just CSS hidden).
+
+**Props:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Controls slide animation |
+| `onClose` | `() => void` | Close handler |
+| `onPlaylistSelect` | `(id, name, provider?) => void` | Fires when user picks a collection |
+| `onAddToQueue` | `(id, name?, provider?) => Promise<AddToQueueResult \| null>` | Append to existing queue |
+| `onPlayLikedTracks` | `(tracks, collectionId, name, provider?) => Promise<void>` | Direct play of liked tracks |
+| `onQueueLikedTracks` | `(tracks, name?) => void` | Queue liked tracks |
+| `initialSearchQuery` | `string` | Pre-populate search on open |
+| `initialViewMode` | `'playlists' \| 'albums'` | Set active tab on open |
+| `lastSession` | `SessionSnapshot \| null` | For ResumeCard |
+| `onResume` | `() => void` | Resume session handler |
+
+**Playlist selection is deferred.** When the user picks a collection, the drawer closes first, then `onPlaylistSelect` fires after `DRAWER_TRANSITION_DURATION` (via `setTimeout`). This prevents layout jank from simultaneous close animation + playback start.
+
+**Library refresh** dispatches a `vorbis-library-refresh` custom event and shows a spinner for a minimum of 1500ms.
+
+## PlaylistSelection
+
+**File:** `src/components/PlaylistSelection/index.tsx`
+
+The main library component. Renders playlist/album grids, search, sort, filter controls, and liked songs cards.
+
+### Data Sources
+
+- **Playlists and albums:** `useLibrarySync()` -- provider-agnostic sync engine that merges collections from all connected providers. Returns `CachedPlaylistInfo[]` and `AlbumInfo[]`.
+- **Liked songs count:** Also from `useLibrarySync()`, with per-provider breakdown.
+- **Unified liked tracks:** `useUnifiedLikedTracks()` -- active when 2+ providers with `hasLikedCollection` are connected.
+- **Pinned items:** `usePinnedItems()` (re-exported from `PinnedItemsContext`).
+
+### Layout Modes
+
+`PlaylistSelection` has two render paths controlled by `inDrawer`:
+
+- **`inDrawer={true}`:** Uses `DrawerContentWrapper` (fills available space, no centering). Used inside `LibraryDrawer`.
+- **`inDrawer={false}`:** Uses `Container` + `SelectionCard` (centered, max-width constrained). Used in `PlayerStateRenderer` idle view. Accepts optional `footer` prop (used for `ResumeCard`).
+
+## LibraryContext
+
+**File:** `src/components/PlaylistSelection/LibraryContext.tsx`
+
+A React context that provides the entire library state and action callbacks to child components (`LibraryMainContent`, `PlaylistGrid`, `AlbumGrid`, `LikedSongsCard`, etc.). Created fresh in every `PlaylistSelection` render via `useMemo`.
+
+```ts
+interface LibraryContextValue {
+  // Layout
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+
+  // Browse state
+  viewMode: 'playlists' | 'albums';
+  setViewMode: (v: 'playlists' | 'albums') => void;
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+
+  // Sort
+  playlistSort: PlaylistSortOption;    // 'name-asc' | 'name-desc' | 'recently-added'
+  setPlaylistSort: (v: PlaylistSortOption) => void;
+  albumSort: AlbumSortOption;          // 'name-asc' | 'name-desc' | 'artist-asc' | 'artist-desc' | 'release-newest' | 'release-oldest' | 'recently-added'
+  setAlbumSort: (v: AlbumSortOption) => void;
+
+  // Filters
+  artistFilter: string;
+  setArtistFilter: (v: string) => void;
+  providerFilters: ProviderId[];
+  setProviderFilters: (v: ProviderId[]) => void;
+  handleProviderToggle: (provider: ProviderId) => void;
+  hasActiveFilters: boolean;
+
+  // Data
+  albums: AlbumInfo[];
+  isInitialLoadComplete: boolean;
+  showProviderBadges: boolean;
+  enabledProviderIds: ProviderId[];
+  likedSongsPerProvider: LikedSongsEntry[];
+  likedSongsCount: number;
+  isLikedSongsSyncing: boolean;
+  isUnifiedLikedActive: boolean;
+  unifiedLikedCount: number;
+
+  // Pinned items (sorted to top of grids)
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  isPlaylistPinned: (id: string) => boolean;
+  canPinMorePlaylists: boolean;
+  isAlbumPinned: (id: string) => boolean;
+  canPinMoreAlbums: boolean;
+
+  // Active provider
+  activeDescriptor: ProviderDescriptor | null;
+
+  // Action callbacks
+  onPlaylistClick: (playlist: PlaylistInfo) => void;
+  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  onLikedSongsClick: (provider?: ProviderId) => void;
+  onAlbumClick: (album: AlbumInfo) => void;
+  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
+  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
+  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+```
+
+## Browse Flow
+
+### Provider Selection -> Collection List -> Track List
+
+1. User opens the library (idle view or drawer).
+2. `useLibrarySync` has already fetched and cached collections from all connected providers.
+3. User selects "Playlists" or "Albums" tab (`viewMode`).
+4. Collections are filtered and sorted via `playlistFilters.ts`:
+   - `filterPlaylistsOnly(items, searchQuery)` / `filterAlbumsOnly(items, searchQuery, yearFilter, artistFilter)` -- text matching on name, description, owner/artist.
+   - `buildLibraryViewWithPins(filtered, pinnedIds, getId, sortFn)` -- splits into pinned (sorted to top) and unpinned groups, applies sort within each group.
+5. User clicks a collection -> `onPlaylistSelect(id, name, provider)` fires.
+6. This triggers `useCollectionLoader.loadCollection` which replaces the queue and starts playback.
+
+### Provider toggle
+
+When multiple providers are connected, `LibraryProviderBar` shows toggle buttons. `handleProviderToggle(provider)` filters the displayed collections:
+- First toggle activates only that provider.
+- Subsequent toggles add/remove providers.
+- Removing the last filter returns to "all" (empty array = no filter).
+
+## Sort and Filter
+
+**Hook:** `useLibraryBrowsing` (`src/components/PlaylistSelection/useLibraryBrowsing.ts`)
+
+| State | Storage | Default |
+|-------|---------|---------|
+| `viewMode` | `useLocalStorage('vorbis-player-view-mode')` | `'playlists'` |
+| `searchQuery` | `useState` | `''` |
+| `playlistSort` | `useLocalStorage('vorbis-player-playlist-sort')` | `'recently-added'` |
+| `albumSort` | `useLocalStorage('vorbis-player-album-sort')` | `'recently-added'` |
+| `artistFilter` | `useState` | `''` |
+| `providerFilters` | `useState` | `[]` (empty = all) |
+
+**Sort options** (from `src/utils/playlistFilters.ts`):
+- Playlists: `name-asc`, `name-desc`, `recently-added`
+- Albums: `name-asc`, `name-desc`, `artist-asc`, `artist-desc`, `release-newest`, `release-oldest`, `recently-added`
+
+**Artist filter** is cleared automatically when switching from albums to playlists view.
+
+**Sort anchors:** Certain special collections (`LIKED_SONGS_ID`, Dropbox "All Music" with id `''`) are exempt from sort reordering -- they always stay in catalog order. Defined in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`.
+
+## Pinned Items
+
+**Context:** `PinnedItemsContext` (`src/contexts/PinnedItemsContext.tsx`)
+
+Pinned playlists and albums are sorted to the top of their respective grids, above unpinned items. Each group (pinned/unpinned) is sorted independently.
+
+### Storage
+
+Pins are stored in IndexedDB via `src/services/settings/pinnedItemsStorage.ts`:
+- Provider namespace: `_unified` (cross-provider).
+- Stores: `playlists` and `albums` (arrays of string IDs).
+- Max pins: 12 total (playlists + albums combined).
+
+### Sync
+
+- On load, pins are migrated from legacy localStorage format if needed (`migratePinsFromLocalStorage`).
+- External updates (e.g., Dropbox preferences sync) dispatch `vorbis-pins-changed` window event. `PinnedItemsContext` listens and reloads.
+- After local pin changes, `getPreferencesSync()?.schedulePush()` pushes to Dropbox (2s debounced).
+
+### API
+
+```ts
+const {
+  pinnedPlaylistIds: string[],
+  pinnedAlbumIds: string[],
+  isPlaylistPinned: (id: string) => boolean,
+  isAlbumPinned: (id: string) => boolean,
+  togglePinPlaylist: (id: string) => void,
+  togglePinAlbum: (id: string) => void,
+  canPinMorePlaylists: boolean,  // totalPinned < 12
+  canPinMoreAlbums: boolean,     // totalPinned < 12
+} = usePinnedItems();
+```
+
+## Unified Liked Songs
+
+**Hook:** `useUnifiedLikedTracks` (`src/hooks/useUnifiedLikedTracks.ts`)
+
+Active when 2+ connected providers have `capabilities.hasLikedCollection`. Merges liked tracks from all qualifying providers, sorted by `addedAt` descending.
+
+Uses a module-level cache with `useSyncExternalStore` for efficient sharing across components. The cache is keyed by sorted provider IDs -- if providers change, the cache is invalidated and re-fetched.
+
+Refresh triggers:
+- `vorbis-library-refresh` event.
+- Provider-specific likes-changed events (e.g., `vorbis-dropbox-likes-changed`).
+
+When unified liked is active and user clicks "Liked Songs" without specifying a provider, `useCollectionLoader.loadUnifiedLiked` fetches from all providers, merges, sorts, and loads into the queue.
+
+## ResumeCard
+
+`LibraryDrawer` renders a `ResumeCard` at the bottom when `lastSession` and `onResume` props are provided. This allows resuming a previous playback session regardless of QAP state.
+
+In the idle/home view (`PlayerStateRenderer`), the `ResumeCard` is passed as a `footer` prop to `PlaylistSelection` (when QAP is disabled) or rendered within `QuickAccessPanel` (when QAP is enabled).
+
+## Swipe Gestures
+
+- **Swipe down on album art:** Opens LibraryDrawer (handled by gesture hooks in the player content area).
+- **Swipe up on LibraryDrawer grip pill:** Closes the drawer.
+- **Keyboard:** `L` or `Down Arrow` toggles the library drawer (desktop). `Down Arrow` maps to volume down on touch-only devices.
+- **Cross-dismiss:** Opening the library closes the queue drawer, and vice versa.
+
+## Idle/Home View
+
+**File:** `src/components/PlayerStateRenderer.tsx`
+
+When no track is loaded (`selectedPlaylistId === null || tracks.length === 0`), `PlayerStateRenderer` decides what to show:
+
+1. **QAP disabled** (default): Shows `PlaylistSelection` inline (full library browser).
+2. **QAP enabled**: Shows `QuickAccessPanel` with a "Browse Library" button that switches to `PlaylistSelection`.
+
+QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (default `false`), read via `useQapEnabled()` hook.
+
+`PlayerStateRenderer` initializes `showLibrary = !qapEnabled`. When the user selects a playlist from either view, `showLibrary` resets to `false` and `onPlaylistSelect` fires.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/components/LibraryDrawer.tsx` | Drawer container with swipe-to-dismiss |
+| `src/components/PlaylistSelection/index.tsx` | Main library component, assembles LibraryContext |
+| `src/components/PlaylistSelection/LibraryContext.tsx` | Context definition for library state |
+| `src/components/PlaylistSelection/LibraryMainContent.tsx` | Tabs, search, sort, filter controls + grids |
+| `src/components/PlaylistSelection/useLibraryBrowsing.ts` | Browse state management (view mode, search, sort, filters) |
+| `src/components/PlaylistSelection/useItemActions.ts` | Context menu actions (play, queue, delete) |
+| `src/components/PlaylistSelection/PlaylistGrid.tsx` | Playlist card grid |
+| `src/components/PlaylistSelection/AlbumGrid.tsx` | Album card grid |
+| `src/components/PlaylistSelection/LikedSongsCard.tsx` | Liked songs entry card |
+| `src/components/PlayerStateRenderer.tsx` | Idle view routing (QAP vs library) |
+| `src/components/QuickAccessPanel/ResumeCard.tsx` | Session resume card |
+| `src/contexts/PinnedItemsContext.tsx` | Pin state and IndexedDB persistence |
+| `src/services/settings/pinnedItemsStorage.ts` | IndexedDB pin storage, MAX_PINS, events |
+| `src/hooks/useLibrarySync.ts` | Collection sync engine across providers |
+| `src/hooks/useUnifiedLikedTracks.ts` | Cross-provider liked songs merge |
+| `src/hooks/useQapEnabled.ts` | QAP preference (localStorage) |
+| `src/utils/playlistFilters.ts` | Filter/sort/pin-split utilities |
+| `src/constants/playlist.ts` | LIKED_SONGS_ID, sort anchor IDs, ID encoding |
+| `src/components/PlayerContent/DrawerOrchestrator.tsx` | Drawer switching and toast management |
+
+## Cross-Cutting Concerns
+
+### Queue interaction
+- Clicking a collection in the library calls `loadCollection` which **replaces** the queue.
+- "Add to queue" (via context menu) calls `handleAddToQueue` which **appends** to the queue.
+- The library drawer closes before playback starts (deferred via timeout).
+
+### Provider system
+- `PlaylistSelection` reads from `ProviderContext` for `activeDescriptor`, `enabledProviderIds`, `getDescriptor`.
+- Collections carry a `provider` field, so clicking one routes to the correct provider for track loading.
+
+### Color system
+- Album art colors drive the accent color. Loading a new collection triggers color extraction.
+- This is not handled by the library components directly -- it happens downstream in `useAccentColor`.
+
+## Gotchas
+
+1. **LibraryContext is NOT a global context.** It is created per `PlaylistSelection` mount. If you need library state outside of `PlaylistSelection`, you cannot use `useLibraryContext()`.
+
+2. **The drawer only renders children when open.** `{isOpen && (<DrawerContent>...`)}. This means `PlaylistSelection` unmounts on close and remounts on open. Any ephemeral state (search query, scroll position) is lost unless passed via props (`initialSearchQuery`, `initialViewMode`).
+
+3. **Sort and view mode are persisted; search and artist filter are not.** `viewMode`, `playlistSort`, and `albumSort` survive across sessions. `searchQuery` and `artistFilter` reset on each drawer open (unless `initialSearchQuery` is passed).
+
+4. **Provider filters are ephemeral.** They reset when the drawer is closed and reopened.
+
+5. **Pin limit is 12 total across playlists and albums.** `canPinMorePlaylists` and `canPinMoreAlbums` both check `pinnedPlaylistIds.length + pinnedAlbumIds.length < MAX_PINS`.
+
+6. **Unified liked songs requires 2+ providers with `hasLikedCollection`.** If only one provider supports liked songs, the unified path is skipped and the provider-specific liked songs are loaded directly.
+
+7. **Library refresh dispatches a DOM event.** `LIBRARY_REFRESH_EVENT` (`vorbis-library-refresh`) is a window-level custom event, not a React state change. `useLibrarySync` and `useUnifiedLikedTracks` both listen for it.

--- a/docs/features/player-controls.md
+++ b/docs/features/player-controls.md
@@ -1,0 +1,369 @@
+# Player Controls
+
+## Overview
+
+The player control system routes user actions (play, pause, next, previous) through a provider-agnostic dispatch layer. The central hook `usePlayerLogic` owns all control handlers and delegates playback to whichever provider is currently driving audio output.
+
+Key concept: **active provider** (selected for browsing/catalog) vs **driving provider** (currently outputting audio). In mixed queues these differ.
+
+## File Map
+
+| File | Role |
+|------|------|
+| `src/hooks/usePlayerLogic.ts` | Central orchestrator; assembles handlers, wires subscriptions, owns local playback state |
+| `src/hooks/useProviderPlayback.ts` | Resolves provider per track, handles cross-provider handoff, error recovery |
+| `src/hooks/usePlaybackSubscription.ts` | Subscribes to all provider state events, filters by driving provider, syncs React state |
+| `src/hooks/useAutoAdvance.ts` | Detects track-end signals, triggers `playTrack(nextIndex)` with cooldown guard |
+| `src/hooks/useKeyboardShortcuts.ts` | Keyboard event handler; device-aware (pointer vs touch) |
+| `src/hooks/useVolume.ts` | Volume + mute state; persisted via `useLocalStorage` |
+| `src/hooks/useZenTouchGestures.ts` | Touch gesture recognizer for zen mode (single tap, double tap, long press) |
+| `src/hooks/useCollectionLoader.ts` | Loads a collection into the queue and starts playback |
+| `src/hooks/useQueueManagement.ts` | Queue mutation: add, remove, reorder |
+| `src/hooks/useRadioSession.ts` | Radio generation session lifecycle |
+| `src/components/PlayerStateRenderer.tsx` | Idle/home view routing (QAP vs library browser) |
+| `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons over album art |
+| `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button (bottom-right of album art) |
+| `src/providers/errors.ts` | `AuthExpiredError`, `UnavailableTrackError` |
+| `src/types/providers.ts` | `PlaybackProvider` interface (line 66) |
+| `src/types/domain.ts` | `PlaybackState` interface (line 81) |
+
+## usePlayerLogic
+
+**Location:** `src/hooks/usePlayerLogic.ts`
+
+Central dispatch hub. Composes all sub-hooks and returns a structured API:
+
+```ts
+return {
+  state: { isLoading, error, selectedPlaylistId, tracks, showLibraryDrawer, isPlaying, playbackPosition },
+  handlers: {
+    loadCollection, playTracksDirectly, handleAddToQueue, queueTracksDirectly,
+    handlePlay, handlePause, handleNext, handlePrevious, playTrack,
+    handleOpenLibraryDrawer, handleCloseLibraryDrawer, handleBackToLibrary,
+    handleStartRadio, handleRemoveFromQueue, handleReorderQueue,
+  },
+  radio: { radioState, isRadioAvailable, stopRadio, authExpired, clearAuthExpired, isActive, radioProgress, dismissRadioProgress },
+  mediaTracksRef,         // imperative mirror of tracks[]
+  setTracks,
+  setOriginalTracks,
+  currentPlaybackProviderRef,  // ref to driving provider ID
+  expectedTrackIdRef,          // guards against stale provider index updates during transitions
+};
+```
+
+### Ref-based state pattern
+
+`tracksRef`, `currentTrackIndexRef`, and `expectedTrackIdRef` are `useRef` mirrors of their corresponding React state. This is intentional: the `usePlaybackSubscription` effect depends only on `activeDescriptor`, not on tracks/index. Without refs, every track change would tear down and recreate the provider subscription, triggering a `getState()` call that briefly resets `currentTrackIndex` to the old track.
+
+### handleNext / handlePrevious
+
+Both wrap around the queue circularly (`% tracks.length`). Before calling `playTrack`, they set `expectedTrackIdRef.current` to the target track's ID. This tells `usePlaybackSubscription` to ignore any stale provider index updates until the expected track arrives.
+
+### handlePlay / handlePause
+
+Route through `getDrivingProviderDescriptor()` -- resolves the driving provider (not the active provider). `handlePlay` calls `descriptor.playback.resume()`. `handlePause` calls `descriptor.playback.pause()`.
+
+### handleBackToLibrary
+
+Pauses playback, stops radio, clears all queue state (`tracks`, `originalTracks`, `mediaTracksRef`, `selectedPlaylistId`, `currentTrackIndex`), and closes drawers.
+
+### Queue change notification
+
+An effect watches `tracks` and `currentTrackIndex` and calls `descriptor.playback.onQueueChanged?.(tracks, currentTrackIndex)` on the driving provider. Spotify uses this to sync its native queue.
+
+## useProviderPlayback
+
+**Location:** `src/hooks/useProviderPlayback.ts`
+
+### Props
+
+```ts
+interface UseProviderPlaybackProps {
+  setCurrentTrackIndex: (index: number) => void;
+  activeDescriptor?: ProviderDescriptor | null;
+  mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  onAuthExpired?: (providerId: ProviderId) => void;
+}
+```
+
+### Provider resolution chain
+
+`resolveTrackProvider(mediaTrack)` returns the first defined value from:
+
+1. `mediaTrack.provider` -- per-track provider ID (set when track was loaded)
+2. `currentPlaybackProviderRef.current` -- last known driving provider
+3. `activeDescriptor.id` -- currently selected provider in UI
+
+### Cross-provider handoff
+
+`pausePreviousProvider(nextProvider)` checks if the driving provider is changing. If so, it pauses the old provider before updating `currentPlaybackProviderRef`.
+
+### playTrack(index, skipOnError?, options?)
+
+1. Read `mediaTracksRef.current[index]`
+2. Resolve provider via `resolveTrackProvider`
+3. `pausePreviousProvider(trackProvider)` -- handoff if needed
+4. Update `currentPlaybackProviderRef.current = trackProvider`
+5. Call `descriptor.playback.playTrack(mediaTrack, options)`
+6. On success: `setCurrentTrackIndex(index)`, then pre-warm next track via `prepareTrack?.(nextTrack)`
+7. On error: see Error Recovery below
+
+### Error recovery
+
+| Error type | Behavior |
+|-----------|----------|
+| `AuthExpiredError` | Calls `onAuthExpired(providerId)`, does NOT skip. UI shows re-auth prompt. |
+| `UnavailableTrackError` | Logs warning. If `skipOnError` and not at end of queue, schedules `playTrack(index + 1)` after 500ms. |
+| Generic error | Logs error. Same skip logic as `UnavailableTrackError`. |
+
+The 500ms delay before skip prevents rapid-fire skipping through consecutive unavailable tracks.
+
+## usePlaybackSubscription
+
+**Location:** `src/hooks/usePlaybackSubscription.ts`
+
+Subscribes to playback state events from ALL registered providers (not just the active one). Only processes events from the driving provider.
+
+### Subscription setup
+
+1. Subscribe to `activeDescriptor.playback.subscribe()`
+2. Iterate `providerRegistry.getAll()` and subscribe to every other provider
+3. Each callback passes `providerId` to `handleProviderStateChange`
+
+### Driving provider filter
+
+```ts
+const drivingProviderId = drivingProviderRef.current ?? activeProviderId;
+if (providerId !== drivingProviderId) return;
+```
+
+Events from non-driving providers are silently dropped.
+
+### State sync
+
+From each `PlaybackState`:
+- `setIsPlaying(state.isPlaying)`
+- `setPlaybackPosition(state.positionMs)`
+- If `state.currentTrackId` is present, find it in `tracksRef.current` and sync `currentTrackIndex`
+- If `state.trackMetadata` is present (Dropbox ID3 enrichment), merge into `tracks[trackIndex]`
+
+### expectedTrackIdRef guard
+
+During transitions (next/previous), `expectedTrackIdRef` is set to the target track ID. While non-null, provider index updates are ignored. When the expected track ID arrives, the ref is cleared and normal sync resumes. This prevents a brief flash of the old track's index being set by a stale provider event.
+
+### Visibility change handler
+
+On `visibilitychange` (tab returns to foreground):
+1. Clear `expectedTrackIdRef` (stale transition guards no longer relevant)
+2. Call `getState()` on the driving provider to resync all playback state
+
+### Dependency strategy (invariant)
+
+The effect depends only on `[activeDescriptor, setCurrentTrackIndex, setTracks]`. Tracks and index are read via refs. This prevents subscription teardown/recreation on every track change.
+
+## useAutoAdvance
+
+**Location:** `src/hooks/useAutoAdvance.ts`
+
+### Props
+
+```ts
+interface UseAutoAdvanceProps {
+  tracks: MediaTrack[];
+  currentTrackIndex: number;
+  playTrack: (index: number, skipOnError?: boolean) => void;
+  enabled?: boolean;          // default: true
+  endThreshold?: number;      // default: 2000ms
+  currentPlaybackProviderRef?: React.RefObject<ProviderId | null>;
+}
+```
+
+### End detection signals
+
+Two independent detection paths:
+
+1. **Near-end**: `timeRemaining <= endThreshold` OR `position >= duration - 1000` while still playing
+2. **Natural end**: `wasPlayingRef.current && isPaused && position === 0 && duration > 0` -- track was playing, is now paused at position 0
+
+### Cooldown guard (PLAY_COOLDOWN_MS = 5000)
+
+The natural-end signal has a cooldown: it checks `msSinceLastPlay > 5000` before advancing. Both Spotify SDK and HTML5 Audio briefly pause at position 0 during buffering, which would falsely trigger advance without this guard. The cooldown reads from `descriptor.playback.getLastPlayTime?.()` if available, falling back to `lastPlayInitiatedRef`.
+
+### Advance behavior
+
+`advanceToNext()` sets `hasEnded = true` and schedules a 100ms timeout. Inside the timeout:
+- If at end of queue (`currentIdx >= totalTracks - 1`): stop, do not wrap
+- Otherwise: `playTrack(currentIdx + 1, true)` with `skipOnError`
+
+The 100ms delay + computing `nextIndex` inside the timeout (not at schedule time) ensures shuffle toggles during the delay use fresh refs.
+
+### Reset on track/queue change
+
+`hasEnded` resets and pending advance timers are cancelled whenever `currentTrackIndex` or `tracks` changes. This prevents stale advance from playing the wrong track after shuffle toggle.
+
+### Subscription pattern
+
+Same as `usePlaybackSubscription`: subscribes to active provider + all others. Events from non-driving providers are only processed when `drivingProviderRef.current === descriptor.id`.
+
+## useKeyboardShortcuts
+
+**Location:** `src/hooks/useKeyboardShortcuts.ts`
+
+### Device detection
+
+Uses `prefersPointerInput` option (from `usePlayerSizing`), which checks CSS media queries `(pointer: fine)` and `(hover: hover)`. This is NOT viewport-based -- a high-resolution tablet with touch input is correctly identified as touch-only.
+
+### Key mappings
+
+| Code | Handler | Condition |
+|------|---------|-----------|
+| `Space` | `onPlayPause` | always |
+| `ArrowRight` | `onNext` | always |
+| `ArrowLeft` | `onPrevious` | always |
+| `ArrowUp` | `onShowQueue` | `prefersPointerInput` |
+| `ArrowUp` | `onVolumeUp` | NOT `prefersPointerInput` |
+| `ArrowDown` | `onOpenQuickAccessPanel` | `prefersPointerInput` |
+| `ArrowDown` | `onVolumeDown` | NOT `prefersPointerInput` |
+| `KeyQ` | `onShowQueue` | always (device-independent alternative) |
+| `KeyL` | `onOpenQuickAccessPanel` | always (device-independent alternative) |
+| `KeyV` | `onCycleVisualizerStyle` | no ctrl/meta |
+| `KeyS` | `onToggleShuffle` | no ctrl/meta, no shift |
+| `KeyS` + Shift | `onToggleVisualEffectsMenu` | no ctrl/meta |
+| `KeyG` | `onToggleGlow` | no ctrl/meta |
+| `KeyT` | `onToggleTranslucence` | no ctrl/meta |
+| `KeyZ` | `onToggleZenMode` | no ctrl/meta |
+| `KeyO` | (not wired -- effects menu uses `Shift+S`) | |
+| `KeyK` | `onToggleLike` | no ctrl/meta |
+| `KeyM` | `onMute` | always |
+| `Slash` | `onToggleHelp` | no ctrl/meta |
+| `Escape` | closes all menus | always |
+
+### Input guard
+
+Shortcuts are suppressed when the event target (via `composedPath()` for Shadow DOM) is `INPUT`, `TEXTAREA`, or `contentEditable`.
+
+## useVolume
+
+**Location:** `src/hooks/useVolume.ts`
+
+### State
+
+- `volume` (0-100): persisted via `useLocalStorage(STORAGE_KEYS.VOLUME, 50)`
+- `isMuted` (boolean): persisted via `useLocalStorage(STORAGE_KEYS.MUTED, false)`
+- `previousVolumeRef`: stores pre-mute volume for restore
+
+### Provider routing
+
+`getPlayingPlayback()` resolves the playback adapter for the currently playing provider:
+- If `currentTrackProvider` differs from `activeDescriptor.id`, looks up the track's provider via `providerRegistry`
+- Otherwise uses `activeDescriptor.playback`
+
+Volume changes call `playback.setVolume(value / 100)` -- the `PlaybackProvider` interface expects 0-1 range.
+
+### setVolumeLevel(newVolume)
+
+Clamps to 0-100, rounds, and auto-syncs mute state: setting volume to 0 enables mute, setting > 0 disables mute.
+
+## Zen Mode
+
+Zen mode hides player controls and expands album art to fill the viewport. Interaction differs by device type.
+
+### Desktop (pointer devices)
+
+`ZenClickZoneOverlay` renders three hover-activated circular buttons (prev, play/pause, next) over the album art. Buttons are transparent (`opacity: 0`) until hovered. The overlay uses `container-type: size` for responsive button sizing (`clamp(72px, 20cqmin, 224px)`).
+
+Visibility condition: `zenModeEnabled && hasPointerInput && !zenTouchActive && !isFlipped`
+
+`ZenLikeOverlay` renders a like heart button at bottom-right of album art. Appears on hover.
+
+Visibility condition: `zenModeEnabled && hasPointerInput && isHovered && !isFlipped`
+
+### Dead zones
+
+`resolveZenZone()` in `src/constants/zenAnimation.ts` maps cursor position to a zone. The top 20% and bottom 20% of album art are dead zones (return `null`). Within the active region:
+- Left 25%: `'left'` (previous)
+- Right 25%: `'right'` (next)
+- Center 50%: `'center'` (play/pause)
+
+Constants: `ZEN_DEAD_ZONE_TOP = 0.2`, `ZEN_DEAD_ZONE_BOTTOM = 0.8`, `ZEN_ZONE_LEFT_BOUNDARY = 0.25`, `ZEN_ZONE_RIGHT_BOUNDARY = 0.75`
+
+### Touch devices (useZenTouchGestures)
+
+**Location:** `src/hooks/useZenTouchGestures.ts`
+
+Uses pointer events (not touch events) for unified handling. Gesture mapping:
+
+| Gesture | Action |
+|---------|--------|
+| Single tap | Play/Pause (after 300ms double-tap window) |
+| Double tap | Like toggle |
+| Long press (500ms) | Flip menu toggle |
+
+Movement beyond 10px cancels long press. The hook returns `{ onPointerDown, onPointerUp, onPointerCancel, onPointerMove }`.
+
+Active condition in `AlbumArtSection`: `isTouchDevice && zenModeEnabled && !isFlipped`
+
+### BottomBar in zen mode
+
+BottomBar shows via grip pill tap with tap-outside-to-dismiss backdrop. (Handled elsewhere in BottomBar component, not in the hooks documented here.)
+
+### Zen animation constants
+
+From `src/constants/zenAnimation.ts`:
+- Art expand: 1000ms duration, 300ms enter delay
+- Controls fade: 300ms duration, 500ms exit delay
+- Art margins: 96px horizontal / 196px vertical (desktop), 32px / 120px (mobile)
+
+## PlayerStateRenderer
+
+**Location:** `src/components/PlayerStateRenderer.tsx`
+
+Renders the idle/home view when no track is loaded (`selectedPlaylistId === null || tracks.length === 0`).
+
+### View routing
+
+```
+qapEnabled (from useQapEnabled) ?
+  -> QuickAccessPanel (with browseLibrary callback)
+  : -> PlaylistSelection (lazy-loaded via React.lazy)
+```
+
+`showLibrary` state initializes to `!qapEnabled`. When the user selects a playlist from the library browser, `showLibrary` is set to `false` and the selection callback fires.
+
+### QAP preference
+
+Stored in `localStorage` under key `vorbis-player-qap-enabled` (default `false`). Toggled via the settings panel (`VisualEffectsMenu`). The `useQapEnabled()` hook wraps `useLocalStorage`.
+
+### Other states
+
+- **Loading**: Animated card with pulse icon and shimmer progress bar
+- **Auth error**: "Connect to {providerName}" card with login button
+- **Generic error**: Destructive alert with error message
+
+## Playback Flow (End to End)
+
+```
+User presses Next
+  -> usePlayerLogic.handleNext()
+    -> sets expectedTrackIdRef to target track ID
+    -> setCurrentTrackIndex(nextIndex)
+    -> useProviderPlayback.playTrack(nextIndex, skipOnError=true)
+      -> resolveTrackProvider(mediaTracksRef[nextIndex])
+      -> pausePreviousProvider(resolvedProvider)    // handoff if provider changed
+      -> currentPlaybackProviderRef.current = resolvedProvider
+      -> descriptor.playback.playTrack(mediaTrack)  // Spotify SDK or HTML5 Audio
+      -> on success: prepareTrack(nextTrack)         // pre-warm next
+      -> on error: skip or surface auth prompt
+
+Provider emits PlaybackState
+  -> usePlaybackSubscription receives event
+    -> filters by drivingProviderRef (ignores non-driving providers)
+    -> expectedTrackIdRef check (ignores stale events during transition)
+    -> syncs isPlaying, playbackPosition, currentTrackIndex to React state
+    -> merges trackMetadata if present
+
+Track nears end (timeRemaining <= 2000ms)
+  -> useAutoAdvance detects near-end signal
+    -> schedules advanceToNext after 100ms
+      -> playTrack(currentIdx + 1, skipOnError=true)
+```

--- a/docs/features/profiler.md
+++ b/docs/features/profiler.md
@@ -1,0 +1,226 @@
+# Profiling and Debug Tools
+
+The app has four independent debug/profiling systems. They are activated differently and serve different purposes.
+
+## 1. Performance Profiler
+
+### What It Does
+
+Wraps React components in `React.Profiler` boundaries to collect render timing data. Also tracks FPS, long tasks (via `PerformanceObserver`), and JS heap memory (Chrome only).
+
+### Activation
+
+Three ways to enable:
+- Settings drawer: Advanced > Performance Profiler > On
+- URL parameter: `?profile=true`
+- Keyboard: `Ctrl+Shift+P`
+
+State is persisted in localStorage at `vorbis-player-profiling` (raw string `'true'`/`'false'`, not JSON).
+
+### Architecture
+
+**Context**: `src/contexts/ProfilingContext.tsx`
+
+- `ProfilingProvider` wraps the app (in `src/App.tsx` via context providers)
+- `useProfilingContext()` returns `{ enabled, collector, toggle }`
+- When disabled, `collector` is `null` and `ProfiledComponent` renders children without a `React.Profiler` wrapper (zero overhead)
+
+**Collector**: `MetricsCollector` class (private to `ProfilingContext.tsx`)
+
+Tracks:
+- **Component renders**: count, mount vs update, average/max duration, "unnecessary renders" (heuristic: `actualDuration / baseDuration > 0.8`)
+- **Context updates**: count and last-update timestamp per context name (via `recordContextUpdate`)
+- **Operations**: named timed operations (via `recordOperation`)
+- **FPS**: sampled every 1 second via `requestAnimationFrame` loop
+- **Long tasks**: count, total duration, max duration via `PerformanceObserver({ entryTypes: ['longtask'] })`
+- **Memory**: `performance.memory.usedJSHeapSize` (Chrome-only, non-standard)
+
+Note: `recordContextUpdate` and `recordOperation` are available on the collector API but currently only `recordRender` is called (from `ProfiledComponent`). The context update and operation tracking infrastructure exists but has no active callers in production code.
+
+**Instrumented components** (`ProfiledComponent` wrapper):
+
+| Profiler ID | Location |
+|---|---|
+| `app-settings-menu` | `VisualEffectsMenu/index.tsx` |
+| `PlayerStateRenderer` | `AudioPlayer.tsx` |
+| `PlayerContent` | `AudioPlayer.tsx` |
+| `AccentColorBackground` | `AudioPlayer.tsx` |
+| `BackgroundVisualizer` | `AudioPlayer.tsx` |
+| `QueueBottomSheet` | `PlayerContent/DrawerOrchestrator.tsx` |
+| `QueueDrawer` | `PlayerContent/DrawerOrchestrator.tsx` |
+| `LibraryDrawer` | `PlayerContent/DrawerOrchestrator.tsx` |
+| `SpotifyPlayerControls` | `PlayerContent/PlayerControlsSection.tsx` |
+| `BottomBar` | `PlayerContent/PlayerControlsSection.tsx` |
+| `AlbumArt` | `PlayerContent/AlbumArtSection.tsx` |
+
+### Overlay
+
+Component: `src/components/ProfilingOverlay.tsx`
+
+Fixed-position panel at top-left (`z-index: 999980`). Polls the collector every 500ms. Shows:
+- Total render count
+- Render heatmap table (top 15 components by render count, color-coded: green < 4ms, yellow < 16ms, red >= 16ms)
+- Context update counts
+- FPS (current, average, min)
+- Heap size (Chrome only)
+- Long task count and max duration
+- Recent render events (last 20)
+- Buttons: Reset, Export JSON, Copy to clipboard
+
+### Mutual Exclusivity with Visualizer Debug
+
+Enabling the profiler disables visualizer debug mode. Enabling visualizer debug disables the profiler. This is enforced in `PlayerControlsSection.tsx`:
+
+```ts
+const handleProfilerToggle = useCallback(() => {
+  if (!profilerEnabled) {
+    vizDebugCtx?.setIsDebugMode(false);
+  }
+  profilerToggle();
+}, [profilerEnabled, profilerToggle, vizDebugCtx]);
+
+const handleVisualizerDebugToggle = useCallback(() => {
+  if (!visualizerDebugEnabled && profilerEnabled) {
+    profilerToggle();
+  }
+  vizDebugCtx?.setIsDebugMode(prev => !prev);
+}, [visualizerDebugEnabled, profilerEnabled, profilerToggle, vizDebugCtx]);
+```
+
+## 2. Visualizer Debug Panel
+
+### What It Does
+
+Live-editable parameter sliders for the Fireflies (particle) and Comet (trail) background visualizers. Allows tuning visual parameters without code changes, with export/import of configurations.
+
+### Activation
+
+URL parameter only: `?debug=visualizer`
+
+The panel also toggleable from Settings > Advanced > Visualizer Debug (which sets `isDebugMode` on the context, though the URL param is the primary trigger).
+
+### Architecture
+
+**Context**: `src/contexts/VisualizerDebugContext.tsx`
+
+- `VisualizerDebugProvider` wraps the app
+- `useVisualizerDebug()` returns full context or `null` if outside provider
+- `useVisualizerDebugConfig()` returns `VisualizerDebugConfig` -- defaults when debug is off, merged config when on
+- Overrides are persisted in localStorage at `vorbis-player-visualizer-debug-overrides`
+
+**Panel**: `src/components/VisualizerDebugPanel/index.tsx`
+
+Fixed panel with collapsible sections for Fireflies and Comet parameters. Each parameter has a slider + number input. Supports:
+- Reset to defaults
+- Copy JSON to clipboard
+- Download JSON file
+- Load config from pasted JSON
+
+**Config source**: `src/constants/visualizerDebugConfig.ts` -- `DEFAULT_VISUALIZER_DEBUG_CONFIG`, `mergeVisualizerConfig()`, type definitions.
+
+**Consumers**: All four visualizer components (`ParticleVisualizer`, `TrailVisualizer`, `WaveVisualizer`, `GridWaveVisualizer`) read from `useVisualizerDebugConfig()`.
+
+### Not a Profiler
+
+Despite being in the "Advanced" settings section alongside the profiler, this panel is a visual design tool, not a performance tool. It does not measure performance.
+
+## 3. Debug Overlay
+
+### What It Does
+
+Captures `console.warn` and `console.error` output into an in-app log viewer. Useful on devices where browser devtools are unavailable (e.g., mobile).
+
+### Activation
+
+Two ways:
+- URL parameter: `?debug=true`
+- 5 rapid taps on the album art area (tap-to-activate gesture via `useDebugActivator`)
+
+State persisted at `vorbis-player-debug-overlay` (raw string).
+
+### Architecture
+
+File: `src/components/DebugOverlay.tsx`
+
+- `useDebugActivator()` hook: tracks tap timestamps, toggles after 5 taps within 2 seconds
+- `DebugOverlay` component: patches `console.warn` and `console.error` to capture output. Shows a fixed badge (bottom-left, `z-index: 999999`) with log count; click to expand full-screen log viewer
+- Max 200 log entries retained
+- Buttons: Close, Clear, Copy all
+
+### Not Connected to Profiler
+
+The debug overlay and the performance profiler are independent systems. The overlay captures console output; the profiler tracks React render performance.
+
+## 4. Debug Logging (debug package)
+
+### What It Does
+
+Structured trace logging for specific subsystems using the `debug` npm package. Silent by default.
+
+### Activation
+
+In browser console:
+```js
+localStorage.debug = 'vorbis:*';    // all namespaces
+localStorage.debug = 'vorbis:queue'; // specific namespace
+location.reload();                   // required to take effect
+```
+
+Disable: `localStorage.removeItem('debug'); location.reload()`
+
+In Node (tests): `DEBUG=vorbis:* npm run test:run`
+
+### Available Namespaces
+
+Defined in `src/lib/debugLog.ts`:
+
+| Export | Namespace | Used For |
+|---|---|---|
+| `logQueue` | `vorbis:queue` | Queue mutations and state changes |
+| `logSpotify` | `vorbis:spotify` | Spotify API calls and SDK events |
+| `logRadio` | `vorbis:radio` | Radio generation and track matching |
+| `logDropboxSync` | `vorbis:dropbox-sync` | Dropbox sync operations |
+| `logApp` | `vorbis:app` | General app lifecycle events |
+| `logSw` | `vorbis:sw` | Service worker events |
+| `logLibrary` | `vorbis:library` | Library loading and caching |
+| `logSession` | `vorbis:session` | Session persistence |
+
+### Relationship to Other Tools
+
+`console.warn`/`console.error` calls always print regardless of debug settings. These are captured by the Debug Overlay when active.
+
+The `debug` package outputs via `console.debug` (or `console.log` depending on the environment), which the Debug Overlay does NOT capture (it only hooks `warn` and `error`).
+
+## 5. DevBug (Visual Feedback Tool)
+
+### What It Does
+
+A floating action button (FAB) with three modes for visual bug reporting: element inspection, area selection, and screenshot annotation.
+
+### Activation
+
+localStorage key: `vorbis-player-devbug` (default `false`). Set to `true` and reload. There is no UI toggle for this in the settings panel.
+
+### Architecture
+
+- Context: `src/contexts/DevBugContext.tsx` -- `DevBugProvider`, `useDevBug()`
+- Components: `src/components/DevBug/` directory
+- Entry: `DevBugFAB` renders via `createPortal` to `document.body` at `z-index: 2147483647`
+- Conditionally rendered in `App.tsx`: `{devbugEnabled && <DevBugFAB />}`
+
+This is a development/QA tool, not a performance profiler.
+
+## Key Files Summary
+
+| File | System |
+|---|---|
+| `src/contexts/ProfilingContext.tsx` | Profiler context, MetricsCollector class |
+| `src/components/ProfiledComponent.tsx` | React.Profiler wrapper component |
+| `src/components/ProfilingOverlay.tsx` | Profiler HUD overlay |
+| `src/contexts/VisualizerDebugContext.tsx` | Visualizer debug context and config |
+| `src/components/VisualizerDebugPanel/index.tsx` | Visualizer parameter editor |
+| `src/constants/visualizerDebugConfig.ts` | Default visualizer parameters |
+| `src/components/DebugOverlay.tsx` | Console capture overlay |
+| `src/lib/debugLog.ts` | Debug package namespace exports |
+| `src/contexts/DevBugContext.tsx` | DevBug context |
+| `src/components/DevBug/` | DevBug visual feedback components |

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -1,0 +1,599 @@
+# Multi-Provider Architecture
+
+## Overview
+
+The app abstracts music sources behind three provider interfaces (`AuthProvider`, `CatalogProvider`, `PlaybackProvider`) and a composite `ProviderDescriptor`. Two providers ship today: **Spotify** (Web Playback SDK, Premium required) and **Dropbox** (HTML5 Audio over temporary links). The queue can mix tracks from different providers.
+
+## Domain Types
+
+Defined in `src/types/domain.ts`.
+
+### ProviderId
+
+```ts
+type ProviderId = 'spotify' | 'dropbox';
+```
+
+To add a new provider, extend this union first. Every domain type carries a `provider` field typed to `ProviderId`.
+
+### MediaTrack
+
+Provider-agnostic track. Key fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `id` | `string` | Unique track ID (Spotify track ID or Dropbox lowercase path) |
+| `provider` | `ProviderId` | Which provider owns this track |
+| `playbackRef` | `PlaybackItemRef` | Opaque ref passed to `PlaybackProvider.playTrack()` |
+| `addedAt` | `number?` | Epoch ms; used for cross-provider sorting in Unified Liked Songs |
+| `musicbrainzRecordingId` | `string?` | Populated from ID3 tags by Dropbox; used for radio matching |
+| `albumId` | `string?` | Spotify: raw album ID. Dropbox: lowercase folder path. Used for album art cache keys |
+
+`PlaybackItemRef` is `{ provider: ProviderId; ref: string }`. For Spotify, `ref` is a Spotify URI (`spotify:track:xxx`). For Dropbox, `ref` is the lowercase Dropbox file path.
+
+### MediaCollection
+
+Provider-agnostic collection. `kind` is `'playlist' | 'album' | 'folder' | 'liked'`. Dropbox uses `'album'` for folders containing audio and `'folder'` for the synthetic "All Music" collection.
+
+### CollectionRef
+
+Discriminated union referencing a collection:
+
+```ts
+type CollectionRef =
+  | { provider: ProviderId; kind: 'playlist'; id: string }
+  | { provider: ProviderId; kind: 'album'; id: string }
+  | { provider: ProviderId; kind: 'folder'; id: string }
+  | { provider: ProviderId; kind: 'liked' };  // no id field
+```
+
+Serialization: `collectionRefToKey(ref)` produces `"spotify:playlist:abc123"` or `"dropbox:liked:"`. Parse back with `keyToCollectionRef(key)`.
+
+## Provider Interfaces
+
+Defined in `src/types/providers.ts`.
+
+### AuthProvider
+
+```ts
+interface AuthProvider {
+  readonly providerId: ProviderId;
+  isAuthenticated(): boolean;
+  getAccessToken(): Promise<string | null>;
+  beginLogin(options?: { popup?: boolean }): Promise<void>;
+  handleCallback(url: URL): Promise<boolean>;
+  logout(): void;
+}
+```
+
+- `handleCallback` returns `true` if the URL was consumed as an OAuth callback for this provider. The app iterates all providers in `usePlayerLogic` calling `handleCallback` on each until one returns `true`.
+- `beginLogin` supports both redirect (default) and popup (`{ popup: true }`) flows.
+- Both providers use PKCE (SHA-256 code challenge). Code verifiers are stored in `localStorage`.
+
+### CatalogProvider
+
+```ts
+interface CatalogProvider {
+  readonly providerId: ProviderId;
+  listCollections(signal?: AbortSignal, options?: { forceRefresh?: boolean }): Promise<MediaCollection[]>;
+  listTracks(collectionRef: CollectionRef, signal?: AbortSignal): Promise<MediaTrack[]>;
+  getLikedCount?(signal?: AbortSignal): Promise<number>;
+  setTrackSaved?(trackId: string, saved: boolean): Promise<void>;
+  isTrackSaved?(trackId: string): Promise<boolean>;
+  setAlbumSaved?(albumId: string, saved: boolean): Promise<void>;
+  isAlbumSaved?(albumId: string): Promise<boolean>;
+  deleteCollection?(collectionId: string, kind: CollectionKind): Promise<void>;
+  resolveDuration?(track: MediaTrack): Promise<number | null>;
+  resolveArtwork?(albumId: string, signal?: AbortSignal): Promise<string | null>;
+  searchTrack?(artist: string, title: string): Promise<MediaTrack | null>;
+  clearArtCache?(): Promise<void>;
+  refreshArtCache?(): Promise<void>;
+  exportLikes?(): Promise<string>;
+  importLikes?(json: string): Promise<number>;
+  refreshLikedMetadata?(): Promise<{ updated: number; removed: number }>;
+}
+```
+
+All methods after `listTracks` are optional. The UI checks `capabilities` flags on the descriptor before calling optional methods.
+
+**Invariant**: `listTracks` must return `MediaTrack[]` with `provider` set to the provider's own ID and `playbackRef.provider` matching. Violating this breaks the provider resolution chain.
+
+### PlaybackProvider
+
+```ts
+interface PlaybackProvider {
+  readonly providerId: ProviderId;
+  initialize(): Promise<void>;
+  playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void>;
+  playCollection?(collectionRef: CollectionRef, options?: { offset?: number }): Promise<void>;
+  pause(): Promise<void>;
+  resume(): Promise<void>;
+  seek(positionMs: number): Promise<void>;
+  next(): Promise<void>;
+  previous(): Promise<void>;
+  setVolume(volume0to1: number): Promise<void>;
+  getState(): Promise<PlaybackState | null>;
+  subscribe(listener: (state: PlaybackState | null) => void): () => void;
+  prepareTrack?(track: MediaTrack): void;
+  refreshCurrentTrackArt?(): void;
+  getLastPlayTime?(): number;
+  onQueueChanged?(tracks: MediaTrack[], fromIndex: number): void;
+}
+```
+
+- `subscribe` returns an unsubscribe function. Multiple subscribers are supported.
+- `getLastPlayTime` returns epoch ms of the last `playTrack` call. Used by `useAutoAdvance` to implement a 5-second cooldown (`PLAY_COOLDOWN_MS`) that prevents false end-of-track triggers during buffering.
+- `onQueueChanged` is called by `usePlayerLogic` whenever `tracks` or `currentTrackIndex` change. Spotify uses this to build upcoming URIs for native queue sync.
+
+### PlaybackState
+
+```ts
+interface PlaybackState {
+  isPlaying: boolean;
+  positionMs: number;
+  durationMs: number;
+  currentTrackId: string | null;
+  currentPlaybackRef: PlaybackItemRef | null;
+  trackMetadata?: Partial<Pick<MediaTrack, 'name' | 'artists' | 'album' | 'image' | 'durationMs'>>;
+  playbackError?: { code: number; message: string };
+}
+```
+
+`trackMetadata` is a one-shot update mechanism: Dropbox populates it with ID3 tag data or cached album art, then clears it after one notification cycle. `usePlaybackSubscription` reads it and patches the track in `tracks` state.
+
+## Provider Descriptor and Capabilities
+
+```ts
+interface ProviderDescriptor {
+  id: ProviderId;
+  name: string;
+  capabilities: ProviderCapabilities;
+  auth: AuthProvider;
+  catalog: CatalogProvider;
+  playback: PlaybackProvider;
+  color?: string;                     // Brand hex, e.g. '#1db954'
+  subscriptionNote?: string;          // Shown on auth screen
+  icon?: ComponentType<{ size?: number }>;
+  likesChangedEvent?: string;         // Window event name for real-time UI
+  getExternalUrl?(info): string;
+  getExternalUrls?(info): Array<{ label; url; icon }>;
+  savePlaylist?(name, tracks): Promise<{ url?; totalTracks; skippedTracks } | null>;
+}
+```
+
+### ProviderCapabilities
+
+| Flag | Spotify | Dropbox | UI Effect |
+|------|---------|---------|-----------|
+| `hasLikedCollection` | `true` | `true` | Shows "Liked Songs" in library |
+| `hasSaveTrack` | `true` | `true` | Heart icon on tracks |
+| `hasSaveAlbum` | `true` | -- | Save album button |
+| `hasDeleteCollection` | `true` | `true` | Delete/unfollow in context menu |
+| `hasExternalLink` | `true` | `true` | "Open in Spotify" / "Search Discogs" |
+| `hasTrackSearch` | `true` | -- | Used for radio cross-provider resolution |
+| `hasNativeQueueSync` | `true` | -- | Syncs queue to Spotify's native player |
+
+**Invariant**: Always check `capabilities` before calling optional catalog/playback methods or rendering provider-specific UI. Both `hasSaveTrack` and `hasLikedCollection` are true for both providers, but `hasSaveAlbum` and `hasTrackSearch` are Spotify-only.
+
+## Provider Registration
+
+### Registry (`src/providers/registry.ts`)
+
+Singleton `providerRegistry` backed by a `Map<ProviderId, ProviderDescriptor>`.
+
+```ts
+class ProviderRegistryImpl implements ProviderRegistry {
+  private providers = new Map<ProviderId, ProviderDescriptor>();
+  register(descriptor: ProviderDescriptor): void;
+  get(id: ProviderId): ProviderDescriptor | undefined;
+  getAll(): ProviderDescriptor[];
+  has(id: ProviderId): boolean;
+}
+export const providerRegistry = new ProviderRegistryImpl();
+```
+
+### Self-Registration Pattern
+
+Each provider module calls `providerRegistry.register(descriptor)` at module scope. Registration happens via ES module side effects when the module is imported.
+
+**Spotify** (`src/providers/spotify/spotifyProvider.ts`): Always registers. The descriptor is a module-level constant.
+
+**Dropbox** (`src/providers/dropbox/dropboxProvider.ts`): Conditionally registers. The entire registration block is gated behind `if (DROPBOX_CLIENT_ID)`, where `DROPBOX_CLIENT_ID = import.meta.env.VITE_DROPBOX_CLIENT_ID ?? ''`. If the env var is missing, Dropbox never enters the registry.
+
+### Import Trigger
+
+`src/contexts/ProviderContext.tsx` has bare imports that trigger registration:
+
+```ts
+import '@/providers/spotify/spotifyProvider';
+import '@/providers/dropbox/dropboxProvider';
+```
+
+These run before the context renders, ensuring the registry is populated.
+
+## ProviderContext
+
+`src/contexts/ProviderContext.tsx` provides the React context.
+
+Key fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `chosenProviderId` | `ProviderId \| null` | Stored value; `null` means show provider picker |
+| `activeProviderId` | `ProviderId` | Always non-null; falls back to first registered |
+| `activeDescriptor` | `ProviderDescriptor \| undefined` | Descriptor for `activeProviderId` |
+| `enabledProviderIds` | `ProviderId[]` | Providers toggled on by user |
+| `connectedProviderIds` | `ProviderId[]` | Subset of enabled that are authenticated |
+| `needsProviderSelection` | `boolean` | `true` when no provider chosen or stored one not registered |
+
+Auto-fallthrough: if the active provider loses auth, the context auto-switches to the next authenticated enabled provider and shows a notification.
+
+## Active Provider vs Driving Provider
+
+This is the most important architectural distinction in the provider system.
+
+- **Active provider** (`activeProviderId` / `activeDescriptor`): The provider context for browsing, catalog actions, and library UI. Stored in localStorage, user-selectable.
+- **Driving provider** (`currentPlaybackProviderRef` / `drivingProviderRef`): The provider currently controlling audio output. A `useRef<ProviderId | null>` in `useProviderPlayback`, exposed as `currentPlaybackProviderRef` from `usePlayerLogic`.
+
+**When they differ**: In a mixed queue (Unified Liked Songs, radio with cross-provider tracks), the user might have Dropbox as the active provider but the current track is a Spotify track. Playback controls (`play`, `pause`, `seek`, `next`) must route to the driving provider, not the active one.
+
+### Provider Resolution Chain
+
+`useProviderPlayback.resolveTrackProvider(mediaTrack)` resolves which provider should play a given track:
+
+```
+mediaTrack.provider           // 1. Track's own provider (preferred)
+  ?? currentPlaybackProviderRef.current  // 2. Last provider that played something
+  ?? activeDescriptor?.id     // 3. Active provider fallback
+  ?? undefined                // 4. No provider available
+```
+
+**Invariant**: Every `MediaTrack` in the queue MUST have a valid `provider` field. If step 1 fails, the fallbacks exist for edge cases but should not be relied upon in normal operation.
+
+## Cross-Provider Handoff
+
+In `useProviderPlayback.playTrack(index)`:
+
+1. `resolveTrackProvider(mediaTrack)` determines the target provider
+2. `pausePreviousProvider(nextProvider)` pauses the old provider if it differs from the new one. This calls `.playback.pause()` on the previous provider and is fire-and-forget (`.catch(() => {})`)
+3. `currentPlaybackProviderRef.current` is updated to the new provider
+4. `descriptor.playback.playTrack(mediaTrack)` is called on the resolved provider
+5. On success, `prepareTrack()` is called on the **next** track's provider (not the current one) for pre-warming
+
+**Error handling during playback**:
+- `AuthExpiredError`: Surfaces a re-auth prompt via `onAuthExpired` callback
+- `UnavailableTrackError`: Auto-skips to next track if `skipOnError` is true (500ms delay)
+- Generic errors: Same auto-skip behavior
+
+## Playback Subscription (`usePlaybackSubscription`)
+
+`src/hooks/usePlaybackSubscription.ts` subscribes to **all registered providers** and filters events by the driving provider.
+
+```ts
+function handleProviderStateChange(providerId: ProviderId, state: PlaybackState | null) {
+  const drivingProviderId = drivingProviderRef.current ?? activeProviderId;
+  if (providerId !== drivingProviderId) return;  // ignore events from non-driving providers
+  // ... sync isPlaying, playbackPosition, currentTrackIndex, trackMetadata
+}
+```
+
+### expectedTrackIdRef
+
+During track transitions, provider state updates from the old track can arrive before the new track starts playing. `expectedTrackIdRef` guards against stale index updates:
+
+- Set to the target track's ID before calling `playTrack()` (in `handleNext`/`handlePrevious`)
+- While non-null, provider index updates are ignored
+- Cleared when the expected track ID arrives in a state update
+- Also cleared on `visibilitychange` (tab returns to foreground), which triggers a full resync via `getState()`
+
+### Visibility Change Handling
+
+When the tab returns to foreground:
+1. `expectedTrackIdRef` is cleared
+2. `getState()` is called on the driving provider
+3. The full state (track, position, play/pause) is resynced
+
+This handles cases where the user interacted with the native Spotify app while the tab was backgrounded.
+
+### Dependency Array Design
+
+The subscription effect intentionally omits `tracks` and `currentTrackIndex` from its deps. These are read via refs (`tracksRef`, `currentTrackIndexRef`) so the subscription is only recreated when `activeDescriptor` changes, not on every track transition.
+
+## Auto-Advance (`useAutoAdvance`)
+
+`src/hooks/useAutoAdvance.ts` detects track end via two signals:
+
+1. **Near-end**: `timeRemaining <= endThreshold` (default 2000ms) or `position >= duration - 1000`
+2. **Natural end**: `wasPlaying && isPaused && position === 0 && duration > 0`
+
+The natural-end signal has a cooldown guard: `msSinceLastPlay > PLAY_COOLDOWN_MS` (5000ms). This prevents false triggers during buffering when both Spotify SDK and HTML5 Audio briefly pause at position 0.
+
+`lastPlayTime` is read from the driving provider's `getLastPlayTime()` method, with a local `lastPlayInitiatedRef` as fallback.
+
+Like `usePlaybackSubscription`, auto-advance subscribes to **all** registered providers but only processes events from the driving provider.
+
+## Spotify Implementation
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `src/providers/spotify/spotifyProvider.ts` | Assembles descriptor, registers |
+| `src/providers/spotify/spotifyAuthAdapter.ts` | Delegates to `spotifyAuth` singleton |
+| `src/providers/spotify/spotifyCatalogAdapter.ts` | Maps Spotify API responses to domain types |
+| `src/providers/spotify/spotifyPlaybackAdapter.ts` | Wraps `spotifyPlayer` singleton |
+| `src/providers/spotify/spotifyQueueSync.ts` | Syncs queue to Spotify's native player |
+| `src/services/spotify/auth.ts` | `SpotifyAuth` class (PKCE, token refresh) |
+| `src/services/spotify/tracks.ts` | Track API calls, batched `checkTrackSaved` |
+| `src/services/spotify/api.ts` | `spotifyApiRequest`, `fetchAllPaginated` |
+| `src/services/spotifyPlayer.ts` | `SpotifyPlayerService` (SDK wrapper) |
+| `src/services/spotifyPlayerSdk.ts` | SDK script injection, HMR state preservation |
+| `src/services/spotifyPlayerPlayback.ts` | Low-level playback commands |
+
+### Lazy SDK Loading
+
+The Spotify Web Playback SDK (`https://sdk.scdn.co/spotify-player.js`) is NOT loaded via a `<script>` tag in `index.html`. Instead:
+
+1. `SpotifyPlayerService.loadSDK()` (in `spotifyPlayerSdk.ts`) dynamically creates a `<script>` element
+2. Waits for `window.onSpotifyWebPlaybackSDKReady` callback (10s timeout)
+3. Only called when the Spotify provider activates (first `initialize()` call)
+4. The pending promise is stored in a ref to deduplicate concurrent calls
+
+### Token Refresh
+
+`SpotifyAuth` (`src/services/spotify/auth.ts`):
+- Token stored in localStorage as `spotify_token` (JSON with `access_token`, `refresh_token`, `expires_at`)
+- `ensureValidToken()` proactively refreshes when within 5 minutes of expiry (`TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000`)
+- On startup, if the access token is expired but a refresh token exists, the token data is kept so `ensureValidToken()` can refresh on first API call
+- `SpotifyPlaybackAdapter.prepareTrack()` pre-warms the auth token for the next track
+
+### API Batching (`checkTrackSaved`)
+
+`src/services/spotify/tracks.ts` implements microtask-based batching for the "is track saved" check:
+
+1. Each call to `checkTrackSaved(trackId)` returns a `Promise<boolean>` and pushes the ID to `_batchQueue`
+2. A 50ms timer (`BATCH_COLLECT_DELAY_MS`) collects calls from the same render cycle
+3. On flush, IDs are chunked into groups of 50 (`BATCH_SIZE`, Spotify API limit)
+4. Each chunk makes a single `GET /me/tracks/contains?ids=...` request
+5. Results are cached in `trackSavedCache` with TTL
+
+This prevents 429 rate limiting when rendering a playlist with many tracks.
+
+### Playback Retry Logic
+
+`SpotifyPlaybackAdapter.playWithRetry()` handles:
+- **401**: Throws `AuthExpiredError` (no retry)
+- **429**: Respects `Retry-After` header, exponential backoff, up to `MAX_PLAY_RETRIES` (5)
+- **403 + "Restriction violated"**: Throws `UnavailableTrackError` (no retry)
+- **403 (other)**: Re-transfers playback to device, exponential backoff, retries
+
+### Fast-Path Playback
+
+After the first successful `playTrack`, `playbackSessionActive` is set to `true`. Subsequent plays skip the full `ensurePlaybackReady()` (which includes `transferPlaybackToDevice` and `ensureDeviceIsActive` API calls) and use `ensurePlaybackReadyFastPath()` instead, which only checks local state (`getIsReady()` and `getDeviceId()`). Falls back to the full path if local state indicates the device went away.
+
+### Native Queue Sync
+
+`SpotifyQueueSyncService` (`src/providers/spotify/spotifyQueueSync.ts`):
+- `onQueueChanged` calls `buildUpcomingUris(tracks, fromIndex)` to build a list of upcoming Spotify URIs
+- These URIs are stored in `pendingUpcomingUris` and passed to `spotifyPlayer.playTrack(uri, upcomingUris)` on the next play call
+- Non-Spotify tracks are included only if a cached Spotify URI exists (from background resolution)
+- `resolveTracksInBackground()` searches Spotify for non-Spotify tracks, caching results
+- Settings: `STORAGE_KEYS.SPOTIFY_QUEUE_SYNC` (sync on/off), `STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER` (cross-provider resolution on/off)
+
+## Dropbox Implementation
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `src/providers/dropbox/dropboxProvider.ts` | Assembles descriptor, conditional registration |
+| `src/providers/dropbox/dropboxAuthAdapter.ts` | PKCE OAuth, token refresh |
+| `src/providers/dropbox/dropboxCatalogAdapter.ts` | Folder scanning, track listing |
+| `src/providers/dropbox/dropboxPlaybackAdapter.ts` | HTML5 Audio, ID3 metadata enrichment |
+| `src/providers/dropbox/dropboxApiClient.ts` | Authenticated Dropbox API calls |
+| `src/providers/dropbox/dropboxArtworkResolver.ts` | Album art resolution (folder images, IndexedDB cache) |
+| `src/providers/dropbox/dropboxArtCache.ts` | IndexedDB database (`vorbis-dropbox-art` v3) |
+| `src/providers/dropbox/dropboxCatalogCache.ts` | Catalog cache in IndexedDB |
+| `src/providers/dropbox/dropboxCatalogHelpers.ts` | Audio file detection, path parsing, track creation |
+| `src/providers/dropbox/dropboxLikesCache.ts` | IndexedDB `likes` store, `LIKES_CHANGED_EVENT` |
+| `src/providers/dropbox/dropboxLikesSync.ts` | Syncs likes to `/.vorbis/likes.json` in Dropbox |
+| `src/providers/dropbox/dropboxPreferencesSync.ts` | Syncs pins + colors to `/.vorbis/preferences.json` |
+| `src/providers/dropbox/dropboxPlaylistStorage.ts` | Saved playlists in `/.vorbis/playlists/` folder |
+| `src/providers/dropbox/dropboxDateScanner.ts` | Background album date scanning |
+| `src/providers/dropbox/dropboxSyncFolder.ts` | Ensures `/.vorbis/` folder exists |
+
+### Folder Structure Convention
+
+```
+Dropbox root/
+  <Artist>/
+    <Album>/
+      cover.jpg          # also: album.jpg, folder.jpg, front.jpg
+      01 - Track Title.mp3
+      02 - Another Track.flac
+```
+
+- A folder containing audio files = album
+- Parent folder = artist name
+- Track ID = lowercase file path
+- Album ID = lowercase folder path
+- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list
+
+### Token Refresh
+
+`DropboxAuthAdapter` (`src/providers/dropbox/dropboxAuthAdapter.ts`):
+- Tokens stored in localStorage (`STORAGE_KEYS.DROPBOX_TOKEN`, `STORAGE_KEYS.DROPBOX_REFRESH_TOKEN`, `STORAGE_KEYS.DROPBOX_TOKEN_EXPIRY`)
+- `ensureValidToken()` proactively refreshes when within 60 seconds of expiry (`TOKEN_EXPIRY_BUFFER_MS = 60 * 1000`)
+- Error handling in `refreshAccessToken()`:
+  - **400/401**: Invalid/revoked grant. Full `logout()` (clears all tokens)
+  - **5xx / network error**: Clears access token but preserves refresh token for retry
+- `reportUnauthorized()`: Called by API consumers when a freshly-refreshed token still gets 401. Triggers full logout and dispatches `DROPBOX_AUTH_ERROR_EVENT` for UI notification
+
+### HTML5 Audio Playback
+
+`DropboxPlaybackAdapter`:
+- Creates a single `HTMLAudioElement`, reused across tracks
+- `playTrack()` flow:
+  1. Calls `audio.play()` **synchronously** (before any `await`) for iOS Safari gesture activation
+  2. Fetches temporary link via `catalog.getTemporaryLink(path)`
+  3. Sets `audio.src` and plays
+  4. Starts a 250ms polling interval for smooth position updates
+  5. Kicks off background metadata enrichment (delayed 2s to not compete with audio buffering)
+- `next()` and `previous()` are no-ops; track advance is handled by `useAutoAdvance`
+- `prepareTrack()` calls `catalog.prefetchTemporaryLink(path)` to pre-fetch the Dropbox temporary link
+
+### ID3 Metadata Enrichment
+
+After starting playback, `enrichMetadataInBackground()`:
+1. Waits 2 seconds (`ENRICHMENT_DELAY_MS`)
+2. Fetches the first 256KB of the audio file via `Range: bytes=0-262143`
+3. Parses ID3 tags: title, artist, album, cover art, MusicBrainz IDs, ISRC
+4. Patches metadata through `PlaybackState.trackMetadata` (consumed by `usePlaybackSubscription`)
+5. Caches tag metadata and album art in IndexedDB
+
+### Liked Songs
+
+Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Each entry is `{ trackId, track: MediaTrack, likedAt: number }`.
+
+Mutations dispatch `vorbis-dropbox-likes-changed` (the `LIKES_CHANGED_EVENT` constant) as a window event. The descriptor sets `likesChangedEvent` to this value, enabling real-time UI updates.
+
+Sync to Dropbox: `dropboxLikesSync.ts` writes to `/.vorbis/likes.json`. Merge is last-write-wins per trackId using `likedAt` vs `deletedAt` timestamps. Tombstones have a 30-day TTL.
+
+### Preferences Sync
+
+`dropboxPreferencesSync.ts` syncs pinned items and accent color overrides to `/.vorbis/preferences.json`. Merge is last-write-wins by `updatedAt`. Push is debounced at 2 seconds.
+
+## Radio Generation
+
+### Overview
+
+Radio is a one-shot action that builds a queue from a seed track. It is not a persistent mode.
+
+### Pipeline (`src/services/radioPipeline.ts`)
+
+`runRadioPipeline()` orchestrates:
+
+1. **Fetch catalog**: `catalogProvider.listTracks()` on "All Music" (falls back to liked songs)
+2. **Generate queue**: `generateRadioQueue(seed, catalogTracks)` via `radioService.ts`
+3. **Cross-provider resolution**: For unmatched Last.fm suggestions, searches providers with `hasTrackSearch` capability
+4. **Dedup + shuffle**: Excludes seed track, shuffles results, prepends seed as first track
+
+### Radio Service (`src/services/radioService.ts`)
+
+`generateRadioQueue()` supports three seed types:
+
+| Seed | Strategy |
+|------|----------|
+| `track` | Get similar tracks from Last.fm, match against catalog. If < 5 matches, also fetch similar artists |
+| `artist` | Get similar artists from Last.fm, find their tracks in catalog. Also includes seed artist's own tracks |
+| `album` | Sample up to 5 album tracks, get similar tracks for each (3 concurrent Last.fm calls max) |
+
+Matching uses `catalogMatcher.ts` with `CatalogIndexes`:
+- Primary: MusicBrainz Recording ID (`byRecordingMbid`)
+- Primary: MusicBrainz Artist ID (`byArtistMbid`)
+- Fallback: normalized artist + title key (`byNormalizedKey`)
+- Fallback: normalized artist name (`byNormalizedArtist`)
+
+### Cross-Provider Resolution
+
+In `radioPipeline.ts`, unmatched suggestions are resolved by searching all providers with `hasTrackSearch` capability:
+
+```ts
+const searchCapableProviders = searchProviders.filter(
+  d => d.capabilities.hasTrackSearch && d.auth.isAuthenticated(),
+);
+```
+
+Currently only Spotify has `hasTrackSearch: true`. This means a Dropbox-seeded radio can include Spotify tracks if the user is authenticated to Spotify.
+
+### Radio Session Hook (`useRadioSession`)
+
+`src/hooks/useRadioSession.ts` connects the pipeline to React state:
+- `handleStartRadio()` runs the pipeline with the current track as seed
+- On success, replaces the queue with the radio results
+- Sets `selectedPlaylistId` to `RADIO_PLAYLIST_ID`
+
+## Error Types
+
+`src/providers/errors.ts`:
+
+```ts
+class AuthExpiredError extends Error {
+  readonly providerId: string;
+}
+
+class UnavailableTrackError extends Error {
+  readonly trackName: string;
+}
+```
+
+- `AuthExpiredError` is thrown by playback adapters when auth fails during play. `useProviderPlayback` catches it and surfaces a re-auth prompt.
+- `UnavailableTrackError` is thrown for Spotify 403 "Restriction violated" (region-restricted, not available on premium, etc.). Triggers auto-skip.
+
+## Adding a New Provider
+
+### Steps
+
+1. **Extend `ProviderId`** in `src/types/domain.ts` to include the new provider name
+
+2. **Create provider directory** at `src/providers/<name>/`
+
+3. **Implement the three interfaces**:
+   - `<Name>AuthAdapter implements AuthProvider`
+   - `<Name>CatalogAdapter implements CatalogProvider`
+   - `<Name>PlaybackAdapter implements PlaybackProvider`
+
+4. **Create the provider module** (`<name>Provider.ts`):
+   - Assemble a `ProviderDescriptor` with adapters, capabilities, and metadata
+   - Call `providerRegistry.register(descriptor)` at module scope
+   - Gate registration behind an env var check if the provider is optional
+
+5. **Import the provider module** in `src/contexts/ProviderContext.tsx`:
+   ```ts
+   import '@/providers/<name>/<name>Provider';
+   ```
+
+6. **Set capabilities** accurately. The UI relies on these flags.
+
+7. **Map all API responses to domain types** (`MediaTrack`, `MediaCollection`). Ensure `provider` is set correctly on every object.
+
+### Invariants to Maintain
+
+- Every `MediaTrack` must have `provider` and `playbackRef.provider` set to the provider's ID
+- `PlaybackProvider.subscribe()` must notify listeners of all state changes (play, pause, position, track change, errors)
+- `PlaybackProvider.getState()` must return current state synchronously (or near-synchronously) for tab visibility resync
+- `getLastPlayTime()` should return the epoch ms of the last `playTrack` call for auto-advance cooldown
+- If the provider supports `onQueueChanged`, it should handle mixed-provider queues gracefully (ignore tracks from other providers)
+
+### Common Gotchas
+
+- **iOS Safari gesture activation**: If your playback requires an async step before playing audio (like fetching a stream URL), you must call `audio.play()` synchronously within the user gesture before the await. See `DropboxPlaybackAdapter.playTrack()`.
+- **Stale state during transitions**: Use `expectedTrackIdRef` in subscription handlers to ignore stale updates. The subscription system assumes providers may emit events for the previous track during transitions.
+- **Token refresh during playback**: The `prepareTrack()` method should pre-warm auth tokens to avoid refresh delays during track transitions.
+
+## Key File Dependency Graph
+
+```
+ProviderContext.tsx
+  imports: providers/spotify/spotifyProvider.ts
+           providers/dropbox/dropboxProvider.ts
+  uses:    providers/registry.ts
+
+usePlayerLogic.ts
+  uses: useProviderPlayback.ts      -- playTrack, resumePlayback, currentPlaybackProviderRef
+        usePlaybackSubscription.ts   -- state sync from all providers
+        useAutoAdvance.ts            -- track end detection
+        useCollectionLoader.ts       -- loading collections into queue
+        useQueueManagement.ts        -- add/remove/reorder queue
+        useRadioSession.ts           -- radio generation
+
+useProviderPlayback.ts
+  uses: providers/registry.ts       -- resolve provider by ID
+        providers/errors.ts          -- AuthExpiredError, UnavailableTrackError
+
+usePlaybackSubscription.ts
+  uses: providers/registry.ts       -- subscribe to all providers
+
+useAutoAdvance.ts
+  uses: providers/registry.ts       -- subscribe to all providers, read getLastPlayTime
+```

--- a/docs/features/queue.md
+++ b/docs/features/queue.md
@@ -1,0 +1,287 @@
+# Queue System
+
+## Terminology
+
+**Queue** = the ordered list of tracks scheduled to play. Users can reorder, remove, and add tracks. Displayed in `QueueDrawer` (desktop) and `QueueBottomSheet` (mobile).
+
+**Playlist** = a library collection from a provider (Spotify playlist, Dropbox folder, Liked Songs). Browsed via `PlaylistSelection`, loaded into the queue via `useCollectionLoader`.
+
+Loading a playlist replaces the queue. Adding a playlist appends to it.
+
+## State Shape
+
+Queue state lives in `TrackContext` (`src/contexts/TrackContext.tsx`), split into two React contexts for render optimization:
+
+### TrackListContext
+
+```ts
+interface TrackListContextValue {
+  tracks: MediaTrack[];              // current playback order (shuffled or original)
+  originalTracks: MediaTrack[];      // pre-shuffle order, used to restore on unshuffle
+  isLoading: boolean;
+  error: string | null;
+  shuffleEnabled: boolean;           // persisted via useLocalStorage (key: vorbis-player-shuffle)
+  selectedPlaylistId: string | null; // ID of the loaded collection
+  // + setters for all above
+  handleShuffleToggle: () => void;
+}
+```
+
+### CurrentTrackContext
+
+```ts
+interface CurrentTrackContextValue {
+  currentTrack: MediaTrack | null;       // derived: tracks[currentTrackIndex] || null
+  currentTrackIndex: number;
+  setCurrentTrackIndex: (index: number | ((prev: number) => number)) => void;
+  showQueue: boolean;                    // controls QueueDrawer/QueueBottomSheet visibility
+  setShowQueue: (visible: boolean | ((prev: boolean) => boolean)) => void;
+}
+```
+
+### mediaTracksRef
+
+`usePlayerLogic` maintains `mediaTracksRef: React.MutableRefObject<MediaTrack[]>` -- an imperative mirror of `tracks` that allows index-based playback without waiting for React renders. It is updated synchronously on every mutation **before** `setTracks` is called.
+
+```ts
+// src/hooks/usePlayerLogic.ts
+const mediaTracksRef = useRef(tracks);
+mediaTracksRef.current = tracks;  // kept in sync every render
+```
+
+This ref is passed into `TrackOperations` and consumed by `useProviderPlayback` and `useCollectionLoader`.
+
+### TrackOperations
+
+Defined in `src/types/trackOperations.ts`. A bag of setters passed to hooks that mutate the queue:
+
+```ts
+interface TrackOperations {
+  setTracks: (tracks: MediaTrack[] | ((prev: MediaTrack[]) => MediaTrack[])) => void;
+  setOriginalTracks: (tracks: MediaTrack[] | ((prev: MediaTrack[]) => MediaTrack[])) => void;
+  setCurrentTrackIndex: (index: number | ((prev: number) => number)) => void;
+  setSelectedPlaylistId: (id: string | null) => void;
+  setError: (error: string | null) => void;
+  setIsLoading: (loading: boolean) => void;
+  mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+}
+```
+
+Constructed once in `usePlayerLogic` via `useMemo` and passed to `useCollectionLoader` and `useQueueManagement`.
+
+## Queue Mutation Flows
+
+### Load Collection
+
+**Hook:** `useCollectionLoader` (`src/hooks/useCollectionLoader.ts`)
+
+**Entry:** `loadCollection(playlistId, provider?)` -- replaces the entire queue.
+
+1. If radio is active, stops it (`stopRadioBase()`).
+2. Routes based on collection type:
+   - `LIKED_SONGS_ID` + unified liked active + no explicit provider -> `loadUnifiedLiked()` (merges liked tracks from all connected providers, sorted by `addedAt` descending).
+   - Otherwise -> `loadProviderCollection()`.
+3. `loadProviderCollection` resolves the collection ref via `resolvePlaylistRef(playlistId, providerId)` -> `{ id, kind }`, then calls `catalog.listTracks(collectionRef)`.
+4. If `listTracks` returns 0 tracks and `playback.playCollection` exists (Spotify context playback), falls back to `loadContextPlayback`.
+5. `applyTracks(tracks)` stores `originalTracks`, optionally shuffles if `shuffleEnabled`, sets `tracks` + `mediaTracksRef`, resets `currentTrackIndex` to 0, then calls `playTrack(0)`.
+
+**Invariant:** `loadCollection` always resets `currentTrackIndex` to 0. The previous queue is fully replaced.
+
+**Also:** `playTracksDirectly(tracks, collectionId, provider?)` -- same as loadCollection but accepts pre-fetched tracks (used by liked-songs direct play from the library).
+
+### Add to Queue
+
+**Hook:** `useQueueManagement` (`src/hooks/useQueueManagement.ts`)
+
+**Entry:** `handleAddToQueue(playlistId, collectionName?, provider?)`
+
+1. If queue is empty, delegates to `loadCollection` (full load + autoplay).
+2. Otherwise:
+   - Resolves provider descriptor and collection ref.
+   - Fetches tracks via `catalog.listTracks(collectionRef)`.
+   - **Deduplicates** by track ID: builds `Set` of existing track IDs, filters new tracks. Already-present tracks are silently skipped.
+   - Appends unique tracks to `mediaTracksRef`, `originalTracks`, and `tracks`.
+   - Does NOT reset `currentTrackIndex`.
+3. Returns `{ added: number, collectionName?: string }` or `null` on failure.
+
+**Also:** `queueTracksDirectly(tracks, collectionName?)` -- same append logic but accepts pre-fetched `MediaTrack[]` directly (used by radio and liked-songs queueing).
+
+### Remove from Queue
+
+**Entry:** `handleRemoveFromQueue(index)`
+
+**Rules:**
+- Cannot remove the currently playing track (`index === currentTrackIndex` -> no-op).
+- If only 1 track remains, calls `handleBackToLibrary()` (full reset to idle state).
+- Removes from `mediaTracksRef` by ID, from `originalTracks` by ID, from `tracks` by index.
+- If the removed track was before `currentTrackIndex`, decrements `currentTrackIndex` by 1.
+
+### Reorder Queue
+
+**Entry:** `handleReorderQueue(fromIndex, toIndex)`
+
+1. `moveItemInArray(tracks, fromIndex, toIndex)` produces new array.
+2. `reorderMediaTracksToMatchTracks(newTracks, mediaTracksRef)` syncs the imperative mirror **synchronously** before `setTracks`.
+3. Recalculates `currentTrackIndex` by finding the currently playing track's ID in the new order.
+4. Only updates `originalTracks` when shuffle is OFF. When shuffle is ON, `originalTracks` preserves the pre-shuffle order.
+
+## Shuffle
+
+**Location:** `TrackContext.handleShuffleToggle`
+
+### Enable shuffle
+1. Takes the current `tracks` array.
+2. Filters out the currently playing track.
+3. Shuffles the rest via `shuffleArray()`.
+4. Prepends the current track at index 0.
+5. Sets `currentTrackIndex` to 0.
+6. `originalTracks` is NOT modified (it preserves the original load order for restore).
+
+### Disable shuffle
+1. Reorders `tracks` to match `originalTracks` order by ID.
+2. Tracks that were added after the original load (queue additions) are appended at the end.
+3. Finds the currently playing track's position in the restored order.
+4. Updates `currentTrackIndex` to the found position.
+
+**Invariant:** `originalTracks` represents the canonical order. Shuffle only reorders `tracks`. Queue additions append to both.
+
+**Persistence:** `shuffleEnabled` is stored in localStorage via `useLocalStorage` (key: `vorbis-player-shuffle`).
+
+## Cross-Provider Queue
+
+Tracks are provider-agnostic `MediaTrack` records (defined in `src/types/domain.ts`). Each track carries a `provider: ProviderId` field. A single queue can mix Spotify and Dropbox tracks.
+
+When playback advances to a track from a different provider:
+- `useProviderPlayback.playTrack(index)` resolves the provider for that track: `track.provider` -> `drivingProviderRef` -> `activeDescriptor.id` fallback.
+- `pausePreviousProvider()` pauses the old provider.
+- The new provider's `playback.playTrack(mediaTrack)` is called.
+
+The **driving provider** (the one currently controlling audio output) can differ from the **active provider** (the one selected for browsing). This happens in unified liked songs, radio queues, or manual cross-provider additions.
+
+## Queue Change Notification
+
+`usePlayerLogic` calls the driving provider's `onQueueChanged` whenever `tracks` or `currentTrackIndex` change:
+
+```ts
+// src/hooks/usePlayerLogic.ts ~line 142
+descriptor?.playback.onQueueChanged?.(tracks, currentTrackIndex);
+```
+
+- **Spotify adapter** (`src/providers/spotify/spotifyPlaybackAdapter.ts`): uses this to build upcoming URIs for Spotify's native queue sync.
+- **Dropbox adapter** (`src/providers/dropbox/dropboxPlaybackAdapter.ts`): no-op.
+
+The `onQueueChanged` method is optional on `PlaybackProvider` (`src/types/providers.ts` line 89).
+
+## UI Components
+
+### QueueDrawer (desktop)
+
+**File:** `src/components/QueueDrawer.tsx`
+
+- Renders via `createPortal` to `document.body`.
+- Fixed position, slides in from the right.
+- Responsive width calculated from `usePlayerSizingContext()` viewport dimensions.
+- Lazy-loads `QueueTrackList` via `React.lazy`.
+- Uses `hasBeenOpenedRef` to defer initial mount until first open (avoids rendering the hidden drawer on page load).
+- Wrapped in `React.memo` with custom `areQueueDrawerPropsEqual` comparator that checks `isOpen`, `currentTrackIndex`, `tracks.length`, track order (by ID string join), `radioActive`, `radioSeedDescription`, and `canSaveQueue`. Callback props are assumed stable.
+
+**Props:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isOpen` | `boolean` | Controls slide animation |
+| `onClose` | `() => void` | Close handler |
+| `tracks` | `MediaTrack[]` | Current queue |
+| `currentTrackIndex` | `number` | Highlighted track |
+| `onTrackSelect` | `(index: number) => void` | Jump to track |
+| `onRemoveTrack` | `(index: number) => void` | Remove from queue |
+| `onReorderTracks` | `(from, to) => void` | Drag-and-drop reorder |
+| `showProviderIcons` | `boolean` | Show provider badge per track |
+| `radioActive` | `boolean` | Changes title to "Radio" |
+| `radioSeedDescription` | `string \| null` | Subtitle when radio is active |
+| `onSaveQueue` | `() => void` | Opens SaveQueueDialog |
+| `canSaveQueue` | `boolean` | Whether save button is shown |
+
+### QueueBottomSheet (mobile)
+
+**File:** `src/components/QueueBottomSheet.tsx`
+
+- Same portal/lazy-load/defer pattern as QueueDrawer.
+- Slides up from bottom, 66dvh height.
+- Swipe-to-dismiss via `useVerticalSwipeGesture` on the header grip pill (threshold: 80px).
+- Same props interface as QueueDrawer.
+
+### QueueTrackList
+
+**File:** `src/components/QueueTrackList.tsx`
+
+Renders the track list inside either drawer. Three rendering modes:
+
+1. **Touch device without reorder support:** Renders `SwipeableQueueItem` components (swipe-to-reveal actions).
+2. **Desktop/touch with reorder support:** Renders `SortableQueueItem` inside `@dnd-kit/core` `DndContext` + `SortableContext` for drag-and-drop.
+3. **Read-only (no `onRemoveTrack` or `onReorderTracks`):** Plain `QueueListItem` elements.
+
+**Edit mode:** Toggled via an "Edit"/"Done" button. Available when `canEdit` is true and queue management callbacks are provided.
+
+**"Play Next" action:** `handlePlayNext(index)` reorders the selected track to `currentTrackIndex + 1`.
+
+**Scroll behavior:** On open, scrolls the current track into view (smooth, centered) after a 100ms delay.
+
+**Sortable IDs:** `${track.name}-${track.id}` -- combined to handle duplicate IDs across providers.
+
+**DnD sensors:** `PointerSensor` (8px activation distance), `TouchSensor` (250ms delay, 5px tolerance).
+
+Each track item shows: album art thumbnail, play icon (for current track), provider icon (optional), track name, artist, duration, liked indicator.
+
+### DrawerOrchestrator
+
+**File:** `src/components/PlayerContent/DrawerOrchestrator.tsx`
+
+Orchestrates both queue and library drawers. Decides between `QueueDrawer` (desktop) and `QueueBottomSheet` (mobile) based on `isMobile` prop. Also manages:
+- `SaveQueueDialog` (lazy-loaded, shown when save button clicked).
+- Toast notifications for add-to-queue results.
+- `RadioProgressToast` for radio generation feedback.
+- Provider icon visibility logic: shows icons when unified liked songs are loaded or radio is active.
+
+## Swipe Gestures
+
+Queue drawer is toggled by:
+- **Swipe up on album art** (from `useKeyboardShortcuts` / swipe gesture handlers in the player content area).
+- **Keyboard:** `Q` or `Up Arrow` (desktop).
+- **QueueBottomSheet:** swipe down on grip pill to dismiss.
+- **QueueDrawer:** click overlay to dismiss.
+
+Cross-dismiss behavior: opening the queue closes the library drawer, and vice versa.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/contexts/TrackContext.tsx` | Queue state (tracks, originalTracks, currentTrackIndex, shuffle) |
+| `src/types/trackOperations.ts` | TrackOperations interface (setter bag) |
+| `src/hooks/usePlayerLogic.ts` | Orchestrates queue mutations, playback, onQueueChanged |
+| `src/hooks/useQueueManagement.ts` | Add, remove, reorder queue operations |
+| `src/hooks/useCollectionLoader.ts` | Load/replace queue from a collection |
+| `src/utils/queueTrackMirror.ts` | Imperative array helpers (reorder, remove, append, move) |
+| `src/components/QueueDrawer.tsx` | Desktop queue UI |
+| `src/components/QueueBottomSheet.tsx` | Mobile queue UI (bottom sheet) |
+| `src/components/QueueTrackList.tsx` | Track list rendering with DnD |
+| `src/components/QueueTrackItem.tsx` | Individual track items (sortable + swipeable variants) |
+| `src/components/PlayerContent/DrawerOrchestrator.tsx` | Drawer switching (mobile vs desktop) |
+| `src/constants/playlist.ts` | LIKED_SONGS_ID, resolvePlaylistRef, ID encoding |
+
+## Gotchas
+
+1. **mediaTracksRef must be updated synchronously** before `setTracks`. Playback index lookup reads from `mediaTracksRef.current`, not from React state. If the ref is stale during a render cycle, the wrong track will play.
+
+2. **Deduplication is by track ID only.** If a track appears in multiple collections with the same ID, only the first instance is kept. This is intentional to prevent duplicate playback.
+
+3. **Reorder does not update originalTracks when shuffle is ON.** This preserves the ability to restore the original order on unshuffle. Queue additions always append to both arrays.
+
+4. **Cannot remove the currently playing track.** The UI should disable the remove action for the track at `currentTrackIndex`. The hook silently no-ops if attempted.
+
+5. **QueueDrawer memo comparator assumes stable callbacks.** If a parent passes an unstable `onClose` or `onTrackSelect`, the memo will incorrectly suppress re-renders. All callback props must be wrapped in `useCallback`.
+
+6. **Empty queue triggers back-to-library.** Removing the last non-playing track calls `handleBackToLibrary()`, which fully resets player state to idle.
+
+7. **Shuffle preserves current track at index 0.** The currently playing track is always first in the shuffled order. `currentTrackIndex` is reset to 0 on shuffle enable.

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -1,0 +1,276 @@
+# Settings System
+
+The settings panel is a right-side sliding drawer rendered via `createPortal` to `document.body`. It is the single entry point for all user-configurable preferences: provider management, visual effects, QAP, cache clearing, profiler, visualizer debug, and provider-specific data operations.
+
+## Entry Point
+
+Component: `src/components/VisualEffectsMenu/index.tsx` (exported as `AppSettingsMenu`).
+
+Opened via:
+- Gear icon on the flip menu back face
+- Keyboard shortcut `O`
+- `useVisualEffectsContext().setShowVisualEffects(true)`
+
+The drawer is lazy-loaded (`React.lazy`) in two places:
+- `src/components/PlayerContent/PlayerControlsSection.tsx` (when a track is loaded)
+- `src/components/AudioPlayer.tsx` (when no track is loaded / idle state)
+
+## Props Interface
+
+```ts
+interface AppSettingsMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onClearCache: (options: ClearCacheOptions) => Promise<void>;
+  profilerEnabled: boolean;
+  onProfilerToggle: () => void;
+  visualizerDebugEnabled: boolean;
+  onVisualizerDebugToggle: () => void;
+  qapEnabled: boolean;
+  onQapToggle: () => void;
+}
+```
+
+The component uses `React.memo` with a custom `arePropsEqual` that only compares `isOpen`, `profilerEnabled`, `visualizerDebugEnabled`, and `qapEnabled`. Callback identity changes are intentionally ignored.
+
+## Panel Organization
+
+The drawer content is structured top-to-bottom:
+
+### 1. Music Sources (`MusicSourcesSection`)
+
+File: `src/components/VisualEffectsMenu/SourcesSections.tsx`
+
+Only renders when 2+ providers are registered. Shows each provider with:
+- Name
+- Status badge: `connected` / `expired` / (empty when disabled)
+- Reconnect button (when enabled but not authenticated)
+- Enable/disable `Switch` toggle (last enabled provider cannot be disabled)
+
+Uses `useProviderContext()` for `registry`, `enabledProviderIds`, `toggleProvider`.
+
+### 2. Native Queue Sync (`NativeQueueSyncSection`)
+
+File: `src/components/VisualEffectsMenu/SourcesSections.tsx`
+
+Only renders when a connected provider has `capabilities.hasNativeQueueSync` (currently only Spotify). Shows:
+- **Queue sync toggle**: keeps Spotify's native queue synced with Vorbis playback. Key: `STORAGE_KEYS.SPOTIFY_QUEUE_SYNC` (default: `true`).
+- **Cross-provider resolve toggle**: replaces non-Spotify tracks with Spotify equivalents in the synced queue. Only visible when sync is enabled AND another provider is connected. Key: `STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER` (default: `true`).
+
+### 3. Quick Access Panel Toggle
+
+Inline in `index.tsx`. On/Off `OptionButton` pair that toggles the QAP preference. See [QAP section](#quick-access-panel-qap) below.
+
+### 4. Advanced (Collapsible)
+
+Wrapped in `CollapsibleSection` (file: `src/components/VisualEffectsMenu/CollapsibleSection.tsx`). Starts collapsed by default.
+
+Contains:
+
+#### Clear Library Cache
+
+Three-state flow: `idle` -> `confirming` -> `success`.
+
+On `confirming`, shows checkboxes:
+- "Also clear Likes" (only when no provider-specific data sections exist)
+- "Also clear Pins"
+- "Also clear Accent Colors"
+
+The `onClearCache` callback in `PlayerControlsSection` calls:
+- `clearCacheWithOptions({ clearLikes })` from `src/services/cache/libraryCache`
+- `clearAllPins()` from `src/services/settings/pinnedItemsStorage` (if clearPins)
+- Removes `ACCENT_COLOR_OVERRIDES` and `CUSTOM_ACCENT_COLORS` from localStorage (if clearAccentColors)
+- If pins or accent colors were cleared, resets the Dropbox preferences sync timestamp and triggers `initialSync()` to pull remote state
+
+#### Performance Profiler
+
+On/Off toggle. See `docs/features/profiler.md`.
+
+Invariant: enabling the profiler disables visualizer debug mode (`vizDebugCtx.setIsDebugMode(false)`).
+
+#### Visualizer Debug
+
+On/Off toggle. Controlled by `VisualizerDebugContext.isDebugMode`.
+
+Invariant: enabling visualizer debug disables the profiler (`profilerToggle()`). These two are mutually exclusive.
+
+#### Provider Data Sections
+
+File: `src/components/VisualEffectsMenu/ProviderDataSection.tsx`
+
+One `ProviderDataSection` per enabled provider that has `catalog.clearArtCache` or `catalog.exportLikes`. Each is a collapsible section titled "{ProviderName} Data". Controls depend on which `CatalogProvider` capabilities exist:
+
+| Capability | Control | Description |
+|---|---|---|
+| `clearArtCache` | "Clear Art Cache" button | Clears cached album art so it re-downloads |
+| `refreshArtCache` | "Refresh Art" button | Clears and immediately re-fetches art; dispatches `ART_REFRESHED_EVENT` |
+| `exportLikes` + `importLikes` | "Export Likes" / "Import Likes" buttons | Export: downloads JSON file. Import: opens file picker, reads JSON, calls `catalog.importLikes(json)` |
+| `refreshLikedMetadata` | "Refresh Metadata" button | Re-scans provider to update metadata for liked tracks; shows count of updated/removed |
+
+All buttons use `useAsyncAction` for loading/success state management with `FEEDBACK_DISPLAY_MS` (from `src/hooks/useAsyncAction.ts`) delay before resetting.
+
+## Quick Access Panel (QAP)
+
+### Storage
+
+Key: `vorbis-player-qap-enabled` (hardcoded in `useQapEnabled`, not in `STORAGE_KEYS`).
+
+Default: `false`.
+
+### Hook
+
+```ts
+// src/hooks/useQapEnabled.ts
+export const useQapEnabled = (): [boolean, (value: boolean) => void] => {
+  return useLocalStorage<boolean>('vorbis-player-qap-enabled', false);
+};
+```
+
+### Behavior
+
+- When QAP is disabled (default): `PlayerStateRenderer` initializes `showLibrary = true`, showing the library browser (`PlaylistSelection`) in the idle/home view.
+- When QAP is enabled: `PlayerStateRenderer` initializes `showLibrary = false`, showing the Quick Access Panel instead.
+- The down-arrow keyboard shortcut routes to either `onOpenQuickAccessPanel` or `onOpenLibraryDrawer` based on `qapEnabled`.
+
+### Gotcha
+
+The QAP key is NOT centralized in `STORAGE_KEYS`. It is hardcoded as a string literal in `useQapEnabled.ts`. If you need to reference it elsewhere, use the hook or duplicate the string.
+
+## Dropbox Preferences Sync
+
+File: `src/providers/dropbox/dropboxPreferencesSync.ts`
+
+Syncs two categories of local state to `/.vorbis/preferences.json` in the user's Dropbox:
+
+1. **Pins** (unified playlists and albums) -- stored in IndexedDB via `pinnedItemsStorage`
+2. **Accent overrides and custom colors** -- stored in localStorage under `ACCENT_COLOR_OVERRIDES` and `CUSTOM_ACCENT_COLORS`
+
+### Architecture
+
+`DropboxPreferencesSyncService` is a singleton created via `initPreferencesSync(auth)`. Access the instance via `getPreferencesSync()`.
+
+### Remote File Format
+
+```ts
+interface RemotePreferencesFile {
+  version: 1;
+  updatedAt: string; // ISO 8601
+  pins: { playlists: string[]; albums: string[] };
+  accent: { overrides: Record<string, string>; customColors: Record<string, string> };
+}
+```
+
+### Merge Strategy
+
+Last-write-wins by `updatedAt` timestamp. Comparison:
+- Remote newer than local -> apply remote to local
+- Local newer than remote -> push local to remote
+- Equal timestamps -> no-op
+
+Local `updatedAt` is tracked in localStorage under `STORAGE_KEYS.PREFERENCES_SYNC_UPDATED_AT`.
+
+### Trigger Points
+
+- **Initial sync**: called after Dropbox OAuth completion and when Dropbox is already authenticated at app startup (in `App.tsx` and `dropboxProvider.ts`).
+- **Push (debounced)**: `PinnedItemsContext` and `ColorContext` call `getPreferencesSync()?.schedulePush()` after local changes. The push is debounced by 2 seconds (`UPLOAD_DEBOUNCE_MS`).
+- **After cache clear**: when pins or accent colors are cleared, `clearPreferencesSyncTimestamp()` resets the local timestamp so the next `initialSync()` pulls from remote.
+
+### Key Files
+
+- `src/providers/dropbox/dropboxPreferencesSync.ts` -- service class, singleton, merge logic
+- `src/providers/dropbox/dropboxSyncFolder.ts` -- `ensureVorbisFolder()` helper
+- `src/contexts/PinnedItemsContext.tsx` -- calls `schedulePush()` after pin mutations
+- `src/contexts/ColorContext.tsx` -- calls `schedulePush()` after accent color changes
+
+## useLocalStorage Hook
+
+File: `src/hooks/useLocalStorage.ts`
+
+```ts
+export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void]
+```
+
+Behavior:
+- Reads from `localStorage` on initial render (lazy `useState` initializer)
+- Writes to `localStorage` synchronously inside the setter
+- Listens for cross-tab `storage` events to sync state
+- JSON serializes/deserializes all values
+- Catches and warns on parse/write failures; falls back to `initialValue`
+
+Convention: all keys use the `vorbis-player-` prefix.
+
+## Complete localStorage Key Reference
+
+All keys from `src/constants/storage.ts` (`STORAGE_KEYS`) plus standalone keys:
+
+| Key | Default | Type | Purpose |
+|---|---|---|---|
+| `vorbis-player-active-provider` | -- | `string` | Currently selected provider for browsing |
+| `vorbis-player-enabled-providers` | -- | `string[]` | Provider IDs enabled in settings |
+| `vorbis-player-volume` | -- | `number` | Playback volume (0-100) |
+| `vorbis-player-muted` | -- | `boolean` | Mute state |
+| `vorbis-player-shuffle-enabled` | -- | `boolean` | Shuffle toggle state |
+| `vorbis-player-visual-effects-enabled` | `true` | `boolean` | Master glow/effects toggle |
+| `vorbis-player-per-album-glow` | `{}` | `Record<string, {intensity, rate}>` | Per-album glow intensity/rate overrides |
+| `vorbis-player-glow-intensity` | -- | `number` | Default glow intensity |
+| `vorbis-player-glow-rate` | -- | `number` | Default glow rate |
+| `vorbis-player-translucence-enabled` | `true` | `boolean` | Album art translucence effect |
+| `vorbis-player-translucence-opacity` | `0.8` | `number` | Translucence opacity level |
+| `vorbis-player-zen-mode-enabled` | `false` | `boolean` | Zen mode state |
+| `vorbis-player-background-visualizer-enabled` | `true` | `boolean` | Background visualizer on/off |
+| `vorbis-player-background-visualizer-style` | `'fireflies'` | `VisualizerStyle` | Active visualizer style |
+| `vorbis-player-background-visualizer-intensity` | `40` | `number` | Visualizer intensity |
+| `vorbis-player-background-visualizer-speed` | `1.0` | `number` | Visualizer speed multiplier |
+| `vorbis-player-accent-color-background-preferred` | `false` | `boolean` | Use accent color as background |
+| `vorbis-player-accent-color-overrides` | `{}` | `Record<string, string>` | Per-collection accent color overrides |
+| `vorbis-player-custom-accent-colors` | `{}` | `Record<string, string>` | User-picked custom accent colors |
+| `vorbis-player-view-mode` | -- | `string` | Library grid/list view mode |
+| `vorbis-player-playlist-sort` | -- | `string` | Playlist sort preference |
+| `vorbis-player-album-sort` | -- | `string` | Album sort preference |
+| `vorbis-player-album-filters` | -- | -- | Album filter state |
+| `vorbis-player-pinned-playlists` | -- | `string[]` | Pinned playlist IDs |
+| `vorbis-player-pinned-albums` | -- | `string[]` | Pinned album IDs |
+| `vorbis-player-dropbox-token` | -- | `string` | Dropbox access token |
+| `vorbis-player-dropbox-refresh-token` | -- | `string` | Dropbox refresh token |
+| `vorbis-player-dropbox-token-expiry` | -- | `string` | Dropbox token expiry timestamp |
+| `vorbis-player-dropbox-code-verifier` | -- | `string` | PKCE code verifier (OAuth) |
+| `vorbis-player-dropbox-oauth-state` | -- | `string` | OAuth state param |
+| `vorbis-player-preferences-sync-updatedAt` | -- | `string` | Last sync timestamp (ISO) |
+| `vorbis-player-spotify-queue-sync-enabled` | `true` | `boolean` | Spotify native queue sync |
+| `vorbis-player-spotify-queue-resolve-cross-provider` | `true` | `boolean` | Replace non-Spotify tracks in synced queue |
+| `vorbis-player-cache-albums` | -- | -- | Cached album data |
+| `vorbis-player-cache-playlists` | -- | -- | Cached playlist data |
+| `vorbis-player-liked-count-snapshots` | -- | -- | Liked song count snapshots |
+| `vorbis-player-library` | -- | -- | Cached library state |
+| `vorbis-player-settings` | -- | -- | General settings cache |
+| `vorbis-player-profiling` | `'false'` | `string` | Profiler enabled (raw string, not JSON) |
+| `vorbis-player-debug-overlay` | `'false'` | `string` | Debug overlay enabled (raw string) |
+| `vorbis-player-visualizer-debug-overrides` | -- | `JSON` | Visualizer param overrides |
+| `vorbis-player-devbug` | `false` | `boolean` | DevBug FAB enabled |
+| `vorbis-player-qap-enabled` | `false` | `boolean` | Quick Access Panel enabled (NOT in STORAGE_KEYS) |
+
+### Gotcha: Raw vs JSON Storage
+
+Most keys use `useLocalStorage` which JSON-serializes values (so `true` is stored as `"true"` which `JSON.parse` reads back).
+
+Two keys bypass `useLocalStorage` and write raw strings directly:
+- `PROFILING` -- written with `localStorage.setItem(key, String(next))` in `ProfilingContext`. Read with `=== 'true'` comparison.
+- `DEBUG_OVERLAY` -- written with `localStorage.setItem(key, String(enabled))`. Read with `=== 'true'` comparison.
+
+These are compatible because `JSON.parse('"true"')` and `'true' === 'true'` both work, but be aware if mixing read methods.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `src/components/VisualEffectsMenu/index.tsx` | Settings drawer component |
+| `src/components/VisualEffectsMenu/SourcesSections.tsx` | Music Sources + Queue Sync sections |
+| `src/components/VisualEffectsMenu/ProviderDataSection.tsx` | Per-provider data management |
+| `src/components/VisualEffectsMenu/CollapsibleSection.tsx` | Generic collapsible section wrapper |
+| `src/components/VisualEffectsMenu/styled.ts` | All styled-components for the drawer |
+| `src/constants/storage.ts` | `STORAGE_KEYS` constant object |
+| `src/hooks/useLocalStorage.ts` | Generic localStorage hook with cross-tab sync |
+| `src/hooks/useQapEnabled.ts` | QAP preference hook |
+| `src/contexts/VisualEffectsContext.tsx` | Visual effects state (glow, visualizer, translucence, zen) |
+| `src/providers/dropbox/dropboxPreferencesSync.ts` | Dropbox preferences sync service |
+| `src/components/PlayerContent/PlayerControlsSection.tsx` | Wires settings props from contexts to the drawer |

--- a/docs/features/visual-effects.md
+++ b/docs/features/visual-effects.md
@@ -1,0 +1,235 @@
+# Visual Effects System
+
+The visual effects system controls ambient visual enhancements around the player: glow behind album art, background color tinting, translucence/opacity of the player card, and the master on/off for all visual effects. This is distinct from the [visualizer system](./visualizers.md), which handles the canvas-based animated backgrounds.
+
+## VisualEffectsContext
+
+**File**: `src/contexts/VisualEffectsContext.tsx`
+
+Central state store for all visual effect preferences. Wraps the app and provides both state values and setters.
+
+### State Shape
+
+```ts
+interface VisualEffectsContextValue {
+  // Persisted via useLocalStorage
+  visualEffectsEnabled: boolean;                  // master toggle for glow
+  perAlbumGlow: Record<string, { intensity: number; rate: number }>;
+  backgroundVisualizerEnabled: boolean;
+  backgroundVisualizerStyle: VisualizerStyle;
+  backgroundVisualizerIntensity: number;          // 0-100
+  backgroundVisualizerSpeed: number;              // multiplier, default 1.0
+  accentColorBackgroundPreferred: boolean;        // user preference
+  translucenceEnabled: boolean;
+  translucenceOpacity: number;                    // 0-1
+  zenModeEnabled: boolean;
+
+  // Derived / transient
+  accentColorBackgroundEnabled: boolean;          // computed from preferred + master toggle
+  showVisualEffects: boolean;                     // whether settings menu is open (transient)
+
+  // Setters (all accept value or updater function)
+  setVisualEffectsEnabled: (enabled: boolean | ((prev: boolean) => boolean)) => void;
+  // ... one setter per state field
+}
+```
+
+### Persistence
+
+All persisted fields use `useLocalStorage` with keys from `src/constants/storage.ts`.
+
+| Field | localStorage key | Default |
+|-------|-----------------|---------|
+| `visualEffectsEnabled` | `vorbis-player-visual-effects-enabled` | `true` |
+| `perAlbumGlow` | `vorbis-player-per-album-glow` | `{}` |
+| `backgroundVisualizerEnabled` | `vorbis-player-background-visualizer-enabled` | `true` |
+| `backgroundVisualizerStyle` | `vorbis-player-background-visualizer-style` | `'fireflies'` |
+| `backgroundVisualizerIntensity` | `vorbis-player-background-visualizer-intensity` | `40` |
+| `backgroundVisualizerSpeed` | `vorbis-player-background-visualizer-speed` | `1.0` |
+| `accentColorBackgroundPreferred` | `vorbis-player-accent-color-background-preferred` | `false` |
+| `translucenceEnabled` | `vorbis-player-translucence-enabled` | `true` |
+| `translucenceOpacity` | `vorbis-player-translucence-opacity` | `0.8` |
+| `zenModeEnabled` | `vorbis-player-zen-mode-enabled` | `false` |
+
+### Derived State
+
+`accentColorBackgroundEnabled` is not directly persisted. It is computed:
+- `false` when `visualEffectsEnabled` is `false` (master toggle off disables accent background)
+- Otherwise equals `accentColorBackgroundPreferred`
+
+### Migration
+
+On mount, the context runs a one-time migration for old style names:
+- `'particles'` -> `'fireflies'`
+- `'trail'` -> `'comet'`
+- `'geometric'` -> `'fireflies'`
+
+It also removes the deprecated `vorbis-player-album-filters` key.
+
+## Glow Effect
+
+The glow is a pulsing colored layer rendered behind album art. It uses the track's accent color and animates with a "breathing" effect.
+
+### Components
+
+**`AccentColorGlowOverlay`** (`src/components/AccentColorGlowOverlay.tsx`):
+- Renders a `GlowBackgroundLayer` div positioned absolutely behind album art
+- Uses the `--accent-color` CSS variable as its `background`
+- Animates via the `breatheGlow` keyframes (`src/styles/animations.ts`): cycles between full brightness and 0.9 brightness
+- Respects `prefers-reduced-motion`: disables animation entirely
+
+Props:
+```ts
+interface AccentColorGlowOverlayProps {
+  glowIntensity: number;   // 0-200, maps to opacity (intensity/100)
+  glowRate?: number;        // animation duration in seconds, default 4.0
+  backgroundImage?: string; // if falsy or intensity is 0, renders null
+}
+```
+
+**Defaults**: `DEFAULT_GLOW_INTENSITY = 110`, `DEFAULT_GLOW_RATE = 4.0` (exported from the component file).
+
+### Glow State Management
+
+**`useVisualEffectsState`** hook (`src/hooks/useVisualEffectsState.ts`):
+- Manages `glowIntensity` and `glowRate` with localStorage persistence
+- Keys: `vorbis-player-glow-intensity`, `vorbis-player-glow-rate`
+- Maintains separate `savedGlowIntensity`/`savedGlowRate` in React state for restoration when toggling effects back on
+- Returns `effectiveGlow: { intensity: number; rate: number }` and handlers
+
+### Per-Album Glow
+
+`perAlbumGlow` in `VisualEffectsContext` is a `Record<string, { intensity: number; rate: number }>` keyed by some track/album identifier. This allows different glow settings per album. The data is persisted but the per-album override logic lives in the consuming components.
+
+### Master Toggle Behavior
+
+The `visualEffectsEnabled` flag is the master glow toggle:
+- When toggled off: glow intensity passed to `AccentColorGlowOverlay` becomes 0
+- When toggled back on: `restoreGlowSettings()` restores the last user-set intensity/rate
+- Keyboard shortcut: `G` key (via `handleGlowToggle` in `PlayerControlsSection.tsx`)
+
+## Translucence
+
+Controls the opacity of the player card, making the background visualizer and accent color visible through the UI.
+
+### State
+
+- `translucenceEnabled: boolean` (default `true`)
+- `translucenceOpacity: number` (default `0.8`, range 0-1)
+
+Both persisted via `useLocalStorage`.
+
+### Keyboard Shortcut
+
+`T` key toggles `translucenceEnabled` (via `handleTranslucenceToggle` in `PlayerControlsSection.tsx`).
+
+### UI Control
+
+Available on the flip menu back (`QuickEffectsRow`) as a toggle switch.
+
+## AccentColorBackground Component
+
+**File**: `src/components/AccentColorBackground.tsx`
+
+A subtle full-viewport gradient tinted by the current track's accent color. Independent from the animated visualizers.
+
+### Props
+
+```ts
+interface AccentColorBackgroundProps {
+  enabled: boolean;
+  accentColor: string;
+}
+```
+
+### Rendering
+
+- `position: fixed; z-index: 0` (below everything, including the visualizer at z-index 1)
+- `pointer-events: none`
+- Renders a diagonal linear gradient using the accent color at very low alpha values (`20`, `15`, `10` hex alpha suffixes)
+- Uses `generateColorVariant()` from `src/utils/visualizerUtils.ts` to create darker tints at gradient stops
+- 0.5s CSS transition on `background` for smooth color changes between tracks
+
+### Activation
+
+Controlled by `accentColorBackgroundEnabled` in `VisualEffectsContext`, which requires both:
+1. `accentColorBackgroundPreferred` is `true` (user opted in)
+2. `visualEffectsEnabled` is `true` (master toggle is on)
+
+Default is disabled (`accentColorBackgroundPreferred` defaults to `false`).
+
+## Speed Multiplier
+
+The `backgroundVisualizerSpeed` value (default `1.0`) is a global speed multiplier passed to all visualizers. Each visualizer applies it to its own speed calculations. It multiplies with the per-visualizer `pausedSpeedMult` when playback is paused.
+
+Controlled via a slider on the flip menu back (`QuickEffectsRow`). Persisted under `vorbis-player-background-visualizer-speed`.
+
+## Settings Menu (VisualEffectsMenu)
+
+**File**: `src/components/VisualEffectsMenu/index.tsx`
+
+Despite the name, this is the **app settings drawer**, not just visual effects. It renders as a right-side drawer via `createPortal` to `document.body`.
+
+### What It Contains
+
+- **Music Sources**: Provider connection management
+- **Native Queue Sync**: Spotify queue sync toggle
+- **Quick Access Panel**: On/Off toggle
+- **Advanced** (collapsible):
+  - Clear Library Cache (with sub-options for likes, pins, accent colors)
+  - Performance Profiler toggle
+  - Visualizer Debug toggle
+  - Per-provider data operations (export/import likes, refresh metadata, clear art cache)
+
+### Visual Effects Controls Are NOT Here
+
+The glow, visualizer style, visualizer speed/intensity, translucence, and accent color controls live on the **flip menu back** (`AlbumArtQuickSwapBack` > `QuickEffectsRow`), not in this settings drawer. The settings drawer is accessed via the gear icon; the flip menu is accessed by long-pressing or clicking the album art.
+
+### Opening
+
+- Gear icon in player controls
+- `O` keyboard shortcut
+- `showVisualEffects` state in `VisualEffectsContext` (transient, not persisted)
+
+## Keyboard Shortcuts
+
+| Key | Action | Handler location |
+|-----|--------|-----------------|
+| `V` | Cycle visualizer style (fireflies -> comet -> wave -> grid -> fireflies) | `PlayerControlsSection.tsx` `handleCycleVisualizerStyle` |
+| `G` | Toggle glow (master visual effects toggle) | `PlayerControlsSection.tsx` `handleGlowToggle` |
+| `T` | Toggle translucence | `PlayerControlsSection.tsx` `handleTranslucenceToggle` |
+| `O` | Toggle settings menu | `PlayerControlsSection.tsx` `handleToggleVisualEffectsMenu` |
+| `Z` | Toggle zen mode | `PlayerControlsSection.tsx` |
+
+## Z-Index Stacking
+
+From back to front:
+1. `AccentColorBackground` -- `z-index: 0`, fixed
+2. `BackgroundVisualizer` -- `z-index: 1`, fixed
+3. `ContentWrapper` -- `z-index: 2`, relative
+4. Drawers, modals, overlays -- higher z-indexes
+
+## Cross-Cutting Concerns
+
+| Feature | Interaction |
+|---------|-------------|
+| **ColorContext** | Provides `accentColor` used by glow overlay and accent background gradient |
+| **Visualizers** | Speed multiplier and enabled/style/intensity flow from this context to `BackgroundVisualizer` |
+| **Zen mode** | `zenModeEnabled` stored here; glow and translucence remain active in zen mode |
+| **Flip menu** | Primary UI surface for effect controls (`QuickEffectsRow` in `AlbumArtQuickSwapBack`) |
+| **Player sizing** | Settings drawer width adapts to viewport via `usePlayerSizingContext` |
+| **Dropbox preferences sync** | Clearing accent colors triggers a Dropbox preferences sync reset |
+
+## Key Files Summary
+
+| File | Role |
+|------|------|
+| `src/contexts/VisualEffectsContext.tsx` | Central state provider for all visual effect settings |
+| `src/hooks/useVisualEffectsState.ts` | Glow intensity/rate state with save/restore |
+| `src/components/AccentColorGlowOverlay.tsx` | Pulsing glow layer behind album art |
+| `src/components/AccentColorBackground.tsx` | Full-viewport accent color gradient |
+| `src/components/VisualEffectsMenu/index.tsx` | Settings drawer (gear icon) |
+| `src/components/AlbumArtQuickSwapBack.tsx` | Flip menu back face, hosts `QuickEffectsRow` |
+| `src/components/controls/QuickEffectsRow.tsx` | Actual effect controls (glow, visualizer, translucence, accent color) |
+| `src/styles/animations.ts` | `breatheGlow` keyframes for glow animation |
+| `src/constants/storage.ts` | All localStorage key constants |

--- a/docs/features/visualizers.md
+++ b/docs/features/visualizers.md
@@ -1,0 +1,231 @@
+# Background Visualizers
+
+Four canvas-based animated backgrounds that render behind the player UI. Each is a React component in `src/components/visualizers/` that implements a shared contract via the `useCanvasVisualizer<T>` hook.
+
+## Visualizer Styles
+
+| Style key | Component | File | Item type `T` | Description |
+|-----------|-----------|------|---------------|-------------|
+| `fireflies` | `ParticleVisualizer` | `src/components/visualizers/ParticleVisualizer.tsx` | `Particle` | Drifting circles with pulsing radius and opacity |
+| `comet` | `TrailVisualizer` | `src/components/visualizers/TrailVisualizer.tsx` | `TrailParticle` | A "ship" moves along a curving path, spawning trail particles that fade |
+| `wave` | `WaveVisualizer` | `src/components/visualizers/WaveVisualizer.tsx` | `Wave` | Layered sine waves rendered as filled regions from wave crest to canvas bottom |
+| `grid` | `GridWaveVisualizer` | `src/components/visualizers/GridWaveVisualizer.tsx` | `GridWaveState` | A dot grid displaced by traveling sine waves |
+
+The type union is `VisualizerStyle` in `src/types/visualizer.d.ts`:
+
+```ts
+export type VisualizerStyle = 'fireflies' | 'comet' | 'wave' | 'grid';
+```
+
+## The `useCanvasVisualizer<T>` Hook
+
+**File**: `src/hooks/useCanvasVisualizer.ts`
+
+This is the core abstraction. It implements a Template Method pattern: the hook owns the canvas lifecycle (sizing, animation loop, resize handling), and each visualizer provides four callbacks that define its specific behavior.
+
+### Interface
+
+```ts
+interface UseCanvasVisualizerProps<T> {
+  accentColor: string;
+  isPlaying: boolean;
+  intensity: number;
+  getItemCount: (width: number, height: number, intensity: number) => number;
+  initializeItems: (count: number, width: number, height: number, color: string) => T[];
+  updateItems: (items: T[], deltaTime: number, isPlaying: boolean, width: number, height: number) => void;
+  renderItems: (ctx: CanvasRenderingContext2D, items: T[], width: number, height: number, intensity: number) => void;
+  onColorChange: (items: T[], color: string) => void;
+}
+```
+
+### Return Value
+
+Returns `React.RefObject<HTMLCanvasElement>`. The caller attaches this to a `<canvas>` element.
+
+### Lifecycle
+
+1. **Initialization** (runs on mount and when `accentColor` or `intensity` changes):
+   - Sets `canvas.width = window.innerWidth`, `canvas.height = window.innerHeight`
+   - Calls `getItemCount(width, height, intensity)` to determine how many items to create
+   - Calls `initializeItems(count, width, height, accentColor)` to populate `itemsRef`
+   - Adds a `resize` listener that re-runs the above
+
+2. **Animation loop** (via `useAnimationFrame`):
+   - Computes `deltaTime` from `performance.now()` timestamps
+   - Skips frames where `deltaTime > 1000` (tab was hidden/backgrounded)
+   - Calls `updateItems(items, deltaTime, isPlaying, width, height)`
+   - Calls `renderItems(ctx, items, width, height, intensity)`
+
+3. **Cleanup**: Removes resize listener; `useAnimationFrame` cancels `requestAnimationFrame`.
+
+### Invariants and Gotchas
+
+- **Re-initialization on color change**: When `accentColor` changes, the entire item array is re-created (the effect depends on `accentColor`). The `onColorChange` callback is declared in the interface but **not called** by the hook -- it exists for future incremental color updates. Currently, color changes trigger full re-init.
+- **Canvas sizing uses `window.innerWidth/Height`**, not CSS dimensions. The canvas element is styled `width: 100%; height: 100%` with `display: block`. The pixel dimensions are set imperatively on the canvas element, so there is **no DPI scaling** (`devicePixelRatio` is not applied). This means on high-DPI screens, the canvas renders at 1x resolution, which is intentional for performance -- these are ambient backgrounds, not crisp UI elements.
+- **Delta time normalization**: All visualizers normalize deltaTime by dividing by 16 (`dt = deltaTime / 16`), treating 16ms (~60fps) as the baseline.
+- **`useAnimationFrame`** (`src/hooks/useAnimationFrame.ts`) wraps `requestAnimationFrame` with cleanup. It skips the first frame to establish a baseline timestamp. The `callback` is a dependency of its internal effect, so it must be stable (wrapped in `useCallback`).
+
+## `BackgroundVisualizer` Component
+
+**File**: `src/components/BackgroundVisualizer.tsx`
+
+This is the switching layer that renders the correct visualizer based on the selected style.
+
+### Props
+
+```ts
+interface BackgroundVisualizerProps {
+  enabled: boolean;
+  style: VisualizerStyle;
+  intensity: number;         // 0-100, from VisualEffectsContext
+  speed?: number;            // multiplier, default 1.0
+  accentColor: string;       // hex color from current track
+  isPlaying: boolean;
+  albumArtBounds?: AlbumArtBounds | null;  // only used by 'comet' style
+}
+```
+
+### Layout Positioning
+
+Wrapped in a `VisualizerContainer` styled-component:
+- `position: fixed; top: 0; left: 0; right: 0; bottom: 0`
+- `z-index: 1` (below ContentWrapper at z-index 2, above AccentColorBackground at z-index 0)
+- `pointer-events: none` -- never intercepts clicks
+- `overflow: hidden`
+
+### Wiring in AudioPlayer
+
+`BackgroundVisualizer` is rendered in `src/components/AudioPlayer.tsx`. It receives:
+- `enabled` = `backgroundVisualizerEnabled && isMainPlayerActive`
+- `style`, `intensity`, `speed` from `VisualEffectsContext`
+- `accentColor` from `ColorContext`
+- `isPlaying` from player state
+
+Note: `albumArtBounds` is declared in the props interface but is **not currently wired** from `AudioPlayer`. The `TrailVisualizer` supports it (constraining the ship to the album art rect) but falls back to viewport center when not provided.
+
+## Per-Visualizer Details
+
+### Fireflies (`ParticleVisualizer`)
+
+- Each particle has position, velocity, radius, opacity, color, and a pulse phase
+- Particles wrap around screen edges (toroidal topology)
+- Pulse cycle modulates radius and opacity sinusoidally
+- When paused, speed drops to `pausedSpeed` multiplier (default 0.3)
+- Color variants generated via `generateColorVariant(baseColor, random)` from `src/utils/visualizerUtils.ts`
+
+### Comet (`TrailVisualizer`)
+
+- Maintains a `ShipState` ref (position, angle, velocity) separate from the particle array
+- Ship follows a curving path with random turn rate and wobble
+- Trail particles spawn at the ship position, move opposite to ship velocity with perpendicular spread, and fade via `life` countdown
+- If `albumArtBounds` is provided, the ship is clamped within the bounds (with 8% inset)
+- If no bounds, ship wraps at screen edges with 40px margin
+- Ship renders a white radial glow at its position (controlled by `glowRadius` config param)
+- Viewport scale factor: `Math.max(0.5, Math.sqrt(width / 1400))` adjusts ship speed for screen size
+
+### Wave (`WaveVisualizer`)
+
+- Creates `waveCount` (default 7) layered sine waves
+- Each wave has a unique phase speed distributed via golden ratio (`PHI^(i/count*2)`)
+- Waves render back-to-front as filled shapes from the sine curve down to the bottom of the canvas
+- `yBase` distributes waves vertically across the canvas (`yBaseStart` to `yBaseStart + yBaseLayerScale`)
+- Amplitude scales by 0.65x on mobile (`width < 768`)
+- Item count is fixed (always `waveCount`), not dependent on screen area
+
+### Grid (`GridWaveVisualizer`)
+
+- Creates a grid of dots at regular spacing (35px desktop, 22px mobile)
+- Multiple `WaveState` objects (default 2) travel through the grid
+- Dot displacement is the average of all wave sine projections
+- Edge and depth factors create a perspective-like intensity gradient
+- **Unusual `T` usage**: The generic type is `GridWaveState[]` but the hook always creates a single-element array (`[{ particles, waves, width, height }]`). The hook's `getItemCount` returns 1 (mobile or desktop), and `initializeItems` returns one `GridWaveState` containing all grid particles and wave states. This is a pattern to pack multiple data structures into the generic slot.
+- `void count` on line 87 suppresses the unused-parameter warning for the count arg
+
+## Debug Panel System
+
+### Files
+- `src/components/VisualizerDebugPanel/index.tsx` -- the panel UI
+- `src/components/VisualizerDebugPanel/styled.ts` -- styled-components for the panel
+- `src/contexts/VisualizerDebugContext.tsx` -- context provider and hooks
+- `src/constants/visualizerDebugConfig.ts` -- default config values and types
+
+### Activation
+
+The debug panel activates when the URL contains `?debug=visualizer`. This is checked by `isDebugModeEnabled()` in `VisualizerDebugContext.tsx`. It can also be toggled via the Settings menu (Advanced > Visualizer Debug On/Off), which calls `vizDebugCtx.setIsDebugMode()`.
+
+Profiler and Visualizer Debug are mutually exclusive: enabling one disables the other (see `handleVisualizerDebugToggle` and `handleProfilerToggle` in `PlayerControlsSection.tsx`).
+
+### Config Architecture
+
+`VisualizerDebugConfig` has four sections: `particle`, `trail`, `wave`, `grid`. Each maps to a visualizer's tunable parameters.
+
+```ts
+interface VisualizerDebugConfig {
+  particle: ParticleVisualizerConfig;  // 14 params
+  trail: TrailVisualizerConfig;        // 20 params
+  wave: WaveVisualizerConfig;          // 12 params
+  grid: GridWaveVisualizerConfig;      // 17 params
+}
+```
+
+Default values are in `DEFAULT_VISUALIZER_DEBUG_CONFIG` (exported from `visualizerDebugConfig.ts`).
+
+### Override Flow
+
+1. Visualizers call `useVisualizerDebugConfig()` which returns:
+   - `DEFAULT_VISUALIZER_DEBUG_CONFIG` when debug mode is off
+   - Merged config (defaults + overrides) when debug mode is on
+2. Overrides are stored in localStorage under `STORAGE_KEYS.VISUALIZER_DEBUG_OVERRIDES` (`vorbis-player-visualizer-debug-overrides`)
+3. `mergeVisualizerConfig()` does a shallow merge per section (override keys replace defaults, unset keys keep defaults)
+4. The debug panel exposes per-param sliders for `particle` and `trail` sections only (wave and grid are not yet in the panel UI but their overrides are loaded/saved)
+
+### Export/Import
+
+The panel supports:
+- **Copy JSON** / **Download JSON**: Exports the full merged config
+- **Load from JSON**: Accepts either a full `VisualizerDebugConfig` or partial `VisualizerDebugOverrides`
+- **Reset to defaults**: Clears localStorage overrides
+
+## Mobile Considerations
+
+- Particle counts are reduced on mobile (`width < 768`) via separate `countBaseMobile` and `countPixelDivisorMobile` params
+- Wave amplitude scales to 0.65x on mobile
+- Grid spacing decreases from 35px to 22px on mobile
+- All visualizers run at 1x canvas resolution (no `devicePixelRatio` scaling) which helps performance
+- The `requestAnimationFrame` loop runs continuously when enabled; there is no frame-skipping or throttling beyond the browser's own vsync
+
+## Album Art Exclusion Zones
+
+Only the `comet` (TrailVisualizer) style has explicit album art awareness via `albumArtBounds`. When provided, the ship is clamped within the album art rect (with 8% inset). Other visualizers draw over the entire viewport, but since they render at `z-index: 1` behind `ContentWrapper` at `z-index: 2`, they appear behind the player UI including album art.
+
+There is no pixel-level exclusion zone system. The visual separation relies entirely on z-index layering.
+
+## Cross-Cutting Concerns
+
+| Feature | Interaction |
+|---------|-------------|
+| **VisualEffectsContext** | Provides `backgroundVisualizerEnabled`, `backgroundVisualizerStyle`, `backgroundVisualizerIntensity`, `backgroundVisualizerSpeed` |
+| **ColorContext** | Provides `accentColor` (extracted from current track's album art) |
+| **Keyboard shortcuts** | `V` key cycles through visualizer styles (via `handleCycleVisualizerStyle` in `PlayerControlsSection.tsx`) |
+| **Flip menu** | Back of album art card (`AlbumArtQuickSwapBack` > `QuickEffectsRow`) has style selector, intensity slider, speed slider, and enable/disable toggle |
+| **Zen mode** | Visualizers continue running in zen mode; no special behavior |
+| **Playback state** | All visualizers slow down when `isPlaying` is false (each has a `pausedSpeed`/`pausedSpeedMult` config) |
+| **Tab visibility** | `useCanvasVisualizer` skips frames with `deltaTime > 1000ms` to avoid large jumps when returning from a hidden tab |
+
+## Key Files Summary
+
+| File | Role |
+|------|------|
+| `src/types/visualizer.d.ts` | `VisualizerStyle` type definition |
+| `src/hooks/useCanvasVisualizer.ts` | Generic canvas lifecycle hook (Template Method) |
+| `src/hooks/useAnimationFrame.ts` | `requestAnimationFrame` wrapper with cleanup |
+| `src/components/BackgroundVisualizer.tsx` | Style switcher component |
+| `src/components/visualizers/ParticleVisualizer.tsx` | Fireflies implementation |
+| `src/components/visualizers/TrailVisualizer.tsx` | Comet implementation |
+| `src/components/visualizers/WaveVisualizer.tsx` | Wave implementation |
+| `src/components/visualizers/GridWaveVisualizer.tsx` | Grid implementation |
+| `src/constants/visualizerDebugConfig.ts` | Default config values, types, merge function |
+| `src/contexts/VisualizerDebugContext.tsx` | Debug mode state, override persistence |
+| `src/components/VisualizerDebugPanel/index.tsx` | Debug panel UI |
+| `src/utils/visualizerUtils.ts` | `generateColorVariant()` color utility |
+| `src/components/AudioPlayer.tsx` | Renders `BackgroundVisualizer` with props from context |

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -60,7 +60,6 @@ const AudioPlayerComponent = () => {
     backgroundVisualizerIntensity,
     backgroundVisualizerSpeed,
     accentColorBackgroundEnabled,
-    zenModeEnabled,
     showVisualEffects,
     setShowVisualEffects,
   } = useVisualEffectsContext();
@@ -351,8 +350,6 @@ const AudioPlayerComponent = () => {
             speed={backgroundVisualizerSpeed}
             accentColor={accentColor}
             isPlaying={state.isPlaying}
-            playbackPosition={state.playbackPosition}
-            zenMode={zenModeEnabled}
           />
         </ProfiledComponent>
         {renderContent()}

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -20,8 +20,6 @@ interface BackgroundVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
   /** When style is 'comet', the trail head is constrained to this rect so it appears to come from the album art */
   albumArtBounds?: AlbumArtBounds | null;
 }
@@ -51,7 +49,6 @@ const VisualizerContainer = styled.div`
  * - intensity: Visualizer intensity (0-100)
  * - accentColor: Current track's accent color
  * - isPlaying: Whether music is currently playing
- * - playbackPosition: Current playback position in milliseconds (optional)
  */
 const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   enabled,
@@ -60,8 +57,6 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   speed,
   accentColor,
   isPlaying,
-  playbackPosition,
-  zenMode,
   albumArtBounds,
 }) => {
   const VisualizerComponent = useMemo(() => {
@@ -92,8 +87,6 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
         speed={speed ?? 1.0}
         accentColor={accentColor}
         isPlaying={isPlaying}
-        playbackPosition={playbackPosition}
-        zenMode={zenMode}
         {...(style === 'comet' && albumArtBounds != null ? { albumArtBounds } : {})}
       />
     </VisualizerContainer>

--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '../icons/QuickActionIcons';
 
 const AUTOHIDE_DELAY = 1000;
+const noop = () => {};
 
 interface BottomBarProps {
   zenModeEnabled?: boolean;
@@ -143,8 +144,8 @@ const BottomBar = React.memo(function BottomBar({
           <VolumeControl
             isMuted={isMuted}
             volume={volume}
-            onClick={onMuteToggle ?? (() => {})}
-            onVolumeChange={onVolumeChange ?? (() => {})}
+            onClick={onMuteToggle ?? noop}
+            onVolumeChange={onVolumeChange ?? noop}
             isMobile={isMobile}
             isTablet={isTablet}
           />

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 import { ZEN_BAR_DURATION } from '@/constants/zenAnimation';
 
 export const BOTTOM_BAR_HEIGHT = 60;
 
 export const BottomBarContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$hidden'].includes(prop),
+  shouldForwardProp: (prop) => prop !== '$hidden',
 })<{ $hidden?: boolean }>`
   position: fixed;
   bottom: 0;
@@ -28,12 +27,12 @@ export const BottomBarInner = styled.div`
   align-items: center;
   justify-content: center;
   gap: ${({ theme }) => theme.spacing.xs};
-  padding: ${({ theme }) => theme.spacing.xs} ${theme.spacing.md};
+  padding: ${({ theme }) => `${theme.spacing.xs} ${theme.spacing.md}`};
   height: ${BOTTOM_BAR_HEIGHT}px;
 `;
 
 export const ZenGripPill = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$visible'].includes(prop),
+  shouldForwardProp: (prop) => prop !== '$visible',
 })<{ $visible: boolean }>`
   width: 36px;
   height: 4px;
@@ -55,13 +54,13 @@ export const ZenTriggerZone = styled.div`
   left: 0;
   right: 0;
   height: 48px;
-  z-index: ${Number(theme.zIndex.mobileMenu) - 1};
+  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 1};
   background: transparent;
 `;
 
 export const ZenBackdrop = styled.div`
   position: fixed;
   inset: 0;
-  z-index: ${Number(theme.zIndex.mobileMenu) - 2};
+  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 2};
   background: transparent;
 `;

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -8,20 +8,18 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
 
-const QueueDrawerContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['isOpen', 'width', 'transitionDuration', 'transitionEasing'].includes(prop),
-}) <{ isOpen: boolean; width: number; transitionDuration: number; transitionEasing: string }>`
+const QueueDrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $transitionDuration: number; $transitionEasing: string }>`
   position: fixed;
   top: 0;
   right: 0;
-  width: ${({ width }) => width}px;
-  height: 100vh;
+  width: ${({ $width }) => $width}px;
+  height: 100dvh;
   background: ${theme.colors.overlay.dark};
   backdrop-filter: blur(${theme.drawer.backdropBlur});
   border-left: 1px solid ${theme.colors.popover.border};
-  transform: translateX(${props => props.isOpen ? '0' : '100%'});
-  transition: transform ${({ transitionDuration }) => transitionDuration}ms ${({ transitionEasing }) => transitionEasing},
-            width ${({ transitionDuration }) => transitionDuration}ms ${({ transitionEasing }) => transitionEasing};
+  transform: translateX(${props => props.$isOpen ? '0' : '100%'});
+  transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
+            width ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
   z-index: ${theme.zIndex.modal};
   overflow-y: auto;
   padding: ${theme.spacing.md};
@@ -69,18 +67,16 @@ const QueueContent = styled.div`
   }
 `;
 
-const QueueOverlay = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['isOpen'].includes(prop),
-}) <{ isOpen: boolean }>`
+const QueueOverlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   background: ${theme.colors.overlay.light};
   backdrop-filter: blur(2px);
-  opacity: ${props => props.isOpen ? 1 : 0};
-  visibility: ${props => props.isOpen ? 'visible' : 'hidden'};
+  opacity: ${props => props.$isOpen ? 1 : 0};
+  visibility: ${props => props.$isOpen ? 'visible' : 'hidden'};
   transition: all ${theme.drawer.transitionDuration}ms ${theme.drawer.transitionEasing};
   z-index: ${theme.zIndex.overlay};
 `;
@@ -238,15 +234,15 @@ const QueueDrawer = memo<QueueDrawerProps>(({
   return createPortal(
     <>
       <QueueOverlay
-        isOpen={isOpen}
+        $isOpen={isOpen}
         onClick={onClose}
       />
 
       <QueueDrawerContainer
-        isOpen={isOpen}
-        width={drawerWidth}
-        transitionDuration={transitionDuration}
-        transitionEasing={transitionEasing}
+        $isOpen={isOpen}
+        $width={drawerWidth}
+        $transitionDuration={transitionDuration}
+        $transitionEasing={transitionEasing}
       >
         <QueueHeader>
           <div>

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -210,7 +210,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         ref={itemRef}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
-        isSelected={isSelected}
+        $isSelected={isSelected}
         {...longPressHandlers}
         {...(isEditMode && onRemove ? { ...attributes, ...listeners } : {})}
         style={isEditMode && onRemove ? { cursor: isDragging ? 'grabbing' : 'grab', touchAction: 'none' } : undefined}
@@ -237,15 +237,15 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         </AlbumArtContainer>
 
         <TrackInfo>
-          <TrackName isSelected={isSelected}>
+          <TrackName $isSelected={isSelected}>
             {track.name}
           </TrackName>
-          <TrackArtist isSelected={isSelected}>
+          <TrackArtist $isSelected={isSelected}>
             {track.artists}
           </TrackArtist>
         </TrackInfo>
 
-        <Duration isSelected={isSelected}>
+        <Duration $isSelected={isSelected}>
           {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
         </Duration>
 
@@ -314,7 +314,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             if (!isEditMode) onSelect(index);
           }}
           onContextMenu={handleContextMenu}
-          isSelected={isSelected}
+          $isSelected={isSelected}
           {...longPressHandlers}
         >
           <AlbumArtContainer>
@@ -333,15 +333,15 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
           </AlbumArtContainer>
 
           <TrackInfo>
-            <TrackName isSelected={isSelected}>
+            <TrackName $isSelected={isSelected}>
               {track.name}
             </TrackName>
-            <TrackArtist isSelected={isSelected}>
+            <TrackArtist $isSelected={isSelected}>
               {track.artists}
             </TrackArtist>
           </TrackInfo>
 
-          <Duration isSelected={isSelected}>
+          <Duration $isSelected={isSelected}>
             {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
           </Duration>
 
@@ -383,7 +383,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             ref={itemRef}
             onClick={() => !isRevealed && !isEditMode && onSelect(index)}
             onContextMenu={handleContextMenu}
-            isSelected={isSelected}
+            $isSelected={isSelected}
             {...longPressHandlers}
           >
             <AlbumArtContainer>
@@ -401,15 +401,15 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             </AlbumArtContainer>
 
             <TrackInfo>
-              <TrackName isSelected={isSelected}>
+              <TrackName $isSelected={isSelected}>
                 {track.name}
               </TrackName>
-              <TrackArtist isSelected={isSelected}>
+              <TrackArtist $isSelected={isSelected}>
                 {track.artists}
               </TrackArtist>
             </TrackInfo>
 
-            <Duration isSelected={isSelected}>
+            <Duration $isSelected={isSelected}>
               {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
             </Duration>
 

--- a/src/components/QueueTrackList.styled.ts
+++ b/src/components/QueueTrackList.styled.ts
@@ -78,9 +78,7 @@ export const QueueListItems = styled.div`
   gap: ${({ theme }) => theme.spacing.sm};
 `;
 
-export const QueueListItem = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const QueueListItem = styled.div<{ $isSelected: boolean }>`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spacing.sm};
@@ -90,7 +88,7 @@ export const QueueListItem = styled.div.withConfig({
   transition: background 0.2s ease, border-color 0.2s ease;
   border: 1px solid transparent;
 
-  ${({ theme, isSelected }) => isSelected ? `
+  ${({ theme, $isSelected }) => $isSelected ? `
     background: color-mix(in srgb, var(--accent-color) 20%, transparent);
     border-color: var(--accent-color);
   ` : `
@@ -121,13 +119,11 @@ export const TrackInfo = styled.div`
   min-width: 0;
 `;
 
-export const TrackName = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const TrackName = styled.div<{ $isSelected: boolean }>`
   font-weight: ${({ theme }) => theme.fontWeight.semibold};
   font-size: ${({ theme }) => theme.fontSize.base};
   line-height: 1.25;
-  color: ${({ isSelected, theme }) => isSelected ? theme.colors.white : '#f5f5f5'};
+  color: ${({ $isSelected, theme }) => $isSelected ? theme.colors.white : '#f5f5f5'};
 
   /* Allow up to 2 lines with ellipsis on overflow */
   display: -webkit-box;
@@ -137,23 +133,19 @@ export const TrackName = styled.div.withConfig({
   word-break: break-word;
 `;
 
-export const TrackArtist = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const TrackArtist = styled.div<{ $isSelected: boolean }>`
   font-size: ${({ theme }) => theme.fontSize.sm};
   margin-top: ${({ theme }) => theme.spacing.xs};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: ${({ isSelected, theme }) => isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
+  color: ${({ $isSelected, theme }) => $isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
 `;
 
-export const Duration = styled.span.withConfig({
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>`
+export const Duration = styled.span<{ $isSelected: boolean }>`
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-family: monospace;
-  color: ${({ isSelected, theme }) => isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
+  color: ${({ $isSelected, theme }) => $isSelected ? 'var(--accent-color)' : theme.colors.gray[400]};
   flex-shrink: 0;
 `;
 

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -260,7 +260,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   key={`${track.name}-${track.id}`}
                   ref={index === currentTrackIndex ? currentTrackRef : undefined}
                   onClick={() => onTrackSelect(index)}
-                  isSelected={index === currentTrackIndex}
+                  $isSelected={index === currentTrackIndex}
                 >
                   <AlbumArtContainer>
                     <Avatar
@@ -288,15 +288,15 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   </AlbumArtContainer>
 
                   <TrackInfo>
-                    <TrackName isSelected={index === currentTrackIndex}>
+                    <TrackName $isSelected={index === currentTrackIndex}>
                       {track.name}
                     </TrackName>
-                    <TrackArtist isSelected={index === currentTrackIndex}>
+                    <TrackArtist $isSelected={index === currentTrackIndex}>
                       {track.artists}
                     </TrackArtist>
                   </TrackInfo>
 
-                  <Duration isSelected={index === currentTrackIndex}>
+                  <Duration $isSelected={index === currentTrackIndex}>
                     {track.durationMs ? formatDuration(track.durationMs) : '--:--'}
                   </Duration>
 

--- a/src/components/VisualEffectsMenu/ProviderDataSection.tsx
+++ b/src/components/VisualEffectsMenu/ProviderDataSection.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useCallback } from 'react';
 
 import type { CatalogProvider } from '@/types/providers';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
+import { useAsyncAction, FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
 
 import {
   ControlGroup,
@@ -11,36 +12,26 @@ import {
 import { CollapsibleSection } from './CollapsibleSection';
 
 export const ProviderDataSection = memo(({ providerName, catalog }: { providerName: string; catalog: CatalogProvider }) => {
-  const [artStatus, setArtStatus] = useState<'idle' | 'working' | 'done'>('idle');
-  const [likesStatus, setLikesStatus] = useState<'idle' | 'working' | 'done'>('idle');
   const [resultMessage, setResultMessage] = useState('');
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-
-  const artBusy = artStatus === 'working';
-  const likesBusy = likesStatus === 'working';
 
   const hasArtCache = !!catalog.clearArtCache;
   const hasRefreshArt = !!catalog.refreshArtCache;
   const hasLikesManagement = !!catalog.exportLikes && !!catalog.importLikes;
   const hasMetadataRefresh = !!catalog.refreshLikedMetadata;
 
-  const handleClearArt = async () => {
-    setArtStatus('working');
-    await catalog.clearArtCache?.();
-    setArtStatus('done');
-    setTimeout(() => setArtStatus('idle'), 1500);
-  };
+  const clearResultMessage = useCallback(() => setResultMessage(''), []);
 
-  const handleRefreshArt = async () => {
-    setArtStatus('working');
+  const clearArtFn = useCallback(async () => {
+    await catalog.clearArtCache?.();
+  }, [catalog]);
+
+  const refreshArtFn = useCallback(async () => {
     await catalog.refreshArtCache?.();
     window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
-    setArtStatus('done');
-    setTimeout(() => setArtStatus('idle'), 1500);
-  };
+  }, [catalog]);
 
-  const handleExport = async () => {
-    setLikesStatus('working');
+  const exportFn = useCallback(async () => {
     try {
       const json = await catalog.exportLikes!();
       const blob = new Blob([json], { type: 'application/json' });
@@ -54,28 +45,9 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
     } catch {
       setResultMessage('Export failed');
     }
-    setLikesStatus('done');
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 1500);
-  };
+  }, [catalog]);
 
-  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setLikesStatus('working');
-    try {
-      const json = await file.text();
-      const count = await catalog.importLikes!(json);
-      setResultMessage(`Imported ${count} tracks`);
-    } catch {
-      setResultMessage('Import failed');
-    }
-    setLikesStatus('done');
-    if (fileInputRef.current) fileInputRef.current.value = '';
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 2000);
-  };
-
-  const handleRefreshMetadata = async () => {
-    setLikesStatus('working');
+  const refreshMetadataFn = useCallback(async () => {
     try {
       const result = await catalog.refreshLikedMetadata!();
       const parts: string[] = [];
@@ -85,25 +57,48 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
     } catch {
       setResultMessage('Refresh failed');
     }
-    setLikesStatus('done');
-    setTimeout(() => { setLikesStatus('idle'); setResultMessage(''); }, 2000);
-  };
+  }, [catalog]);
+
+  const [clearArtStatus, runClearArt] = useAsyncAction(clearArtFn);
+  const [refreshArtStatus, runRefreshArt] = useAsyncAction(refreshArtFn);
+  const [exportStatus, runExport] = useAsyncAction(exportFn, { onReset: clearResultMessage });
+  const [metadataStatus, runRefreshMetadata] = useAsyncAction(refreshMetadataFn, { onReset: clearResultMessage });
+  const [importStatus, setImportStatus] = useState<'idle' | 'working' | 'done'>('idle');
+
+  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportStatus('working');
+    try {
+      const json = await file.text();
+      const count = await catalog.importLikes!(json);
+      setResultMessage(`Imported ${count} tracks`);
+    } catch {
+      setResultMessage('Import failed');
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setImportStatus('done');
+    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, FEEDBACK_DISPLAY_MS);
+  }, [catalog]);
+
+  const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';
+  const likesBusy = exportStatus === 'working' || importStatus === 'working' || metadataStatus === 'working';
 
   return (
     <CollapsibleSection title={`${providerName} Data`}>
       {hasArtCache && (
         <ControlGroup>
           <ControlLabel>Clear cached art so it re-downloads on next library load</ControlLabel>
-          <ResetButton onClick={handleClearArt} disabled={artBusy}>
-            {artStatus === 'done' ? 'Cleared!' : artBusy ? 'Working...' : 'Clear Art Cache'}
+          <ResetButton onClick={runClearArt} disabled={artBusy}>
+            {clearArtStatus === 'done' ? 'Cleared!' : artBusy ? 'Working...' : 'Clear Art Cache'}
           </ResetButton>
         </ControlGroup>
       )}
       {hasRefreshArt && (
         <ControlGroup>
           <ControlLabel>Clear and immediately re-fetch fresh art in the background</ControlLabel>
-          <ResetButton onClick={handleRefreshArt} disabled={artBusy}>
-            {artStatus === 'done' ? 'Started!' : artBusy ? 'Working...' : 'Refresh Art'}
+          <ResetButton onClick={runRefreshArt} disabled={artBusy}>
+            {refreshArtStatus === 'done' ? 'Started!' : artBusy ? 'Working...' : 'Refresh Art'}
           </ResetButton>
         </ControlGroup>
       )}
@@ -111,8 +106,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
         <>
           <ControlGroup>
             <ControlLabel>Export liked songs to a JSON file for backup</ControlLabel>
-            <ResetButton onClick={handleExport} disabled={likesBusy}>
-              {likesStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working...' : 'Export Likes'}
+            <ResetButton onClick={runExport} disabled={likesBusy}>
+              {exportStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working...' : 'Export Likes'}
             </ResetButton>
           </ControlGroup>
           <ControlGroup>
@@ -125,7 +120,7 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
               style={{ display: 'none' }}
             />
             <ResetButton onClick={() => fileInputRef.current?.click()} disabled={likesBusy}>
-              {likesStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working...' : 'Import Likes'}
+              {importStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working...' : 'Import Likes'}
             </ResetButton>
           </ControlGroup>
         </>
@@ -133,8 +128,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       {hasMetadataRefresh && (
         <ControlGroup>
           <ControlLabel>Re-scan {providerName} to update metadata for liked tracks</ControlLabel>
-          <ResetButton onClick={handleRefreshMetadata} disabled={likesBusy}>
-            {likesStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning...' : 'Refresh Metadata'}
+          <ResetButton onClick={runRefreshMetadata} disabled={likesBusy}>
+            {metadataStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning...' : 'Refresh Metadata'}
           </ResetButton>
         </ControlGroup>
       )}

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -26,6 +26,8 @@ import {
   CacheCancelButton,
 } from './styled';
 
+import { FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
+
 import { MusicSourcesSection, NativeQueueSyncSection } from './SourcesSections';
 import { ProviderDataSection } from './ProviderDataSection';
 import { CollapsibleSection } from './CollapsibleSection';
@@ -110,7 +112,7 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
     setClearLikes(false);
     setClearPins(false);
     setClearAccentColors(false);
-    setTimeout(() => setClearState('idle'), 1500);
+    setTimeout(() => setClearState('idle'), FEEDBACK_DISPLAY_MS);
   }, [onClearCache, clearLikes, clearPins, clearAccentColors]);
 
   return createPortal(

--- a/src/components/VisualEffectsMenu/styled.ts
+++ b/src/components/VisualEffectsMenu/styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { theme } from '../../styles/theme';
 
 export const DrawerOverlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
@@ -7,13 +6,13 @@ export const DrawerOverlay = styled.div<{ $isOpen: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background: ${theme.colors.overlay.light};
-  z-index: ${theme.zIndex.overlay};
+  background: ${({ theme }) => theme.colors.overlay.light};
+  z-index: ${({ theme }) => theme.zIndex.overlay};
   opacity: ${({ $isOpen }) => ($isOpen ? '1' : '0')};
   visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
   pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
-  transition: opacity ${theme.drawer.transitionDuration}ms ${theme.drawer.transitionEasing},
-            visibility ${theme.drawer.transitionDuration}ms ${theme.drawer.transitionEasing};
+  transition: opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
+            visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
 `;
 
 export const DrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $transitionDuration: number; $transitionEasing: string }>`
@@ -23,15 +22,15 @@ export const DrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $t
   bottom: 0;
   width: ${({ $width }) => $width}px;
   max-width: 95vw;
-  background: ${theme.colors.overlay.dark};
-  backdrop-filter: blur(${theme.drawer.backdropBlur});
-  border-left: 1px solid ${theme.colors.popover.border};
+  background: ${({ theme }) => theme.colors.overlay.dark};
+  backdrop-filter: blur(${({ theme }) => theme.drawer.backdropBlur});
+  border-left: 1px solid ${({ theme }) => theme.colors.popover.border};
   transform: translateX(${({ $isOpen }) => ($isOpen ? '0' : '100%')});
   visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
   transition: transform ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
             visibility ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing},
             width ${({ $transitionDuration }) => $transitionDuration}ms ${({ $transitionEasing }) => $transitionEasing};
-  z-index: ${theme.zIndex.modal};
+  z-index: ${({ theme }) => theme.zIndex.modal};
   overflow-y: auto;
   overflow-x: hidden;
 
@@ -40,22 +39,22 @@ export const DrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $t
   container-name: visual-effects;
 
   /* Container query responsive adjustments */
-  @container visual-effects (max-width: ${theme.drawer.breakpoints.mobile}) {
-    width: ${theme.drawer.widths.mobile};
+  @container visual-effects (max-width: ${({ theme }) => theme.drawer.breakpoints.mobile}) {
+    width: ${({ theme }) => theme.drawer.widths.mobile};
   }
 
-  @container visual-effects (min-width: ${theme.drawer.breakpoints.mobile}) and (max-width: ${theme.drawer.breakpoints.tablet}) {
-    width: ${theme.drawer.widths.tablet};
+  @container visual-effects (min-width: ${({ theme }) => theme.drawer.breakpoints.mobile}) and (max-width: ${({ theme }) => theme.drawer.breakpoints.tablet}) {
+    width: ${({ theme }) => theme.drawer.widths.tablet};
   }
 
-  @container visual-effects (min-width: ${theme.drawer.breakpoints.tablet}) {
-    width: ${theme.drawer.widths.desktop};
+  @container visual-effects (min-width: ${({ theme }) => theme.drawer.breakpoints.tablet}) {
+    width: ${({ theme }) => theme.drawer.widths.desktop};
   }
 
   /* Fallback for browsers without container query support */
   @supports not (container-type: inline-size) {
-    @media (max-width: ${theme.breakpoints.md}) {
-      width: ${theme.drawer.widths.mobile};
+    @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+      width: ${({ theme }) => theme.drawer.widths.mobile};
     }
   }
 `;
@@ -64,7 +63,7 @@ export const DrawerHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: calc(${theme.spacing.lg} + env(safe-area-inset-top, 0px)) ${theme.spacing.lg} ${theme.spacing.md};
+  padding: calc(${({ theme }) => theme.spacing.lg} + env(safe-area-inset-top, 0px)) ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.md};
   border-bottom: 1px solid ${({ theme }) => theme.colors.popover.border};
   min-height: 60px;
   flex-shrink: 0; /* Prevent header from shrinking */
@@ -80,15 +79,15 @@ export const DrawerTitle = styled.h3`
 export const CloseButton = styled.button`
   background: none;
   border: none;
-  color: ${theme.colors.muted.foreground};
+  color: ${({ theme }) => theme.colors.muted.foreground};
   cursor: pointer;
-  padding: ${theme.spacing.sm};
-  border-radius: ${theme.borderRadius.md};
+  padding: ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
   transition: all ${({ theme }) => theme.transitions.fast} ease;
 
   &:hover {
-    color: ${theme.colors.white};
-    background: ${theme.colors.muted.background};
+    color: ${({ theme }) => theme.colors.white};
+    background: ${({ theme }) => theme.colors.muted.background};
   }
 
   svg {
@@ -98,7 +97,7 @@ export const CloseButton = styled.button`
 `;
 
 export const DrawerContent = styled.div`
-  padding: ${({ theme }) => theme.spacing.md} ${theme.spacing.lg} ${theme.spacing.lg};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.lg};
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing.md};
@@ -188,7 +187,7 @@ export const ResetButton = styled.button`
   background: ${({ theme }) => theme.colors.control.background};
   border: 1px solid ${({ theme }) => theme.colors.border};
   color: ${({ theme }) => theme.colors.muted.foreground};
-  padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   cursor: pointer;
   font-size: ${({ theme }) => theme.fontSize.sm};
@@ -220,15 +219,15 @@ export const ProviderRow = styled.div`
 
 export const ProviderName = styled.span`
   font-size: 0.8125rem;
-  font-weight: ${theme.fontWeight.medium};
-  color: ${theme.colors.white};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  color: ${({ theme }) => theme.colors.white};
   flex-shrink: 0;
 `;
 
 export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'expired' | 'disabled' }>`
   font-size: 0.6875rem;
-  font-weight: ${theme.fontWeight.medium};
-  color: ${({ $status }) =>
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  color: ${({ $status, theme }) =>
     $status === 'connected'
       ? theme.colors.success
       : $status === 'expired'
@@ -243,12 +242,12 @@ export const ProviderConnectAction = styled.button`
   padding: 0;
   color: var(--accent-color);
   font-size: 0.6875rem;
-  font-weight: ${theme.fontWeight.semibold};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
   text-transform: uppercase;
   letter-spacing: 0.04em;
   cursor: pointer;
   flex-shrink: 0;
-  transition: opacity ${theme.transitions.fast};
+  transition: opacity ${({ theme }) => theme.transitions.fast};
 
   &:hover {
     opacity: 0.8;
@@ -319,7 +318,7 @@ export const CacheCancelButton = styled.button`
   background: ${({ theme }) => theme.colors.control.background};
   border: 1px solid ${({ theme }) => theme.colors.border};
   color: ${({ theme }) => theme.colors.muted.foreground};
-  padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   cursor: pointer;
   font-size: ${({ theme }) => theme.fontSize.sm};
@@ -336,21 +335,21 @@ export const CacheCancelButton = styled.button`
 `;
 
 export const OptionButton = styled.button<{ $isActive: boolean }>`
-  background: ${({ $isActive }) => $isActive ? 'var(--accent-color)' : theme.colors.muted.background};
-  border: 1px solid ${({ $isActive }) => $isActive ? 'var(--accent-color)' : theme.colors.border};
-  color: ${({ $isActive }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.muted.foreground};
+  background: ${({ $isActive, theme }) => $isActive ? 'var(--accent-color)' : theme.colors.muted.background};
+  border: 1px solid ${({ $isActive, theme }) => $isActive ? 'var(--accent-color)' : theme.colors.border};
+  color: ${({ $isActive, theme }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.muted.foreground};
   padding: 0.375rem 0.75rem;
-  border-radius: ${theme.borderRadius.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
   font-size: 0.75rem;
-  font-weight: ${theme.fontWeight.medium};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
   transition: all ${({ theme }) => theme.transitions.fast} ease;
   min-width: 60px;
 
   &:hover {
     background: ${({ $isActive }) => $isActive ? 'color-mix(in srgb, var(--accent-color) 87%, transparent)' : 'color-mix(in srgb, var(--accent-color) 13%, transparent)'};
     border-color: var(--accent-color);
-    color: ${({ $isActive }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.white};
+    color: ${({ $isActive, theme }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.white};
     transform: translateY(-1px);
   }
 `;

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -44,6 +44,7 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
     isMobile: false,
     isTablet: false,
     isDesktop: true,
+    isTouchDevice: false,
     hasPointerInput: true,
     viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
     dimensions: { width: 600, height: 600 },

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import BottomBar from '../BottomBar';
 import { TestWrapper } from '@/test/testWrappers';
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 vi.mock('@/services/spotifyPlayer', () => ({
   spotifyPlayer: {
@@ -38,17 +39,19 @@ vi.mock('@/services/spotify', () => ({
   getUserLibraryInterleaved: vi.fn(),
 }));
 
+const mockSizingContext = {
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  isTouchDevice: false,
+  hasPointerInput: true,
+  viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
+  dimensions: { width: 600, height: 600 },
+};
+
 vi.mock('@/contexts/PlayerSizingContext', () => ({
   PlayerSizingProvider: ({ children }: { children: React.ReactNode }) => children,
-  usePlayerSizingContext: vi.fn(() => ({
-    isMobile: false,
-    isTablet: false,
-    isDesktop: true,
-    isTouchDevice: false,
-    hasPointerInput: true,
-    viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
-    dimensions: { width: 600, height: 600 },
-  })),
+  usePlayerSizingContext: vi.fn(() => mockSizingContext),
 }));
 
 const defaultProps = {
@@ -163,5 +166,280 @@ describe('BottomBar', () => {
 
     // #then — zen mode adds one extra element (ZenTriggerZone)
     expect(zenCount).toBe(normalCount + 1);
+  });
+});
+
+describe('BottomBar — zen mode show/hide state machine', () => {
+  const AUTOHIDE_DELAY = 1000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('bar initializes as hidden when zen mode is already enabled', () => {
+    // #given — zen mode is on from the start; useEffect fires startHideTimer immediately
+    renderBottomBar({ zenModeEnabled: true });
+
+    // #when — autohide delay elapses
+    act(() => {
+      vi.advanceTimersByTime(AUTOHIDE_DELAY);
+    });
+
+    // #then — trigger zone is present (zen mode on) and backdrop is absent (bar hidden)
+    const portalChildren = Array.from(document.body.children);
+    const backdrop = portalChildren.find(
+      (el) => el.tagName === 'DIV' && el.getAttribute('style')?.includes('inset')
+    );
+    expect(backdrop).toBeUndefined();
+  });
+
+  it('trigger zone is rendered only when zen mode is enabled', () => {
+    // #given
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    const countWithoutZen = document.body.childElementCount;
+
+    // #when
+    rerender(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    // #then — one extra portal child (ZenTriggerZone) is added
+    expect(document.body.childElementCount).toBe(countWithoutZen + 1);
+  });
+
+  it('bar re-appears when zen mode is disabled after being enabled', () => {
+    // #given — start in zen mode and let the bar auto-hide
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(AUTOHIDE_DELAY);
+    });
+
+    const countWhileZen = document.body.childElementCount;
+
+    // #when — zen mode is turned off
+    rerender(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    // #then — trigger zone is gone, portal has fewer children again
+    expect(document.body.childElementCount).toBe(countWhileZen - 1);
+
+    // bar buttons are accessible (bar is not hidden)
+    expect(screen.getByTitle('App settings')).toBeTruthy();
+  });
+
+  it('bar hides after autohide delay following zen mode enable', () => {
+    // #given — zen disabled initially (bar visible); transitioning to zen on starts the timer
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    // #when — toggle zen mode on
+    rerender(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    const countBeforeTimeout = document.body.childElementCount;
+
+    // advance past the autohide delay
+    act(() => {
+      vi.advanceTimersByTime(AUTOHIDE_DELAY);
+    });
+
+    // #then — the number of portal children is unchanged (bar stays in DOM but hidden)
+    // and no new ZenBackdrop appeared (bar not visible on touch device path)
+    expect(document.body.childElementCount).toBe(countBeforeTimeout);
+  });
+
+  it('mouseenter on the bar container cancels the hide timer', () => {
+    // #given — zen mode on, bar is visible, hide timer is running
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    // BottomBarContainer is always the last direct child of document.body (portal renders it last)
+    const barContainer = document.body.lastElementChild as HTMLElement;
+
+    // #when — mouse enters the bar before the timer fires
+    act(() => { fireEvent.mouseEnter(barContainer); });
+
+    act(() => {
+      vi.advanceTimersByTime(AUTOHIDE_DELAY * 2);
+    });
+
+    // #then — bar is still visible (buttons are reachable)
+    expect(screen.getByTitle('App settings')).toBeTruthy();
+  });
+
+  it('mouseleave on the bar container restarts the hide timer', () => {
+    // #given — zen mode on, mouse entered (timer cancelled)
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
+        </TestWrapper>
+      </ThemeProvider>
+    );
+
+    const barContainer = document.body.lastElementChild as HTMLElement;
+
+    act(() => { fireEvent.mouseEnter(barContainer); });
+    act(() => { vi.advanceTimersByTime(AUTOHIDE_DELAY * 2); });
+
+    // bar is still visible after hovering
+    const countBeforeLeave = document.body.childElementCount;
+
+    // #when — mouse leaves the bar
+    act(() => { fireEvent.mouseLeave(barContainer); });
+
+    // advance past autohide delay
+    act(() => { vi.advanceTimersByTime(AUTOHIDE_DELAY); });
+
+    // #then — portal structure unchanged (bar hidden via CSS, still in DOM)
+    expect(document.body.childElementCount).toBe(countBeforeLeave);
+  });
+
+  it('mouseenter on the trigger zone shows the bar on non-touch device', () => {
+    // #given — zen mode on, bar has auto-hidden after timeout
+    renderBottomBar({ zenModeEnabled: true });
+
+    act(() => { vi.advanceTimersByTime(AUTOHIDE_DELAY); });
+
+    // portal structure: [RTL-container, ZenTriggerZone, BottomBarContainer]
+    // ZenTriggerZone is the second-to-last body child
+    const getBodyChildren = () => Array.from(document.body.children) as HTMLElement[];
+    const triggerZone = getBodyChildren()[getBodyChildren().length - 2];
+
+    // #when — non-touch device hovers over trigger zone (showBar fires for pointer devices)
+    act(() => { fireEvent.mouseEnter(triggerZone); });
+
+    // #then — bar is visible again; no backdrop is added on desktop (DOM count unchanged)
+    expect(screen.getByTitle('App settings')).toBeTruthy();
+  });
+
+  it('backdrop appears when bar is shown on touch device', () => {
+    // #given — touch device, zen mode on
+    vi.mocked(usePlayerSizingContext).mockReturnValue({
+      ...mockSizingContext,
+      isTouchDevice: true,
+    });
+
+    renderBottomBar({ zenModeEnabled: true });
+
+    // barVisible starts false (= !zenModeEnabled); portal has: [RTL-div, ZenTriggerZone, BottomBarContainer]
+    const countHidden = document.body.childElementCount;
+
+    // ZenTriggerZone is second-to-last (BottomBarContainer is last)
+    const getBodyChildren = () => Array.from(document.body.children) as HTMLElement[];
+    const triggerZone = getBodyChildren()[getBodyChildren().length - 2];
+
+    // #when — touch tap on trigger zone toggles bar visible
+    act(() => { fireEvent.touchStart(triggerZone); });
+
+    // #then — ZenBackdrop is inserted before ZenTriggerZone, so count increases by 1
+    expect(document.body.childElementCount).toBe(countHidden + 1);
+  });
+
+  it('backdrop click dismisses the bar on touch device', () => {
+    // #given — touch device, zen mode on, bar visible (backdrop present)
+    vi.mocked(usePlayerSizingContext).mockReturnValue({
+      ...mockSizingContext,
+      isTouchDevice: true,
+    });
+
+    renderBottomBar({ zenModeEnabled: true });
+
+    const getBodyChildren = () => Array.from(document.body.children) as HTMLElement[];
+    const triggerZone = getBodyChildren()[getBodyChildren().length - 2];
+
+    // show the bar via touch tap
+    act(() => { fireEvent.touchStart(triggerZone); });
+    const countWithBackdrop = document.body.childElementCount;
+
+    // backdrop is now the second body child (after RTL-div, before ZenTriggerZone)
+    const backdrop = getBodyChildren()[1];
+
+    // #when — user taps the backdrop to dismiss
+    act(() => { fireEvent.click(backdrop); });
+
+    // #then — backdrop is removed, count drops by 1
+    expect(document.body.childElementCount).toBe(countWithBackdrop - 1);
+  });
+
+  it('touch toggle: second tap hides bar and removes backdrop', () => {
+    // #given — touch device, zen mode on
+    vi.mocked(usePlayerSizingContext).mockReturnValue({
+      ...mockSizingContext,
+      isTouchDevice: true,
+    });
+
+    renderBottomBar({ zenModeEnabled: true });
+
+    const getBodyChildren = () => Array.from(document.body.children) as HTMLElement[];
+    const triggerZone = () => getBodyChildren()[getBodyChildren().length - 2];
+
+    // first tap shows bar and adds backdrop
+    act(() => { fireEvent.touchStart(triggerZone()); });
+    const countAfterShow = document.body.childElementCount;
+
+    // #when — second tap toggles bar hidden again
+    act(() => { fireEvent.touchStart(triggerZone()); });
+
+    // #then — backdrop is removed
+    expect(document.body.childElementCount).toBe(countAfterShow - 1);
   });
 });

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -158,32 +158,12 @@ export const ControlButton = styled.button.withConfig({
   cursor: pointer;
   touch-action: manipulation; /* Remove 300ms tap delay on iOS */
   transition: all 0.2s ease;
-  padding: ${({ $isMobile, $isTablet, $compact, theme }) => {
-    if ($compact) return theme.spacing.sm;
-    if ($isMobile) return theme.spacing.sm;
-    if ($isTablet) return theme.spacing.sm;
-    return theme.spacing.sm;
-  }};
-  border-radius: ${({ $isMobile, $isTablet, $compact, theme }) => {
-    if ($compact) return theme.borderRadius.md;
-    if ($isMobile) return theme.borderRadius.md;
-    if ($isTablet) return theme.borderRadius.md;
-    return theme.borderRadius.md;
-  }};
+  padding: ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
 
   svg {
-    width: ${({ $isMobile, $isTablet, $compact }) => {
-    if ($compact) return '1.5rem';
-    if ($isMobile) return '1.5rem';
-    if ($isTablet) return '1.5rem';
-    return '1.5rem';
-  }};
-    height: ${({ $isMobile, $isTablet, $compact }) => {
-    if ($compact) return '1.5rem';
-    if ($isMobile) return '1.5rem';
-    if ($isTablet) return '1.5rem';
-    return '1.5rem';
-  }};
+    width: 1.5rem;
+    height: 1.5rem;
     fill: currentColor;
   }
 

--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -5,14 +5,7 @@ export const QueueIcon = () => (
 );
 
 export const VisualEffectsIcon = () => (
-  <svg
-    viewBox="0 0 24 24"
-    style={{ display: 'block' }}
-    width="1.5rem"
-    height="1.5rem"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       fill="currentColor"
       fillRule="evenodd"

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -166,24 +166,6 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     [g]
   );
 
-  const handleColorChange = useCallback(
-    (states: GridWaveState[], color: string): void => {
-      const state = states[0];
-      if (!state) return;
-      const spacing = state.width < 768 ? g.spacingMobile : g.spacing;
-      const cols = Math.ceil(state.width / spacing) + 1;
-      const rows = Math.ceil(state.height / spacing) + 1;
-      const centerX = (cols - 1) * spacing / 2;
-      state.particles.forEach(particle => {
-        const edgeFactor = Math.abs(particle.baseX - centerX) / Math.max(1, centerX);
-        const depthFactor = particle.gridY / Math.max(1, rows - 1);
-        const intensityFactor = edgeFactor * g.edgeIntensity + depthFactor * (1 - g.edgeIntensity);
-        particle.color = generateColorVariant(color, 0.3 + intensityFactor * 0.5);
-      });
-    },
-    [g]
-  );
-
   const canvasRef = useCanvasVisualizer<GridWaveState>({
     accentColor,
     isPlaying,
@@ -192,7 +174,6 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     initializeItems,
     updateItems,
     renderItems,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -8,8 +8,6 @@ interface GridWaveVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface GridParticle {

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -120,12 +120,6 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     });
   }, []);
 
-  const handleColorChange = useCallback((particles: Particle[], color: string) => {
-    particles.forEach(particle => {
-      particle.color = generateColorVariant(color, Math.random() * 0.5 + 0.3);
-    });
-  }, []);
-
   const canvasRef = useCanvasVisualizer<Particle>({
     accentColor,
     isPlaying,
@@ -134,7 +128,6 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
     initializeItems: initializeParticles,
     updateItems: updateParticles,
     renderItems: renderParticles,
-    onColorChange: handleColorChange
   });
 
   return (

--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -8,8 +8,6 @@ interface ParticleVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface Particle {

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -227,12 +227,6 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     }
   }, [t]);
 
-  const handleColorChange = useCallback((particles: TrailParticle[], color: string) => {
-    particles.forEach(particle => {
-      particle.color = generateColorVariant(color, Math.random() * 0.5 + 0.3);
-    });
-  }, []);
-
   const canvasRef = useCanvasVisualizer<TrailParticle>({
     accentColor,
     isPlaying,
@@ -241,7 +235,6 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
     initializeItems: initializeParticles,
     updateItems: updateParticles,
     renderItems: renderParticles,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -15,8 +15,6 @@ interface TrailVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
   /** When set, the trail head (ship) stays inside this rect so the trail appears to come from the album art */
   albumArtBounds?: AlbumArtBounds | null;
 }

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -117,17 +117,6 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
     []
   );
 
-  const handleColorChange = useCallback(
-    (waves: Wave[], color: string): void => {
-      const count = waves.length;
-      waves.forEach((wave, i) => {
-        const layerRatio = i / Math.max(1, count - 1);
-        wave.color = generateColorVariant(color, 0.2 + layerRatio * 0.6);
-      });
-    },
-    []
-  );
-
   const canvasRef = useCanvasVisualizer<Wave>({
     accentColor,
     isPlaying,
@@ -136,7 +125,6 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
     initializeItems,
     updateItems,
     renderItems,
-    onColorChange: handleColorChange,
   });
 
   return (

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -8,8 +8,6 @@ interface WaveVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
-  playbackPosition?: number;
-  zenMode?: boolean;
 }
 
 interface Wave {

--- a/src/constants/spotify.ts
+++ b/src/constants/spotify.ts
@@ -1,0 +1,20 @@
+/**
+ * Spotify API, SDK, and playback constants
+ * Shared across provider and service implementations
+ */
+
+// Retry and backoff behavior
+export const SPOTIFY_MAX_RETRIES = 5;
+export const SPOTIFY_BASE_BACKOFF_MS = 1000;
+export const SPOTIFY_TRANSFER_RETRY_COUNT = 2;
+
+// Rate limiting
+export const SPOTIFY_RATE_LIMIT_WAIT_S = 5;
+
+// SDK loading
+export const SPOTIFY_SDK_LOAD_TIMEOUT_MS = 10000;
+
+// Playback timing
+export const SPOTIFY_RESUME_TIMEOUT_MS = 3000;
+export const SPOTIFY_INITIAL_RETRY_DELAY_MS = 300;
+export const SPOTIFY_INITIAL_VOLUME = 0.5;

--- a/src/contexts/__tests__/VisualEffectsContext.test.tsx
+++ b/src/contexts/__tests__/VisualEffectsContext.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { VisualEffectsProvider, useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  isProfilingEnabled: () => false,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <VisualEffectsProvider>{children}</VisualEffectsProvider>;
+}
+
+describe('VisualEffectsContext', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+    vi.mocked(window.localStorage.removeItem).mockClear();
+    vi.mocked(window.localStorage.setItem).mockClear();
+  });
+
+  describe('visualizer style migration', () => {
+    it("migrates 'particles' to 'fireflies' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'particles';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'fireflies',
+      );
+    });
+
+    it("migrates 'trail' to 'comet' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'trail';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'comet',
+      );
+    });
+
+    it("migrates 'geometric' to 'fireflies' on mount", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return 'geometric';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        'fireflies',
+      );
+    });
+
+    it("leaves a valid style unchanged — 'fireflies' is not remapped", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return '"fireflies"';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then — setItem should only have been called for ALBUM_FILTERS removal, not for BG_VISUALIZER_STYLE
+      const styleSetCalls = vi.mocked(window.localStorage.setItem).mock.calls.filter(
+        ([key]) => key === STORAGE_KEYS.BG_VISUALIZER_STYLE,
+      );
+      expect(styleSetCalls).toHaveLength(0);
+    });
+
+    it("leaves a valid style unchanged — 'comet' is not remapped", () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.BG_VISUALIZER_STYLE) return '"comet"';
+        return null;
+      });
+
+      // #when
+      renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      const styleSetCalls = vi.mocked(window.localStorage.setItem).mock.calls.filter(
+        ([key]) => key === STORAGE_KEYS.BG_VISUALIZER_STYLE,
+      );
+      expect(styleSetCalls).toHaveLength(0);
+    });
+  });
+
+  describe('context defaults', () => {
+    it('exposes default backgroundVisualizerStyle of fireflies when no value is stored', () => {
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.backgroundVisualizerStyle).toBe('fireflies');
+    });
+
+    it('exposes default visualEffectsEnabled of true', () => {
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.visualEffectsEnabled).toBe(true);
+    });
+
+    it('disables accentColorBackgroundEnabled when visualEffectsEnabled is false', () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.VISUAL_EFFECTS_ENABLED) return 'false';
+        if (key === STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED) return 'true';
+        return null;
+      });
+
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.accentColorBackgroundEnabled).toBe(false);
+    });
+
+    it('sets accentColorBackgroundEnabled based on preference when visual effects are on', () => {
+      // #given
+      vi.mocked(window.localStorage.getItem).mockImplementation((key) => {
+        if (key === STORAGE_KEYS.VISUAL_EFFECTS_ENABLED) return 'true';
+        if (key === STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED) return 'true';
+        return null;
+      });
+
+      // #when
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #then
+      expect(result.current.accentColorBackgroundEnabled).toBe(true);
+    });
+  });
+
+  describe('setters', () => {
+    it('updates backgroundVisualizerStyle and persists to localStorage', () => {
+      // #given
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #when
+      act(() => {
+        result.current.setBackgroundVisualizerStyle('wave');
+      });
+
+      // #then
+      expect(result.current.backgroundVisualizerStyle).toBe('wave');
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.BG_VISUALIZER_STYLE,
+        expect.stringContaining('wave'),
+      );
+    });
+
+    it('updates zenModeEnabled and persists to localStorage', () => {
+      // #given
+      const { result } = renderHook(() => useVisualEffectsContext(), { wrapper });
+
+      // #when
+      act(() => {
+        result.current.setZenModeEnabled(true);
+      });
+
+      // #then
+      expect(result.current.zenModeEnabled).toBe(true);
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ZEN_MODE_ENABLED,
+        'true',
+      );
+    });
+  });
+
+  describe('useVisualEffectsContext guard', () => {
+    it('throws when used outside VisualEffectsProvider', () => {
+      // #when / #then
+      expect(() => renderHook(() => useVisualEffectsContext())).toThrow(
+        'useVisualEffectsContext must be used within VisualEffectsProvider',
+      );
+    });
+  });
+});

--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -1,168 +1,142 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useLocalStorage } from '../useLocalStorage';
-
-// Mock localStorage since it's not available in all test environments
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-
-  return {
-    getItem: (key: string) => store[key] || null,
-    setItem: (key: string, value: string) => {
-      store[key] = value.toString();
-    },
-    removeItem: (key: string) => {
-      delete store[key];
-    },
-    clear: () => {
-      store = {};
-    }
-  };
-})();
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 describe('useLocalStorage', () => {
   beforeEach(() => {
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-      writable: true
-    });
-    localStorageMock.clear();
-    vi.clearAllMocks();
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
   });
 
-  afterEach(() => {
-    localStorageMock.clear();
-  });
-
-  it('should initialize with the provided initial value when localStorage is empty', () => {
+  it('returns the initial value when localStorage has no entry for the key', () => {
+    // #when
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
-    const [value] = result.current;
-    expect(value).toBe('initial');
+
+    // #then
+    expect(result.current[0]).toBe('initial');
   });
 
-  it('should read value from localStorage on initialization', () => {
-    localStorageMock.setItem('test-key', JSON.stringify('stored-value'));
+  it('returns the stored value when localStorage has data for the key', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify('stored-value'));
+
+    // #when
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
-    const [value] = result.current;
-    expect(value).toBe('stored-value');
+
+    // #then
+    expect(result.current[0]).toBe('stored-value');
   });
 
-  it('should update localStorage when value changes', () => {
+  it('writes to localStorage when setValue is called with a direct value', () => {
     // #given
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
 
-    // #when - update value to 'updated'
+    // #when
     act(() => {
-      const [, setValue] = result.current;
-      setValue('updated');
+      result.current[1]('updated');
     });
 
     // #then
-    const storedValue = localStorageMock.getItem('test-key');
-    expect(storedValue).toBe(JSON.stringify('updated'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('test-key', JSON.stringify('updated'));
+    expect(result.current[0]).toBe('updated');
   });
 
-  it('should support function updates like useState', () => {
+  it('writes to localStorage when setValue is called with an updater function', () => {
     // #given
+    vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(10));
     const { result } = renderHook(() => useLocalStorage('counter', 0));
 
-    // #when - increment counter using function update
+    // #when
     act(() => {
-      const [, setValue] = result.current;
-      setValue(prev => prev + 1);
+      result.current[1]((prev) => prev + 5);
     });
 
     // #then
-    expect(result.current[0]).toBe(1);
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('counter', JSON.stringify(15));
+    expect(result.current[0]).toBe(15);
   });
 
-  it('should handle complex objects', () => {
+  it('falls back to the initial value and warns when stored JSON is malformed', () => {
     // #given
-    const initialObj = { name: 'test', values: [1, 2, 3] };
-    const { result } = renderHook(() => useLocalStorage('obj-key', initialObj));
+    vi.mocked(window.localStorage.getItem).mockReturnValue('not-valid-json{{');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    // #when - update object to new values
-    act(() => {
-      const [, setValue] = result.current;
-      setValue({ name: 'updated', values: [4, 5, 6] });
-    });
-
-    // #then
-    const [value] = result.current;
-    expect(value).toEqual({ name: 'updated', values: [4, 5, 6] });
-    expect(localStorageMock.getItem('obj-key')).toBe(JSON.stringify({ name: 'updated', values: [4, 5, 6] }));
-  });
-
-  it('should handle JSON parse errors gracefully', () => {
-    // #given - store invalid JSON
-    localStorageMock.setItem('bad-json', 'not-valid-json');
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    // #when - initialize with bad JSON key
+    // #when
     const { result } = renderHook(() => useLocalStorage('bad-json', 'fallback'));
-    const [value] = result.current;
 
     // #then
-    expect(value).toBe('fallback');
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(result.current[0]).toBe('fallback');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bad-json'), expect.anything());
 
-    consoleSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
-  it('should handle localStorage quota exceeded gracefully', () => {
-    // #given - mock failing localStorage and console
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('warns and still updates React state when localStorage.setItem throws', () => {
+    // #given
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useLocalStorage('test-key', 'original'));
 
-    const failingStorage = {
-      getItem: (key: string) => localStorageMock.getItem(key),
-      setItem: () => {
-        throw new Error('QuotaExceededError');
-      },
-      removeItem: (key: string) => localStorageMock.removeItem(key),
-      clear: () => localStorageMock.clear()
-    };
-
-    Object.defineProperty(window, 'localStorage', {
-      value: failingStorage,
-      writable: true
+    // #when
+    act(() => {
+      result.current[1]('new-value');
     });
 
+    // #then
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('test-key'), expect.anything());
+    expect(result.current[0]).toBe('new-value');
+
+    warnSpy.mockRestore();
+  });
+
+  it('syncs state from a StorageEvent fired by another tab', () => {
+    // #given
     const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
 
-    // #when - attempt to set value when storage is full
-    try {
-      act(() => {
-        const [, setValue] = result.current;
-        setValue('new-value');
-      });
-    } catch {
-      // Expected error from React boundary
-    }
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'test-key',
+          newValue: JSON.stringify('from-other-tab'),
+        }),
+      );
+    });
 
     // #then
-    expect(consoleSpy).toHaveBeenCalled();
-
-    // Restore original localStorage
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-      writable: true
-    });
-    consoleSpy.mockRestore();
-    errorSpy.mockRestore();
+    expect(result.current[0]).toBe('from-other-tab');
   });
 
-  it('should handle different data types', () => {
-    // #given - initialize hooks with various data types
-    const { result: stringResult } = renderHook(() => useLocalStorage('string', 'hello'));
-    const { result: numberResult } = renderHook(() => useLocalStorage('number', 42));
-    const { result: booleanResult } = renderHook(() => useLocalStorage('boolean', true));
-    const { result: arrayResult } = renderHook(() => useLocalStorage('array', [1, 2, 3]));
+  it('ignores StorageEvents for unrelated keys', () => {
+    // #given
+    const { result } = renderHook(() => useLocalStorage('test-key', 'original'));
 
-    // #then - verify each type is preserved
-    expect(stringResult.current[0]).toBe('hello');
-    expect(numberResult.current[0]).toBe(42);
-    expect(booleanResult.current[0]).toBe(true);
-    expect(arrayResult.current[0]).toEqual([1, 2, 3]);
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'other-key',
+          newValue: JSON.stringify('should-not-apply'),
+        }),
+      );
+    });
+
+    // #then
+    expect(result.current[0]).toBe('original');
+  });
+
+  it('removes the storage event listener when the hook unmounts', () => {
+    // #given
+    const removeListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useLocalStorage('test-key', 0));
+
+    // #when
+    unmount();
+
+    // #then
+    expect(removeListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+    removeListenerSpy.mockRestore();
   });
 });

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback, useRef } from 'react';
+
+export const FEEDBACK_DISPLAY_MS = 1500;
+
+type AsyncStatus = 'idle' | 'working' | 'done';
+
+export function useAsyncAction(
+  asyncFn: () => Promise<void>,
+  { resetMs = FEEDBACK_DISPLAY_MS, onReset }: { resetMs?: number; onReset?: () => void } = {},
+): [AsyncStatus, () => Promise<void>] {
+  const [status, setStatus] = useState<AsyncStatus>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const run = useCallback(async () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+    setStatus('working');
+    await asyncFn();
+    setStatus('done');
+    timerRef.current = setTimeout(() => {
+      setStatus('idle');
+      onReset?.();
+      timerRef.current = null;
+    }, resetMs);
+  }, [asyncFn, resetMs, onReset]);
+
+  return [status, run];
+}

--- a/src/hooks/useCanvasVisualizer.ts
+++ b/src/hooks/useCanvasVisualizer.ts
@@ -21,12 +21,6 @@ interface UseCanvasVisualizerProps<T> {
    * Render items to the canvas
    */
   renderItems: (ctx: CanvasRenderingContext2D, items: T[], width: number, height: number, intensity: number) => void;
-  /**
-   * Update item colors when accent color changes. 
-   * This runs in addition to re-initialization to ensure immediate feedback without full reset if desired,
-   * though currently the hook re-initializes on color change by default due to dependency.
-   */
-  onColorChange: (items: T[], color: string) => void;
 }
 
 /**

--- a/src/hooks/useSwipeGesture.ts
+++ b/src/hooks/useSwipeGesture.ts
@@ -29,6 +29,12 @@ interface SwipeGestureReturn {
 const DIRECTION_LOCK_THRESHOLD = 10;
 const DAMPENING_FACTOR = 0.8;
 
+export const DEFAULT_SWIPE_THRESHOLD = 50;
+export const DEFAULT_VELOCITY_THRESHOLD = 0.3;
+export const DEFAULT_TAP_MAX_DURATION = 250;
+export const DEFAULT_TAP_MAX_DISTANCE = 10;
+export const DEFAULT_ANIMATION_DURATION = 300;
+
 const noopHandlers: SwipeGestureReturn = {
   offsetX: 0,
   isSwiping: false,
@@ -45,12 +51,12 @@ export function useSwipeGesture(
   options: SwipeGestureOptions = {}
 ): SwipeGestureReturn {
   const {
-    swipeThreshold = 50,
-    velocityThreshold = 0.3,
-    tapMaxDuration = 250,
-    tapMaxDistance = 10,
+    swipeThreshold = DEFAULT_SWIPE_THRESHOLD,
+    velocityThreshold = DEFAULT_VELOCITY_THRESHOLD,
+    tapMaxDuration = DEFAULT_TAP_MAX_DURATION,
+    tapMaxDistance = DEFAULT_TAP_MAX_DISTANCE,
     enabled = true,
-    animationDuration = 300,
+    animationDuration = DEFAULT_ANIMATION_DURATION,
   } = options;
 
   const [offsetX, setOffsetX] = useState(0);

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -10,6 +10,10 @@ import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import { putDurationMs, putTagMetadata } from './dropboxArtCache';
 
+const PLAYBACK_POLL_INTERVAL_MS = 250;
+const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
+const ENRICHMENT_DELAY_MS = 2000; // Wait for audio to buffer before fetching ID3 tags
+
 export class DropboxPlaybackAdapter implements PlaybackProvider {
   readonly providerId: ProviderId = 'dropbox';
   private audio: HTMLAudioElement | null = null;
@@ -114,9 +118,6 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   }
 
   private enrichMetadataInBackground(track: MediaTrack, streamUrl: string): void {
-    const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
-    const ENRICHMENT_DELAY_MS = 2000; // Wait for audio to buffer before fetching ID3 tags
-
     const doEnrich = async () => {
       // Let the audio element buffer first before competing for bandwidth
       await new Promise((resolve) => setTimeout(resolve, ENRICHMENT_DELAY_MS));
@@ -316,12 +317,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
   private startUpdateInterval(): void {
     this.stopUpdateInterval();
-    // Poll every 250ms for smooth timeline updates
     this.updateInterval = setInterval(() => {
       if (this.audio && !this.audio.paused) {
         this.notifyListeners();
       }
-    }, 250);
+    }, PLAYBACK_POLL_INTERVAL_MS);
   }
 
   private stopUpdateInterval(): void {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -8,6 +8,7 @@ import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/typ
 import { spotifyPlayer } from '@/services/spotifyPlayer';
 import { spotifyAuth } from '@/services/spotify';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
+import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { spotifyQueueSync } from './spotifyQueueSync';
 import { logSpotify } from '@/lib/debugLog';
@@ -27,9 +28,6 @@ function mapPlaybackState(state: SpotifyPlaybackState | null): PlaybackState | n
       : null,
   };
 }
-
-const MAX_PLAY_RETRIES = 5;
-const BASE_RETRY_BACKOFF_MS = 1000;
 
 export class SpotifyPlaybackAdapter implements PlaybackProvider {
   readonly providerId: ProviderId = 'spotify';
@@ -140,7 +138,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         throw new AuthExpiredError('spotify');
       }
 
-      if (retryCount >= MAX_PLAY_RETRIES) {
+      if (retryCount >= SPOTIFY_MAX_RETRIES) {
         throw error;
       }
 
@@ -149,8 +147,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1], 10) : 0;
         const backoffMs = retryAfterSec > 0
           ? retryAfterSec * 1000
-          : BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
-        logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
+          : SPOTIFY_BASE_BACKOFF_MS * Math.pow(2, retryCount);
+        logSpotify('429 during play, retrying (%d/%d) after %dms', retryCount + 1, SPOTIFY_MAX_RETRIES, backoffMs);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
@@ -161,8 +159,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         }
 
         this.playbackSessionActive = false;
-        const backoffMs = BASE_RETRY_BACKOFF_MS * Math.pow(2, retryCount);
-        logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, MAX_PLAY_RETRIES, backoffMs);
+        const backoffMs = SPOTIFY_BASE_BACKOFF_MS * Math.pow(2, retryCount);
+        logSpotify('403 during play, retrying (%d/%d) after %dms', retryCount + 1, SPOTIFY_MAX_RETRIES, backoffMs);
         await spotifyPlayer.transferPlaybackToDevice(true);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         await spotifyPlayer.ensureDeviceIsActive(3, 1000);

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -7,6 +7,10 @@
 import type { LastFmSimilarTrack, LastFmSimilarArtist } from '@/types/radio';
 
 const LASTFM_BASE = 'https://ws.audioscrobbler.com/2.0/';
+const RATE_LIMIT_PADDING_MS = 10;
+const SIMILAR_TRACKS_DEFAULT_LIMIT = 50;
+const SIMILAR_ARTISTS_DEFAULT_LIMIT = 20;
+const TOP_TRACKS_DEFAULT_LIMIT = 10;
 
 function getApiKey(): string {
   const key = import.meta.env.VITE_LASTFM_API_KEY as string | undefined;
@@ -26,7 +30,7 @@ async function waitForRateLimit(): Promise<void> {
   requestTimestamps = requestTimestamps.filter((t) => now - t < WINDOW_MS);
   if (requestTimestamps.length >= RATE_LIMIT) {
     const oldest = requestTimestamps[0];
-    const waitMs = WINDOW_MS - (now - oldest) + 10;
+    const waitMs = WINDOW_MS - (now - oldest) + RATE_LIMIT_PADDING_MS;
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
   requestTimestamps.push(Date.now());
@@ -94,7 +98,7 @@ function parseSimilarArtist(raw: Record<string, unknown>): LastFmSimilarArtist {
 export async function getSimilarTracks(
   artist: string,
   track: string,
-  limit = 50,
+  limit = SIMILAR_TRACKS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarTrack[]> {
   const data = (await lastfmGet({
     method: 'track.getsimilar',
@@ -115,7 +119,7 @@ export async function getSimilarTracks(
 
 export async function getSimilarArtists(
   artist: string,
-  limit = 20,
+  limit = SIMILAR_ARTISTS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarArtist[]> {
   const data = (await lastfmGet({
     method: 'artist.getsimilar',
@@ -135,7 +139,7 @@ export async function getSimilarArtists(
 
 export async function getArtistTopTracks(
   artist: string,
-  limit = 10,
+  limit = TOP_TRACKS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarTrack[]> {
   const data = (await lastfmGet({
     method: 'artist.gettoptracks',

--- a/src/services/settings/__tests__/settingsDb.test.ts
+++ b/src/services/settings/__tests__/settingsDb.test.ts
@@ -1,0 +1,138 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  settingsGet,
+  settingsPut,
+  settingsClearStore,
+  initSettingsDb,
+  STORE_NAMES,
+  _settingsDbTesting,
+} from '@/services/settings/settingsDb';
+
+async function resetDb(): Promise<void> {
+  await initSettingsDb();
+
+  const { db, fallbackStores } = _settingsDbTesting;
+  fallbackStores[STORE_NAMES.PINS].clear();
+
+  if (db) {
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_NAMES.PINS, 'readwrite');
+      tx.objectStore(STORE_NAMES.PINS).clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    });
+  }
+
+  _settingsDbTesting.reset();
+}
+
+describe('settingsDb (IDB happy path)', () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it('returns undefined for a key that has never been stored', async () => {
+    // #when
+    const result = await settingsGet(STORE_NAMES.PINS, 'missing-key');
+
+    // #then
+    expect(result).toBeUndefined();
+  });
+
+  it('round-trips a value: settingsPut then settingsGet returns the stored record', async () => {
+    // #given
+    const record = { key: 'pin-1', ids: ['a', 'b', 'c'] };
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, record);
+    const result = await settingsGet<typeof record>(STORE_NAMES.PINS, 'pin-1');
+
+    // #then
+    expect(result).toEqual(record);
+  });
+
+  it('overwrites an existing record when settingsPut is called with the same key', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['old'] });
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['new'] });
+    const result = await settingsGet<{ key: string; ids: string[] }>(STORE_NAMES.PINS, 'pin-1');
+
+    // #then
+    expect(result?.ids).toEqual(['new']);
+  });
+
+  it('clears all records in the store after settingsClearStore', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-1', ids: ['a'] });
+    await settingsPut(STORE_NAMES.PINS, { key: 'pin-2', ids: ['b'] });
+
+    // #when
+    await settingsClearStore(STORE_NAMES.PINS);
+
+    // #then
+    expect(await settingsGet(STORE_NAMES.PINS, 'pin-1')).toBeUndefined();
+    expect(await settingsGet(STORE_NAMES.PINS, 'pin-2')).toBeUndefined();
+  });
+});
+
+describe('settingsDb (in-memory fallback mode)', () => {
+  beforeEach(async () => {
+    await resetDb();
+    _settingsDbTesting.reset();
+    // Force fallback mode by making initSettingsDb think IDB is missing
+    Object.defineProperty(_settingsDbTesting, 'fallbackMode', {
+      get() { return true; },
+      configurable: true,
+    });
+    // Bypass the normal init by patching the module-level flag via reset + manual state
+    // The cleanest way is to reset and then simulate fallback via the testing helper
+    _settingsDbTesting.reset();
+    // Patch indexedDB to force the error path on next init
+    const originalIndexedDB = globalThis.indexedDB;
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    await initSettingsDb();
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: originalIndexedDB,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('returns undefined for a missing key in fallback mode', async () => {
+    // #when
+    const result = await settingsGet(STORE_NAMES.PINS, 'nonexistent');
+
+    // #then
+    expect(result).toBeUndefined();
+  });
+
+  it('round-trips a value using the in-memory store when IDB is unavailable', async () => {
+    // #given
+    const record = { key: 'fallback-pin', ids: ['x', 'y'] };
+
+    // #when
+    await settingsPut(STORE_NAMES.PINS, record);
+    const result = await settingsGet<typeof record>(STORE_NAMES.PINS, 'fallback-pin');
+
+    // #then
+    expect(result).toEqual(record);
+  });
+
+  it('clears the in-memory store when settingsClearStore is called in fallback mode', async () => {
+    // #given
+    await settingsPut(STORE_NAMES.PINS, { key: 'fb-1', ids: ['a'] });
+
+    // #when
+    await settingsClearStore(STORE_NAMES.PINS);
+
+    // #then
+    expect(await settingsGet(STORE_NAMES.PINS, 'fb-1')).toBeUndefined();
+  });
+});

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -1,4 +1,5 @@
 import type { PaginatedResponse } from './types';
+import { SPOTIFY_RATE_LIMIT_WAIT_S } from '@/constants/spotify';
 
 // =============================================================================
 // Rate Limiting & Request Deduplication
@@ -28,8 +29,8 @@ function isRateLimited(): boolean {
 function handleRateLimitResponse(response: Response): void {
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
-    const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : 5;
-    const waitMs = (isNaN(waitSeconds) ? 5 : Math.max(waitSeconds, 1)) * 1000;
+    const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : SPOTIFY_RATE_LIMIT_WAIT_S;
+    const waitMs = (isNaN(waitSeconds) ? SPOTIFY_RATE_LIMIT_WAIT_S : Math.max(waitSeconds, 1)) * 1000;
     rateLimitedUntil = Date.now() + waitMs;
     console.warn(`[spotify] 429 rate-limited — backing off for ${waitMs}ms`);
   }

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -1,5 +1,11 @@
 import { spotifyAuth } from './spotify';
 import { logSpotify } from '@/lib/debugLog';
+import {
+  SPOTIFY_MAX_RETRIES,
+  SPOTIFY_INITIAL_RETRY_DELAY_MS,
+  SPOTIFY_INITIAL_VOLUME,
+  SPOTIFY_RESUME_TIMEOUT_MS,
+} from '@/constants/spotify';
 import { getHMRState, saveHMRState, loadSpotifySDK } from './spotifyPlayerSdk';
 import {
   apiPlayTrack,
@@ -69,7 +75,7 @@ class SpotifyPlayerService {
           spotifyAuth.redirectToAuth();
         });
       },
-      volume: 0.5
+      volume: SPOTIFY_INITIAL_VOLUME
     });
 
     this.player.addListener('ready', ({ device_id }: { device_id: string }) => {
@@ -261,7 +267,7 @@ class SpotifyPlayerService {
     }
   }
 
-  async ensureDeviceIsActive(maxRetries = 5, initialDelayMs = 300): Promise<boolean> {
+  async ensureDeviceIsActive(maxRetries = SPOTIFY_MAX_RETRIES, initialDelayMs = SPOTIFY_INITIAL_RETRY_DELAY_MS): Promise<boolean> {
     if (this.isReady && Date.now() - this.lastDeviceActiveAt < SpotifyPlayerService.DEVICE_ACTIVE_TTL_MS) {
       return true;
     }
@@ -274,7 +280,7 @@ class SpotifyPlayerService {
     return active;
   }
 
-  waitForPlaybackOrResume(activateDevice: () => Promise<void>, timeoutMs = 3000): void {
+  waitForPlaybackOrResume(activateDevice: () => Promise<void>, timeoutMs = SPOTIFY_RESUME_TIMEOUT_MS): void {
     let settled = false;
     let unsub: (() => void) | null = null;
 

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -1,4 +1,5 @@
 import { spotifyAuth } from './spotify';
+import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 
 export async function apiPlayTrack(
@@ -143,7 +144,7 @@ export async function apiTransferPlayback(
   const body = JSON.stringify({ device_ids: [deviceId], play: false });
   const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < SPOTIFY_TRANSFER_RETRY_COUNT; attempt++) {
     try {
       const response = await fetch('https://api.spotify.com/v1/me/player', {
         method: 'PUT',

--- a/src/services/spotifyPlayerSdk.ts
+++ b/src/services/spotifyPlayerSdk.ts
@@ -1,3 +1,4 @@
+import { SPOTIFY_SDK_LOAD_TIMEOUT_MS } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 
 interface HMRPlayerState {
@@ -43,7 +44,7 @@ export function loadSpotifySDK(pendingRef: { current: Promise<void> | null }): P
     const timeout = setTimeout(() => {
       pendingRef.current = null;
       reject(new Error('Spotify SDK failed to load within timeout'));
-    }, 10000);
+    }, SPOTIFY_SDK_LOAD_TIMEOUT_MS);
 
     window.onSpotifyWebPlaybackSDKReady = () => {
       clearTimeout(timeout);

--- a/src/types/visualizer.d.ts
+++ b/src/types/visualizer.d.ts
@@ -11,12 +11,3 @@ export type VisualizerStyle =
   | 'wave'
   | 'grid';
 
-interface VisualizerConfig {
-  particleCount?: number;
-  animationSpeed?: number;
-  colorVariation?: number;
-  barCount?: number;
-  shapeCount?: number;
-  layerCount?: number;
-}
-

--- a/src/utils/colorExtractor.ts
+++ b/src/utils/colorExtractor.ts
@@ -6,6 +6,16 @@ import { hasCache, getFromCache, addToCache } from './colorCache';
 import type { ExtractedColor } from './colorCache';
 export type { ExtractedColor } from './colorCache';
 
+// Color extraction algorithm constants
+const IMAGE_MAX_SIZE = 150;
+const PIXEL_SAMPLE_STRIDE = 16;
+const ALPHA_THRESHOLD = 128;
+const COLOR_BUCKET_SIZE = 8;
+const MIN_LIGHTNESS = 40;
+const MAX_LIGHTNESS = 85;
+const MIN_SATURATION = 50;
+const COLOR_SIMILARITY_THRESHOLD = 40;
+
 /** Pixel color data used during extraction. */
 interface ColorData {
   r: number;
@@ -55,13 +65,13 @@ function rgbToHex(r: number, g: number, b: number): string {
 /** Returns true if lightness is in the 40-85% range (suitable for UI accent use). */
 function isGoodContrast(r: number, g: number, b: number): boolean {
   const [, , lightness] = rgbToHsl(r, g, b);
-  return lightness >= 40 && lightness <= 85;
+  return lightness >= MIN_LIGHTNESS && lightness <= MAX_LIGHTNESS;
 }
 
 /** Returns true if saturation is >= 50% (vibrant enough for accent use). */
 function isVibrant(r: number, g: number, b: number): boolean {
   const [, saturation] = rgbToHsl(r, g, b);
-  return saturation >= 50;
+  return saturation >= MIN_SATURATION;
 }
 
 /**
@@ -89,8 +99,7 @@ export async function extractDominantColor(imageUrl: string): Promise<ExtractedC
             return;
           }
 
-          const maxSize = 150;
-          const scale = Math.min(maxSize / img.width, maxSize / img.height);
+          const scale = Math.min(IMAGE_MAX_SIZE / img.width, IMAGE_MAX_SIZE / img.height);
           canvas.width = img.width * scale;
           canvas.height = img.height * scale;
 
@@ -101,17 +110,17 @@ export async function extractDominantColor(imageUrl: string): Promise<ExtractedC
 
           const colorMap = new Map<string, ColorData>();
 
-          for (let i = 0; i < data.length; i += 16) {
+          for (let i = 0; i < data.length; i += PIXEL_SAMPLE_STRIDE) {
             const r = data[i];
             const g = data[i + 1];
             const b = data[i + 2];
             const a = data[i + 3];
 
-            if (a < 128) continue;
+            if (a < ALPHA_THRESHOLD) continue;
 
-            const rBucket = Math.floor(r / 8) * 8;
-            const gBucket = Math.floor(g / 8) * 8;
-            const bBucket = Math.floor(b / 8) * 8;
+            const rBucket = Math.floor(r / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
+            const gBucket = Math.floor(g / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
+            const bBucket = Math.floor(b / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
 
             const key = `${rBucket}-${gBucket}-${bBucket}`;
 
@@ -210,8 +219,7 @@ export async function extractTopVibrantColors(imageUrl: string, count = 3): Prom
             return;
           }
 
-          const maxSize = 150;
-          const scale = Math.min(maxSize / img.width, maxSize / img.height);
+          const scale = Math.min(IMAGE_MAX_SIZE / img.width, IMAGE_MAX_SIZE / img.height);
           canvas.width = img.width * scale;
           canvas.height = img.height * scale;
 
@@ -222,15 +230,15 @@ export async function extractTopVibrantColors(imageUrl: string, count = 3): Prom
 
           const colorMap = new Map<string, ColorData>();
 
-          for (let i = 0; i < data.length; i += 16) {
+          for (let i = 0; i < data.length; i += PIXEL_SAMPLE_STRIDE) {
             const r = data[i];
             const g = data[i + 1];
             const b = data[i + 2];
             const a = data[i + 3];
-            if (a < 128) continue;
-            const rBucket = Math.floor(r / 8) * 8;
-            const gBucket = Math.floor(g / 8) * 8;
-            const bBucket = Math.floor(b / 8) * 8;
+            if (a < ALPHA_THRESHOLD) continue;
+            const rBucket = Math.floor(r / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
+            const gBucket = Math.floor(g / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
+            const bBucket = Math.floor(b / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
             const key = `${rBucket}-${gBucket}-${bBucket}`;
             if (colorMap.has(key)) {
               colorMap.get(key)!.count++;
@@ -253,7 +261,7 @@ export async function extractTopVibrantColors(imageUrl: string, count = 3): Prom
 
           scoredColors.sort((a, b) => b.score - a.score);
 
-          function isTooSimilar(c1: ColorData, c2: ColorData, threshold = 40) {
+          function isTooSimilar(c1: ColorData, c2: ColorData, threshold = COLOR_SIMILARITY_THRESHOLD) {
             const dr = c1.r - c2.r;
             const dg = c1.g - c2.g;
             const db = c1.b - c2.b;

--- a/src/utils/sizingUtils.ts
+++ b/src/utils/sizingUtils.ts
@@ -1,5 +1,38 @@
 import { theme } from '@/styles/theme';
 
+// Sizing configuration constants
+const SIZING_CONFIG = {
+  // Optimal aspect ratios for different viewport types
+  aspectRatios: {
+    veryTall: 0.6,      // Portrait phones, tablets (viewportRatio < 0.75)
+    standard: 0.8,      // Standard portrait (viewportRatio < 1.0)
+    squarish: 0.86,     // Square-ish or landscape tablets (viewportRatio < 1.5)
+    landscape: 0.9,     // Standard landscape (viewportRatio < 2.0)
+    ultraWide: 1.2,     // Ultra-wide screens (viewportRatio >= 2.0)
+  },
+  // Viewport ratio breakpoints for determining screen type
+  viewportRatioBreakpoints: {
+    veryTall: 0.75,
+    standard: 1.0,
+    squarish: 1.5,
+    landscape: 2.0,
+  },
+  // Responsive padding values in pixels based on screen size
+  padding: {
+    verySmall: 2,       // 2px for very small screens
+    small: 4,           // 4px for small phones
+    medium: 6,          // 6px for standard phones
+    large: 10,          // 10px for large phones / small tablets
+  },
+  // Viewport usage overrides for mobile devices
+  mobileViewportUsage: {
+    width: 0.98,
+    height: 0.95,
+  },
+  // Conversion factor: 1rem = 16px
+  remToPxFactor: 16,
+} as const;
+
 // Type definition for Window with Visual Viewport API support
 interface WindowWithVisualViewport extends Window {
   visualViewport: VisualViewport | null;
@@ -39,8 +72,8 @@ const createDefaultSizingConstraints = (viewport: ViewportInfo): SizingConstrain
   viewportUsageHeight: number;
 } => {
   const isMobile = viewport.width < parseInt(theme.breakpoints.lg);
-  const viewportUsageWidth = isMobile ? 0.98 : theme.playerConstraints.viewportUsage.width;
-  const viewportUsageHeight = isMobile ? 0.95 : theme.playerConstraints.viewportUsage.height;
+  const viewportUsageWidth = isMobile ? SIZING_CONFIG.mobileViewportUsage.width : theme.playerConstraints.viewportUsage.width;
+  const viewportUsageHeight = isMobile ? SIZING_CONFIG.mobileViewportUsage.height : theme.playerConstraints.viewportUsage.height;
 
   return {
     minWidth: parseInt(theme.breakpoints.xs),
@@ -160,7 +193,7 @@ export const shouldUseFluidSizing = (viewport: ViewportInfo): boolean => {
 // Helper function to convert rem values to pixels
 const remToPixels = (remValue: string): number => {
   const numericValue = parseFloat(remValue);
-  return numericValue * 16; // 1rem = 16px
+  return numericValue * SIZING_CONFIG.remToPxFactor;
 };
 
 export const calculateOptimalPadding = (viewport: ViewportInfo): number => {
@@ -172,50 +205,45 @@ export const calculateOptimalPadding = (viewport: ViewportInfo): number => {
     lg: parseInt(theme.breakpoints.lg),
   };
 
-  if (viewport.width < breakpoints.xs) return 2;  // 2px for very small screens
-  if (viewport.width < breakpoints.sm) return 4;   // 4px for small phones
-  if (viewport.width < breakpoints.md) return 6;   // 6px for standard phones
-  if (viewport.width < breakpoints.lg) return 10;  // 10px for large phones / small tablets
-  return remToPixels(theme.spacing.md);             // 16px for desktop
+  if (viewport.width < breakpoints.xs) return SIZING_CONFIG.padding.verySmall;
+  if (viewport.width < breakpoints.sm) return SIZING_CONFIG.padding.small;
+  if (viewport.width < breakpoints.md) return SIZING_CONFIG.padding.medium;
+  if (viewport.width < breakpoints.lg) return SIZING_CONFIG.padding.large;
+  return remToPixels(theme.spacing.md);
 };
 
 // Enhanced aspect ratio utilities
 export const getOptimalAspectRatio = (viewport: ViewportInfo): number => {
   const viewportRatio = viewport.width / viewport.height;
-  
+
   // Define aspect ratio ranges for different screen types
-  if (viewportRatio < 0.75) {
-    // Very tall screens (portrait phones, tablets)
-    return 0.6;
-  } else if (viewportRatio < 1.0) {
-    // Standard portrait
-    return 0.8;
-  } else if (viewportRatio < 1.5) {
-    // Square-ish or landscape tablets
-    return 0.86;
-  } else if (viewportRatio < 2.0) {
-    // Standard landscape
-    return 0.9;
+  if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.veryTall) {
+    return SIZING_CONFIG.aspectRatios.veryTall;
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.standard) {
+    return SIZING_CONFIG.aspectRatios.standard;
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.squarish) {
+    return SIZING_CONFIG.aspectRatios.squarish;
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.landscape) {
+    return SIZING_CONFIG.aspectRatios.landscape;
   } else {
-    // Ultra-wide screens
-    return 1.2;
+    return SIZING_CONFIG.aspectRatios.ultraWide;
   }
 };
 
 export const calculateAspectRatioConstraints = (viewport: ViewportInfo): { min: number; max: number } => {
   const viewportRatio = viewport.width / viewport.height;
-  
+
   // Define reasonable aspect ratio bounds based on viewport
-  if (viewportRatio < 0.75) {
+  if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.veryTall) {
     // Very tall screens - allow wider ratios
     return { min: 0.5, max: 1.0 };
-  } else if (viewportRatio < 1.0) {
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.standard) {
     // Portrait - standard bounds
     return { min: 0.6, max: 0.9 };
-  } else if (viewportRatio < 1.5) {
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.squarish) {
     // Square-ish - balanced bounds
     return { min: 0.7, max: 1.1 };
-  } else if (viewportRatio < 2.0) {
+  } else if (viewportRatio < SIZING_CONFIG.viewportRatioBreakpoints.landscape) {
     // Landscape - allow taller ratios
     return { min: 0.8, max: 1.3 };
   } else {


### PR DESCRIPTION
## Summary

- Added 10 comprehensive feature guides documenting architecture, invariants, and gotchas across core areas (visualizers, visual effects, queue, library, providers, player controls, album art, settings, profiler)
- Extracted magic numbers and constants: Spotify retry/backoff, Dropbox and Last.fm APIs, sizing/aspect ratios, color algorithms, gesture thresholds, control styling
- Removed dead code: VisualizerConfig interface, unused canvas visualizer props, conditional branches
- Fixed zen mode button overflow and placement, queue drawer sizing, drawer flash on load
- Added state machine tests for BottomBar zen mode and persistence tests for settings
- Improved visual effects context and local storage hook test coverage

## Test plan

- [ ] Verify `npm run build` succeeds with no type errors
- [ ] Run `npm run test:run` — all tests pass
- [ ] Verify feature guides render correctly in docs/
- [ ] Spot-check extracted constants are used correctly in their respective modules
- [ ] Test zen mode button sizing on mobile and desktop
- [ ] Verify queue drawer displays correctly at various viewport sizes