### PR TITLE
feat(library): improve visual hierarchy

### DIFF
--- a/src/components/PlaylistSelection/AlbumGrid.tsx
+++ b/src/components/PlaylistSelection/AlbumGrid.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { AlbumInfo } from '../../services/spotify';
 import ProviderIcon from '../ProviderIcon';
+import { AlbumTypeIcon } from '../icons/QuickActionIcons';
 import {
   MobileGrid,
   PlaylistGridDiv,
@@ -9,7 +10,7 @@ import {
   GridCardTitle,
   GridCardSubtitle,
   PlaylistInfoDiv,
-  PlaylistName,
+  PlaylistNameRow,
   PlaylistDetails,
   PinButton,
   PinnableListItem,
@@ -19,6 +20,8 @@ import {
   PinnedSectionLabel,
   EmptyState,
   ClickableArtist,
+  CollectionTypeLabel,
+  GridCardTitleRow,
 } from './styled';
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 import { useLibraryContext } from './LibraryContext';
@@ -60,7 +63,10 @@ export const AlbumGrid: React.FC = React.memo(function AlbumGrid() {
           </GridCardPinOverlay>
         </GridCardArtWrapper>
         <GridCardTextArea>
-          <GridCardTitle>{album.name}</GridCardTitle>
+          <GridCardTitleRow>
+            <GridCardTitle>{album.name}</GridCardTitle>
+            <CollectionTypeLabel title="Album"><AlbumTypeIcon /></CollectionTypeLabel>
+          </GridCardTitleRow>
           <GridCardSubtitle
             $clickable={true}
             onClick={(e) => onArtistClick(album.artists, e)}
@@ -89,7 +95,10 @@ export const AlbumGrid: React.FC = React.memo(function AlbumGrid() {
           )}
         </div>
         <PlaylistInfoDiv>
-          <PlaylistName>{album.name}</PlaylistName>
+          <PlaylistNameRow>
+            <span>{album.name}</span>
+            <CollectionTypeLabel title="Album"><AlbumTypeIcon /></CollectionTypeLabel>
+          </PlaylistNameRow>
           <PlaylistDetails>
             <ClickableArtist onClick={(e) => onArtistClick(album.artists, e)}>
               {album.artists}

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { PlaylistInfo } from '../../services/spotify';
 import { LIKED_SONGS_ID } from '@/constants/playlist';
 import ProviderIcon from '../ProviderIcon';
+import { PlaylistTypeIcon } from '../icons/QuickActionIcons';
 import {
   MobileGrid,
   PlaylistGridDiv,
@@ -10,7 +11,7 @@ import {
   GridCardTitle,
   GridCardSubtitle,
   PlaylistInfoDiv,
-  PlaylistName,
+  PlaylistNameRow,
   PlaylistDetails,
   PinButton,
   PinnableListItem,
@@ -19,6 +20,8 @@ import {
   PinnableGridCard,
   PinnedSectionLabel,
   EmptyState,
+  CollectionTypeLabel,
+  GridCardTitleRow,
 } from './styled';
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 import { useLibraryContext } from './LibraryContext';
@@ -86,7 +89,10 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
           </GridCardPinOverlay>
         </GridCardArtWrapper>
         <GridCardTextArea>
-          <GridCardTitle>{playlist.name}</GridCardTitle>
+          <GridCardTitleRow>
+            <GridCardTitle>{playlist.name}</GridCardTitle>
+            <CollectionTypeLabel title="Playlist"><PlaylistTypeIcon /></CollectionTypeLabel>
+          </GridCardTitleRow>
           <GridCardSubtitle>
             {playlist.tracks?.total ?? 0} tracks
             {playlist.owner?.display_name && ` • ${playlist.owner.display_name}`}
@@ -109,7 +115,10 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
           )}
         </div>
         <PlaylistInfoDiv>
-          <PlaylistName>{playlist.name}</PlaylistName>
+          <PlaylistNameRow>
+            <span>{playlist.name}</span>
+            <CollectionTypeLabel title="Playlist"><PlaylistTypeIcon /></CollectionTypeLabel>
+          </PlaylistNameRow>
           <PlaylistDetails>
             {playlist.tracks?.total ?? 0} tracks
             {playlist.owner?.display_name && ` • by ${playlist.owner.display_name}`}

--- a/src/components/PlaylistSelection/styled.grids.ts
+++ b/src/components/PlaylistSelection/styled.grids.ts
@@ -150,6 +150,25 @@ export const PlaylistName = styled.div`
   margin-bottom: 0.25rem;
 `;
 
+export const PlaylistNameRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-width: 0;
+  margin-bottom: 0.25rem;
+
+  & > :first-child {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: ${({ theme }) => theme.fontWeight.semibold};
+    font-size: ${({ theme }) => theme.fontSize.base};
+    color: ${({ theme }) => theme.colors.white};
+  }
+`;
+
 export const PlaylistDetails = styled.div`
   font-size: 0.875rem;
   color: rgba(255, 255, 255, 0.6);
@@ -249,6 +268,35 @@ export const ProviderBadgeOverlay = styled.div`
 export const PinnableGridCard = styled(GridCard)`
   &:hover ${GridCardPinOverlay} {
     opacity: 1;
+  }
+`;
+
+export const CollectionTypeLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: ${({ theme }) => theme.colors.muted.foreground};
+  flex-shrink: 0;
+
+  svg {
+    width: 0.75em;
+    height: 0.75em;
+    opacity: 0.7;
+  }
+`;
+
+export const GridCardTitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-width: 0;
+
+  & > :first-child {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 `;
 

--- a/src/components/icons/QuickActionIcons.tsx
+++ b/src/components/icons/QuickActionIcons.tsx
@@ -57,3 +57,15 @@ export const QuickAccessPanelIcon = () => (
   </svg>
 );
 
+export const PlaylistTypeIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M3 5h18v2H3V5zm0 6h18v2H3v-2zm0 6h18v2H3v-2z" />
+  </svg>
+);
+
+export const AlbumTypeIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 14.5c-2.49 0-4.5-2.01-4.5-4.5S9.51 7.5 12 7.5s4.5 2.01 4.5 4.5-2.01 4.5-4.5 4.5zm0-5.5c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z" />
+  </svg>
+);
+


### PR DESCRIPTION
Closes #899

Add small inline type icons next to playlist and album card titles so users can immediately distinguish between the two collection types while browsing the library.

**Changes:**
- `PlaylistTypeIcon` (horizontal lines) and `AlbumTypeIcon` (vinyl disc) added to `QuickActionIcons.tsx`
- `CollectionTypeLabel`, `GridCardTitleRow`, and `PlaylistNameRow` styled components added to `styled.grids.ts`
- Both grid and list views updated in `PlaylistGrid.tsx` and `AlbumGrid.tsx`

**Visual behaviour:** Icons are `0.75em` sized, muted color (`theme.colors.muted.foreground`), rendered at 70% opacity — subtle but readable. No layout disruption; icons are inline after the title text using flex.