### PR TITLE
fix(library): album play context menu loads album in desktop drawer

### DIFF
--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -192,34 +192,33 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
           </ProfiledComponent>
         )}
       </Suspense>
-      {showLibrary && (
-        isMobile ? (
-          <LibraryOverlay>
-            <Suspense fallback={null}>
-              <ProfiledComponent id="LibraryPage">
-                <LibraryPage
-                  onPlaylistSelect={handleLibraryPlaylistSelect}
-                  onPlayLikedTracks={onPlayLikedTracks}
-                  onQueueLikedTracks={onQueueLikedTracks}
-                  onNavigateToPlayer={onCloseLibrary}
-                  isPlaying={isPlaying}
-                />
-              </ProfiledComponent>
-            </Suspense>
-          </LibraryOverlay>
-        ) : (
+      {showLibrary && isMobile && (
+        <LibraryOverlay>
           <Suspense fallback={null}>
-            <LibraryDrawer
-              isOpen={showLibrary}
-              onClose={onCloseLibrary}
-              onPlaylistSelect={handleLibraryPlaylistSelect}
-              onPlayLikedTracks={onPlayLikedTracks}
-              onQueueLikedTracks={onQueueLikedTracks}
-              lastSession={tracks.length === 0 ? lastSession : undefined}
-              onResume={tracks.length === 0 ? onResume : undefined}
-            />
+            <ProfiledComponent id="LibraryPage">
+              <LibraryPage
+                onPlaylistSelect={handleLibraryPlaylistSelect}
+                onPlayLikedTracks={onPlayLikedTracks}
+                onQueueLikedTracks={onQueueLikedTracks}
+                onNavigateToPlayer={onCloseLibrary}
+                isPlaying={isPlaying}
+              />
+            </ProfiledComponent>
           </Suspense>
-        )
+        </LibraryOverlay>
+      )}
+      {!isMobile && (
+        <Suspense fallback={null}>
+          <LibraryDrawer
+            isOpen={showLibrary}
+            onClose={onCloseLibrary}
+            onPlaylistSelect={handleLibraryPlaylistSelect}
+            onPlayLikedTracks={onPlayLikedTracks}
+            onQueueLikedTracks={onQueueLikedTracks}
+            lastSession={tracks.length === 0 ? lastSession : undefined}
+            onResume={tracks.length === 0 ? onResume : undefined}
+          />
+        </Suspense>
       )}
       {showSaveQueueDialog && (
         <Suspense fallback={null}>


### PR DESCRIPTION
## Summary

- Fixed "Play {album}" context menu in desktop `LibraryDrawer` not loading the album
- Root cause: `LibraryDrawer` was conditionally rendered with `showLibrary &&`, so calling `onClose()` set `showLibrary=false`, unmounting the component and clearing the pending `setTimeout` that would have fired `onPlaylistSelect`
- Fix: always render `LibraryDrawer` on desktop (matching how `QueueDrawer` is handled), letting the `isOpen` prop control visibility/animation while the component stays mounted

Closes #944

## Test plan

- [ ] Open library drawer on desktop
- [ ] Right-click an album, select "Play {album name}"
- [ ] Verify the drawer closes and the album loads/plays
- [ ] Verify "Add to Queue" context menu option still works
- [ ] Verify mobile library page still works as before