### PR TITLE
docs: update library architecture docs for full-screen view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 
 **Vorbis Player** is a React/TypeScript music player with customizable visual effects and a pluggable provider architecture. Supports **Spotify** (streaming, Premium required) and **Dropbox** (personal files via HTML5 Audio), including cross-provider queues.
 
-Key capabilities: multi-provider auth/catalog/playback adapters, unified liked songs, cross-provider playback handoff, Last.fm-powered radio queue generation, background visualizers, album art flip menu, bottom bar, swipe gestures (drawer toggles), keyboard shortcuts, IndexedDB caching, responsive layout.
+Key capabilities: multi-provider auth/catalog/playback adapters, unified liked songs, cross-provider playback handoff, Last.fm-powered radio queue generation, background visualizers, album art flip menu, bottom bar, swipe gestures (queue drawer / full-screen library), keyboard shortcuts, IndexedDB caching, responsive layout.
 
 ## Build Verification
 
@@ -91,9 +91,12 @@ AppContainer (flexCenter, min-height: 100dvh)
 - **`overflow: visible` is required on ContentWrapper** — `container-type: inline-size` creates containment that clips absolutely-positioned children
 - **`100dvh`** throughout to handle iOS address bar changes
 - **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
-- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle **queue** (up) and **library** (down) drawers (`QueueDrawer` / `QueueBottomSheet` vs `LibraryDrawer`)
-- **Idle/home view** — when no track is loaded, `PlayerStateRenderer` shows the library browser (`PlaylistSelection`) by default. The Quick Access Panel (QAP) is opt-in: toggled via the "Quick Access Panel" On/Off control in the settings panel (gear icon, `VisualEffectsMenu`). The preference is stored under the `vorbis-player-qap-enabled` localStorage key (default `false`) via `useQapEnabled()`. `PlayerStateRenderer` initializes `showLibrary` to `!qapEnabled` and routes accordingly.
-- **ResumeCard** — `LibraryDrawer` accepts `lastSession` and `onResume` props and renders a `ResumeCard` at the bottom of the drawer, allowing users to resume a previous session regardless of whether QAP is enabled.
+- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle the **queue** (up) drawer (`QueueDrawer` / `QueueBottomSheet`)
+- **Full-screen library** — the library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered in `AudioPlayer.tsx` via `React.lazy` when `showLibrary` is true.
+- **Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
+- **Filter state** for the library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`, `vorbis-player-library-recently-added`). Opening the library from the QAP "Browse Library" button clears these keys before navigating.
+- **Idle/home view** — when no track is loaded, `PlayerStateRenderer` shows the library browser (`LibraryPage`) by default. The Quick Access Panel (QAP) is opt-in: toggled via the "Quick Access Panel" On/Off control in the settings panel (gear icon, `VisualEffectsMenu`). The preference is stored under the `vorbis-player-qap-enabled` localStorage key (default `false`) via `useQapEnabled()`. `PlayerStateRenderer` initializes `showLibrary` to `!qapEnabled` and routes accordingly.
+- **ResumeCard** — passed as the `footer` prop to `LibraryPage`, allowing users to resume a previous session regardless of whether QAP is enabled.
 - **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout
 - **Zen mode overlays** (`ZenClickZoneOverlay`, `ZenLikeOverlay`): hover-activated on desktop (pointer devices only), hidden when flip menu is open (`isFlipped`), with vertical dead zones (top/bottom 20% of album art ignored). Mobile zen uses touch gestures instead (`useZenTouchGestures`). BottomBar in zen mode shows via grip pill tap with tap-outside-to-dismiss backdrop.
 

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -5,142 +5,60 @@
 The library browser shows the user's music collections (playlists, albums, liked songs) across all connected providers. It appears in two contexts:
 
 1. **Idle/home view** -- rendered inline by `PlayerStateRenderer` when no track is loaded.
-2. **LibraryDrawer** -- a slide-down overlay accessible during playback via swipe-down on album art, `L` key, or `Down Arrow`.
+2. **Full-screen library** -- `LibraryPage` opened during playback via swipe-down on album art, BottomBar library button, `L` key, or `Down Arrow`.
 
-Both contexts render the same `PlaylistSelection` component. The difference is layout and dismissal behavior.
+Both contexts render `LibraryPage` (default export from `src/components/PlaylistSelection/index.tsx`).
 
-## LibraryDrawer
+## LibraryPage
 
-**File:** `src/components/LibraryDrawer.tsx`
+**File:** `src/components/PlaylistSelection/index.tsx`
 
-- Renders via `createPortal` to `document.body`.
-- Fixed position, slides down from top. Height: 85vh.
-- Swipe-to-dismiss via `useVerticalSwipeGesture` on a grip pill at the **bottom** of the drawer (swipe up to close, threshold: 80px).
-- Uses `hasBeenOpenedRef` to defer mount until first open.
-- Constrained to 700px width on desktop (`@media min-width: lg`), centered with auto margins and border-radius on bottom corners.
-- Only renders children when `isOpen` is true (conditional rendering, not just CSS hidden).
+`LibraryPage` is the full-screen library view. It replaces the former `LibraryDrawer` slide-down overlay.
+
+- Rendered in `AudioPlayer.tsx` via `React.lazy` when `state.showLibrary` is true.
+- `showLibrary` state lives in `usePlayerLogic`. Toggled via `handleOpenLibrary` / `handleCloseLibrary`.
+- Uses `PageContainer` + `PageSelectionCard` layout (centered, max-width constrained).
+- Accepts an optional `footer` prop used to render `ResumeCard`.
 
 **Props:**
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `isOpen` | `boolean` | Controls slide animation |
-| `onClose` | `() => void` | Close handler |
 | `onPlaylistSelect` | `(id, name, provider?) => void` | Fires when user picks a collection |
 | `onAddToQueue` | `(id, name?, provider?) => Promise<AddToQueueResult \| null>` | Append to existing queue |
 | `onPlayLikedTracks` | `(tracks, collectionId, name, provider?) => Promise<void>` | Direct play of liked tracks |
 | `onQueueLikedTracks` | `(tracks, name?) => void` | Queue liked tracks |
-| `initialSearchQuery` | `string` | Pre-populate search on open |
-| `initialViewMode` | `'playlists' \| 'albums'` | Set active tab on open |
-| `lastSession` | `SessionSnapshot \| null` | For ResumeCard |
-| `onResume` | `() => void` | Resume session handler |
-
-**Playlist selection is deferred.** When the user picks a collection, the drawer closes first, then `onPlaylistSelect` fires after `DRAWER_TRANSITION_DURATION` (via `setTimeout`). This prevents layout jank from simultaneous close animation + playback start.
+| `footer` | `React.ReactNode` | Optional footer (used for `ResumeCard`) |
 
 **Library refresh** dispatches a `vorbis-library-refresh` custom event and shows a spinner for a minimum of 1500ms.
-
-## PlaylistSelection
-
-**File:** `src/components/PlaylistSelection/index.tsx`
-
-The main library component. Renders playlist/album grids, search, sort, filter controls, and liked songs cards.
-
-### Data Sources
-
-- **Playlists and albums:** `useLibrarySync()` -- provider-agnostic sync engine that merges collections from all connected providers. Returns `CachedPlaylistInfo[]` and `AlbumInfo[]`.
-- **Liked songs count:** Also from `useLibrarySync()`, with per-provider breakdown.
-- **Unified liked tracks:** `useUnifiedLikedTracks()` -- active when 2+ providers with `hasLikedCollection` are connected.
-- **Pinned items:** `usePinnedItems()` (re-exported from `PinnedItemsContext`).
-
-### Layout Modes
-
-`PlaylistSelection` has two render paths controlled by `inDrawer`:
-
-- **`inDrawer={true}`:** Uses `DrawerContentWrapper` (fills available space, no centering). Used inside `LibraryDrawer`.
-- **`inDrawer={false}`:** Uses `Container` + `SelectionCard` (centered, max-width constrained). Used in `PlayerStateRenderer` idle view. Accepts optional `footer` prop (used for `ResumeCard`).
 
 ## LibraryContext
 
 **File:** `src/components/PlaylistSelection/LibraryContext.tsx`
 
-A React context that provides the entire library state and action callbacks to child components (`LibraryMainContent`, `PlaylistGrid`, `AlbumGrid`, `LikedSongsCard`, etc.). Created fresh in every `PlaylistSelection` render via `useMemo`.
+Library state is split into four focused sub-contexts, each consumed independently to avoid unnecessary re-renders:
 
-```ts
-interface LibraryContextValue {
-  // Layout
-  inDrawer: boolean;
-  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+| Context | Provider | Hook | Contents |
+|---------|----------|------|----------|
+| `LibraryBrowsingContext` | `LibraryBrowsingProvider` | `useLibraryBrowsingContext()` | viewMode, searchQuery, sort, filters |
+| `LibraryPinContext` | `LibraryPinProvider` | `useLibraryPins()` | pinned/unpinned collections, pin actions |
+| `LibraryActionsContext` | `LibraryActionsProvider` | `useLibraryActions()` | click/context-menu callbacks |
+| `LibraryDataContext` | `LibraryDataProvider` | `useLibraryData()` | albums, liked songs, provider data |
 
-  // Browse state
-  viewMode: 'playlists' | 'albums';
-  setViewMode: (v: 'playlists' | 'albums') => void;
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-
-  // Sort
-  playlistSort: PlaylistSortOption;    // 'name-asc' | 'name-desc' | 'recently-added'
-  setPlaylistSort: (v: PlaylistSortOption) => void;
-  albumSort: AlbumSortOption;          // 'name-asc' | 'name-desc' | 'artist-asc' | 'artist-desc' | 'release-newest' | 'release-oldest' | 'recently-added'
-  setAlbumSort: (v: AlbumSortOption) => void;
-
-  // Filters
-  artistFilter: string;
-  setArtistFilter: (v: string) => void;
-  providerFilters: ProviderId[];
-  setProviderFilters: (v: ProviderId[]) => void;
-  handleProviderToggle: (provider: ProviderId) => void;
-  hasActiveFilters: boolean;
-
-  // Data
-  albums: AlbumInfo[];
-  isInitialLoadComplete: boolean;
-  showProviderBadges: boolean;
-  enabledProviderIds: ProviderId[];
-  likedSongsPerProvider: LikedSongsEntry[];
-  likedSongsCount: number;
-  isLikedSongsSyncing: boolean;
-  isUnifiedLikedActive: boolean;
-  unifiedLikedCount: number;
-
-  // Pinned items (sorted to top of grids)
-  pinnedPlaylists: PlaylistInfo[];
-  unpinnedPlaylists: PlaylistInfo[];
-  pinnedAlbums: AlbumInfo[];
-  unpinnedAlbums: AlbumInfo[];
-  isPlaylistPinned: (id: string) => boolean;
-  canPinMorePlaylists: boolean;
-  isAlbumPinned: (id: string) => boolean;
-  canPinMoreAlbums: boolean;
-
-  // Active provider
-  activeDescriptor: ProviderDescriptor | null;
-
-  // Action callbacks
-  onPlaylistClick: (playlist: PlaylistInfo) => void;
-  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
-  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
-  onLikedSongsClick: (provider?: ProviderId) => void;
-  onAlbumClick: (album: AlbumInfo) => void;
-  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
-  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
-  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
-  onLibraryRefresh?: () => void;
-  isLibraryRefreshing?: boolean;
-}
-```
+`LibraryContextValue` is the union of all four interfaces (used internally).
 
 ## Browse Flow
 
 ### Provider Selection -> Collection List -> Track List
 
-1. User opens the library (idle view or drawer).
+1. User opens the library (idle view or full-screen).
 2. `useLibrarySync` has already fetched and cached collections from all connected providers.
 3. User selects "Playlists" or "Albums" tab (`viewMode`).
 4. Collections are filtered and sorted via `playlistFilters.ts`:
    - `filterPlaylistsOnly(items, searchQuery)` / `filterAlbumsOnly(items, searchQuery, yearFilter, artistFilter)` -- text matching on name, description, owner/artist.
    - `buildLibraryViewWithPins(filtered, pinnedIds, getId, sortFn)` -- splits into pinned (sorted to top) and unpinned groups, applies sort within each group.
 5. User clicks a collection -> `onPlaylistSelect(id, name, provider)` fires.
-6. This triggers `useCollectionLoader.loadCollection` which replaces the queue and starts playback.
+6. `handleCloseLibrary()` is called first, then `handlePlaylistSelect` triggers `useCollectionLoader.loadCollection` which replaces the queue and starts playback.
 
 ### Provider toggle
 
@@ -156,22 +74,34 @@ The library browser provides multi-level filtering and searching via a pipeline 
 1. **Text search** — case-insensitive matching on name, description, owner, and artist fields
 2. **Provider filter** — show items from selected providers only (empty array = all providers)
 3. **Artist filter** (albums only) — filter albums by a single artist
-4. **Decade filter** (albums only, future expansion) — group albums by release decade
+4. **Recently added filter** — limit to items added within a time window
 5. **Pinned partitioning** — pinned items always sort to top
 
 **UI Components**:
-- **FilterChipRow** (`src/components/FilterChipRow.tsx`) — renders in drawer mode only. Shows search chip, provider filter chips, and top 5 artists (albums only). "More..." button opens a popover with full artist list (max 15 artists).
-- **FilterSidebar** (`src/components/LibraryDrawer/FilterSidebar.tsx`) — collection type (Playlists/Albums) toggle buttons, provider checkboxes, and a "Clear Filters" button. Desktop-only; on mobile, controlled by a "Filters" toggle button that expands it with smooth animation.
-- **LibraryControls** (`src/components/PlaylistSelection/LibraryControls.tsx`) — idle view (non-drawer) filtering. Renders similar controls to FilterChipRow and sort dropdowns.
+- **FilterSidebar** (`src/components/LibraryDrawer/FilterSidebar.tsx`) — collection type (Playlists/Albums) toggle buttons, provider checkboxes, and a "Clear Filters" button. Desktop-only (≥700px); on mobile, filter chips are rendered inline in `LibraryControls`.
+- **LibraryControls** (`src/components/PlaylistSelection/LibraryControls.tsx`) — search, sort dropdowns, and (on mobile) provider/filter chip controls.
 
-**Filter State Persistence** (`src/hooks/useFilterState.ts`):
-- Collection type and selected provider IDs are saved in `localStorage` key `vorbis-player-filter-state`
-- Default: `{ collectionType: 'playlists', selectedProviderIds: [] }`
-- Search query and artist filter are ephemeral (not persisted)
+**Filter State Persistence** (`src/components/PlaylistSelection/useLibraryBrowsing.ts`):
+
+All filter and sort state is persisted to `localStorage` via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*`:
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `vorbis-player-view-mode` | `'playlists'` | Playlists or albums tab |
+| `vorbis-player-library-search` | `''` | Search query |
+| `vorbis-player-playlist-sort` | `'recently-added'` | Playlist sort order |
+| `vorbis-player-album-sort` | `'recently-added'` | Album sort order |
+| `vorbis-player-library-provider-filters` | `[]` | Active provider filters |
+| `vorbis-player-library-genres` | `[]` | Genre filter (future expansion) |
+| `vorbis-player-library-recently-added` | `'all'` | Recently added filter window |
+
+`artistFilter` is ephemeral (`useState`) — it is not persisted and resets on unmount.
+
+**Opening library from QAP:** When the user taps "Browse Library" in the Quick Access Panel, the above filter keys are cleared from localStorage before `handleOpenLibrary()` is called, ensuring a clean state.
 
 **Responsive Design**:
