### PR TITLE
fix(library): make liked-songs provider resolution explicit

### DIFF
--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -197,8 +197,29 @@ export function useLibraryRoot({
   }
 
   function handleLikedSongsClick(provider?: ProviderId): void {
-    const resolvedProvider = provider ?? (likedSongsPerProvider.length === 1 ? likedSongsPerProvider[0].provider : undefined);
-    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
+    if (provider !== undefined) {
+      logQueue('liked songs click: explicit provider %s', provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, provider);
+      return;
+    }
+
+    if (isUnifiedLikedActive) {
+      logQueue('liked songs click: unified path');
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, undefined);
+      return;
+    }
+
+    if (likedSongsPerProvider.length === 1) {
+      logQueue('liked songs click: single provider %s', likedSongsPerProvider[0].provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, likedSongsPerProvider[0].provider);
+      return;
+    }
+
+    logQueue(
+      'liked songs click: ambiguous — %d providers, unified inactive; falling back to active provider',
+      likedSongsPerProvider.length,
+    );
+    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, activeDescriptor?.id);
   }
 
   function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {

--- a/src/components/__tests__/PlaylistSelection.test.tsx
+++ b/src/components/__tests__/PlaylistSelection.test.tsx
@@ -203,7 +203,7 @@ describe('PlaylistSelection', () => {
   });
 
   it('Liked Songs item is present with LIKED_SONGS_ID', () => {
-    // #given
+    // #given — likedSongsPerProvider is empty and unified is inactive: resolves to active provider
     const { onPlaylistSelect } = renderLibraryPage();
 
     // #when
@@ -211,7 +211,7 @@ describe('PlaylistSelection', () => {
 
     // #then
     expect(screen.getByText('Liked Songs')).toBeTruthy();
-    expect(onPlaylistSelect).toHaveBeenCalledWith(LIKED_SONGS_ID, 'Liked Songs', undefined);
+    expect(onPlaylistSelect).toHaveBeenCalledWith(LIKED_SONGS_ID, 'Liked Songs', 'spotify');
   });
 
 });


### PR DESCRIPTION
## Summary

- Replaces the implicit `??` fallback in `handleLikedSongsClick` with four explicit, auditable branches: per-provider card click, unified-liked path, single-provider shortcut, and a `logQueue` warning fallback to active provider for the ambiguous case.
- Updates `PlaylistSelection.test.tsx` to reflect the new explicit resolution (fallback branch now yields `activeDescriptor.id` instead of silent `undefined`).

## Test plan

- [ ] TypeScript: `npx tsc -b --noEmit` passes (clean)
- [ ] Lint: no new errors in changed files
- [ ] Tests: 6 pre-existing failures unchanged; no new failures

Closes #997