### PR TITLE
feat(library): add mini player bar to full-screen library view

### DIFF
--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -44,6 +44,7 @@ interface DrawerOrchestratorProps {
   onCloseQueue: () => void;
   showLibrary: boolean;
   onCloseLibrary: () => void;
+  isPlaying?: boolean;
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
@@ -66,6 +67,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
   onCloseQueue,
   showLibrary,
   onCloseLibrary,
+  isPlaying,
   onPlaylistSelect,
   onPlayLikedTracks,
   onQueueLikedTracks,
@@ -189,6 +191,8 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
               onPlaylistSelect={handleLibraryPlaylistSelect}
               onPlayLikedTracks={onPlayLikedTracks}
               onQueueLikedTracks={onQueueLikedTracks}
+              onNavigateToPlayer={onCloseLibrary}
+              isPlaying={isPlaying}
               footer={lastSession && onResume ? (
                 <ResumeCard session={lastSession} onResume={onResume} />
               ) : undefined}

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -240,6 +240,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
         onCloseQueue={handleCloseQueue}
         showLibrary={showLibrary}
         onCloseLibrary={handleCloseLibrary}
+        isPlaying={isPlaying}
         onPlaylistSelect={handlers.onPlaylistSelect}
         onPlayLikedTracks={handlers.onPlayLikedTracks}
         onQueueLikedTracks={handlers.onQueueLikedTracks}

--- a/src/components/PlaylistSelection/LibraryMiniPlayer.tsx
+++ b/src/components/PlaylistSelection/LibraryMiniPlayer.tsx
@@ -1,0 +1,133 @@
+import styled, { keyframes } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { useCurrentTrackContext } from '@/contexts/TrackContext';
+
+const Strip = styled.button`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  width: 100%;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: none;
+  border-top: 1px solid ${theme.colors.borderSubtle};
+  border-radius: 0 0 1.25rem 1.25rem;
+  cursor: pointer;
+  color: ${theme.colors.foreground};
+  text-align: left;
+  transition: background ${theme.transitions.fast};
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.75);
+  }
+
+  &:active {
+    background: rgba(0, 0, 0, 0.85);
+  }
+`;
+
+const Artwork = styled.img`
+  width: 40px;
+  height: 40px;
+  border-radius: ${theme.borderRadius.md};
+  object-fit: cover;
+  flex-shrink: 0;
+`;
+
+const ArtworkPlaceholder = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: ${theme.borderRadius.md};
+  background: ${theme.colors.control.background};
+  flex-shrink: 0;
+`;
+
+const Info = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const TrackName = styled.span`
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.medium};
+  color: ${theme.colors.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const ArtistName = styled.span`
+  font-size: ${theme.fontSize.xs};
+  color: ${theme.colors.muted.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const equalize = keyframes`
+  0%, 100% { transform: scaleY(0.3); }
+  50% { transform: scaleY(1); }
+`;
+
+const Bars = styled.div<{ $paused: boolean }>`
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 16px;
+  padding-right: ${theme.spacing.xs};
+
+  & > span {
+    display: block;
+    width: 3px;
+    height: 100%;
+    background: ${theme.colors.muted.foreground};
+    border-radius: 1px;
+    transform-origin: bottom;
+    animation: ${equalize} 0.8s ease-in-out infinite;
+    animation-play-state: ${({ $paused }) => ($paused ? 'paused' : 'running')};
+  }
+
+  & > span:nth-child(1) { animation-delay: 0s; }
+  & > span:nth-child(2) { animation-delay: 0.2s; }
+  & > span:nth-child(3) { animation-delay: 0.4s; }
+`;
+
+interface LibraryMiniPlayerProps {
+  isPlaying: boolean;
+  onNavigateToPlayer: () => void;
+}
+
+export function LibraryMiniPlayer({ isPlaying, onNavigateToPlayer }: LibraryMiniPlayerProps): JSX.Element | null {
+  const { currentTrack } = useCurrentTrackContext();
+
+  if (!currentTrack) return null;
+
+  return (
+    <Strip
+      onClick={onNavigateToPlayer}
+      type="button"
+      aria-label={`Now playing: ${currentTrack.name} by ${currentTrack.artists}. Tap to return to player.`}
+    >
+      {currentTrack.image ? (
+        <Artwork src={currentTrack.image} alt="" />
+      ) : (
+        <ArtworkPlaceholder />
+      )}
+      <Info>
+        <TrackName>{currentTrack.name}</TrackName>
+        <ArtistName>{currentTrack.artists}</ArtistName>
+      </Info>
+      <Bars $paused={!isPlaying}>
+        <span />
+        <span />
+        <span />
+      </Bars>
+    </Strip>
+  );
+}

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -14,6 +14,7 @@ import {
   LibraryDataProvider,
 } from './LibraryContext';
 import { useLibraryRoot } from './useLibraryRoot';
+import { LibraryMiniPlayer } from './LibraryMiniPlayer';
 
 interface LibraryPageProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -24,6 +25,8 @@ interface LibraryPageProps {
   ) => Promise<AddToQueueResult | null>;
   onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  onNavigateToPlayer?: () => void;
+  isPlaying?: boolean;
   footer?: React.ReactNode;
 }
 
@@ -32,6 +35,8 @@ export const LibraryPage = React.memo(function LibraryPage({
   onAddToQueue,
   onPlayLikedTracks,
   onQueueLikedTracks,
+  onNavigateToPlayer,
+  isPlaying,
   footer,
 }: LibraryPageProps): JSX.Element {
   const {
@@ -68,6 +73,9 @@ export const LibraryPage = React.memo(function LibraryPage({
             {confirmDeletePortal}
           </CardContent>
           {footer}
+          {onNavigateToPlayer && (
+            <LibraryMiniPlayer isPlaying={isPlaying ?? false} onNavigateToPlayer={onNavigateToPlayer} />
+          )}
         </PageSelectionCard>
       </PageContainer>
     </LibraryActionsProvider>


### PR DESCRIPTION
## Summary
- Adds a `LibraryMiniPlayer` strip at the bottom of the full-screen library view showing album art, track name, artist, and animated playback indicator bars
- Only renders when a track is loaded; tapping the strip closes the library and returns to the player
- Threads `isPlaying` state through `PlayerContent` → `DrawerOrchestrator` → `LibraryPage` for the playback indicator animation

## Test plan
- [ ] Open library while a track is playing — mini player strip appears at bottom with track info and animated bars
- [ ] Open library while paused — mini player shows with frozen bars
- [ ] Tap the mini player strip — library closes and player is visible
- [ ] Open library with no track loaded — no mini player rendered
- [ ] Verify mini player text truncates gracefully for long track/artist names

Closes #920