-- **Desktop (≥700px):** FilterSidebar is always visible as a static left sidebar. FilterChipRow appears at the top of the drawer.
-- **Mobile (<700px):** FilterSidebar is hidden by default. A "Filters" button at the top expands it inline with a smooth height animation and dark overlay backdrop. Max height: 70vh.
+- **Desktop (≥700px):** `FilterSidebar` is always visible as a static left sidebar.
+- **Mobile (<700px):** `FilterSidebar` is hidden; filter controls are rendered inline via `LibraryControls`.
 
 ## Sort and Filter State
 
@@ -180,11 +110,12 @@ The library browser provides multi-level filtering and searching via a pipeline 
 | State | Storage | Default |
 |-------|---------|---------|
 | `viewMode` | `useLocalStorage('vorbis-player-view-mode')` | `'playlists'` |
-| `searchQuery` | `useState` | `''` |
+| `searchQuery` | `useLocalStorage('vorbis-player-library-search')` | `''` |
 | `playlistSort` | `useLocalStorage('vorbis-player-playlist-sort')` | `'recently-added'` |
 | `albumSort` | `useLocalStorage('vorbis-player-album-sort')` | `'recently-added'` |
 | `artistFilter` | `useState` | `''` |
-| `providerFilters` | `useState` | `[]` (empty = all) |
+| `providerFilters` | `useLocalStorage('vorbis-player-library-provider-filters')` | `[]` (empty = all) |
+| `recentlyAddedFilter` | `useLocalStorage('vorbis-player-library-recently-added')` | `'all'` |
 
 **Sort options** (from `src/utils/playlistFilters.ts`):
 - Playlists: `name-asc`, `name-desc`, `recently-added`
