### PR TITLE
test(library): cover mobile search, sort, and provider-filter bypass

### DIFF
--- a/src/components/PlaylistSelection/__tests__/MobileLibraryBottomBar.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/MobileLibraryBottomBar.test.tsx
@@ -1,0 +1,215 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { MobileLibraryBottomBar } from '../MobileLibraryBottomBar';
+import {
+  LibraryBrowsingProvider,
+  type LibraryBrowsingContextValue,
+} from '../LibraryContext';
+import type {
+  AlbumSortOption,
+  PlaylistSortOption,
+  RecentlyAddedFilterOption,
+} from '@/utils/playlistFilters';
+import type { ProviderId } from '@/types/domain';
+
+interface HarnessOverrides {
+  initialViewMode?: 'playlists' | 'albums';
+  initialSearchQuery?: string;
+  initialPlaylistSort?: PlaylistSortOption;
+  initialAlbumSort?: AlbumSortOption;
+}
+
+function BrowsingStateHarness({
+  initialViewMode = 'playlists',
+  initialSearchQuery = '',
+  initialPlaylistSort = 'recently-added',
+  initialAlbumSort = 'recently-added',
+  children,
+}: HarnessOverrides & { children: React.ReactNode }): React.ReactElement {
+  const [viewMode, setViewMode] = useState<'playlists' | 'albums'>(initialViewMode);
+  const [searchQuery, setSearchQuery] = useState<string>(initialSearchQuery);
+  const [playlistSort, setPlaylistSort] = useState<PlaylistSortOption>(initialPlaylistSort);
+  const [albumSort, setAlbumSort] = useState<AlbumSortOption>(initialAlbumSort);
+  const [artistFilter, setArtistFilter] = useState<string>('');
+  const [providerFilters, setProviderFilters] = useState<ProviderId[]>([]);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [recentlyAddedFilter, setRecentlyAddedFilter] =
+    useState<RecentlyAddedFilterOption>('all');
+
+  const value: LibraryBrowsingContextValue = {
+    viewMode,
+    setViewMode,
+    searchQuery,
+    setSearchQuery,
+    playlistSort,
+    setPlaylistSort,
+    albumSort,
+    setAlbumSort,
+    artistFilter,
+    setArtistFilter,
+    providerFilters,
+    setProviderFilters,
+    handleProviderToggle: () => undefined,
+    availableGenres: [],
+    selectedGenres,
+    setSelectedGenres,
+    recentlyAddedFilter,
+    setRecentlyAddedFilter,
+    hasActiveFilters: false,
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <LibraryBrowsingProvider value={value}>{children}</LibraryBrowsingProvider>
+    </ThemeProvider>
+  );
+}
+
+function getSearchInput(): HTMLInputElement {
+  return screen.getByRole('textbox', {
+    name: /search playlists and albums/i,
+  }) as HTMLInputElement;
+}
+
+describe('MobileLibraryBottomBar', () => {
+  describe('search input', () => {
+    it('updates searchQuery state when the user types', () => {
+      // #when
+      render(
+        <BrowsingStateHarness>
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+      const input = getSearchInput();
+      fireEvent.change(input, { target: { value: 'foo' } });
+
+      // #then
+      expect(input.value).toBe('foo');
+    });
+
+    it('initialises from the provided searchQuery value', () => {
+      // #when
+      render(
+        <BrowsingStateHarness initialSearchQuery="chill">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+
+      // #then
+      expect(getSearchInput().value).toBe('chill');
+    });
+  });
+
+  describe('clear button', () => {
+    it('is hidden while the search query is empty', () => {
+      // #when
+      render(
+        <BrowsingStateHarness>
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+
+      // #then
+      expect(screen.queryByRole('button', { name: /clear search/i })).toBeNull();
+    });
+
+    it('clears the search input when clicked', () => {
+      // #given
+      render(
+        <BrowsingStateHarness initialSearchQuery="rock">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+      const input = getSearchInput();
+      expect(input.value).toBe('rock');
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+
+      // #then
+      expect(input.value).toBe('');
+      expect(screen.queryByRole('button', { name: /clear search/i })).toBeNull();
+    });
+  });
+
+  describe('sort dropdown', () => {
+    it('renders the playlist sort selector when viewMode is playlists', () => {
+      // #when
+      render(
+        <BrowsingStateHarness initialViewMode="playlists">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+
+      // #then
+      expect(screen.getByLabelText(/sort playlists/i)).toBeTruthy();
+      expect(screen.queryByLabelText(/sort albums/i)).toBeNull();
+    });
+
+    it('renders the album sort selector when viewMode is albums', () => {
+      // #when
+      render(
+        <BrowsingStateHarness initialViewMode="albums">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+
+      // #then
+      expect(screen.getByLabelText(/sort albums/i)).toBeTruthy();
+      expect(screen.queryByLabelText(/sort playlists/i)).toBeNull();
+    });
+
+    it('updates playlistSort when a new playlist option is selected', () => {
+      // #given
+      render(
+        <BrowsingStateHarness initialViewMode="playlists">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+      const select = screen.getByLabelText(/sort playlists/i) as HTMLSelectElement;
+      expect(select.value).toBe('recently-added');
+
+      // #when
+      fireEvent.change(select, { target: { value: 'name-asc' } });
+
+      // #then
+      expect(select.value).toBe('name-asc');
+    });
+
+    it('updates albumSort when a new album option is selected', () => {
+      // #given
+      render(
+        <BrowsingStateHarness initialViewMode="albums">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+      const select = screen.getByLabelText(/sort albums/i) as HTMLSelectElement;
+      expect(select.value).toBe('recently-added');
+
+      // #when
+      fireEvent.change(select, { target: { value: 'artist-asc' } });
+
+      // #then
+      expect(select.value).toBe('artist-asc');
+    });
+
+    it('leaves playlistSort unchanged when switching album sort in albums view', () => {
+      // #given
+      render(
+        <BrowsingStateHarness initialViewMode="albums" initialPlaylistSort="name-desc">
+          <MobileLibraryBottomBar />
+        </BrowsingStateHarness>,
+      );
+      const albumSelect = screen.getByLabelText(/sort albums/i) as HTMLSelectElement;
+
+      // #when
+      fireEvent.change(albumSelect, { target: { value: 'release-newest' } });
+
+      // #then
+      expect(albumSelect.value).toBe('release-newest');
+    });
+  });
+});

--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { PlaylistInfo, AlbumInfo } from '@/services/spotify';
+import { makePlaylistInfo, makeAlbumInfo } from '@/test/fixtures';
+
+const {
+  mockIsMobile,
+  mockUseLibrarySync,
+  mockUseUnifiedLikedTracks,
+  mockUseProviderContext,
+  mockUsePinnedItems,
+} = vi.hoisted(() => ({
+  mockIsMobile: { current: false },
+  mockUseLibrarySync: vi.fn(),
+  mockUseUnifiedLikedTracks: vi.fn(),
+  mockUseProviderContext: vi.fn(),
+  mockUsePinnedItems: vi.fn(),
+}));
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  PlayerSizingProvider: ({ children }: { children: React.ReactNode }) => children,
+  usePlayerSizingContext: () => ({
+    viewport: { width: mockIsMobile.current ? 400 : 1400, height: 800 },
+    isMobile: mockIsMobile.current,
+    isTablet: false,
+    isDesktop: !mockIsMobile.current,
+    hasPointerInput: !mockIsMobile.current,
+    dimensions: { width: 600, height: 600 },
+  }),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => mockUseProviderContext(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useLibrarySync')>(
+    '@/hooks/useLibrarySync',
+  );
+  return {
+    ...actual,
+    useLibrarySync: () => mockUseLibrarySync(),
+  };
+});
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: () => mockUseUnifiedLikedTracks(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockUsePinnedItems(),
+}));
+
+import { useLibraryRoot } from '../useLibraryRoot';
+
+function setupDefaultMocks(): void {
+  const descriptor = {
+    id: 'spotify',
+    name: 'Spotify',
+    auth: { isAuthenticated: () => true },
+  };
+  mockUseProviderContext.mockReturnValue({
+    activeDescriptor: descriptor,
+    hasMultipleProviders: true,
+    enabledProviderIds: ['spotify', 'dropbox'],
+    getDescriptor: (id: string) => (id === 'spotify' ? descriptor : undefined),
+  });
+  mockUseUnifiedLikedTracks.mockReturnValue({
+    isUnifiedLikedActive: false,
+    totalCount: 0,
+  });
+  mockUsePinnedItems.mockReturnValue({
+    pinnedPlaylistIds: [],
+    pinnedAlbumIds: [],
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+    canPinMorePlaylists: true,
+    canPinMoreAlbums: true,
+  });
+}
+
+function setLibrarySync(playlists: PlaylistInfo[], albums: AlbumInfo[]): void {
+  mockUseLibrarySync.mockReturnValue({
+    playlists,
+    albums,
+    likedSongsCount: 0,
+    likedSongsPerProvider: [],
+    isInitialLoadComplete: true,
+    isSyncing: false,
+    isLikedSongsSyncing: false,
+    lastSyncTimestamp: Date.now(),
+    syncError: null,
+    refreshNow: vi.fn(),
+    removeCollection: vi.fn(),
+  });
+}
+
+function renderLibraryRoot() {
+  return renderHook(() =>
+    useLibraryRoot({
+      onPlaylistSelect: vi.fn(),
+      inDrawer: false,
+    }),
+  );
+}
+
+function playlistNames(result: { current: ReturnType<typeof useLibraryRoot> }): string[] {
+  return result.current.pinValue.unpinnedPlaylists.map((p) => p.name);
+}
+
+function albumNames(result: { current: ReturnType<typeof useLibraryRoot> }): string[] {
+  return result.current.pinValue.unpinnedAlbums.map((a) => a.name);
+}
+
+describe('useLibraryRoot grid behavior', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockIsMobile.current = false;
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  describe('mobile viewport', () => {
+    beforeEach(() => {
+      mockIsMobile.current = true;
+    });
+
+    it('filters playlists by searchQuery (case-insensitive substring match)', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Foo Fighters Mix' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Jazz Classics' }),
+          makePlaylistInfo({ id: 'p-3', name: 'Foolish Love' }),
+        ],
+        [],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setSearchQuery('foo');
+      });
+
+      // #then
+      expect(playlistNames(result).sort()).toEqual(['Foo Fighters Mix', 'Foolish Love']);
+    });
+
+    it('reorders playlists when playlistSort changes from recently-added to name-asc', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Charlie', added_at: '2024-01-03T00:00:00Z' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Alpha', added_at: '2024-01-01T00:00:00Z' }),
+          makePlaylistInfo({ id: 'p-3', name: 'Bravo', added_at: '2024-01-02T00:00:00Z' }),
+        ],
+        [],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setPlaylistSort('name-asc');
+      });
+
+      // #then
+      expect(playlistNames(result)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('ignores providerFilters when listing playlists', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Spotify Mix', provider: 'spotify' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Dropbox Mix', provider: 'dropbox' }),
+        ],
+        [],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['spotify']);
+      });
+
+      // #then
+      expect(playlistNames(result).sort()).toEqual(['Dropbox Mix', 'Spotify Mix']);
+    });
+
+    it('ignores providerFilters when listing albums', () => {
+      // #given
+      setLibrarySync(
+        [],
+        [
+          makeAlbumInfo({ id: 'a-1', name: 'Spotify Album', provider: 'spotify' }),
+          makeAlbumInfo({ id: 'a-2', name: 'Dropbox Album', provider: 'dropbox' }),
+        ],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['dropbox']);
+      });
+
+      // #then
+      expect(albumNames(result).sort()).toEqual(['Dropbox Album', 'Spotify Album']);
+    });
+
+    it('filters albums by searchQuery', () => {
+      // #given
+      setLibrarySync(
+        [],
+        [
+          makeAlbumInfo({ id: 'a-1', name: 'Kind of Blue', artists: 'Miles Davis' }),
+          makeAlbumInfo({ id: 'a-2', name: 'Random Access Memories', artists: 'Daft Punk' }),
+        ],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setSearchQuery('blue');
+      });
+
+      // #then
+      expect(albumNames(result)).toEqual(['Kind of Blue']);
+    });
+  });
+
+  describe('desktop viewport', () => {
+    beforeEach(() => {
+      mockIsMobile.current = false;
+    });
+
+    it('applies providerFilters to playlists', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Spotify Mix', provider: 'spotify' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Dropbox Mix', provider: 'dropbox' }),
+        ],
+        [],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['spotify']);
+      });
+
+      // #then
+      expect(playlistNames(result)).toEqual(['Spotify Mix']);
+    });
+
+    it('applies providerFilters to albums', () => {
+      // #given
+      setLibrarySync(
+        [],
+        [
+          makeAlbumInfo({ id: 'a-1', name: 'Spotify Album', provider: 'spotify' }),
+          makeAlbumInfo({ id: 'a-2', name: 'Dropbox Album', provider: 'dropbox' }),
+        ],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['dropbox']);
+      });
+
+      // #then
+      expect(albumNames(result)).toEqual(['Dropbox Album']);
+    });
+
+    it('returns all items when providerFilters is empty', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Spotify Mix', provider: 'spotify' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Dropbox Mix', provider: 'dropbox' }),
+        ],
+        [],
+      );
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      expect(playlistNames(result).sort()).toEqual(['Dropbox Mix', 'Spotify Mix']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Regression coverage for the mobile library search/sort feature (PR #978):
- `MobileLibraryBottomBar`: search input, sort dropdown, clear button
- Mobile grid: search filters, sort reorders, providerFilters bypassed
- Desktop grid: providerFilters still applies (regression guard)

## Test plan
- [ ] `npm run test:run` passes
- [ ] New tests run in CI
- [ ] BDD convention followed

Closes #974

Part of epic #976