### PR TITLE
feat(library): add genre filter UI

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -14,6 +14,12 @@ interface FilterSidebarProps {
   onProviderFilterChange: (providerIds: ProviderId[]) => void;
 
   showProviderFilter: boolean;
+
+  /** Available genres derived from the current collection set. */
+  availableGenres: string[];
+  /** Currently selected genres (empty = all genres included). */
+  selectedGenres: string[];
+  onGenreChange: (genres: string[]) => void;
 }
 
 const SidebarContainer = styled.div`
@@ -232,16 +238,21 @@ export const FilterSidebar = ({
   selectedProviderIds,
   onProviderFilterChange,
   showProviderFilter,
+  availableGenres,
+  selectedGenres,
+  onGenreChange,
 }: FilterSidebarProps) => {
   const hasActiveFilters =
     searchQuery !== '' ||
     collectionType === 'albums' ||
-    selectedProviderIds.length > 0;
+    selectedProviderIds.length > 0 ||
+    selectedGenres.length > 0;
 
   const handleClearFilters = () => {
     onSearchChange('');
     onCollectionTypeChange('playlists');
     onProviderFilterChange([]);
+    onGenreChange([]);
   };
 
   const handleProviderToggle = (provider: ProviderId) => {
@@ -250,6 +261,14 @@ export const FilterSidebar = ({
       onProviderFilterChange(next.length === enabledProviderIds.length ? [] : next);
     } else {
       onProviderFilterChange([...selectedProviderIds, provider]);
+    }
+  };
+
+  const handleGenreToggle = (genre: string) => {
+    if (selectedGenres.includes(genre)) {
+      onGenreChange(selectedGenres.filter((g) => g !== genre));
+    } else {
+      onGenreChange([...selectedGenres, genre]);
     }
   };
 
@@ -314,6 +333,37 @@ export const FilterSidebar = ({
                   aria-label={`Filter by ${provider}`}
                 />
                 <CheckboxLabel>{provider}</CheckboxLabel>
+              </ProviderCheckboxContainer>
+            ))}
+          </div>
+        </FilterSection>
+      )}
+
+      {availableGenres.length > 0 && (
+        <FilterSection>
+          <SectionTitle>Genres</SectionTitle>
+          <div>
+            {/* "All genres" acts as a clear shortcut when genres are selected */}
+            {selectedGenres.length > 0 && (
+              <ProviderCheckboxContainer>
+                <Checkbox
+                  type="checkbox"
+                  checked={false}
+                  onChange={() => onGenreChange([])}
+                  aria-label="Show all genres"
+                />
+                <CheckboxLabel>All genres</CheckboxLabel>
+              </ProviderCheckboxContainer>
+            )}
+            {availableGenres.map((genre) => (
+              <ProviderCheckboxContainer key={genre}>
+                <Checkbox
+                  type="checkbox"
+                  checked={selectedGenres.length === 0 || selectedGenres.includes(genre)}
+                  onChange={() => handleGenreToggle(genre)}
+                  aria-label={`Filter by genre: ${genre}`}
+                />
+                <CheckboxLabel>{genre}</CheckboxLabel>
               </ProviderCheckboxContainer>
             ))}
           </div>

--- a/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
+++ b/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
@@ -7,12 +7,17 @@ import { FilterSidebar } from '../FilterSidebar';
 
 function renderFilterSidebar(props = {}) {
   const defaultProps = {
+    searchQuery: '',
+    onSearchChange: vi.fn(),
     collectionType: 'playlists' as const,
     onCollectionTypeChange: vi.fn(),
     enabledProviderIds: [] as const,
     selectedProviderIds: [] as const,
     onProviderFilterChange: vi.fn(),
     showProviderFilter: false,
+    availableGenres: [] as string[],
+    selectedGenres: [] as string[],
+    onGenreChange: vi.fn(),
     ...props,
   };
 

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -26,6 +26,10 @@ export interface LibraryContextValue {
   providerFilters: ProviderId[];
   setProviderFilters: (v: ProviderId[]) => void;
   handleProviderToggle: (provider: ProviderId) => void;
+  /** Available genres derived from the current album set for the genre filter UI. */
+  availableGenres: string[];
+  selectedGenres: string[];
+  setSelectedGenres: (v: string[]) => void;
   recentlyAddedFilter: RecentlyAddedFilterOption;
   setRecentlyAddedFilter: (v: RecentlyAddedFilterOption) => void;
   hasActiveFilters: boolean;

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -52,6 +52,9 @@ export function LibraryMainContent(): React.JSX.Element {
     providerFilters,
     setProviderFilters,
     handleProviderToggle,
+    availableGenres,
+    selectedGenres,
+    setSelectedGenres,
     hasActiveFilters,
     albums,
     isInitialLoadComplete,
@@ -90,6 +93,9 @@ export function LibraryMainContent(): React.JSX.Element {
           selectedProviderIds={providerFilters}
           onProviderFilterChange={setProviderFilters}
           showProviderFilter={showProviderBadges}
+          availableGenres={availableGenres}
+          selectedGenres={selectedGenres}
+          onGenreChange={setSelectedGenres}
         />
         <MainContent>
           <div ref={swipeZoneRef} style={{ flexShrink: 0, touchAction: 'pan-y' }}>
@@ -131,6 +137,7 @@ export function LibraryMainContent(): React.JSX.Element {
                       setSearchQuery('');
                       setArtistFilter('');
                       setProviderFilters([]);
+                      setSelectedGenres([]);
                     }}
                     aria-label="Clear filters"
                   >

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -10,6 +10,7 @@ import {
   filterAlbumsOnly,
   sortAlbumSubgroup,
   buildLibraryViewWithPins,
+  getAvailableGenres,
 } from '../../utils/playlistFilters';
 import { usePinnedItems } from '../../hooks/usePinnedItems';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
@@ -97,6 +98,10 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     providerFilters,
     setProviderFilters,
     handleProviderToggle,
+    selectedGenres,
+    setSelectedGenres,
+    recentlyAddedFilter,
+    setRecentlyAddedFilter,
     hasActiveFilters,
   } = useLibraryBrowsing(initialSearchQuery, initialViewMode);
 
@@ -143,14 +148,14 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     if (providerFilters.length > 0) {
       items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
     }
-    const filtered = filterPlaylistsOnly(items, searchQuery);
+    const filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
     return buildLibraryViewWithPins(
       filtered,
       pinnedPlaylistIds,
       (p) => p.id,
       (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
     );
-  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds]);
+  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds, selectedGenres]);
 
   const pinnedPlaylists = playlistLibraryView.pinned;
   const unpinnedPlaylists = playlistLibraryView.unpinned;
@@ -160,17 +165,20 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
     if (providerFilters.length > 0) {
       items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
     }
-    const filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter);
+    const filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
     return buildLibraryViewWithPins(
       filtered,
       pinnedAlbumIds,
       (a) => a.id,
       (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
     );
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds]);
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds, selectedGenres]);
 
   const pinnedAlbums = albumLibraryView.pinned;
   const unpinnedAlbums = albumLibraryView.unpinned;
+
+  // Derive available genres from the full album list (albums carry genre metadata; playlists don't)
+  const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
 
   const isAuthenticated = useMemo(
     () =>
@@ -242,6 +250,9 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
       providerFilters,
       setProviderFilters,
       handleProviderToggle,
+      availableGenres,
+      selectedGenres,
+      setSelectedGenres,
       recentlyAddedFilter,
       setRecentlyAddedFilter,
       hasActiveFilters,
@@ -283,6 +294,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
       albumSort,
       artistFilter,
       providerFilters,
+      availableGenres,
+      selectedGenres,
       hasActiveFilters,
       albums,
       isInitialLoadComplete,

--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
-import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+import type { PlaylistSortOption, AlbumSortOption, RecentlyAddedFilterOption } from '@/utils/playlistFilters';
 import type { ProviderId } from '@/types/domain';
 
 type ViewMode = 'playlists' | 'albums';
@@ -25,6 +25,9 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
 
   const [artistFilter, setArtistFilter] = useState<string>('');
   const [providerFilters, setProviderFilters] = useState<ProviderId[]>([]);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  // Placeholder for #898 — no-op until recently-added filter is implemented
+  const [recentlyAddedFilter, setRecentlyAddedFilter] = useState<RecentlyAddedFilterOption>('all');
 
   // Sync when initial props change (e.g., drawer re-opened with new filter)
   useEffect(() => {
@@ -63,7 +66,11 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     });
   }, []);
 
-  const hasActiveFilters = searchQuery !== '' || artistFilter !== '' || providerFilters.length > 0;
+  const hasActiveFilters =
+    searchQuery !== '' ||
+    artistFilter !== '' ||
+    providerFilters.length > 0 ||
+    selectedGenres.length > 0;
 
   return {
     viewMode,
@@ -79,6 +86,10 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     providerFilters,
     setProviderFilters,
     handleProviderToggle,
+    selectedGenres,
+    setSelectedGenres,
+    recentlyAddedFilter,
+    setRecentlyAddedFilter,
     hasActiveFilters,
   };
 }

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -140,6 +140,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
           trackCount: count,
           ownerName: artistName ?? null,
           imageUrl: dirToImageUrl.get(dirPath),
+          // Dropbox folder metadata does not include genre information
+          genres: [],
         });
       }
 
@@ -158,6 +160,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         kind: 'folder',
         name: 'All Music',
         trackCount: totalTracks,
+        // Dropbox folder metadata does not include genre information
+        genres: [],
       };
 
       let savedPlaylists: MediaCollection[] = [];

--- a/src/providers/dropbox/dropboxCatalogHelpers.ts
+++ b/src/providers/dropbox/dropboxCatalogHelpers.ts
@@ -93,6 +93,8 @@ export function entryToMediaTrack(entry: DropboxFileEntry, imageUrl?: string): M
     trackNumber,
     durationMs: 0,
     image: imageUrl,
+    // Dropbox file metadata does not include genre information
+    genres: [],
   };
 }
 

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -75,6 +75,8 @@ function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
     description: album.artists,
     imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
+    // Genres come from the Spotify album object (may be empty for simplified library responses)
+    genres: album.genres,
   };
 }
 

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -41,6 +41,8 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
     name: string;
     images?: SpotifyImage[];
     tracks: { items: SpotifyTrackItem[] };
+    /** Genres from the full album object (absent on simplified objects). */
+    genres?: string[];
   }
 
   const album = await spotifyApiRequest<AlbumResponse>(
@@ -58,6 +60,8 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
       image: albumImage,
     });
     if (track) {
+      // Propagate album genres to each track (Spotify genres live at album level)
+      if (album.genres?.length) track.genres = album.genres;
       tracks.push(track);
     }
   }
@@ -146,6 +150,8 @@ export async function getAlbumsPage(
       uri: album.uri ?? '',
       album_type: album.album_type,
       added_at: item.added_at,
+      // Genres are present on full album objects; simplified library objects may omit them
+      genres: album.genres,
     } as AlbumInfo;
   });
   return {
@@ -183,6 +189,8 @@ export async function getAllUserAlbums(signal?: AbortSignal): Promise<AlbumInfo[
         uri: album.uri ?? '',
         album_type: album.album_type,
         added_at: item.added_at,
+        // Genres are present on full album objects; simplified library objects may omit them
+        genres: album.genres,
       });
     }
     nextUrl = data.next;

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -93,6 +93,7 @@ export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
     image: t.image,
     externalUrl: t.preview_url,
     addedAt: t.added_at,
+    genres: t.genres,
   }));
 }
 

--- a/src/services/spotify/types.ts
+++ b/src/services/spotify/types.ts
@@ -22,6 +22,8 @@ export interface Track {
   preview_url?: string;
   image?: string;
   added_at?: number;
+  /** Genre tags inherited from the parent album (Spotify stores genres at album/artist level). */
+  genres?: string[];
 }
 
 interface TokenData {
@@ -62,6 +64,8 @@ export interface AlbumInfo {
   added_at?: string; // ISO 8601 timestamp when saved to library
   /** Which provider this album belongs to (for multi-provider library view). */
   provider?: ProviderId;
+  /** Genre tags returned by the Spotify album object. */
+  genres?: string[];
 }
 
 interface SpotifyArtist {
@@ -90,6 +94,8 @@ interface SpotifyAlbum {
   total_tracks?: number;
   album_type?: string;
   artists?: SpotifyArtist[];
+  /** Present on full album objects (e.g. GET /albums/{id}); absent on simplified objects in library listings. */
+  genres?: string[];
 }
 
 interface SpotifyTrackItem {

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -38,6 +38,8 @@ export interface MediaTrack {
   isrc?: string;
   /** Epoch ms when the track was added/liked. Populated for liked tracks to enable cross-provider sorting. */
   addedAt?: number;
+  /** Genre tags for the track (e.g. from album metadata). Empty array means unavailable. */
+  genres?: string[];
 }
 
 /**
@@ -73,6 +75,8 @@ export interface MediaCollection {
   releaseDate?: string;
   /** Album paths for mosaic thumbnails (multi-album playlists). Resolved to art at render time via IndexedDB cache. */
   mosaicAlbumPaths?: string[];
+  /** Genre tags for the collection (e.g. from album metadata). Empty array means unavailable. */
+  genres?: string[];
 }
 
 /**

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -16,6 +16,12 @@ export type AlbumSortOption =
   | 'release-oldest'
   | 'recently-added';
 
+/**
+ * Filter option for recently-added collections (#898).
+ * Defined here so imports in LibraryContext compile; full implementation is in #898.
+ */
+export type RecentlyAddedFilterOption = 'all' | 'week' | 'month' | '3months';
+
 type YearFilterOption =
   | 'all'
   | '2020s'
@@ -109,6 +115,35 @@ function matchesYearFilter(year: number | null, filter: YearFilterOption): boole
   return year >= decadeStart && year < decadeStart + 10;
 }
 
+/**
+ * Check if a collection matches the genre filter.
+ * Returns true when no genres are selected (show all).
+ * When genres are selected, returns true if the collection has at least one matching genre.
+ * Collections with no genres are excluded when a genre filter is active.
+ */
+export function matchesGenreFilter(genres: string[] | undefined, selectedGenres: string[]): boolean {
+  if (selectedGenres.length === 0) return true;
+  if (!genres || genres.length === 0) return false;
+  // Match if any of the collection's genres appears in the selected set
+  return genres.some((g) => selectedGenres.includes(g));
+}
+
+/**
+ * Extract the sorted unique genres from a list of collections.
+ * Collections with empty or missing genres arrays are skipped.
+ */
+export function getAvailableGenres(items: Array<{ genres?: string[] }>): string[] {
+  const genreSet = new Set<string>();
+  for (const item of items) {
+    if (item.genres) {
+      for (const g of item.genres) {
+        if (g) genreSet.add(g);
+      }
+    }
+  }
+  return Array.from(genreSet).sort((a, b) => a.localeCompare(b));
+}
+
 // ============================================================
 // MAIN FILTER/SORT FUNCTIONS
 // ============================================================
@@ -134,9 +169,15 @@ function sortPlaylistArrayInPlace(playlists: PlaylistInfo[], sortOption: Playlis
 
 /**
  * Filter playlists by search query (no sorting).
+ * Genre filter is intentionally not applied here — PlaylistInfo carries no genre metadata.
+ * The genre filter UI is most useful in album view where albums do carry genre tags.
  */
-export function filterPlaylistsOnly(playlists: PlaylistInfo[], searchQuery: string): PlaylistInfo[] {
-  return playlists.filter(p => matchesSearch(p, searchQuery));
+export function filterPlaylistsOnly(
+  playlists: PlaylistInfo[],
+  searchQuery: string,
+  _selectedGenres: string[] = []
+): PlaylistInfo[] {
+  return playlists.filter((p) => matchesSearch(p, searchQuery));
 }
 
 /**
@@ -158,27 +199,32 @@ export function sortPlaylistSubgroup(
 }
 
 /**
- * Filter and sort playlists based on search query and sort option
+ * Filter and sort playlists based on search query, genre filter, and sort option.
  */
 export function filterAndSortPlaylists(
   playlists: PlaylistInfo[],
   searchQuery: string,
-  sortOption: PlaylistSortOption
+  sortOption: PlaylistSortOption,
+  selectedGenres: string[] = []
 ): PlaylistInfo[] {
-  const filtered = filterPlaylistsOnly(playlists, searchQuery);
+  const filtered = filterPlaylistsOnly(playlists, searchQuery, selectedGenres);
   return sortPlaylistSubgroup(filtered, sortOption);
 }
 
 /**
- * Filter albums by search, decade, and artist (no sorting).
+ * Filter albums by search, decade, artist, and optional genre selection (no sorting).
+ * When selectedGenres is non-empty, only albums whose genres overlap are shown.
  */
 export function filterAlbumsOnly(
   albums: AlbumInfo[],
   searchQuery: string,
   yearFilter: YearFilterOption = 'all',
-  artistFilter: string = ''
+  artistFilter: string = '',
+  selectedGenres: string[] = []
 ): AlbumInfo[] {
-  let result = albums.filter(a => matchesSearch(a, searchQuery));
+  let result = albums.filter(
+    (a) => matchesSearch(a, searchQuery) && matchesGenreFilter(a.genres, selectedGenres)
+  );
 
   if (yearFilter !== 'all') {
     result = result.filter(a => {
@@ -259,16 +305,17 @@ export function sortAlbumSubgroup(
 }
 
 /**
- * Filter and sort albums based on search query, sort option, year filter, and artist filter
+ * Filter and sort albums based on search query, sort option, year filter, artist filter, and genre filter.
  */
 export function filterAndSortAlbums(
   albums: AlbumInfo[],
   searchQuery: string,
   sortOption: AlbumSortOption,
   yearFilter: YearFilterOption = 'all',
-  artistFilter: string = ''
+  artistFilter: string = '',
+  selectedGenres: string[] = []
 ): AlbumInfo[] {
-  const filtered = filterAlbumsOnly(albums, searchQuery, yearFilter, artistFilter);
+  const filtered = filterAlbumsOnly(albums, searchQuery, yearFilter, artistFilter, selectedGenres);
   return sortAlbumSubgroup(filtered, sortOption);
 }
 


### PR DESCRIPTION
Closes #896

## Summary
- Adds multi-select genre filter section to `FilterSidebar` component, dynamically populated from album genre metadata
- Adds `matchesGenreFilter()` and `getAvailableGenres()` helper functions to `playlistFilters.ts`
- Updates `filterAlbumsOnly()` to apply genre filter (albums carry genre metadata; playlists don't)
- Wires `selectedGenres` state through `useLibraryBrowsing` → `LibraryContext` → `LibraryMainContent` → `FilterSidebar`
- Also fixes pre-existing TypeScript compile errors by adding `RecentlyAddedFilterOption` stub type (imported but missing)

## Test plan
- [ ] TypeScript check passes: `npx tsc -b --noEmit`
- [ ] Build passes: `npm run build`
- [ ] FilterSidebar tests pass
- [ ] Selecting a genre in the sidebar filters the album grid to only albums with matching genre tags
- [ ] "Clear Filters" button also clears genre selection
- [ ] Genre section only appears when albums with genre data are present (`availableGenres.length > 0`)