### PR TITLE
feat(providers): extract and expose genre metadata

### DIFF
--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -140,6 +140,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
           trackCount: count,
           ownerName: artistName ?? null,
           imageUrl: dirToImageUrl.get(dirPath),
+          // Dropbox folder metadata does not include genre information
+          genres: [],
         });
       }
 
@@ -158,6 +160,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         kind: 'folder',
         name: 'All Music',
         trackCount: totalTracks,
+        // Dropbox folder metadata does not include genre information
+        genres: [],
       };
 
       let savedPlaylists: MediaCollection[] = [];

--- a/src/providers/dropbox/dropboxCatalogHelpers.ts
+++ b/src/providers/dropbox/dropboxCatalogHelpers.ts
@@ -93,6 +93,8 @@ export function entryToMediaTrack(entry: DropboxFileEntry, imageUrl?: string): M
     trackNumber,
     durationMs: 0,
     image: imageUrl,
+    // Dropbox file metadata does not include genre information
+    genres: [],
   };
 }
 

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -75,6 +75,8 @@ function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
     description: album.artists,
     imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
+    // Genres come from the Spotify album object (may be empty for simplified library responses)
+    genres: album.genres,
   };
 }
 

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -41,6 +41,8 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
     name: string;
     images?: SpotifyImage[];
     tracks: { items: SpotifyTrackItem[] };
+    /** Genres from the full album object (absent on simplified objects). */
+    genres?: string[];
   }
 
   const album = await spotifyApiRequest<AlbumResponse>(
@@ -58,6 +60,8 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
       image: albumImage,
     });
     if (track) {
+      // Propagate album genres to each track (Spotify genres live at album level)
+      if (album.genres?.length) track.genres = album.genres;
       tracks.push(track);
     }
   }
@@ -146,6 +150,8 @@ export async function getAlbumsPage(
       uri: album.uri ?? '',
       album_type: album.album_type,
       added_at: item.added_at,
+      // Genres are present on full album objects; simplified library objects may omit them
+      genres: album.genres,
     } as AlbumInfo;
   });
   return {
@@ -183,6 +189,8 @@ export async function getAllUserAlbums(signal?: AbortSignal): Promise<AlbumInfo[
         uri: album.uri ?? '',
         album_type: album.album_type,
         added_at: item.added_at,
+        // Genres are present on full album objects; simplified library objects may omit them
+        genres: album.genres,
       });
     }
     nextUrl = data.next;

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -93,6 +93,7 @@ export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
     image: t.image,
     externalUrl: t.preview_url,
     addedAt: t.added_at,
+    genres: t.genres,
   }));
 }
 

--- a/src/services/spotify/types.ts
+++ b/src/services/spotify/types.ts
@@ -22,6 +22,8 @@ export interface Track {
   preview_url?: string;
   image?: string;
   added_at?: number;
+  /** Genre tags inherited from the parent album (Spotify stores genres at album/artist level). */
+  genres?: string[];
 }
 
 interface TokenData {
@@ -62,6 +64,8 @@ export interface AlbumInfo {
   added_at?: string; // ISO 8601 timestamp when saved to library
   /** Which provider this album belongs to (for multi-provider library view). */
   provider?: ProviderId;
+  /** Genre tags returned by the Spotify album object. */
+  genres?: string[];
 }
 
 interface SpotifyArtist {
@@ -90,6 +94,8 @@ interface SpotifyAlbum {
   total_tracks?: number;
   album_type?: string;
   artists?: SpotifyArtist[];
+  /** Present on full album objects (e.g. GET /albums/{id}); absent on simplified objects in library listings. */
+  genres?: string[];
 }
 
 interface SpotifyTrackItem {

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -38,6 +38,8 @@ export interface MediaTrack {
   isrc?: string;
   /** Epoch ms when the track was added/liked. Populated for liked tracks to enable cross-provider sorting. */
   addedAt?: number;
+  /** Genre tags for the track (e.g. from album metadata). Empty array means unavailable. */
+  genres?: string[];
 }
 
 /**
@@ -73,6 +75,8 @@ export interface MediaCollection {
   releaseDate?: string;
   /** Album paths for mosaic thumbnails (multi-album playlists). Resolved to art at render time via IndexedDB cache. */
   mosaicAlbumPaths?: string[];
+  /** Genre tags for the collection (e.g. from album metadata). Empty array means unavailable. */
+  genres?: string[];
 }
 
 /**


### PR DESCRIPTION
Closes #895

## Summary
- Adds `genres?: string[]` field to `MediaTrack` and `MediaCollection` in `src/types/domain.ts`
- Spotify catalog adapter extracts genres from album objects and populates collections and tracks
- Dropbox catalog adapter returns `genres: []` (genre unavailable from Dropbox file metadata)
- Adds `genres` field to internal `Track` and `AlbumInfo` types in Spotify service layer

## Notes
- Spotify genres come from the full album object (`GET /albums/{id}`); the simplified library listing (`/me/albums`) may not include them
- For album tracks, genres are propagated from the parent album to each track
- Dropbox genres are explicitly set to `[]` to distinguish "unavailable" from "not fetched"
- No UI changes — this is a data-layer foundation for genre filtering (#896)