### PR TITLE
fix(library): wire bottom bar library button to full-screen library view

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -186,7 +186,7 @@ const AudioPlayerComponent = () => {
     onPlayLikedTracks: handlePlayLikedTracks,
     onQueueLikedTracks: handleQueueLikedTracks,
     onAlbumPlay: handleAlbumPlay,
-    onBackToLibrary: handleOpenQuickAccessPanel,
+    onBackToLibrary: handlers.handleOpenLibrary,
     onStartRadio: handlers.handleStartRadio,
     onRemoveFromQueue: handlers.handleRemoveFromQueue,
     onReorderQueue: handlers.handleReorderQueue,


### PR DESCRIPTION
Closes #921

## Summary
- `onBackToLibrary` in `AudioPlayer.tsx` was wired to `handleOpenQuickAccessPanel` (opens QAP) instead of `handlers.handleOpenLibrary` (opens full-screen library view)
- One-line fix: replaced the incorrect handler reference

## Test plan
- [ ] Tap the library button in BottomBar while a track is playing — full-screen library view should open
- [ ] Swipe down on album art — full-screen library view should open (unchanged)
- [ ] `↓` / `L` keyboard shortcut — opens library or QAP depending on QAP setting (unchanged)
- [ ] TypeScript: `npx tsc -b --noEmit` passes with zero errors
- [ ] `npm run test:run` — 6 pre-existing failures unrelated to this change