@@ -249,16 +180,16 @@ When unified liked is active and user clicks "Liked Songs" without specifying a 
 
 ## ResumeCard
 
-`LibraryDrawer` renders a `ResumeCard` at the bottom when `lastSession` and `onResume` props are provided. This allows resuming a previous playback session regardless of QAP state.
+`LibraryPage` accepts a `footer` prop. `AudioPlayer.tsx` passes a `ResumeCard` as the footer when `lastSession` and `handleResume` are available, allowing users to resume a previous playback session regardless of QAP state.
 
-In the idle/home view (`PlayerStateRenderer`), the `ResumeCard` is passed as a `footer` prop to `PlaylistSelection` (when QAP is disabled) or rendered within `QuickAccessPanel` (when QAP is enabled).
+In the idle/home view (`PlayerStateRenderer`), the `ResumeCard` is passed as a `footer` prop to `LibraryPage` (when QAP is disabled) or rendered within `QuickAccessPanel` (when QAP is enabled).
 
-## Swipe Gestures
+## Navigation
 
-- **Swipe down on album art:** Opens LibraryDrawer (handled by gesture hooks in the player content area).
-- **Swipe up on LibraryDrawer grip pill:** Closes the drawer.
-- **Keyboard:** `L` or `Down Arrow` toggles the library drawer (desktop). `Down Arrow` maps to volume down on touch-only devices.
-- **Cross-dismiss:** Opening the library closes the queue drawer, and vice versa.
+- **Swipe down on album art:** Opens `LibraryPage` (handled by gesture hooks in the player content area).
+- **BottomBar library button:** Opens `LibraryPage`.
+- **Keyboard:** `L` or `Down Arrow` opens/closes the library (desktop). `Down Arrow` maps to volume down on touch-only devices.
+- **Cross-dismiss:** Opening the library closes the queue drawer.
 
 ## Idle/Home View
 
