### PR TITLE
fix(library): unify and repair desktop filter semantics

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import type { ProviderId } from '@/types/domain';
@@ -13,12 +12,12 @@ interface FilterSidebarProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
 
-  collectionType: 'playlists' | 'albums';
-  onCollectionTypeChange: (type: 'playlists' | 'albums') => void;
+  viewMode: 'playlists' | 'albums';
+  onViewModeChange: (type: 'playlists' | 'albums') => void;
 
   enabledProviderIds: ProviderId[];
   selectedProviderIds: ProviderId[];
-  onProviderFilterChange: (providerIds: ProviderId[]) => void;
+  onProviderToggle: (provider: ProviderId) => void;
 
   showProviderFilter: boolean;
 
@@ -26,7 +25,7 @@ interface FilterSidebarProps {
   availableGenres: string[];
   /** Currently selected genres (empty = all genres included). */
   selectedGenres: string[];
-  onGenreChange: (genres: string[]) => void;
+  onGenreToggle: (genre: string) => void;
 
   recentlyAdded: RecentlyAddedFilterOption;
   onRecentlyAddedChange: (value: RecentlyAddedFilterOption) => void;
@@ -35,6 +34,9 @@ interface FilterSidebarProps {
   setPlaylistSort: (v: PlaylistSortOption) => void;
   albumSort: AlbumSortOption;
   setAlbumSort: (v: AlbumSortOption) => void;
+
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
 }
 
 const SidebarContainer = styled.div`
@@ -185,34 +187,36 @@ const ToggleButton = styled.button<{ $active: boolean }>`
   }
 `;
 
-const ProviderCheckboxContainer = styled.label`
+const ChipList = styled.div`
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: ${theme.spacing.sm};
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
+`;
+
+const FilterChip = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? theme.colors.control.borderHover : theme.colors.control.border};
+  background: ${({ $active }) =>
+    $active ? theme.colors.control.backgroundHover : 'transparent'};
+  color: ${({ $active }) => ($active ? theme.colors.white : theme.colors.muted.foreground)};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
   cursor: pointer;
