### PR TITLE
refactor(library): split PlaylistSelection into LibraryPage and DrawerLibrary

### DIFF
--- a/src/components/LibraryDrawer.tsx
+++ b/src/components/LibraryDrawer.tsx
@@ -10,7 +10,7 @@ import {
   DRAWER_TRANSITION_DURATION,
   DRAWER_TRANSITION_EASING
 } from './styled';
-import PlaylistSelection from './PlaylistSelection';
+import { DrawerLibrary } from './PlaylistSelection';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
@@ -150,12 +150,11 @@ const LibraryDrawer = React.memo(function LibraryDrawer({ isOpen, onClose, onPla
         {isOpen && (
           <>
             <DrawerContent>
-              <PlaylistSelection
+              <DrawerLibrary
                 onPlaylistSelect={handlePlaylistSelectWrapper}
                 onAddToQueue={onAddToQueue}
                 onPlayLikedTracks={onPlayLikedTracks}
                 onQueueLikedTracks={onQueueLikedTracks}
-                inDrawer
                 initialSearchQuery={initialSearchQuery}
                 initialViewMode={initialViewMode}
                 onLibraryRefresh={handleRefresh}

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -12,7 +12,7 @@ import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 
-const PlaylistSelection = React.lazy(() => import('./PlaylistSelection'));
+const LibraryPage = React.lazy(() => import('./PlaylistSelection'));
 
 const pulseWave = keyframes`
   0%, 100% {
@@ -280,7 +280,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
             </LoadingContainer>
           </LoadingCard>
         }>
-          <PlaylistSelection
+          <LibraryPage
             onPlaylistSelect={handlePlaylistSelectWrapped}
             onPlayLikedTracks={onPlayLikedTracks}
             onQueueLikedTracks={onQueueLikedTracks}

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -1,31 +1,11 @@
-import { useState, useMemo } from 'react';
 import * as React from 'react';
-import { useProviderContext } from '@/contexts/ProviderContext';
 import { CardContent } from '../styled';
-import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
-import { useLibrarySync } from '../../hooks/useLibrarySync';
-import {
-  filterPlaylistsOnly,
-  sortPlaylistSubgroup,
-  filterAlbumsOnly,
-  sortAlbumSubgroup,
-  buildLibraryViewWithPins,
-  getAvailableGenres,
-  matchesRecentlyAddedFilter,
-} from '../../utils/playlistFilters';
-import { usePinnedItems } from '../../hooks/usePinnedItems';
-import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
-import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
-import { logQueue } from '@/lib/debugLog';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
-import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import {
-  Container,
-  SelectionCard,
+  PageContainer,
+  PageSelectionCard,
   DrawerContentWrapper,
 } from './styled';
-import { useLibraryBrowsing } from './useLibraryBrowsing';
-import { useItemActions } from './useItemActions';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
 import {
@@ -34,14 +14,9 @@ import {
   LibraryActionsProvider,
   LibraryDataProvider,
 } from './LibraryContext';
-import type {
-  LibraryBrowsingContextValue,
-  LibraryPinContextValue,
-  LibraryActionsContextValue,
-  LibraryDataContextValue,
-} from './LibraryContext';
+import { useLibraryRoot } from './useLibraryRoot';
 
-interface PlaylistSelectionProps {
+interface LibraryPageProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue?: (
     playlistId: string,
@@ -50,358 +25,42 @@ interface PlaylistSelectionProps {
   ) => Promise<AddToQueueResult | null>;
   onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
-  /** When true, uses compact layout for drawer context (no centering, fills available space) */
-  inDrawer?: boolean;
-  /** Ref for swipe-to-close gesture zone (search/filters area only, not the scrollable list) */
-  swipeZoneRef?: React.RefObject<HTMLDivElement>;
-  /** Pre-populate the search input when the drawer opens */
-  initialSearchQuery?: string;
-  /** Set the active tab when the drawer opens */
-  initialViewMode?: 'playlists' | 'albums';
-  /** Drawer-only: show refresh button near the sort dropdown */
-  onLibraryRefresh?: () => void;
-  /** Drawer-only: controls the refresh spinner */
-  isLibraryRefreshing?: boolean;
-  /** Optional element rendered below the grid inside the card */
   footer?: React.ReactNode;
 }
 
-const PlaylistSelection = React.memo(function PlaylistSelection({
+export const LibraryPage = React.memo(function LibraryPage({
   onPlaylistSelect,
   onAddToQueue,
   onPlayLikedTracks,
   onQueueLikedTracks,
-  inDrawer = false,
-  swipeZoneRef,
-  initialSearchQuery,
-  initialViewMode,
-  onLibraryRefresh,
-  isLibraryRefreshing,
   footer,
-}: PlaylistSelectionProps): JSX.Element {
-  const { activeDescriptor, hasMultipleProviders, enabledProviderIds, getDescriptor } = useProviderContext();
-  const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
-  const showProviderBadges = hasMultipleProviders && enabledProviderIds.length > 1;
-
+}: LibraryPageProps): JSX.Element {
   const {
-    playlists,
-    albums,
-    likedSongsCount,
-    likedSongsPerProvider,
-    isInitialLoadComplete,
-    isLikedSongsSyncing,
-    removeCollection,
-  } = useLibrarySync();
-
-  const [loginError, setLoginError] = useState<string | null>(null);
-
-  const {
-    viewMode,
-    setViewMode,
-    searchQuery,
-    setSearchQuery,
-    playlistSort,
-    setPlaylistSort,
-    albumSort,
-    setAlbumSort,
-    artistFilter,
-    setArtistFilter,
-    providerFilters,
-    setProviderFilters,
-    handleProviderToggle,
-    selectedGenres,
-    setSelectedGenres,
-    recentlyAddedFilter,
-    setRecentlyAddedFilter,
-    hasActiveFilters,
-  } = useLibraryBrowsing(initialSearchQuery, initialViewMode);
-
-  const {
-    handlePlaylistContextMenu,
-    handleAlbumContextMenu,
+    browsingValue,
+    pinValue,
+    actionsValue,
+    dataValue,
+    statusContentProps,
+    showMainContent,
+    maxWidth,
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
-  } = useItemActions({
+  } = useLibraryRoot({
     onPlaylistSelect,
     onAddToQueue,
     onPlayLikedTracks,
     onQueueLikedTracks,
-    activeDescriptor: activeDescriptor ?? null,
-    getDescriptor,
-    removeCollection,
+    inDrawer: false,
   });
-
-  const { viewport, isMobile, isTablet } = usePlayerSizingContext();
-  const {
-    pinnedPlaylistIds,
-    pinnedAlbumIds,
-    isPlaylistPinned,
-    isAlbumPinned,
-    togglePinPlaylist,
-    togglePinAlbum,
-    canPinMorePlaylists,
-    canPinMoreAlbums,
-  } = usePinnedItems();
-
-  const maxWidth = useMemo(() => {
-    if (isMobile) {
-      return Math.min(viewport.width * 0.95, 400);
-    }
-    if (isTablet) {
-      return Math.min(viewport.width * 0.8, 500);
-    }
-    return Math.min(viewport.width * 0.6, 600);
-  }, [viewport.width, isMobile, isTablet]);
-
-  const playlistLibraryView = useMemo(() => {
-    let items = playlists;
-    if (providerFilters.length > 0) {
-      items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
-    }
-    let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((p) => matchesRecentlyAddedFilter(p.added_at, recentlyAddedFilter));
-    }
-    return buildLibraryViewWithPins(
-      filtered,
-      pinnedPlaylistIds,
-      (p) => p.id,
-      (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
-    );
-  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
-
-  const pinnedPlaylists = playlistLibraryView.pinned;
-  const unpinnedPlaylists = playlistLibraryView.unpinned;
-
-  const albumLibraryView = useMemo(() => {
-    let items = albums;
-    if (providerFilters.length > 0) {
-      items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
-    }
-    let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((a) => matchesRecentlyAddedFilter(a.added_at, recentlyAddedFilter));
-    }
-    return buildLibraryViewWithPins(
-      filtered,
-      pinnedAlbumIds,
-      (a) => a.id,
-      (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
-    );
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
-
-  const pinnedAlbums = albumLibraryView.pinned;
-  const unpinnedAlbums = albumLibraryView.unpinned;
-
-  // Derive available genres from the full album list (albums carry genre metadata; playlists don't)
-  const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
-
-  const isAuthenticated = useMemo(
-    () =>
-      enabledProviderIds.some(id => getDescriptor(id)?.auth.isAuthenticated()) ||
-      (activeDescriptor?.auth.isAuthenticated() ?? false),
-    [activeDescriptor, enabledProviderIds, getDescriptor]
-  );
-
-  const isLoading = false;
-
-  const libraryError = useMemo(() => {
-    if (!isInitialLoadComplete) return null;
-    if (playlists.length === 0 && albums.length === 0 && likedSongsCount === 0) {
-      const providerName = activeDescriptor?.name ?? 'your music service';
-      return `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`;
-    }
-    return null;
-  }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount, activeDescriptor]);
-
-  const error = loginError ?? libraryError;
-
-  function handlePlaylistClick(playlist: PlaylistInfo): void {
-    logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
-    onPlaylistSelect(playlist.id, playlist.name, playlist.provider);
-  }
-
-  function handleAlbumClick(album: AlbumInfo): void {
-    logQueue('selected album: %s (%s)', album.name, album.id);
-    onPlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
-  }
-
-  function handleLikedSongsClick(provider?: ProviderId): void {
-    const resolvedProvider = provider ?? (likedSongsPerProvider.length === 1 ? likedSongsPerProvider[0].provider : undefined);
-    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
-  }
-
-  function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    togglePinPlaylist(id);
-  }
-
-  function handlePinAlbumClick(id: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    togglePinAlbum(id);
-  }
-
-  function handleArtistClick(artistName: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    setArtistFilter(artistName);
-  }
-
-  const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
-  const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
-
-  const browsingValue: LibraryBrowsingContextValue = useMemo(
-    () => ({
-      viewMode,
-      setViewMode,
-      searchQuery,
-      setSearchQuery,
-      playlistSort,
-      setPlaylistSort,
-      albumSort,
-      setAlbumSort,
-      artistFilter,
-      setArtistFilter,
-      providerFilters,
-      setProviderFilters,
-      handleProviderToggle,
-      availableGenres,
-      selectedGenres,
-      setSelectedGenres,
-      recentlyAddedFilter,
-      setRecentlyAddedFilter,
-      hasActiveFilters,
-    }),
-    [
-      viewMode,
-      searchQuery,
-      playlistSort,
-      albumSort,
-      artistFilter,
-      providerFilters,
-      availableGenres,
-      selectedGenres,
-      recentlyAddedFilter,
-      hasActiveFilters,
-    ]
-  );
-
-  const pinValue: LibraryPinContextValue = useMemo(
-    () => ({
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
-      onPinPlaylistClick: handlePinPlaylistClick,
-      onPinAlbumClick: handlePinAlbumClick,
-    }),
-    [
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
-      handlePinPlaylistClick,
-      handlePinAlbumClick,
-    ]
-  );
-
-  const actionsValue: LibraryActionsContextValue = useMemo(
-    () => ({
-      onPlaylistClick: handlePlaylistClick,
-      onPlaylistContextMenu: handlePlaylistContextMenu,
-      onLikedSongsClick: handleLikedSongsClick,
-      onAlbumClick: handleAlbumClick,
-      onAlbumContextMenu: handleAlbumContextMenu,
-      onArtistClick: handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
-    }),
-    [
-      handlePlaylistClick,
-      handlePlaylistContextMenu,
-      handleLikedSongsClick,
-      handleAlbumClick,
-      handleAlbumContextMenu,
-      handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
-    ]
-  );
-
-  const dataValue: LibraryDataContextValue = useMemo(
-    () => ({
-      inDrawer,
-      swipeZoneRef,
-      albums,
-      isInitialLoadComplete,
-      showProviderBadges,
-      enabledProviderIds,
-      likedSongsPerProvider,
-      likedSongsCount,
-      isLikedSongsSyncing,
-      isUnifiedLikedActive,
-      unifiedLikedCount,
-      activeDescriptor: activeDescriptor ?? null,
-    }),
-    [
-      inDrawer,
-      swipeZoneRef,
-      albums,
-      isInitialLoadComplete,
-      showProviderBadges,
-      enabledProviderIds,
-      likedSongsPerProvider,
-      likedSongsCount,
-      isLikedSongsSyncing,
-      isUnifiedLikedActive,
-      unifiedLikedCount,
-      activeDescriptor,
-    ]
-  );
-
-  const statusContentProps = {
-    isLoading,
-    isAuthenticated,
-    error,
-    activeDescriptor: activeDescriptor ?? null,
-    setError: setLoginError,
-  };
-
-  if (inDrawer) {
-    return (
-      <LibraryDataProvider value={dataValue}>
-      <LibraryBrowsingProvider value={browsingValue}>
-      <LibraryPinProvider value={pinValue}>
-      <LibraryActionsProvider value={actionsValue}>
-        <DrawerContentWrapper>
-          <LibraryStatusContent {...statusContentProps} />
-          {showMainContent && <LibraryMainContent />}
-          {albumPopoverPortal}
-          {playlistPopoverPortal}
-          {confirmDeletePortal}
-        </DrawerContentWrapper>
-      </LibraryActionsProvider>
-      </LibraryPinProvider>
-      </LibraryBrowsingProvider>
-      </LibraryDataProvider>
-    );
-  }
 
   return (
     <LibraryDataProvider value={dataValue}>
     <LibraryBrowsingProvider value={browsingValue}>
     <LibraryPinProvider value={pinValue}>
     <LibraryActionsProvider value={actionsValue}>
-      <Container $inDrawer={false}>
-        <SelectionCard $maxWidth={maxWidth} $inDrawer={false}>
+      <PageContainer>
+        <PageSelectionCard $maxWidth={maxWidth}>
           <CardContent style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
             <LibraryStatusContent {...statusContentProps} />
             {showMainContent && <LibraryMainContent />}
@@ -410,8 +69,8 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
             {confirmDeletePortal}
           </CardContent>
           {footer}
-        </SelectionCard>
-      </Container>
+        </PageSelectionCard>
+      </PageContainer>
     </LibraryActionsProvider>
     </LibraryPinProvider>
     </LibraryBrowsingProvider>
@@ -419,4 +78,73 @@ const PlaylistSelection = React.memo(function PlaylistSelection({
   );
 });
 
-export default PlaylistSelection;
+interface DrawerLibraryProps {
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+  initialSearchQuery?: string;
+  initialViewMode?: 'playlists' | 'albums';
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+export const DrawerLibrary = React.memo(function DrawerLibrary({
+  onPlaylistSelect,
+  onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
+  swipeZoneRef,
+  initialSearchQuery,
+  initialViewMode,
+  onLibraryRefresh,
+  isLibraryRefreshing,
+}: DrawerLibraryProps): JSX.Element {
+  const {
+    browsingValue,
+    pinValue,
+    actionsValue,
+    dataValue,
+    statusContentProps,
+    showMainContent,
+    albumPopoverPortal,
+    playlistPopoverPortal,
+    confirmDeletePortal,
+  } = useLibraryRoot({
+    onPlaylistSelect,
+    onAddToQueue,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
+    inDrawer: true,
+    swipeZoneRef,
+    initialSearchQuery,
+    initialViewMode,
+    onLibraryRefresh,
+    isLibraryRefreshing,
+  });
+
+  return (
+    <LibraryDataProvider value={dataValue}>
+    <LibraryBrowsingProvider value={browsingValue}>
+    <LibraryPinProvider value={pinValue}>
+    <LibraryActionsProvider value={actionsValue}>
+      <DrawerContentWrapper>
+        <LibraryStatusContent {...statusContentProps} />
+        {showMainContent && <LibraryMainContent />}
+        {albumPopoverPortal}
+        {playlistPopoverPortal}
+        {confirmDeletePortal}
+      </DrawerContentWrapper>
+    </LibraryActionsProvider>
+    </LibraryPinProvider>
+    </LibraryBrowsingProvider>
+    </LibraryDataProvider>
+  );
+});
+
+export default LibraryPage;

--- a/src/components/PlaylistSelection/styled.layout.ts
+++ b/src/components/PlaylistSelection/styled.layout.ts
@@ -2,63 +2,31 @@ import styled from 'styled-components';
 import { Card } from '../styled';
 import { theme } from '@/styles/theme';
 
-export const Container = styled.div<{ $inDrawer?: boolean }>`
+export const PageContainer = styled.div`
   width: 100%;
   display: flex;
-  ${({ $inDrawer }) =>
-    $inDrawer
-      ? `
-    flex: 1;
-    min-height: 0;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: flex-start;
-    padding: 0 ${theme.spacing.lg} ${theme.spacing.md};
-    box-sizing: border-box;
-  `
-      : `
-    min-height: 100vh;
-    min-height: 100dvh;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
+  min-height: 100vh;
+  min-height: 100dvh;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
 
-    @media (max-width: ${theme.breakpoints.lg}) {
-      padding: 0.5rem;
-    }
-  `}
+  @media (max-width: ${theme.breakpoints.lg}) {
+    padding: 0.5rem;
+  }
 `;
 
-export const SelectionCard = styled(Card)<{ $maxWidth: number; $inDrawer?: boolean }>`
+export const PageSelectionCard = styled(Card)<{ $maxWidth: number }>`
   width: 100%;
-  max-width: ${({ $maxWidth, $inDrawer }) => ($inDrawer ? 'none' : `${$maxWidth}px`)};
-  ${({ $inDrawer }) =>
-    $inDrawer
-      ? `
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    background: none;
-    background-color: transparent;
-    backdrop-filter: none;
-    border: none;
-    border-radius: 0;
-    box-shadow: none;
-    padding: 0;
-    margin: 0;
-  `
-      : `
-    background: ${theme.colors.muted.background};
-    backdrop-filter: blur(12px);
-    border: 1px solid ${theme.colors.control.border};
-    border-radius: 1.25rem;
-    box-shadow: ${theme.shadows.albumArt};
-    display: flex;
-    flex-direction: column;
-    max-height: min(90dvh, 900px);
-  `}
+  max-width: ${({ $maxWidth }) => `${$maxWidth}px`};
+  background: ${theme.colors.muted.background};
+  backdrop-filter: blur(12px);
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: 1.25rem;
+  box-shadow: ${theme.shadows.albumArt};
+  display: flex;
+  flex-direction: column;
+  max-height: min(90dvh, 900px);
 `;
 
 export const DrawerContentWrapper = styled.div`

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -1,0 +1,357 @@
+import { useState, useMemo } from 'react';
+import * as React from 'react';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import { useLibrarySync } from '../../hooks/useLibrarySync';
+import {
+  filterPlaylistsOnly,
+  sortPlaylistSubgroup,
+  filterAlbumsOnly,
+  sortAlbumSubgroup,
+  buildLibraryViewWithPins,
+  getAvailableGenres,
+  matchesRecentlyAddedFilter,
+} from '../../utils/playlistFilters';
+import { usePinnedItems } from '../../hooks/usePinnedItems';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
+import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
+import { logQueue } from '@/lib/debugLog';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
+import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
+import { useLibraryBrowsing } from './useLibraryBrowsing';
+import { useItemActions } from './useItemActions';
+import type {
+  LibraryBrowsingContextValue,
+  LibraryPinContextValue,
+  LibraryActionsContextValue,
+  LibraryDataContextValue,
+} from './LibraryContext';
+
+interface UseLibraryRootParams {
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+  initialSearchQuery?: string;
+  initialViewMode?: 'playlists' | 'albums';
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+}
+
+export function useLibraryRoot({
+  onPlaylistSelect,
+  onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
+  inDrawer,
+  swipeZoneRef,
+  initialSearchQuery,
+  initialViewMode,
+  onLibraryRefresh,
+  isLibraryRefreshing,
+}: UseLibraryRootParams) {
+  const { activeDescriptor, hasMultipleProviders, enabledProviderIds, getDescriptor } = useProviderContext();
+  const { isUnifiedLikedActive, totalCount: unifiedLikedCount } = useUnifiedLikedTracks();
+  const showProviderBadges = hasMultipleProviders && enabledProviderIds.length > 1;
+
+  const {
+    playlists,
+    albums,
+    likedSongsCount,
+    likedSongsPerProvider,
+    isInitialLoadComplete,
+    isLikedSongsSyncing,
+    removeCollection,
+  } = useLibrarySync();
+
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const browsingState = useLibraryBrowsing(initialSearchQuery, initialViewMode);
+
+  const {
+    searchQuery,
+    playlistSort,
+    albumSort,
+    artistFilter,
+    providerFilters,
+    selectedGenres,
+    recentlyAddedFilter,
+  } = browsingState;
+
+  const {
+    handlePlaylistContextMenu,
+    handleAlbumContextMenu,
+    albumPopoverPortal,
+    playlistPopoverPortal,
+    confirmDeletePortal,
+  } = useItemActions({
+    onPlaylistSelect,
+    onAddToQueue,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
+    activeDescriptor: activeDescriptor ?? null,
+    getDescriptor,
+    removeCollection,
+  });
+
+  const { viewport, isMobile, isTablet } = usePlayerSizingContext();
+  const {
+    pinnedPlaylistIds,
+    pinnedAlbumIds,
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+    canPinMorePlaylists,
+    canPinMoreAlbums,
+  } = usePinnedItems();
+
+  const maxWidth = useMemo(() => {
+    if (isMobile) {
+      return Math.min(viewport.width * 0.95, 400);
+    }
+    if (isTablet) {
+      return Math.min(viewport.width * 0.8, 500);
+    }
+    return Math.min(viewport.width * 0.6, 600);
+  }, [viewport.width, isMobile, isTablet]);
+
+  const playlistLibraryView = useMemo(() => {
+    let items = playlists;
+    if (providerFilters.length > 0) {
+      items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
+    }
+    let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
+    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
+      filtered = filtered.filter((p) => matchesRecentlyAddedFilter(p.added_at, recentlyAddedFilter));
+    }
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedPlaylistIds,
+      (p) => p.id,
+      (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
+    );
+  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
+
+  const pinnedPlaylists = playlistLibraryView.pinned;
+  const unpinnedPlaylists = playlistLibraryView.unpinned;
+
+  const albumLibraryView = useMemo(() => {
+    let items = albums;
+    if (providerFilters.length > 0) {
+      items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
+    }
+    let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
+    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
+      filtered = filtered.filter((a) => matchesRecentlyAddedFilter(a.added_at, recentlyAddedFilter));
+    }
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedAlbumIds,
+      (a) => a.id,
+      (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
+    );
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
+
+  const pinnedAlbums = albumLibraryView.pinned;
+  const unpinnedAlbums = albumLibraryView.unpinned;
+
+  const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
+
+  const isAuthenticated = useMemo(
+    () =>
+      enabledProviderIds.some(id => getDescriptor(id)?.auth.isAuthenticated()) ||
+      (activeDescriptor?.auth.isAuthenticated() ?? false),
+    [activeDescriptor, enabledProviderIds, getDescriptor]
+  );
+
+  const isLoading = false;
+
+  const libraryError = useMemo(() => {
+    if (!isInitialLoadComplete) return null;
+    if (playlists.length === 0 && albums.length === 0 && likedSongsCount === 0) {
+      const providerName = activeDescriptor?.name ?? 'your music service';
+      return `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`;
+    }
+    return null;
+  }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount, activeDescriptor]);
+
+  const error = loginError ?? libraryError;
+
+  function handlePlaylistClick(playlist: PlaylistInfo): void {
+    logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
+    onPlaylistSelect(playlist.id, playlist.name, playlist.provider);
+  }
+
+  function handleAlbumClick(album: AlbumInfo): void {
+    logQueue('selected album: %s (%s)', album.name, album.id);
+    onPlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
+  }
+
+  function handleLikedSongsClick(provider?: ProviderId): void {
+    const resolvedProvider = provider ?? (likedSongsPerProvider.length === 1 ? likedSongsPerProvider[0].provider : undefined);
+    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
+  }
+
+  function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    togglePinPlaylist(id);
+  }
+
+  function handlePinAlbumClick(id: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    togglePinAlbum(id);
+  }
+
+  function handleArtistClick(artistName: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    browsingState.setArtistFilter(artistName);
+  }
+
+  const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
+  const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
+
+  const browsingValue: LibraryBrowsingContextValue = useMemo(
+    () => ({
+      viewMode: browsingState.viewMode,
+      setViewMode: browsingState.setViewMode,
+      searchQuery: browsingState.searchQuery,
+      setSearchQuery: browsingState.setSearchQuery,
+      playlistSort: browsingState.playlistSort,
+      setPlaylistSort: browsingState.setPlaylistSort,
+      albumSort: browsingState.albumSort,
+      setAlbumSort: browsingState.setAlbumSort,
+      artistFilter: browsingState.artistFilter,
+      setArtistFilter: browsingState.setArtistFilter,
+      providerFilters: browsingState.providerFilters,
+      setProviderFilters: browsingState.setProviderFilters,
+      handleProviderToggle: browsingState.handleProviderToggle,
+      availableGenres,
+      selectedGenres: browsingState.selectedGenres,
+      setSelectedGenres: browsingState.setSelectedGenres,
+      recentlyAddedFilter: browsingState.recentlyAddedFilter,
+      setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
+      hasActiveFilters: browsingState.hasActiveFilters,
+    }),
+    [
+      browsingState.viewMode,
+      browsingState.searchQuery,
+      browsingState.playlistSort,
+      browsingState.albumSort,
+      browsingState.artistFilter,
+      browsingState.providerFilters,
+      availableGenres,
+      browsingState.selectedGenres,
+      browsingState.recentlyAddedFilter,
+      browsingState.hasActiveFilters,
+    ]
+  );
+
+  const pinValue: LibraryPinContextValue = useMemo(
+    () => ({
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      onPinPlaylistClick: handlePinPlaylistClick,
+      onPinAlbumClick: handlePinAlbumClick,
+    }),
+    [
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      handlePinPlaylistClick,
+      handlePinAlbumClick,
+    ]
+  );
+
+  const actionsValue: LibraryActionsContextValue = useMemo(
+    () => ({
+      onPlaylistClick: handlePlaylistClick,
+      onPlaylistContextMenu: handlePlaylistContextMenu,
+      onLikedSongsClick: handleLikedSongsClick,
+      onAlbumClick: handleAlbumClick,
+      onAlbumContextMenu: handleAlbumContextMenu,
+      onArtistClick: handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    }),
+    [
+      handlePlaylistClick,
+      handlePlaylistContextMenu,
+      handleLikedSongsClick,
+      handleAlbumClick,
+      handleAlbumContextMenu,
+      handleArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    ]
+  );
+
+  const dataValue: LibraryDataContextValue = useMemo(
+    () => ({
+      inDrawer,
+      swipeZoneRef,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      activeDescriptor: activeDescriptor ?? null,
+    }),
+    [
+      inDrawer,
+      swipeZoneRef,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      activeDescriptor,
+    ]
+  );
+
+  const statusContentProps = {
+    isLoading,
+    isAuthenticated,
+    error,
+    activeDescriptor: activeDescriptor ?? null,
+    setError: setLoginError,
+  };
+
+  return {
+    browsingValue,
+    pinValue,
+    actionsValue,
+    dataValue,
+    statusContentProps,
+    showMainContent,
+    maxWidth,
+    albumPopoverPortal,
+    playlistPopoverPortal,
+    confirmDeletePortal,
+  };
+}

--- a/src/components/__tests__/LibraryDrawer.test.tsx
+++ b/src/components/__tests__/LibraryDrawer.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
 }));
 
 vi.mock('@/components/PlaylistSelection', () => ({
-  default: ({ onPlaylistSelect }: { onPlaylistSelect: (id: string, name: string) => void }) => (
+  DrawerLibrary: ({ onPlaylistSelect }: { onPlaylistSelect: (id: string, name: string) => void }) => (
     <div data-testid="playlist-selection">
       <button onClick={() => onPlaylistSelect('pl-1', 'Mock Playlist')}>Mock Playlist</button>
     </div>

--- a/src/components/__tests__/PlaylistSelection.test.tsx
+++ b/src/components/__tests__/PlaylistSelection.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
-import PlaylistSelection from '../PlaylistSelection';
+import { LibraryPage, DrawerLibrary } from '../PlaylistSelection';
 import { TestWrapper } from '@/test/testWrappers';
 import { makePlaylistInfo, makeAlbumInfo } from '@/test/fixtures';
 import { LIKED_SONGS_ID } from '@/constants/playlist';
@@ -97,12 +97,24 @@ function setMockLibrarySync(overrides?: Record<string, unknown>) {
   } as ReturnType<typeof useLibrarySync>);
 }
 
-function renderPlaylistSelection(props?: Partial<Parameters<typeof PlaylistSelection>[0]>) {
+function renderLibraryPage(props?: Partial<Parameters<typeof LibraryPage>[0]>) {
   const onPlaylistSelect = vi.fn();
   const result = render(
     <ThemeProvider theme={theme}>
       <TestWrapper>
-        <PlaylistSelection onPlaylistSelect={onPlaylistSelect} {...props} />
+        <LibraryPage onPlaylistSelect={onPlaylistSelect} {...props} />
+      </TestWrapper>
+    </ThemeProvider>
+  );
+  return { ...result, onPlaylistSelect };
+}
+
+function renderDrawerLibrary(props?: Partial<Parameters<typeof DrawerLibrary>[0]>) {
+  const onPlaylistSelect = vi.fn();
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <TestWrapper>
+        <DrawerLibrary onPlaylistSelect={onPlaylistSelect} {...props} />
       </TestWrapper>
     </ThemeProvider>
   );
@@ -115,14 +127,14 @@ describe('PlaylistSelection', () => {
   });
 
   it('renders Playlists and Albums tab buttons', () => {
-    renderPlaylistSelection();
+    renderLibraryPage();
     expect(screen.getByRole('button', { name: /playlists/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /albums/i })).toBeTruthy();
   });
 
   it('switching to Albums tab shows the album grid', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
 
     // #when
     fireEvent.click(screen.getByRole('button', { name: /albums/i }));
@@ -134,7 +146,7 @@ describe('PlaylistSelection', () => {
 
   it('search input filters playlist list by name (case-insensitive)', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...');
 
     // #when
@@ -146,14 +158,14 @@ describe('PlaylistSelection', () => {
   });
 
   it('pinned items appear before unpinned items', () => {
-    renderPlaylistSelection();
+    renderLibraryPage();
     const items = screen.getAllByText(/tracks/);
     expect(items.length).toBeGreaterThan(0);
   });
 
   it('clicking a playlist calls onPlaylistSelect with the correct playlist ID', () => {
     // #given
-    const { onPlaylistSelect } = renderPlaylistSelection();
+    const { onPlaylistSelect } = renderLibraryPage();
 
     // #when
     fireEvent.click(screen.getByText('Chill Vibes'));
@@ -173,7 +185,7 @@ describe('PlaylistSelection', () => {
     });
 
     // #when
-    renderPlaylistSelection();
+    renderLibraryPage();
 
     // #then
     // When auth is resolved but initial load is not complete, the component renders
@@ -194,7 +206,7 @@ describe('PlaylistSelection', () => {
     });
 
     // #when
-    renderPlaylistSelection();
+    renderLibraryPage();
 
     // #then
     expect(
@@ -204,7 +216,7 @@ describe('PlaylistSelection', () => {
 
   it('Liked Songs item is present with LIKED_SONGS_ID', () => {
     // #given
-    const { onPlaylistSelect } = renderPlaylistSelection();
+    const { onPlaylistSelect } = renderLibraryPage();
 
     // #when
     fireEvent.click(screen.getByText('Liked Songs'));
@@ -214,9 +226,9 @@ describe('PlaylistSelection', () => {
     expect(onPlaylistSelect).toHaveBeenCalledWith(LIKED_SONGS_ID, 'Liked Songs', undefined);
   });
 
-  it('inDrawer: tapping a playlist opens the menu; Play then calls onPlaylistSelect', () => {
+  it('DrawerLibrary: tapping a playlist opens the menu; Play then calls onPlaylistSelect', () => {
     // #given
-    const { onPlaylistSelect } = renderPlaylistSelection({ inDrawer: true });
+    const { onPlaylistSelect } = renderDrawerLibrary();
 
     // #when
     fireEvent.click(screen.getByText('Chill Vibes'));
@@ -239,7 +251,7 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('filters playlists by search query', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...');
 
     // #when
@@ -253,7 +265,7 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('shows empty state when search matches nothing', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...');
 
     // #when
@@ -266,7 +278,7 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('clears search when clear button is clicked', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...') as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: MOCK_PLAYLIST_NAMES.CHILL } });
     expect(searchInput.value).toBe(MOCK_PLAYLIST_NAMES.CHILL);
@@ -288,7 +300,7 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('search is case-insensitive', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...');
 
     // #when
@@ -308,7 +320,7 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('search updates live as user types', () => {
     // #given
-    renderPlaylistSelection();
+    renderLibraryPage();
     const searchInput = screen.getByPlaceholderText('Search playlists...');
 
     // #when


### PR DESCRIPTION
Closes #840

## Summary

- Extract shared state/context wiring into `useLibraryRoot` hook
- Create `LibraryPage` composition root for standalone full-screen library view
- Create `DrawerLibrary` composition root for drawer-embedded library view
- Remove `$inDrawer` conditionals from `Container`/`SelectionCard` in `styled.layout.ts`, replacing them with dedicated `PageContainer`/`PageSelectionCard` components
- Keep `inDrawer` in `LibraryDataContext` since child components (`AlbumGrid`, `PlaylistGrid`, `LibraryMainContent`) still read it to switch rendering modes
- Update all callsites: `LibraryDrawer` uses `DrawerLibrary`, `PlayerStateRenderer` uses `LibraryPage`
- Update test mocks and render helpers accordingly

## Test plan

- [x] `npx tsc -b --noEmit` passes with zero errors
- [x] `npm run test:run` — 964 tests pass (1 pre-existing failure in `useFilterState.test.ts` unrelated to changes)