### PR TITLE
refactor(library): remove duplicate search from LibraryControls

### DIFF
--- a/src/components/PlaylistSelection/LibraryControls.tsx
+++ b/src/components/PlaylistSelection/LibraryControls.tsx
@@ -5,7 +5,6 @@ import type { ProviderId } from '@/types/domain';
 import {
   ControlsContainer,
   SortControlsRow,
-  SearchInput,
   SelectDropdown,
   RefreshButton,
   ClearButton,
@@ -15,8 +14,6 @@ import { RefreshIcon } from './utils';
 interface LibraryControlsProps {
   inDrawer: boolean;
   viewMode: 'playlists' | 'albums';
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
   playlistSort: PlaylistSortOption;
   setPlaylistSort: (v: PlaylistSortOption) => void;
   albumSort: AlbumSortOption;
@@ -31,8 +28,6 @@ interface LibraryControlsProps {
 export function LibraryControls({
   inDrawer,
   viewMode,
-  searchQuery,
-  setSearchQuery,
   playlistSort,
   setPlaylistSort,
   albumSort,
@@ -44,7 +39,6 @@ export function LibraryControls({
   isLibraryRefreshing,
 }: LibraryControlsProps): React.JSX.Element {
   const clearFilters = () => {
-    setSearchQuery('');
     setArtistFilter('');
     setProviderFilters([]);
   };
@@ -52,13 +46,6 @@ export function LibraryControls({
   if (inDrawer) {
     return (
       <ControlsContainer $inDrawer>
-        <SearchInput
-          type="text"
-          placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-
         <SortControlsRow>
           {viewMode === 'playlists' ? (
             <SelectDropdown
@@ -94,7 +81,7 @@ export function LibraryControls({
           )}
         </SortControlsRow>
 
-        {(searchQuery || artistFilter) && (
+        {artistFilter && (
           <ClearButton onClick={clearFilters}>Clear</ClearButton>
         )}
       </ControlsContainer>
@@ -103,13 +90,6 @@ export function LibraryControls({
 
   return (
     <ControlsContainer>
-      <SearchInput
-        type="text"
-        placeholder={viewMode === 'playlists' ? 'Search playlists...' : 'Search albums...'}
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-      />
-
       {viewMode === 'playlists' ? (
         <SelectDropdown
           value={playlistSort}
@@ -130,7 +110,7 @@ export function LibraryControls({
         </SelectDropdown>
       )}
 
-      {(searchQuery || artistFilter) && (
+      {artistFilter && (
         <ClearButton onClick={clearFilters}>Clear</ClearButton>
       )}
     </ControlsContainer>

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -182,8 +182,6 @@ export function LibraryMainContent(): React.JSX.Element {
         <LibraryControls
           inDrawer={false}
           viewMode={viewMode}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
           playlistSort={playlistSort}
           setPlaylistSort={setPlaylistSort}
           albumSort={albumSort}

--- a/src/components/PlaylistSelection/styled.controls.ts
+++ b/src/components/PlaylistSelection/styled.controls.ts
@@ -80,28 +80,6 @@ export const SortControlsRow = styled.div`
   min-width: 0;
 `;
 
-export const SearchInput = styled.input`
-  flex: 1;
-  min-width: 180px;
-  padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
-  background: ${({ theme }) => theme.colors.control.background};
-  border: 1px solid ${({ theme }) => theme.colors.control.borderHover};
-  border-radius: ${({ theme }) => theme.borderRadius.lg};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  outline: none;
-  transition: border-color ${({ theme }) => theme.transitions.fast}, background ${({ theme }) => theme.transitions.fast};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.muted.foreground};
-  }
-
-  &:focus {
-    background: ${({ theme }) => theme.colors.control.backgroundHover};
-    border-color: ${({ theme }) => theme.colors.accent};
-  }
-`;
-
 export const SelectDropdown = styled.select`
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: ${({ theme }) => theme.colors.control.background};

--- a/src/components/__tests__/PlaylistSelection.test.tsx
+++ b/src/components/__tests__/PlaylistSelection.test.tsx
@@ -146,8 +146,8 @@ describe('PlaylistSelection', () => {
 
   it('search input filters playlist list by name (case-insensitive)', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...');
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i });
 
     // #when
     fireEvent.change(searchInput, { target: { value: 'chill' } });
@@ -251,8 +251,8 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('filters playlists by search query', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...');
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i });
 
     // #when
     fireEvent.change(searchInput, { target: { value: MOCK_PLAYLIST_NAMES.CHILL } });
@@ -265,26 +265,25 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('shows empty state when search matches nothing', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...');
+    setMockLibrarySync({ likedSongsCount: 0 });
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i });
 
     // #when
     fireEvent.change(searchInput, { target: { value: 'XYZ123NonExistent' } });
 
     // #then
-    const noResultsText = screen.queryByText(/no/i);
-    expect(noResultsText || searchInput.parentElement?.textContent).toBeTruthy();
+    expect(screen.getByText(/no playlists match/i)).toBeTruthy();
   });
 
   it('clears search when clear button is clicked', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...') as HTMLInputElement;
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i }) as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: MOCK_PLAYLIST_NAMES.CHILL } });
     expect(searchInput.value).toBe(MOCK_PLAYLIST_NAMES.CHILL);
 
-    const clearButton = screen.queryByRole('button', { name: /clear|close|reset/i })
-      || screen.getByRole('button', { name: /✕|✖|×|x/i });
+    const clearButton = screen.queryByRole('button', { name: /clear search/i });
 
     // #when
     if (clearButton) {
@@ -300,8 +299,8 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('search is case-insensitive', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...');
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i });
 
     // #when
     fireEvent.change(searchInput, { target: { value: 'JAZZ' } });
@@ -320,8 +319,8 @@ describe('PlaylistSelection — search and filter', () => {
 
   it('search updates live as user types', () => {
     // #given
-    renderLibraryPage();
-    const searchInput = screen.getByPlaceholderText('Search playlists...');
+    renderDrawerLibrary();
+    const searchInput = screen.getByRole('textbox', { name: /search playlists and albums/i });
 
     // #when
     fireEvent.change(searchInput, { target: { value: MOCK_PLAYLIST_NAMES.CHILL } });


### PR DESCRIPTION
## Summary
- Removes the `SearchInput` and `searchQuery`/`setSearchQuery` props from `LibraryControls` — the sidebar (`FilterSidebar`) is now the single search entry point
- Removes the now-unused `SearchInput` styled-component from `styled.controls.ts`
- Updates call site in `LibraryMainContent` to no longer pass search props to `LibraryControls`
- Updates `PlaylistSelection` tests to exercise search via the sidebar's accessible input

Closes #901