-  border-radius: ${theme.borderRadius.md};
-  transition: background ${theme.transitions.fast};
+  transition: all ${theme.transitions.fast};
 
   &:hover {
-    background: ${theme.colors.control.background};
-  }
-`;
-
-const Checkbox = styled.input`
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  accent-color: ${theme.colors.spotify};
-`;
-
-const CheckboxLabel = styled.span`
-  font-size: ${theme.fontSize.sm};
-  color: ${theme.colors.muted.foreground};
-  transition: color ${theme.transitions.fast};
-
-  ${ProviderCheckboxContainer}:hover & {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
     color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
   }
 `;
 
@@ -290,53 +294,29 @@ const RECENTLY_ADDED_OPTIONS: { label: string; value: RecentlyAddedFilterOption 
 export const FilterSidebar = ({
   searchQuery,
   onSearchChange,
-  collectionType,
-  onCollectionTypeChange,
+  viewMode,
+  onViewModeChange,
   enabledProviderIds,
   selectedProviderIds,
-  onProviderFilterChange,
+  onProviderToggle,
   showProviderFilter,
   availableGenres,
   selectedGenres,
-  onGenreChange,
+  onGenreToggle,
   recentlyAdded,
   onRecentlyAddedChange,
   playlistSort,
   setPlaylistSort,
   albumSort,
   setAlbumSort,
+  hasActiveFilters,
+  onClearFilters,
 }: FilterSidebarProps) => {
-  const hasActiveFilters =
-    searchQuery !== '' ||
-    collectionType === 'albums' ||
-    selectedProviderIds.length > 0 ||
-    selectedGenres.length > 0 ||
-    (recentlyAdded !== 'all' && recentlyAdded !== undefined);
+  const isProviderActive = (provider: ProviderId): boolean =>
+    selectedProviderIds.length === 0 || selectedProviderIds.includes(provider);
 
-  const handleClearFilters = useCallback(() => {
-    onSearchChange('');
-    onCollectionTypeChange('playlists');
-    onProviderFilterChange([]);
-    onGenreChange([]);
-    onRecentlyAddedChange('all');
-  }, [onSearchChange, onCollectionTypeChange, onProviderFilterChange, onGenreChange, onRecentlyAddedChange]);
-
-  const handleProviderToggle = useCallback((provider: ProviderId) => {
-    if (selectedProviderIds.includes(provider)) {
-      const next = selectedProviderIds.filter((p) => p !== provider);
-      onProviderFilterChange(next.length === enabledProviderIds.length ? [] : next);
-    } else {
-      onProviderFilterChange([...selectedProviderIds, provider]);
-    }
-  }, [selectedProviderIds, enabledProviderIds, onProviderFilterChange]);
-
-  const handleGenreToggle = useCallback((genre: string) => {
-    if (selectedGenres.includes(genre)) {
-      onGenreChange(selectedGenres.filter((g) => g !== genre));
-    } else {
-      onGenreChange([...selectedGenres, genre]);
-    }
-  }, [selectedGenres, onGenreChange]);
+  const isGenreActive = (genre: string): boolean =>
+    selectedGenres.length === 0 || selectedGenres.includes(genre);
 
   return (
     <SidebarContainer>
@@ -369,14 +349,14 @@ export const FilterSidebar = ({
         <SectionTitle>Collection Type</SectionTitle>
         <ToggleGroup>
           <ToggleButton
-            $active={collectionType === 'playlists'}
-            onClick={() => onCollectionTypeChange('playlists')}
+            $active={viewMode === 'playlists'}
+            onClick={() => onViewModeChange('playlists')}
           >
             Playlists
           </ToggleButton>
           <ToggleButton
-            $active={collectionType === 'albums'}
-            onClick={() => onCollectionTypeChange('albums')}
+            $active={viewMode === 'albums'}
+            onClick={() => onViewModeChange('albums')}
           >
             Albums
           </ToggleButton>
@@ -386,52 +366,46 @@ export const FilterSidebar = ({
       {showProviderFilter && (
         <FilterSection>
           <SectionTitle>Providers</SectionTitle>
-          <div>
-            {enabledProviderIds.map((provider) => (
-              <ProviderCheckboxContainer key={provider}>
-                <Checkbox
-                  type="checkbox"
-                  checked={
-                    selectedProviderIds.length === 0 ||
-                    selectedProviderIds.includes(provider)
-                  }
-                  onChange={() => handleProviderToggle(provider)}
+          <ChipList>
+            {enabledProviderIds.map((provider) => {
+              const active = isProviderActive(provider);
+              return (
+                <FilterChip
+                  key={provider}
+                  type="button"
+                  $active={active}
+                  aria-pressed={active}
                   aria-label={`Filter by ${provider}`}
-                />
-                <CheckboxLabel>{provider}</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            ))}
-          </div>
+                  onClick={() => onProviderToggle(provider)}
+                >
+                  {provider}
+                </FilterChip>
+              );
+            })}
+          </ChipList>
         </FilterSection>
       )}
 
       {availableGenres.length > 0 && (
         <FilterSection>
           <SectionTitle>Genres</SectionTitle>
-          <div>
-            {selectedGenres.length > 0 && (
-              <ProviderCheckboxContainer>
-                <Checkbox
-                  type="checkbox"
-                  checked={false}
-                  onChange={() => onGenreChange([])}
-                  aria-label="Show all genres"
-                />
-                <CheckboxLabel>All genres</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            )}
-            {availableGenres.map((genre) => (
-              <ProviderCheckboxContainer key={genre}>
-                <Checkbox
-                  type="checkbox"
-                  checked={selectedGenres.length === 0 || selectedGenres.includes(genre)}
-                  onChange={() => handleGenreToggle(genre)}
+          <ChipList>
+            {availableGenres.map((genre) => {
+              const active = isGenreActive(genre);
+              return (
+                <FilterChip
+                  key={genre}
+                  type="button"
+                  $active={active}
+                  aria-pressed={active}
                   aria-label={`Filter by genre: ${genre}`}
-                />
-                <CheckboxLabel>{genre}</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            ))}
-          </div>
+                  onClick={() => onGenreToggle(genre)}
+                >
+                  {genre}
+                </FilterChip>
+              );
+            })}
+          </ChipList>
         </FilterSection>
       )}
 
@@ -452,7 +426,7 @@ export const FilterSidebar = ({
 
       <FilterSection>
         <SectionTitle>Sort</SectionTitle>
-        {collectionType === 'playlists' ? (
+        {viewMode === 'playlists' ? (
           <SortSelect
             value={playlistSort}
             onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
@@ -476,7 +450,7 @@ export const FilterSidebar = ({
       </FilterSection>
 
       {hasActiveFilters && (
-        <ClearFiltersButton onClick={handleClearFilters}>
+        <ClearFiltersButton onClick={onClearFilters}>
           Clear Filters
         </ClearFiltersButton>
       )}

--- a/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
+++ b/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
@@ -9,17 +9,23 @@ function renderFilterSidebar(props = {}) {
   const defaultProps = {
     searchQuery: '',
     onSearchChange: vi.fn(),
-    collectionType: 'playlists' as const,
-    onCollectionTypeChange: vi.fn(),
+    viewMode: 'playlists' as const,
+    onViewModeChange: vi.fn(),
     enabledProviderIds: [] as const,
     selectedProviderIds: [] as const,
-    onProviderFilterChange: vi.fn(),
+    onProviderToggle: vi.fn(),
     showProviderFilter: false,
     availableGenres: [] as string[],
     selectedGenres: [] as string[],
-    onGenreChange: vi.fn(),
+    onGenreToggle: vi.fn(),
     recentlyAdded: 'all' as const,
     onRecentlyAddedChange: vi.fn(),
+    playlistSort: 'recently-added' as const,
+    setPlaylistSort: vi.fn(),
+    albumSort: 'recently-added' as const,
+    setAlbumSort: vi.fn(),
+    hasActiveFilters: false,
+    onClearFilters: vi.fn(),
     ...props,
   };
 
@@ -37,7 +43,7 @@ describe('FilterSidebar', () => {
 
   it('renders collection type toggle buttons', () => {
     // #given
-    renderFilterSidebar({ collectionType: 'playlists' });
+    renderFilterSidebar({ viewMode: 'playlists' });
 
     // #when
     const playlistsBtn = screen.getByRole('button', { name: 'Playlists' });
@@ -50,7 +56,7 @@ describe('FilterSidebar', () => {
 
   it('highlights active collection type', () => {
     // #given
-    renderFilterSidebar({ collectionType: 'albums' });
+    renderFilterSidebar({ viewMode: 'albums' });
 
     // #when
     const albumsBtn = screen.getByRole('button', { name: 'Albums' });
@@ -59,12 +65,12 @@ describe('FilterSidebar', () => {
     expect(albumsBtn).toBeInTheDocument();
   });
 
-  it('calls onCollectionTypeChange when clicking playlists button', () => {
+  it('calls onViewModeChange when clicking playlists button', () => {
     // #given
-    const onCollectionTypeChange = vi.fn();
+    const onViewModeChange = vi.fn();
     renderFilterSidebar({
-      collectionType: 'albums',
-      onCollectionTypeChange,
+      viewMode: 'albums',
+      onViewModeChange,
     });
 
     // #when
@@ -72,15 +78,15 @@ describe('FilterSidebar', () => {
     fireEvent.click(playlistsBtn);
 
     // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('playlists');
+    expect(onViewModeChange).toHaveBeenCalledWith('playlists');
   });
 
-  it('calls onCollectionTypeChange when clicking albums button', () => {
+  it('calls onViewModeChange when clicking albums button', () => {
     // #given
-    const onCollectionTypeChange = vi.fn();
+    const onViewModeChange = vi.fn();
     renderFilterSidebar({
-      collectionType: 'playlists',
-      onCollectionTypeChange,
+      viewMode: 'playlists',
+      onViewModeChange,
     });
 
     // #when
@@ -88,7 +94,7 @@ describe('FilterSidebar', () => {
     fireEvent.click(albumsBtn);
 
     // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('albums');
+    expect(onViewModeChange).toHaveBeenCalledWith('albums');
   });
 
   it('does not render provider filter when showProviderFilter is false', () => {
@@ -105,7 +111,7 @@ describe('FilterSidebar', () => {
     expect(providers).toHaveLength(0);
   });
 
-  it('renders provider filter checkboxes when showProviderFilter is true', () => {
+  it('renders provider filter chips when showProviderFilter is true', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -114,38 +120,34 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify');
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox');
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox).toBeInTheDocument();
-    expect(dropboxCheckbox).toBeInTheDocument();
+    expect(spotifyChip).toBeInTheDocument();
+    expect(dropboxChip).toBeInTheDocument();
   });
 
-  it('toggles provider when clicking provider checkbox', () => {
+  it('calls onProviderToggle with provider id when clicking a provider chip', () => {
     // #given
-    const onProviderFilterChange = vi.fn();
+    const onProviderToggle = vi.fn();
     renderFilterSidebar({
       showProviderFilter: true,
       enabledProviderIds: ['spotify', 'dropbox'],
       selectedProviderIds: [],
-      onProviderFilterChange,
+      onProviderToggle,
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify');
-    fireEvent.click(spotifyCheckbox);
+    fireEvent.click(screen.getByLabelText('Filter by spotify'));
 
     // #then
-    expect(onProviderFilterChange).toHaveBeenCalled();
+    expect(onProviderToggle).toHaveBeenCalledWith('spotify');
   });
 
-  it('does not render Clear Filters button when no filters are active', () => {
+  it('does not render Clear Filters button when hasActiveFilters is false', () => {
     // #given
-    renderFilterSidebar({
-      collectionType: 'playlists',
-      selectedProviderIds: [],
-    });
+    renderFilterSidebar({ hasActiveFilters: false });
 
     // #when
     const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
@@ -154,12 +156,9 @@ describe('FilterSidebar', () => {
     expect(clearBtn).not.toBeInTheDocument();
   });
 
-  it('renders Clear Filters button when collection type is albums', () => {
+  it('renders Clear Filters button when hasActiveFilters is true', () => {
     // #given
-    renderFilterSidebar({
-      collectionType: 'albums',
-      selectedProviderIds: [],
-    });
+    renderFilterSidebar({ hasActiveFilters: true });
 
     // #when
     const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
@@ -168,41 +167,22 @@ describe('FilterSidebar', () => {
     expect(clearBtn).toBeInTheDocument();
   });
 
-  it('renders Clear Filters button when providers are filtered', () => {
+  it('calls onClearFilters when clicking Clear Filters', () => {
     // #given
+    const onClearFilters = vi.fn();
     renderFilterSidebar({
-      collectionType: 'playlists',
-      selectedProviderIds: ['spotify'],
+      hasActiveFilters: true,
+      onClearFilters,
     });
 
     // #when
-    const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Filters' }));
 
     // #then
-    expect(clearBtn).toBeInTheDocument();
+    expect(onClearFilters).toHaveBeenCalled();
   });
 
-  it('resets filters to default when clicking Clear Filters', () => {
-    // #given
-    const onCollectionTypeChange = vi.fn();
-    const onProviderFilterChange = vi.fn();
-    renderFilterSidebar({
-      collectionType: 'albums',
-      selectedProviderIds: ['spotify'],
-      onCollectionTypeChange,
-      onProviderFilterChange,
-    });
-
-    // #when
-    const clearBtn = screen.getByRole('button', { name: 'Clear Filters' });
-    fireEvent.click(clearBtn);
-
-    // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('playlists');
-    expect(onProviderFilterChange).toHaveBeenCalledWith([]);
-  });
-
-  it('checks providers by default when no filter is active', () => {
+  it('shows every provider chip as active when no filter is set', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -211,15 +191,15 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify') as HTMLInputElement;
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox') as HTMLInputElement;
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox.checked).toBe(true);
-    expect(dropboxCheckbox.checked).toBe(true);
+    expect(spotifyChip).toHaveAttribute('aria-pressed', 'true');
+    expect(dropboxChip).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('only checks selected providers when filter is active', () => {
+  it('shows only selected provider chips as active when filter is non-empty', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -228,12 +208,74 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify') as HTMLInputElement;
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox') as HTMLInputElement;
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox.checked).toBe(true);
-    expect(dropboxCheckbox.checked).toBe(false);
+    expect(spotifyChip).toHaveAttribute('aria-pressed', 'true');
+    expect(dropboxChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows every genre chip as active when no genre is selected', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: [],
+    });
+
+    // #when
+    const rockChip = screen.getByLabelText('Filter by genre: rock');
+    const popChip = screen.getByLabelText('Filter by genre: pop');
+
+    // #then
+    expect(rockChip).toHaveAttribute('aria-pressed', 'true');
+    expect(popChip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows only selected genre chips as active when filter is non-empty', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: ['rock'],
+    });
+
+    // #when
+    const rockChip = screen.getByLabelText('Filter by genre: rock');
+    const popChip = screen.getByLabelText('Filter by genre: pop');
+
+    // #then
+    expect(rockChip).toHaveAttribute('aria-pressed', 'true');
+    expect(popChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onGenreToggle with genre when clicking a genre chip', () => {
+    // #given
+    const onGenreToggle = vi.fn();
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: [],
+      onGenreToggle,
+    });
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Filter by genre: rock'));
+
+    // #then
+    expect(onGenreToggle).toHaveBeenCalledWith('rock');
+  });
+
+  it('does not render an "All genres" pseudo-row when a genre is selected', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: ['rock'],
+    });
+
+    // #when
+    const allGenres = screen.queryByLabelText('Show all genres');
+
+    // #then
+    expect(allGenres).not.toBeInTheDocument();
   });
 
   it('renders recently added section with all time options', () => {
@@ -257,25 +299,5 @@ describe('FilterSidebar', () => {
 
     // #then
     expect(onRecentlyAddedChange).toHaveBeenCalledWith('30-days');
-  });
-
-  it('shows Clear Filters button when recently added is not all', () => {
-    // #given
-    renderFilterSidebar({ recentlyAdded: '7-days' });
-
-    // #then
-    expect(screen.getByRole('button', { name: 'Clear Filters' })).toBeInTheDocument();
-  });
-
-  it('resets recently added when clicking Clear Filters', () => {
-    // #given
-    const onRecentlyAddedChange = vi.fn();
-    renderFilterSidebar({ recentlyAdded: '7-days', onRecentlyAddedChange });
-
-    // #when
-    fireEvent.click(screen.getByRole('button', { name: 'Clear Filters' }));
-
-    // #then
-    expect(onRecentlyAddedChange).toHaveBeenCalledWith('all');
   });
 });

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -27,9 +27,11 @@ export interface LibraryBrowsingContextValue {
   availableGenres: string[];
   selectedGenres: string[];
   setSelectedGenres: (v: string[]) => void;
+  handleGenreToggle: (genre: string) => void;
   recentlyAddedFilter: RecentlyAddedFilterOption;
   setRecentlyAddedFilter: (v: RecentlyAddedFilterOption) => void;
   hasActiveFilters: boolean;
+  handleClearFilters: () => void;
 }
 
 export interface LibraryPinContextValue {

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -94,13 +94,14 @@ export function LibraryMainContent(): React.JSX.Element {
     albumSort,
     setAlbumSort,
     providerFilters,
-    setProviderFilters,
     handleProviderToggle,
     availableGenres,
     selectedGenres,
-    setSelectedGenres,
+    handleGenreToggle,
     recentlyAddedFilter,
     setRecentlyAddedFilter,
+    hasActiveFilters,
+    handleClearFilters,
   } = useLibraryBrowsingContext();
   const { onLibraryRefresh, isLibraryRefreshing } = useLibraryActions();
   const { inDrawer, showProviderBadges, enabledProviderIds } = useLibraryData();
@@ -112,21 +113,23 @@ export function LibraryMainContent(): React.JSX.Element {
         <FilterSidebar
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          collectionType={viewMode}
-          onCollectionTypeChange={setViewMode}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
           enabledProviderIds={enabledProviderIds}
           selectedProviderIds={providerFilters}
-          onProviderFilterChange={setProviderFilters}
+          onProviderToggle={handleProviderToggle}
           showProviderFilter={showProviderBadges}
           availableGenres={availableGenres}
           selectedGenres={selectedGenres}
-          onGenreChange={setSelectedGenres}
+          onGenreToggle={handleGenreToggle}
           recentlyAdded={recentlyAddedFilter}
           onRecentlyAddedChange={setRecentlyAddedFilter}
           playlistSort={playlistSort}
           setPlaylistSort={setPlaylistSort}
           albumSort={albumSort}
           setAlbumSort={setAlbumSort}
+          hasActiveFilters={hasActiveFilters}
+          onClearFilters={handleClearFilters}
         />
         <MainContent>
           {viewMode === 'playlists' && <PlaylistGrid />}

--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -40,7 +40,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     'all',
   );
 
-  // Sync when initial props change (e.g., drawer re-opened with new filter)
   useEffect(() => {
     if (initialSearchQuery !== undefined) {
       setSearchQuery(initialSearchQuery);
@@ -53,29 +52,49 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     }
   }, [initialViewMode]);
 
-  // Clear artist filter when switching away from albums view
   useEffect(() => {
-    if (viewMode === 'playlists') {
-      if (artistFilter !== '') {
-        setArtistFilter('');
-      }
+    if (viewMode === 'playlists' && artistFilter !== '') {
+      setArtistFilter('');
     }
   }, [viewMode, artistFilter]);
 
   const handleProviderToggle = useCallback((provider: ProviderId) => {
     setProviderFilters((prev) => {
       if (prev.length === 0) {
-        // First toggle: activate only this provider (deactivate others)
         return [provider];
       }
+      if (prev.length === 1 && prev[0] === provider) {
+        return [];
+      }
       if (prev.includes(provider)) {
-        const next = prev.filter((p) => p !== provider);
-        // If removing last filter, return to "all" (empty = no filter)
-        return next;
+        return prev.filter((p) => p !== provider);
       }
       return [...prev, provider];
     });
-  }, []);
+  }, [setProviderFilters]);
+
+  const handleGenreToggle = useCallback((genre: string) => {
+    setSelectedGenres((prev) => {
+      if (prev.length === 0) {
+        return [genre];
+      }
+      if (prev.length === 1 && prev[0] === genre) {
+        return [];
+      }
+      if (prev.includes(genre)) {
+        return prev.filter((g) => g !== genre);
+      }
+      return [...prev, genre];
+    });
+  }, [setSelectedGenres]);
+
+  const handleClearFilters = useCallback(() => {
+    setSearchQuery('');
+    setArtistFilter('');
+    setProviderFilters([]);
+    setSelectedGenres([]);
+    setRecentlyAddedFilter('all');
+  }, [setSearchQuery, setProviderFilters, setSelectedGenres, setRecentlyAddedFilter]);
 
   const hasActiveFilters =
     searchQuery !== '' ||
@@ -100,8 +119,10 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     handleProviderToggle,
     selectedGenres,
     setSelectedGenres,
+    handleGenreToggle,
     recentlyAddedFilter,
     setRecentlyAddedFilter,
     hasActiveFilters,
+    handleClearFilters,
   };
 }

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -237,9 +237,11 @@ export function useLibraryRoot({
       availableGenres,
       selectedGenres: browsingState.selectedGenres,
       setSelectedGenres: browsingState.setSelectedGenres,
+      handleGenreToggle: browsingState.handleGenreToggle,
       recentlyAddedFilter: browsingState.recentlyAddedFilter,
       setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
       hasActiveFilters: browsingState.hasActiveFilters,
+      handleClearFilters: browsingState.handleClearFilters,
     }),
     [
       browsingState.viewMode,


### PR DESCRIPTION
Closes #984
Closes #985
Closes #986
Closes #987
Closes #989
Closes #995

## Summary

Six related issues around the desktop library `FilterSidebar`:

- **#984/#985** — provider and genre filters used checkboxes whose \"empty means all selected\" convention produced broken toggle semantics (a checked box stayed checked on click, silently unchecked all its peers). Replaced with toggle chips that match the mobile provider chip row: empty selection renders all chips active, click enters exclusive selection, click the sole-selected chip clears back to empty. Removed the obsolete \"All genres\" pseudo-row.
- **#986** — the sidebar's inline `hasActiveFilters` disagreed with the hook's version (one counted `collectionType`, the other counted `artistFilter`). Now a single `hasActiveFilters` lives on `useLibraryBrowsing` and is threaded through `LibraryBrowsingContext`. `viewMode` is intentionally excluded — it's a view toggle, not a filter.
- **#987** — `Clear Filters` did not reset `artistFilter`, so users drilling in via \"artist: X\" then clicking Clear Filters kept the filter silently applied. `handleClearFilters` now lives on the hook and resets the full filter surface including `artistFilter`.
- **#989** — two `handleProviderToggle` implementations diverged. Kept the hook's canonical version and updated it to handle the \"sole-selected click\" case (clearing back to empty). Sidebar and mobile chip row both consume it via context.
- **#995** — renamed `FilterSidebar` props `collectionType`/`onCollectionTypeChange` to `viewMode`/`onViewModeChange` to match the rest of the codebase.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run lint` — no new errors or warnings on changed files
- [x] `npm run test:run` — 971 passing (baseline 970; added one genre-toggle test). Pre-existing failures in `PlaylistSelection.test.tsx` and `useFilterState.test.ts` are unrelated and present on develop.
- [ ] Manual: desktop library — click a provider chip → only that provider active; click again → all providers active again.
- [ ] Manual: drill into artist X in albums view → Clear Filters → artist filter clears.
- [ ] Manual: mobile provider chip row continues to work (same `handleProviderToggle`).