### PR TITLE
refactor(library): tidy LibraryContext exports and provider nesting

### DIFF
--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type * as React from 'react';
+import * as React from 'react';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
@@ -71,12 +71,6 @@ export interface LibraryDataContextValue {
   activeDescriptor: ProviderDescriptor | null;
 }
 
-export type LibraryContextValue =
-  LibraryBrowsingContextValue &
-  LibraryPinContextValue &
-  LibraryActionsContextValue &
-  LibraryDataContextValue;
-
 const LibraryBrowsingContext = createContext<LibraryBrowsingContextValue | null>(null);
 const LibraryPinContext = createContext<LibraryPinContextValue | null>(null);
 const LibraryActionsContext = createContext<LibraryActionsContextValue | null>(null);
@@ -119,10 +113,24 @@ export function useLibraryData(): LibraryDataContextValue {
   return ctx;
 }
 
-export function useLibraryContext(): LibraryContextValue {
-  const browsing = useLibraryBrowsingContext();
-  const pins = useLibraryPins();
-  const actions = useLibraryActions();
-  const data = useLibraryData();
-  return { ...browsing, ...pins, ...actions, ...data };
+export function LibraryProviders({ values, children }: {
+  values: {
+    browsing: LibraryBrowsingContextValue;
+    pin: LibraryPinContextValue;
+    actions: LibraryActionsContextValue;
+    data: LibraryDataContextValue;
+  };
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <LibraryDataProvider value={values.data}>
+      <LibraryBrowsingProvider value={values.browsing}>
+        <LibraryPinProvider value={values.pin}>
+          <LibraryActionsProvider value={values.actions}>
+            {children}
+          </LibraryActionsProvider>
+        </LibraryPinProvider>
+      </LibraryBrowsingProvider>
+    </LibraryDataProvider>
+  );
 }

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -9,12 +9,7 @@ import {
 } from './styled';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
-import {
-  LibraryBrowsingProvider,
-  LibraryPinProvider,
-  LibraryActionsProvider,
-  LibraryDataProvider,
-} from './LibraryContext';
+import { LibraryProviders } from './LibraryContext';
 import { useLibraryRoot } from './useLibraryRoot';
 import { LibraryMiniPlayer } from './LibraryMiniPlayer';
 
@@ -61,10 +56,7 @@ export const LibraryPage = React.memo(function LibraryPage({
   });
 
   return (
-    <LibraryDataProvider value={dataValue}>
-    <LibraryBrowsingProvider value={browsingValue}>
-    <LibraryPinProvider value={pinValue}>
-    <LibraryActionsProvider value={actionsValue}>
+    <LibraryProviders values={{ browsing: browsingValue, pin: pinValue, actions: actionsValue, data: dataValue }}>
       <PageContainer $overlay>
         <PageSelectionCard $maxWidth={maxWidth} $overlay>
           <CardContent
@@ -88,10 +80,7 @@ export const LibraryPage = React.memo(function LibraryPage({
           )}
         </PageSelectionCard>
       </PageContainer>
-    </LibraryActionsProvider>
-    </LibraryPinProvider>
-    </LibraryBrowsingProvider>
-    </LibraryDataProvider>
+    </LibraryProviders>
   );
 });
 
@@ -146,10 +135,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
   });
 
   return (
-    <LibraryDataProvider value={dataValue}>
-    <LibraryBrowsingProvider value={browsingValue}>
-    <LibraryPinProvider value={pinValue}>
-    <LibraryActionsProvider value={actionsValue}>
+    <LibraryProviders values={{ browsing: browsingValue, pin: pinValue, actions: actionsValue, data: dataValue }}>
       <DrawerContentWrapper>
         <LibraryStatusContent {...statusContentProps} />
         {showMainContent && <LibraryMainContent />}
@@ -157,10 +143,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
         {playlistPopoverPortal}
         {confirmDeletePortal}
       </DrawerContentWrapper>
-    </LibraryActionsProvider>
-    </LibraryPinProvider>
-    </LibraryBrowsingProvider>
-    </LibraryDataProvider>
+    </LibraryProviders>
   );
 });
 


### PR DESCRIPTION
## Summary

- Removes the `useLibraryContext` composite hook and `LibraryContextValue` type — they bundled all four split contexts back together, silently reversing the render-isolation benefit of the Browsing/Pin/Actions/Data split. No callers existed outside the file itself.
- Adds a `LibraryProviders` composite wrapper component to `LibraryContext.tsx` that encapsulates the 4-provider nesting ladder.
- Replaces the duplicated provider ladders in both `LibraryPage` and `DrawerLibrary` with `<LibraryProviders values={...} />`.

## Test plan

- [ ] TypeScript check passes (`npx tsc -b --noEmit`)
- [ ] Lint passes on changed files (no new errors introduced)
- [ ] Test suite passes at same baseline (6 pre-existing failures unrelated to this change)
- [ ] Verify `rg "useLibraryContext" src/` returns nothing
- [ ] Verify both `LibraryPage` and `DrawerLibrary` render trees use `LibraryProviders`

Closes #988
Closes #998