### PR TITLE
refactor(library): deduplicate sort option definitions into shared constants

### DIFF
--- a/src/components/LibraryDrawerSortChip.tsx
+++ b/src/components/LibraryDrawerSortChip.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { theme } from '@/styles/theme';
 import { Chip, SortChipWrapper, SortDropdown, SortOption } from './styled/FilterChips';
 import type { AlbumSortOption, PlaylistSortOption } from '@/utils/playlistFilters';
+import { PLAYLIST_SORT_LABELS, ALBUM_SORT_LABELS } from '@/utils/playlistFilters';
 
 const SortIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -18,22 +19,6 @@ const ChevronDownIcon = () => (
     <polyline points="6 9 12 15 18 9" />
   </svg>
 );
-
-const PLAYLIST_SORT_LABELS: Record<PlaylistSortOption, string> = {
-  'recently-added': 'Recently Added',
-  'name-asc': 'Name (A-Z)',
-  'name-desc': 'Name (Z-A)',
-};
-
-const ALBUM_SORT_LABELS: Record<AlbumSortOption, string> = {
-  'recently-added': 'Recently Added',
-  'name-asc': 'Name (A-Z)',
-  'name-desc': 'Name (Z-A)',
-  'artist-asc': 'Artist (A-Z)',
-  'artist-desc': 'Artist (Z-A)',
-  'release-newest': 'Release (Newest)',
-  'release-oldest': 'Release (Oldest)',
-};
 
 interface LibraryDrawerSortChipProps {
   viewMode: 'playlists' | 'albums';

--- a/src/components/PlaylistSelection/LibraryControls.tsx
+++ b/src/components/PlaylistSelection/LibraryControls.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+import { PLAYLIST_SORT_LABELS, ALBUM_SORT_LABELS } from '@/utils/playlistFilters';
 import type { ProviderId } from '@/types/domain';
 import {
   ControlsContainer,
@@ -65,9 +66,9 @@ export function LibraryControls({
               onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
               style={{ flex: 1, minWidth: 0 }}
             >
-              <option value="recently-added">Recently Added</option>
-              <option value="name-asc">Name (A-Z)</option>
-              <option value="name-desc">Name (Z-A)</option>
+              {Object.entries(PLAYLIST_SORT_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>{label}</option>
+              ))}
             </SelectDropdown>
           ) : (
             <SelectDropdown
@@ -75,13 +76,9 @@ export function LibraryControls({
               onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
               style={{ flex: 1, minWidth: 0 }}
             >
-              <option value="recently-added">Recently Added</option>
-              <option value="name-asc">Name (A-Z)</option>
-              <option value="name-desc">Name (Z-A)</option>
-              <option value="artist-asc">Artist (A-Z)</option>
-              <option value="artist-desc">Artist (Z-A)</option>
-              <option value="release-newest">Release (Newest)</option>
-              <option value="release-oldest">Release (Oldest)</option>
+              {Object.entries(ALBUM_SORT_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>{label}</option>
+              ))}
             </SelectDropdown>
           )}
 
@@ -118,22 +115,18 @@ export function LibraryControls({
           value={playlistSort}
           onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
         >
-          <option value="recently-added">Recently Added</option>
-          <option value="name-asc">Name (A-Z)</option>
-          <option value="name-desc">Name (Z-A)</option>
+          {Object.entries(PLAYLIST_SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
         </SelectDropdown>
       ) : (
         <SelectDropdown
           value={albumSort}
           onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
         >
-          <option value="recently-added">Recently Added</option>
-          <option value="name-asc">Name (A-Z)</option>
-          <option value="name-desc">Name (Z-A)</option>
-          <option value="artist-asc">Artist (A-Z)</option>
-          <option value="artist-desc">Artist (Z-A)</option>
-          <option value="release-newest">Release (Newest)</option>
-          <option value="release-oldest">Release (Oldest)</option>
+          {Object.entries(ALBUM_SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
         </SelectDropdown>
       )}
 

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -39,6 +39,22 @@ export interface FilterState {
 
 export type RecentlyAddedFilterOption = FilterState['recentlyAdded'];
 
+export const PLAYLIST_SORT_LABELS: Record<PlaylistSortOption, string> = {
+  'recently-added': 'Recently Added',
+  'name-asc': 'Name (A-Z)',
+  'name-desc': 'Name (Z-A)',
+};
+
+export const ALBUM_SORT_LABELS: Record<AlbumSortOption, string> = {
+  'recently-added': 'Recently Added',
+  'name-asc': 'Name (A-Z)',
+  'name-desc': 'Name (Z-A)',
+  'artist-asc': 'Artist (A-Z)',
+  'artist-desc': 'Artist (Z-A)',
+  'release-newest': 'Release (Newest)',
+  'release-oldest': 'Release (Oldest)',
+};
+
 type YearFilterOption =
   | 'all'
   | '2020s'


### PR DESCRIPTION
## Summary
- Moved `PLAYLIST_SORT_LABELS` and `ALBUM_SORT_LABELS` from `LibraryDrawerSortChip.tsx` into `src/utils/playlistFilters.ts`, co-located with the `PlaylistSortOption` and `AlbumSortOption` type definitions
- Updated `LibraryDrawerSortChip.tsx` to import from the shared location instead of defining locally
- Updated `LibraryControls.tsx` to replace duplicated inline `<option>` elements with `Object.entries()` renders driven by the same shared maps

Closes #845