### PR TITLE
feat(library): add provider filter chips to mobile library overlay

### DIFF
--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -15,6 +15,7 @@ import {
   TabsContainer,
   TabButton,
 } from './styled';
+import type { ProviderId } from '@/types/domain';
 
 const DrawerContent = styled.div`
   display: flex;
@@ -40,6 +41,47 @@ const MainContent = styled.div`
   }
 `;
 
+const ProviderFilterRow = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  gap: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  overflow-x: auto;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ProviderChip = styled.button<{ $active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.xs};
+  flex-shrink: 0;
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? theme.colors.control.borderHover : theme.colors.control.border};
+  background: ${({ $active }) =>
+    $active ? theme.colors.control.backgroundHover : 'transparent'};
+  color: ${({ $active }) => ($active ? theme.colors.white : theme.colors.muted.foreground)};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
+    color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+`;
+
 export function LibraryMainContent(): React.JSX.Element {
   const {
     viewMode,
@@ -52,6 +94,7 @@ export function LibraryMainContent(): React.JSX.Element {
     setAlbumSort,
     providerFilters,
     setProviderFilters,
+    handleProviderToggle,
     availableGenres,
     selectedGenres,
     setSelectedGenres,
@@ -111,6 +154,22 @@ export function LibraryMainContent(): React.JSX.Element {
 
   return (
     <>
+      {showProviderBadges && (
+        <ProviderFilterRow>
+          {enabledProviderIds.map((provider: ProviderId) => (
+            <ProviderChip
+              key={provider}
+              $active={providerFilters.length === 0 || providerFilters.includes(provider)}
+              onClick={() => handleProviderToggle(provider)}
+              aria-pressed={providerFilters.length === 0 || providerFilters.includes(provider)}
+              aria-label={`Filter by ${provider}`}
+            >
+              {provider}
+            </ProviderChip>
+          ))}
+        </ProviderFilterRow>
+      )}
+
       <div style={{ flexShrink: 0 }}>
         <TabsContainer>
           <TabButton $active={viewMode === 'playlists'} onClick={() => setViewMode('playlists')}>

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -15,7 +15,6 @@ import {
   TabsContainer,
   TabButton,
 } from './styled';
-import type { ProviderId } from '@/types/domain';
 
 const DrawerContent = styled.div`
   display: flex;
@@ -156,17 +155,20 @@ export function LibraryMainContent(): React.JSX.Element {
     <>
       {showProviderBadges && (
         <ProviderFilterRow>
-          {enabledProviderIds.map((provider: ProviderId) => (
-            <ProviderChip
-              key={provider}
-              $active={providerFilters.length === 0 || providerFilters.includes(provider)}
-              onClick={() => handleProviderToggle(provider)}
-              aria-pressed={providerFilters.length === 0 || providerFilters.includes(provider)}
-              aria-label={`Filter by ${provider}`}
-            >
-              {provider}
-            </ProviderChip>
-          ))}
+          {enabledProviderIds.map((provider) => {
+            const isActive = providerFilters.length === 0 || providerFilters.includes(provider);
+            return (
+              <ProviderChip
+                key={provider}
+                $active={isActive}
+                onClick={() => handleProviderToggle(provider)}
+                aria-pressed={isActive}
+                aria-label={`Filter by ${provider}`}
+              >
+                {provider}
+              </ProviderChip>
+            );
+          })}
         </ProviderFilterRow>
       )}
 


### PR DESCRIPTION
## What
- Adds a horizontal pill-chip row to the mobile (non-drawer) `LibraryPage` view, one chip per connected provider
- Chips are conditionally rendered only when `showProviderBadges` is true (2+ providers connected)
- Wires directly to `handleProviderToggle` from `useLibraryBrowsingContext` — same toggle logic as the desktop `FilterSidebar`

## Why
Provider filters set on desktop persist to mobile via localStorage with no mobile UI to clear them, leaving users stuck with a partial library view. Closes #958.

## Test plan
- [ ] Connect two providers (Spotify + Dropbox) and open the mobile library overlay — chip row should appear above the Playlists/Albums tabs
- [ ] Tapping a chip deactivates that provider's content; tapping again restores it
- [ ] With a single provider connected, chip row should be hidden
- [ ] Desktop drawer view unchanged (FilterSidebar still handles provider filters there)
- [ ] Filter state persists across overlay open/close via localStorage