@@ -266,8 +197,8 @@ In the idle/home view (`PlayerStateRenderer`), the `ResumeCard` is passed as a `
 
 When no track is loaded (`selectedPlaylistId === null || tracks.length === 0`), `PlayerStateRenderer` decides what to show:
 
-1. **QAP disabled** (default): Shows `PlaylistSelection` inline (full library browser).
-2. **QAP enabled**: Shows `QuickAccessPanel` with a "Browse Library" button that switches to `PlaylistSelection`.
+1. **QAP disabled** (default): Shows `LibraryPage` inline (full library browser).
+2. **QAP enabled**: Shows `QuickAccessPanel` with a "Browse Library" button that clears filter state and calls `handleOpenLibrary`.
 
 QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (default `false`), read via `useQapEnabled()` hook.
 
@@ -277,27 +208,27 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 
 | File | Role |
 |------|------|
-| `src/components/LibraryDrawer.tsx` | Drawer container with swipe-to-dismiss |
-| `src/components/FilterChipRow.tsx` | Search and provider/artist filter chips (drawer only) |
-| `src/components/LibraryDrawer/FilterSidebar.tsx` | Collection type toggle and provider checkboxes (responsive) |
-| `src/components/PlaylistSelection/index.tsx` | Main library component, assembles LibraryContext |
-| `src/components/PlaylistSelection/LibraryContext.tsx` | Context definition for library state |
+| `src/components/PlaylistSelection/index.tsx` | `LibraryPage` component — full-screen library view |
+| `src/components/PlaylistSelection/LibraryContext.tsx` | Four sub-context definitions and providers |
 | `src/components/PlaylistSelection/LibraryMainContent.tsx` | Tabs, filter chips, sort chip, clear filters button |
-| `src/components/PlaylistSelection/LibraryControls.tsx` | Idle view (non-drawer) search, sort, and filter controls |
-| `src/components/PlaylistSelection/useLibraryBrowsing.ts` | Browse state management (view mode, search, sort, filters) |
-| `src/components/PlaylistSelection/useItemActions.ts` | Context menu actions (play, queue, delete) |
+| `src/components/PlaylistSelection/LibraryControls.tsx` | Search, sort, and filter controls |
+| `src/components/PlaylistSelection/useLibraryBrowsing.ts` | Browse state management (view mode, search, sort, filters) with localStorage persistence |
+| `src/components/PlaylistSelection/useLibraryRoot.ts` | Assembles all four context values for `LibraryPage` |
+| `src/components/PlaylistSelection/useItemActions.tsx` | Context menu actions (play, queue, delete) |
 | `src/components/PlaylistSelection/PlaylistGrid.tsx` | Playlist card grid |
 | `src/components/PlaylistSelection/AlbumGrid.tsx` | Album card grid |
 | `src/components/PlaylistSelection/LikedSongsCard.tsx` | Liked songs entry card |
+| `src/components/LibraryDrawer/FilterSidebar.tsx` | Collection type toggle and provider checkboxes (desktop only) |
+| `src/components/AudioPlayer.tsx` | Renders `LibraryPage` lazily when `showLibrary` is true |
 | `src/components/PlayerStateRenderer.tsx` | Idle view routing (QAP vs library) |
 | `src/components/QuickAccessPanel/ResumeCard.tsx` | Session resume card |
 | `src/contexts/PinnedItemsContext.tsx` | Pin state and IndexedDB persistence |
 | `src/services/settings/pinnedItemsStorage.ts` | IndexedDB pin storage, MAX_PINS, events |
-| `src/hooks/useFilterState.ts` | Filter state persistence (collection type, provider filters) |
 | `src/hooks/useLibrarySync.ts` | Collection sync engine across providers |
 | `src/hooks/useUnifiedLikedTracks.ts` | Cross-provider liked songs merge |
 | `src/hooks/useQapEnabled.ts` | QAP preference (localStorage) |
-| `src/utils/playlistFilters.ts` | Filter/sort/pin-split utilities; genre/decade logic (future) |
+| `src/hooks/usePlayerLogic.ts` | `showLibrary`, `handleOpenLibrary`, `handleCloseLibrary` |
+| `src/utils/playlistFilters.ts` | Filter/sort/pin-split utilities |
 | `src/constants/playlist.ts` | LIKED_SONGS_ID, sort anchor IDs, ID encoding |
 | `src/components/PlayerContent/DrawerOrchestrator.tsx` | Drawer switching and toast management |
 
@@ -306,10 +237,10 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 ### Queue interaction
 - Clicking a collection in the library calls `loadCollection` which **replaces** the queue.
 - "Add to queue" (via context menu) calls `handleAddToQueue` which **appends** to the queue.
-- The library drawer closes before playback starts (deferred via timeout).
+- `handleCloseLibrary()` is called before `handlePlaylistSelect` fires.
 
 ### Provider system
-- `PlaylistSelection` reads from `ProviderContext` for `activeDescriptor`, `enabledProviderIds`, `getDescriptor`.
+- `LibraryPage` reads from `ProviderContext` for `activeDescriptor`, `enabledProviderIds`, `getDescriptor`.
 - Collections carry a `provider` field, so clicking one routes to the correct provider for track loading.
 
 ### Color system
@@ -318,16 +249,14 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 
 ## Gotchas
 
-1. **LibraryContext is NOT a global context.** It is created per `PlaylistSelection` mount. If you need library state outside of `PlaylistSelection`, you cannot use `useLibraryContext()`.
+1. **LibraryContext sub-contexts are NOT global contexts.** They are created per `LibraryPage` mount. If you need library state outside of `LibraryPage`, you cannot use the library context hooks.
 
-2. **The drawer only renders children when open.** `{isOpen && (<DrawerContent>...`)}. This means `PlaylistSelection` unmounts on close and remounts on open. Any ephemeral state (search query, scroll position) is lost unless passed via props (`initialSearchQuery`, `initialViewMode`).
+2. **`LibraryPage` unmounts when `showLibrary` is false.** All state resets on close. Filter state survives because it is persisted to `localStorage`, but `artistFilter` (ephemeral `useState`) resets on every mount.
 
-3. **Sort and view mode are persisted; search and artist filter are not.** `viewMode`, `playlistSort`, and `albumSort` survive across sessions. `searchQuery` and `artistFilter` reset on each drawer open (unless `initialSearchQuery` is passed).
+3. **Opening library from QAP clears filter state.** The `onBrowseLibrary` handler in `AudioPlayer.tsx` removes the `vorbis-player-library-*` keys before calling `handleOpenLibrary`.
 
-4. **Provider filters are ephemeral.** They reset when the drawer is closed and reopened.
+4. **Pin limit is 12 total across playlists and albums.** `canPinMorePlaylists` and `canPinMoreAlbums` both check `pinnedPlaylistIds.length + pinnedAlbumIds.length < MAX_PINS`.
 
-5. **Pin limit is 12 total across playlists and albums.** `canPinMorePlaylists` and `canPinMoreAlbums` both check `pinnedPlaylistIds.length + pinnedAlbumIds.length < MAX_PINS`.
+5. **Unified liked songs requires 2+ providers with `hasLikedCollection`.** If only one provider supports liked songs, the unified path is skipped and the provider-specific liked songs are loaded directly.
 
-6. **Unified liked songs requires 2+ providers with `hasLikedCollection`.** If only one provider supports liked songs, the unified path is skipped and the provider-specific liked songs are loaded directly.
-
-7. **Library refresh dispatches a DOM event.** `LIBRARY_REFRESH_EVENT` (`vorbis-library-refresh`) is a window-level custom event, not a React state change. `useLibrarySync` and `useUnifiedLikedTracks` both listen for it.
+6. **Library refresh dispatches a DOM event.** `LIBRARY_REFRESH_EVENT` (`vorbis-library-refresh`) is a window-level custom event, not a React state change. `useLibrarySync` and `useUnifiedLikedTracks` both listen for it.


### PR DESCRIPTION
## Summary

- Replace all `LibraryDrawer` references with `LibraryPage` (full-screen view) in `CLAUDE.md` and `docs/features/library.md`
- Document `showLibrary` / `handleOpenLibrary` / `handleCloseLibrary` in `usePlayerLogic`
- Document filter state localStorage persistence (`vorbis-player-library-*` keys) and QAP filter-clear behavior
- Update `LibraryContext` section to reflect 4 sub-contexts (`LibraryBrowsingContext`, `LibraryPinContext`, `LibraryActionsContext`, `LibraryDataContext`)
- Update navigation triggers: swipe-down on album art, BottomBar library button, keyboard ↓/L
- Update Key Files table and Gotchas to remove stale drawer references

Closes #924