### PR TITLE
refactor(library): remove derived-state effects from useLibraryBrowsing

### DIFF
--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -13,7 +13,7 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
 
   const [searchQuery, setSearchQuery] = useLocalStorage<string>(
     'vorbis-player-library-search',
-    '',
+    initialSearchQuery ?? '',
   );
 
   const [playlistSort, setPlaylistSort] = useLocalStorage<PlaylistSortOption>(
@@ -39,18 +39,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     'vorbis-player-library-recently-added',
     'all',
   );
-
-  useEffect(() => {
-    if (initialSearchQuery !== undefined) {
-      setSearchQuery(initialSearchQuery);
-    }
-  }, [initialSearchQuery]);
-
-  useEffect(() => {
-    if (initialViewMode) {
-      setViewMode(initialViewMode);
-    }
-  }, [initialViewMode]);
 
   useEffect(() => {
     if (viewMode === 'playlists' && artistFilter !== '') {


### PR DESCRIPTION
## Summary

- Removes two `useEffect` blocks in `useLibraryBrowsing.ts` that wrote `initialSearchQuery` and `initialViewMode` props back into state on every prop change, silently overriding user input
- Seeds `searchQuery` via the `useLocalStorage` initializer (`initialSearchQuery ?? ''`) to preserve the one caller that passes this prop at mount
- `viewMode` was already correctly seeded via `initialViewMode ?? 'playlists'` in its `useLocalStorage` call — the effect was redundant

No callers change these props after mount, so direct initializer seeding is the correct pattern.

Closes #994