### PR TITLE
refactor(library): decompose LibraryContextValue into focused sub-contexts

### DIFF
--- a/src/components/PlaylistSelection/AlbumGrid.tsx
+++ b/src/components/PlaylistSelection/AlbumGrid.tsx
@@ -24,24 +24,13 @@ import {
   GridCardTitleRow,
 } from './styled';
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
-import { useLibraryContext } from './LibraryContext';
+import { useLibraryBrowsingContext, useLibraryPins, useLibraryActions, useLibraryData } from './LibraryContext';
 
 export const AlbumGrid: React.FC = React.memo(function AlbumGrid() {
-  const {
-    inDrawer,
-    isInitialLoadComplete,
-    showProviderBadges,
-    searchQuery,
-    artistFilter,
-    pinnedAlbums,
-    unpinnedAlbums,
-    isAlbumPinned,
-    canPinMoreAlbums,
-    onAlbumClick,
-    onAlbumContextMenu,
-    onPinAlbumClick,
-    onArtistClick,
-  } = useLibraryContext();
+  const { searchQuery, artistFilter } = useLibraryBrowsingContext();
+  const { pinnedAlbums, unpinnedAlbums, isAlbumPinned, canPinMoreAlbums, onPinAlbumClick } = useLibraryPins();
+  const { onAlbumClick, onAlbumContextMenu, onArtistClick } = useLibraryActions();
+  const { inDrawer, isInitialLoadComplete, showProviderBadges } = useLibraryData();
 
   const renderAlbumGrid = (album: AlbumInfo) => {
     const pinned = isAlbumPinned(album.id);

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -10,9 +10,7 @@ interface LikedSongsEntry {
   count: number;
 }
 
-export interface LibraryContextValue {
-  inDrawer: boolean;
-  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+export interface LibraryBrowsingContextValue {
   viewMode: 'playlists' | 'albums';
   setViewMode: (v: 'playlists' | 'albums') => void;
   searchQuery: string;
@@ -26,13 +24,41 @@ export interface LibraryContextValue {
   providerFilters: ProviderId[];
   setProviderFilters: (v: ProviderId[]) => void;
   handleProviderToggle: (provider: ProviderId) => void;
-  /** Available genres derived from the current album set for the genre filter UI. */
   availableGenres: string[];
   selectedGenres: string[];
   setSelectedGenres: (v: string[]) => void;
   recentlyAddedFilter: RecentlyAddedFilterOption;
   setRecentlyAddedFilter: (v: RecentlyAddedFilterOption) => void;
   hasActiveFilters: boolean;
+}
+
+export interface LibraryPinContextValue {
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  isPlaylistPinned: (id: string) => boolean;
+  canPinMorePlaylists: boolean;
+  isAlbumPinned: (id: string) => boolean;
+  canPinMoreAlbums: boolean;
+  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
+}
+
+export interface LibraryActionsContextValue {
+  onPlaylistClick: (playlist: PlaylistInfo) => void;
+  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  onLikedSongsClick: (provider?: ProviderId) => void;
+  onAlbumClick: (album: AlbumInfo) => void;
+  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
+  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+export interface LibraryDataContextValue {
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
   albums: AlbumInfo[];
   isInitialLoadComplete: boolean;
   showProviderBadges: boolean;
@@ -42,35 +68,61 @@ export interface LibraryContextValue {
   isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
-  pinnedPlaylists: PlaylistInfo[];
-  unpinnedPlaylists: PlaylistInfo[];
-  pinnedAlbums: AlbumInfo[];
-  unpinnedAlbums: AlbumInfo[];
-  isPlaylistPinned: (id: string) => boolean;
-  canPinMorePlaylists: boolean;
-  isAlbumPinned: (id: string) => boolean;
-  canPinMoreAlbums: boolean;
   activeDescriptor: ProviderDescriptor | null;
-  onPlaylistClick: (playlist: PlaylistInfo) => void;
-  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
-  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
-  onLikedSongsClick: (provider?: ProviderId) => void;
-  onAlbumClick: (album: AlbumInfo) => void;
-  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
-  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
-  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
-  onLibraryRefresh?: () => void;
-  isLibraryRefreshing?: boolean;
 }
 
-const LibraryContext = createContext<LibraryContextValue | null>(null);
+export type LibraryContextValue =
+  LibraryBrowsingContextValue &
+  LibraryPinContextValue &
+  LibraryActionsContextValue &
+  LibraryDataContextValue;
 
-export const LibraryProvider = LibraryContext.Provider;
+const LibraryBrowsingContext = createContext<LibraryBrowsingContextValue | null>(null);
+const LibraryPinContext = createContext<LibraryPinContextValue | null>(null);
+const LibraryActionsContext = createContext<LibraryActionsContextValue | null>(null);
+const LibraryDataContext = createContext<LibraryDataContextValue | null>(null);
 
-export function useLibraryContext(): LibraryContextValue {
-  const ctx = useContext(LibraryContext);
+export const LibraryBrowsingProvider = LibraryBrowsingContext.Provider;
+export const LibraryPinProvider = LibraryPinContext.Provider;
+export const LibraryActionsProvider = LibraryActionsContext.Provider;
+export const LibraryDataProvider = LibraryDataContext.Provider;
+
+export function useLibraryBrowsingContext(): LibraryBrowsingContextValue {
+  const ctx = useContext(LibraryBrowsingContext);
   if (!ctx) {
-    throw new Error('useLibraryContext must be used within a LibraryProvider');
+    throw new Error('useLibraryBrowsingContext must be used within a LibraryBrowsingProvider');
   }
   return ctx;
+}
+
+export function useLibraryPins(): LibraryPinContextValue {
+  const ctx = useContext(LibraryPinContext);
+  if (!ctx) {
+    throw new Error('useLibraryPins must be used within a LibraryPinProvider');
+  }
+  return ctx;
+}
+
+export function useLibraryActions(): LibraryActionsContextValue {
+  const ctx = useContext(LibraryActionsContext);
+  if (!ctx) {
+    throw new Error('useLibraryActions must be used within a LibraryActionsProvider');
+  }
+  return ctx;
+}
+
+export function useLibraryData(): LibraryDataContextValue {
+  const ctx = useContext(LibraryDataContext);
+  if (!ctx) {
+    throw new Error('useLibraryData must be used within a LibraryDataProvider');
+  }
+  return ctx;
+}
+
+export function useLibraryContext(): LibraryContextValue {
+  const browsing = useLibraryBrowsingContext();
+  const pins = useLibraryPins();
+  const actions = useLibraryActions();
+  const data = useLibraryData();
+  return { ...browsing, ...pins, ...actions, ...data };
 }

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -8,7 +8,7 @@ import { FilterSidebar } from '../LibraryDrawer/FilterSidebar';
 import { PlaylistGrid } from './PlaylistGrid';
 import { AlbumGrid } from './AlbumGrid';
 import { LibraryControls } from './LibraryControls';
-import { useLibraryContext } from './LibraryContext';
+import { useLibraryBrowsingContext, useLibraryActions, useLibraryData } from './LibraryContext';
 import { RefreshIcon } from './utils';
 import {
   TabSpinner,
@@ -43,8 +43,6 @@ const MainContent = styled.div`
 
 export function LibraryMainContent(): React.JSX.Element {
   const {
-    inDrawer,
-    swipeZoneRef,
     viewMode,
     setViewMode,
     searchQuery,
@@ -64,13 +62,9 @@ export function LibraryMainContent(): React.JSX.Element {
     recentlyAddedFilter,
     setRecentlyAddedFilter,
     hasActiveFilters,
-    albums,
-    isInitialLoadComplete,
-    showProviderBadges,
-    enabledProviderIds,
-    onLibraryRefresh,
-    isLibraryRefreshing,
-  } = useLibraryContext();
+  } = useLibraryBrowsingContext();
+  const { onLibraryRefresh, isLibraryRefreshing } = useLibraryActions();
+  const { inDrawer, swipeZoneRef, albums, isInitialLoadComplete, showProviderBadges, enabledProviderIds } = useLibraryData();
 
   const tabsBar = (
     <TabsContainer>

--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -19,7 +19,7 @@ import {
   TabSpinner,
 } from './styled';
 import { getLikedSongsGradient, likedSongsAsPlaylistInfo, PinIcon } from './utils';
-import { useLibraryContext } from './LibraryContext';
+import { useLibraryPins, useLibraryActions, useLibraryData } from './LibraryContext';
 
 interface LikedSongsCardProps {
   layout: 'grid' | 'list';
@@ -42,16 +42,9 @@ const HeartArt: React.FC<{ gradient: string; layout: 'grid' | 'list' }> = ({ gra
 );
 
 const LikedSongsCard: React.FC<LikedSongsCardProps> = React.memo(function LikedSongsCard({ layout, provider, count }) {
-  const {
-    isLikedSongsSyncing,
-    isUnifiedLikedActive,
-    isPlaylistPinned,
-    canPinMorePlaylists,
-    activeDescriptor,
-    onPlaylistContextMenu,
-    onPinPlaylistClick,
-    onLikedSongsClick,
-  } = useLibraryContext();
+  const { isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
+  const { onPlaylistContextMenu, onLikedSongsClick } = useLibraryActions();
+  const { isLikedSongsSyncing, isUnifiedLikedActive, activeDescriptor } = useLibraryData();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
   const isPerProvider = provider !== undefined;

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -24,29 +24,14 @@ import {
   GridCardTitleRow,
 } from './styled';
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
-import { useLibraryContext } from './LibraryContext';
+import { useLibraryBrowsingContext, useLibraryPins, useLibraryActions, useLibraryData } from './LibraryContext';
 import { LikedSongsCard } from './LikedSongsCard';
 
 export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
-  const {
-    inDrawer,
-    likedSongsPerProvider,
-    likedSongsCount,
-    isUnifiedLikedActive,
-    unifiedLikedCount,
-    isInitialLoadComplete,
-    showProviderBadges,
-    hasActiveFilters,
-    searchQuery,
-    providerFilters,
-    pinnedPlaylists,
-    unpinnedPlaylists,
-    isPlaylistPinned,
-    canPinMorePlaylists,
-    onPlaylistClick,
-    onPlaylistContextMenu,
-    onPinPlaylistClick,
-  } = useLibraryContext();
+  const { hasActiveFilters, searchQuery, providerFilters } = useLibraryBrowsingContext();
+  const { pinnedPlaylists, unpinnedPlaylists, isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
+  const { onPlaylistClick, onPlaylistContextMenu } = useLibraryActions();
+  const { inDrawer, likedSongsPerProvider, likedSongsCount, isUnifiedLikedActive, unifiedLikedCount, isInitialLoadComplete, showProviderBadges } = useLibraryData();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
 

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -28,8 +28,18 @@ import { useLibraryBrowsing } from './useLibraryBrowsing';
 import { useItemActions } from './useItemActions';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
-import { LibraryProvider } from './LibraryContext';
-import type { LibraryContextValue } from './LibraryContext';
+import {
+  LibraryBrowsingProvider,
+  LibraryPinProvider,
+  LibraryActionsProvider,
+  LibraryDataProvider,
+} from './LibraryContext';
+import type {
+  LibraryBrowsingContextValue,
+  LibraryPinContextValue,
+  LibraryActionsContextValue,
+  LibraryDataContextValue,
+} from './LibraryContext';
 
 interface PlaylistSelectionProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -240,10 +250,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
   const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
 
-  const libraryContextValue: LibraryContextValue = useMemo(
+  const browsingValue: LibraryBrowsingContextValue = useMemo(
     () => ({
-      inDrawer,
-      swipeZoneRef,
       viewMode,
       setViewMode,
       searchQuery,
@@ -263,38 +271,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
       recentlyAddedFilter,
       setRecentlyAddedFilter,
       hasActiveFilters,
-      albums,
-      isInitialLoadComplete,
-      showProviderBadges,
-      enabledProviderIds,
-      likedSongsPerProvider,
-      likedSongsCount,
-      isLikedSongsSyncing,
-      isUnifiedLikedActive,
-      unifiedLikedCount,
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
-      activeDescriptor: activeDescriptor ?? null,
-      onPlaylistClick: handlePlaylistClick,
-      onPlaylistContextMenu: handlePlaylistContextMenu,
-      onPinPlaylistClick: handlePinPlaylistClick,
-      onLikedSongsClick: handleLikedSongsClick,
-      onAlbumClick: handleAlbumClick,
-      onAlbumContextMenu: handleAlbumContextMenu,
-      onPinAlbumClick: handlePinAlbumClick,
-      onArtistClick: handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
     }),
     [
-      inDrawer,
-      swipeZoneRef,
       viewMode,
       searchQuery,
       playlistSort,
@@ -305,6 +283,63 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
       selectedGenres,
       recentlyAddedFilter,
       hasActiveFilters,
+    ]
+  );
+
+  const pinValue: LibraryPinContextValue = useMemo(
+    () => ({
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      onPinPlaylistClick: handlePinPlaylistClick,
+      onPinAlbumClick: handlePinAlbumClick,
+    }),
+    [
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      handlePinPlaylistClick,
+      handlePinAlbumClick,
+    ]
+  );
+
+  const actionsValue: LibraryActionsContextValue = useMemo(
+    () => ({
+      onPlaylistClick: handlePlaylistClick,
+      onPlaylistContextMenu: handlePlaylistContextMenu,
+      onLikedSongsClick: handleLikedSongsClick,
+      onAlbumClick: handleAlbumClick,
+      onAlbumContextMenu: handleAlbumContextMenu,
+      onArtistClick: handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    }),
+    [
+      handlePlaylistClick,
+      handlePlaylistContextMenu,
+      handleLikedSongsClick,
+      handleAlbumClick,
+      handleAlbumContextMenu,
+      handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    ]
+  );
+
+  const dataValue: LibraryDataContextValue = useMemo(
+    () => ({
+      inDrawer,
+      swipeZoneRef,
       albums,
       isInitialLoadComplete,
       showProviderBadges,
@@ -314,25 +349,21 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
       isLikedSongsSyncing,
       isUnifiedLikedActive,
       unifiedLikedCount,
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
+      activeDescriptor: activeDescriptor ?? null,
+    }),
+    [
+      inDrawer,
+      swipeZoneRef,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
       activeDescriptor,
-      handlePlaylistClick,
-      handlePlaylistContextMenu,
-      handlePinPlaylistClick,
-      handleLikedSongsClick,
-      handleAlbumClick,
-      handleAlbumContextMenu,
-      handlePinAlbumClick,
-      handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
     ]
   );
 
@@ -346,7 +377,10 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
 
   if (inDrawer) {
     return (
-      <LibraryProvider value={libraryContextValue}>
+      <LibraryDataProvider value={dataValue}>
+      <LibraryBrowsingProvider value={browsingValue}>
+      <LibraryPinProvider value={pinValue}>
+      <LibraryActionsProvider value={actionsValue}>
         <DrawerContentWrapper>
           <LibraryStatusContent {...statusContentProps} />
           {showMainContent && <LibraryMainContent />}
@@ -354,12 +388,18 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
           {playlistPopoverPortal}
           {confirmDeletePortal}
         </DrawerContentWrapper>
-      </LibraryProvider>
+      </LibraryActionsProvider>
+      </LibraryPinProvider>
+      </LibraryBrowsingProvider>
+      </LibraryDataProvider>
     );
   }
 
   return (
-    <LibraryProvider value={libraryContextValue}>
+    <LibraryDataProvider value={dataValue}>
+    <LibraryBrowsingProvider value={browsingValue}>
+    <LibraryPinProvider value={pinValue}>
+    <LibraryActionsProvider value={actionsValue}>
       <Container $inDrawer={false}>
         <SelectionCard $maxWidth={maxWidth} $inDrawer={false}>
           <CardContent style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
@@ -372,7 +412,10 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
           {footer}
         </SelectionCard>
       </Container>
-    </LibraryProvider>
+    </LibraryActionsProvider>
+    </LibraryPinProvider>
+    </LibraryBrowsingProvider>
+    </LibraryDataProvider>
   );
 });
 


### PR DESCRIPTION
## Summary
- Split the monolithic `LibraryContextValue` (30+ fields) into four focused contexts: `LibraryBrowsingContext`, `LibraryPinContext`, `LibraryActionsContext`, `LibraryDataContext`
- Updated all four consumers (`AlbumGrid`, `PlaylistGrid`, `LikedSongsCard`, `LibraryMainContent`) to import from focused hooks
- Preserved backward-compatible `useLibraryContext()` facade that composes all four sub-contexts

## Test plan
- [x] `npx tsc -b --noEmit` passes with zero errors
- [x] `npm run test:run` — 964 tests pass, 1 pre-existing failure (unrelated `useFilterState` missing import)
- [ ] Manual smoke test: library browsing, filtering, pinning, album/playlist clicks all work as before

Closes #839