### PR TITLE
feat(providers): expose genre metadata from Spotify albums

### DIFF
--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -75,6 +75,7 @@ function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
     description: album.artists,
     imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
+    genres: album.genres,
   };
 }
 

--- a/src/services/spotify/types.ts
+++ b/src/services/spotify/types.ts
@@ -62,6 +62,8 @@ export interface AlbumInfo {
   added_at?: string; // ISO 8601 timestamp when saved to library
   /** Which provider this album belongs to (for multi-provider library view). */
   provider?: ProviderId;
+  /** Genre tags returned by the Spotify album object. */
+  genres?: string[];
 }
 
 interface SpotifyArtist {

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -38,6 +38,8 @@ export interface MediaTrack {
   isrc?: string;
   /** Epoch ms when the track was added/liked. Populated for liked tracks to enable cross-provider sorting. */
   addedAt?: number;
+  /** Genre tags for the track (e.g. from album metadata). Empty array means unavailable. */
+  genres?: string[];
 }
 
 /**
@@ -73,6 +75,8 @@ export interface MediaCollection {
   releaseDate?: string;
   /** Album paths for mosaic thumbnails (multi-album playlists). Resolved to art at render time via IndexedDB cache. */
   mosaicAlbumPaths?: string[];
+  /** Populated by Spotify; undefined for Dropbox collections (no provider-level genre data available). */
+  genres?: string[];
 }
 
 /**


### PR DESCRIPTION
Closes #895

## Summary
- Adds `genres?: string[]` to `MediaTrack` and `MediaCollection` in `src/types/domain.ts`
- Adds `genres?: string[]` to `AlbumInfo` in `src/services/spotify/types.ts`
- Spotify catalog adapter maps `album.genres` from Spotify API responses into `MediaCollection.genres`
- Field is optional — Dropbox collections (no provider-level genre data) are unaffected

## Test plan
- [ ] Verify TypeScript compiles clean on changed files
- [ ] Verify Spotify albums surface genre metadata in library collections
- [ ] Verify Dropbox collections compile without changes (optional field)