### PR TITLE
feat(library): mobile search + sort, bypass provider filters on mobile

### DIFF
--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -1,11 +1,13 @@
 import type * as React from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { FilterSidebar } from '../LibraryDrawer/FilterSidebar';
 import { PlaylistGrid } from './PlaylistGrid';
 import { AlbumGrid } from './AlbumGrid';
 import { LibraryControls } from './LibraryControls';
 import { useLibraryBrowsingContext, useLibraryActions, useLibraryData } from './LibraryContext';
+import { MobileLibraryBottomBar } from './MobileLibraryBottomBar';
 import { RefreshIcon } from './utils';
 import {
   DrawerRefreshButton,
@@ -102,6 +104,7 @@ export function LibraryMainContent(): React.JSX.Element {
   } = useLibraryBrowsingContext();
   const { onLibraryRefresh, isLibraryRefreshing } = useLibraryActions();
   const { inDrawer, showProviderBadges, enabledProviderIds } = useLibraryData();
+  const { isMobile } = usePlayerSizingContext();
 
   if (inDrawer) {
     return (
@@ -174,23 +177,27 @@ export function LibraryMainContent(): React.JSX.Element {
         isLibraryRefreshing={isLibraryRefreshing}
       />
 
-      {showProviderBadges && (
-        <ProviderFilterRow>
-          {enabledProviderIds.map((provider) => {
-            const isActive = providerFilters.length === 0 || providerFilters.includes(provider);
-            return (
-              <ProviderChip
-                key={provider}
-                $active={isActive}
-                onClick={() => handleProviderToggle(provider)}
-                aria-pressed={isActive}
-                aria-label={`Filter by ${provider}`}
-              >
-                {provider}
-              </ProviderChip>
-            );
-          })}
-        </ProviderFilterRow>
+      {isMobile ? (
+        <MobileLibraryBottomBar />
+      ) : (
+        showProviderBadges && (
+          <ProviderFilterRow>
+            {enabledProviderIds.map((provider) => {
+              const isActive = providerFilters.length === 0 || providerFilters.includes(provider);
+              return (
+                <ProviderChip
+                  key={provider}
+                  $active={isActive}
+                  onClick={() => handleProviderToggle(provider)}
+                  aria-pressed={isActive}
+                  aria-label={`Filter by ${provider}`}
+                >
+                  {provider}
+                </ProviderChip>
+              );
+            })}
+          </ProviderFilterRow>
+        )
       )}
     </>
   );

--- a/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
+++ b/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
@@ -1,0 +1,212 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import {
+  PLAYLIST_SORT_LABELS,
+  ALBUM_SORT_LABELS,
+} from '@/utils/playlistFilters';
+import type {
+  PlaylistSortOption,
+  AlbumSortOption,
+} from '@/utils/playlistFilters';
+import { useLibraryBrowsingContext } from './LibraryContext';
+
+const MIN_TAP_TARGET = '44px';
+
+const BarContainer = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: stretch;
+  gap: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm} 0 ${theme.spacing.md};
+`;
+
+const SearchInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  padding: 0 ${theme.spacing.sm};
+  min-height: ${MIN_TAP_TARGET};
+  transition: all ${theme.transitions.fast};
+
+  &:focus-within {
+    border-color: ${theme.colors.control.borderHover};
+    background: ${theme.colors.control.backgroundHover};
+  }
+`;
+
+const SearchIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: ${theme.colors.muted.foreground};
+  flex-shrink: 0;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+`;
+
+const SearchInput = styled.input`
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: ${theme.spacing.sm} ${theme.spacing.xs};
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.white};
+  min-width: 0;
+
+  &::placeholder {
+    color: ${theme.colors.muted.foreground};
+  }
+`;
+
+const ClearSearchButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${MIN_TAP_TARGET};
+  height: ${MIN_TAP_TARGET};
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: ${theme.colors.muted.foreground};
+  transition: color ${theme.transitions.fast};
+  flex-shrink: 0;
+
+  &:hover {
+    color: ${theme.colors.white};
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+`;
+
+const SortSelect = styled.select`
+  flex-shrink: 0;
+  min-height: ${MIN_TAP_TARGET};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+  appearance: none;
+  max-width: 9rem;
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${theme.colors.control.borderHover};
+  }
+
+  option {
+    background: ${theme.colors.popover.background};
+    color: ${theme.colors.white};
+  }
+`;
+
+const SearchIconSvg = () => (
+  <svg viewBox="0 0 24 24">
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const ClearIconSvg = () => (
+  <svg viewBox="0 0 24 24">
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+export function MobileLibraryBottomBar(): JSX.Element {
+  const {
+    viewMode,
+    searchQuery,
+    setSearchQuery,
+    playlistSort,
+    setPlaylistSort,
+    albumSort,
+    setAlbumSort,
+  } = useLibraryBrowsingContext();
+
+  return (
+    <BarContainer>
+      <SearchInputWrapper>
+        <SearchIcon>
+          <SearchIconSvg />
+        </SearchIcon>
+        <SearchInput
+          type="text"
+          placeholder="Search..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="Search playlists and albums"
+        />
+        {searchQuery && (
+          <ClearSearchButton
+            onClick={() => setSearchQuery('')}
+            aria-label="Clear search"
+            type="button"
+          >
+            <ClearIconSvg />
+          </ClearSearchButton>
+        )}
+      </SearchInputWrapper>
+
+      {viewMode === 'playlists' ? (
+        <SortSelect
+          value={playlistSort}
+          onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
+          aria-label="Sort playlists"
+        >
+          {Object.entries(PLAYLIST_SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </SortSelect>
+      ) : (
+        <SortSelect
+          value={albumSort}
+          onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
+          aria-label="Sort albums"
+        >
+          {Object.entries(ALBUM_SORT_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </SortSelect>
+      )}
+    </BarContainer>
+  );
+}

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -122,9 +122,11 @@ export function useLibraryRoot({
     return Math.min(viewport.width * 0.6, 600);
   }, [viewport.width, isMobile, isTablet]);
 
+  const ignoreProviderFilters = isMobile;
+
   const playlistLibraryView = useMemo(() => {
     let items = playlists;
-    if (providerFilters.length > 0) {
+    if (!ignoreProviderFilters && providerFilters.length > 0) {
       items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
     }
     let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
@@ -137,14 +139,14 @@ export function useLibraryRoot({
       (p) => p.id,
       (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
     );
-  }, [playlists, searchQuery, playlistSort, providerFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
+  }, [playlists, searchQuery, playlistSort, providerFilters, ignoreProviderFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
 
   const pinnedPlaylists = playlistLibraryView.pinned;
   const unpinnedPlaylists = playlistLibraryView.unpinned;
 
   const albumLibraryView = useMemo(() => {
     let items = albums;
-    if (providerFilters.length > 0) {
+    if (!ignoreProviderFilters && providerFilters.length > 0) {
       items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
     }
     let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
@@ -157,7 +159,7 @@ export function useLibraryRoot({
       (a) => a.id,
       (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
     );
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, ignoreProviderFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
 
   const pinnedAlbums = albumLibraryView.pinned;
   const unpinnedAlbums = albumLibraryView.unpinned;


### PR DESCRIPTION
## Summary
- Adds `MobileLibraryBottomBar` (search + sort) replacing the mobile provider chip row
- Mobile grid now bypasses `providerFilters` entirely — shows items from all enabled providers
- Desktop behaviour unchanged (still uses FilterSidebar + providerFilters)

## Test plan
- [ ] Mobile: search filters grid; sort reorders; × clears query
- [ ] Mobile: stale desktop providerFilter does not filter mobile grid
- [ ] Desktop: providerFilters still works
- [ ] `npx tsc -b --noEmit` clean
- [ ] `npm run test:run` passes

Closes #971
Closes #972
Closes #973

Part of epic #976