### PR TITLE
feat(library): clear filter state when opening library from QAP

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -372,6 +372,10 @@ const AudioPlayerComponent = () => {
                   return handleAddToQueueFromPanel(id, name, provider);
                 }}
                 onBrowseLibrary={() => {
+                  localStorage.removeItem(STORAGE_KEYS.LIBRARY_SEARCH);
+                  localStorage.removeItem(STORAGE_KEYS.LIBRARY_PROVIDER_FILTERS);
+                  localStorage.removeItem(STORAGE_KEYS.LIBRARY_GENRES);
+                  localStorage.removeItem(STORAGE_KEYS.LIBRARY_RECENTLY_ADDED);
                   handleCloseQuickAccessPanel();
                   handlers.handleOpenLibrary();
                 }}


### PR DESCRIPTION
## Summary

- When the QAP "Browse Library" button is clicked, the four persisted library filter keys (`LIBRARY_SEARCH`, `LIBRARY_PROVIDER_FILTERS`, `LIBRARY_GENRES`, `LIBRARY_RECENTLY_ADDED`) are removed from localStorage before opening the library view
- This ensures users always start with a clean, unfiltered library when navigating from QAP, not from residual filter state from a previous session
- The filter reset only applies to the QAP path — opening the library via swipe-down or BottomBar is unaffected

## Test plan

- [ ] Open the library, apply search/provider/genre/recently-added filters
- [ ] Close the library
- [ ] Open the QAP and click "Browse Library"
- [ ] Confirm the library opens with no filters applied
- [ ] Confirm that opening the library via swipe-down (non-QAP path) still preserves filter state

Closes #902