### PR TITLE
release: desktop library polish (RC 2026-04-15.2)

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.styled.ts
+++ b/src/components/LibraryDrawer/FilterSidebar.styled.ts
@@ -1,0 +1,233 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const SidebarContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.lg};
+  padding: ${theme.spacing.lg};
+  background: rgba(20, 20, 20, 0.3);
+  flex-shrink: 0;
+
+  /* Desktop: persistent left sidebar */
+  @media (min-width: ${theme.breakpoints.lg}) {
+    border-right: 1px solid ${theme.colors.popover.border};
+    min-width: 160px;
+    max-height: 100%;
+    overflow-y: auto;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;
+
+export const FilterSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.md};
+`;
+
+export const SectionTitle = styled.h3`
+  margin: 0;
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.semibold};
+  color: ${theme.colors.muted.foreground};
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+export const SearchInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  padding: 0 ${theme.spacing.sm};
+  transition: all ${theme.transitions.fast};
+
+  &:focus-within {
+    border-color: ${theme.colors.control.borderHover};
+    background: ${theme.colors.control.backgroundHover};
+  }
+`;
+
+export const SearchIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: ${theme.colors.muted.foreground};
+  flex-shrink: 0;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+`;
+
+export const SearchInput = styled.input`
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: ${theme.spacing.sm} 0;
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.white};
+  min-width: 0;
+
+  &::placeholder {
+    color: ${theme.colors.muted.foreground};
+  }
+`;
+
+export const ClearSearchButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: ${theme.colors.muted.foreground};
+  transition: color ${theme.transitions.fast};
+  flex-shrink: 0;
+
+  &:hover {
+    color: ${theme.colors.white};
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+`;
+
+export const ToggleGroup = styled.div`
+  display: flex;
+  gap: ${theme.spacing.sm};
+  flex-direction: column;
+`;
+
+export const ToggleButton = styled.button<{ $active: boolean }>`
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: ${({ $active }) =>
+    $active ? theme.colors.control.backgroundHover : theme.colors.control.background};
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? theme.colors.control.borderHover : theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  color: ${({ $active }) =>
+    $active ? theme.colors.white : theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+  text-align: left;
+  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+`;
+
+export const ChipList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${theme.spacing.sm};
+`;
+
+export const FilterChip = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? theme.colors.control.borderHover : theme.colors.control.border};
+  background: ${({ $active }) =>
+    $active ? theme.colors.control.backgroundHover : 'transparent'};
+  color: ${({ $active }) => ($active ? theme.colors.white : theme.colors.muted.foreground)};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
+    color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+`;
+
+export const SortSelect = styled.select`
+  width: 100%;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+  appearance: none;
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${theme.colors.control.borderHover};
+  }
+
+  option {
+    background: ${theme.colors.popover.background};
+    color: ${theme.colors.white};
+  }
+`;
+
+export const ClearFiltersButton = styled.button`
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.xs};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+  margin-top: auto;
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    color: ${theme.colors.white};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -1,5 +1,3 @@
-import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 import type { ProviderId } from '@/types/domain';
 import type {
   RecentlyAddedFilterOption,
@@ -7,6 +5,21 @@ import type {
   AlbumSortOption,
 } from '@/utils/playlistFilters';
 import { PLAYLIST_SORT_LABELS, ALBUM_SORT_LABELS } from '@/utils/playlistFilters';
+import {
+  SidebarContainer,
+  FilterSection,
+  SectionTitle,
+  SearchInputWrapper,
+  SearchIcon,
+  SearchInput,
+  ClearSearchButton,
+  ToggleGroup,
+  ToggleButton,
+  ChipList,
+  FilterChip,
+  SortSelect,
+  ClearFiltersButton,
+} from './FilterSidebar.styled';
 
 interface FilterSidebarProps {
   searchQuery: string;
@@ -38,237 +51,6 @@ interface FilterSidebarProps {
   hasActiveFilters: boolean;
   onClearFilters: () => void;
 }
-
-const SidebarContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.spacing.lg};
-  padding: ${theme.spacing.lg};
-  background: rgba(20, 20, 20, 0.3);
-  flex-shrink: 0;
-
-  /* Desktop: persistent left sidebar */
-  @media (min-width: ${theme.breakpoints.lg}) {
-    border-right: 1px solid ${theme.colors.popover.border};
-    min-width: 160px;
-    max-height: 100%;
-    overflow-y: auto;
-    scrollbar-width: none;
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-`;
-
-const FilterSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.spacing.md};
-`;
-
-const SectionTitle = styled.h3`
-  margin: 0;
-  font-size: ${theme.fontSize.sm};
-  font-weight: ${theme.fontWeight.semibold};
-  color: ${theme.colors.muted.foreground};
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-`;
-
-const SearchInputWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  position: relative;
-  background: ${theme.colors.control.background};
-  border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
-  padding: 0 ${theme.spacing.sm};
-  transition: all ${theme.transitions.fast};
-
-  &:focus-within {
-    border-color: ${theme.colors.control.borderHover};
-    background: ${theme.colors.control.backgroundHover};
-  }
-`;
-
-const SearchIcon = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  color: ${theme.colors.muted.foreground};
-  flex-shrink: 0;
-
-  svg {
-    width: 14px;
-    height: 14px;
-    stroke: currentColor;
-    fill: none;
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-`;
-
-const SearchInput = styled.input`
-  flex: 1;
-  background: transparent;
-  border: none;
-  outline: none;
-  padding: ${theme.spacing.sm} 0;
-  font-size: ${theme.fontSize.sm};
-  color: ${theme.colors.white};
-  min-width: 0;
-
-  &::placeholder {
-    color: ${theme.colors.muted.foreground};
-  }
-`;
-
-const ClearSearchButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: ${theme.colors.muted.foreground};
-  transition: color ${theme.transitions.fast};
-  flex-shrink: 0;
-
-  &:hover {
-    color: ${theme.colors.white};
-  }
-
-  svg {
-    width: 14px;
-    height: 14px;
-    stroke: currentColor;
-    fill: none;
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-`;
-
-const ToggleGroup = styled.div`
-  display: flex;
-  gap: ${theme.spacing.sm};
-  flex-direction: column;
-`;
-
-const ToggleButton = styled.button<{ $active: boolean }>`
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
-  background: ${({ $active }) =>
-    $active ? theme.colors.control.backgroundHover : theme.colors.control.background};
-  border: 1px solid
-    ${({ $active }) =>
-      $active ? theme.colors.control.borderHover : theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
-  color: ${({ $active }) =>
-    $active ? theme.colors.white : theme.colors.muted.foreground};
-  font-size: ${theme.fontSize.sm};
-  cursor: pointer;
-  transition: all ${theme.transitions.fast};
-  text-align: left;
-  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
-
-  &:hover {
-    background: ${theme.colors.control.backgroundHover};
-    color: ${theme.colors.white};
-  }
-
-  &:active {
-    opacity: 0.8;
-  }
-`;
-
-const ChipList = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${theme.spacing.sm};
-`;
-
-const FilterChip = styled.button<{ $active: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  padding: ${theme.spacing.xs} ${theme.spacing.md};
-  border-radius: 999px;
-  border: 1px solid
-    ${({ $active }) =>
-      $active ? theme.colors.control.borderHover : theme.colors.control.border};
-  background: ${({ $active }) =>
-    $active ? theme.colors.control.backgroundHover : 'transparent'};
-  color: ${({ $active }) => ($active ? theme.colors.white : theme.colors.muted.foreground)};
-  font-size: ${theme.fontSize.sm};
-  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
-  cursor: pointer;
-  transition: all ${theme.transitions.fast};
-
-  &:hover {
-    background: ${theme.colors.control.backgroundHover};
-    border-color: ${theme.colors.control.borderHover};
-    color: ${theme.colors.white};
-  }
-
-  &:active {
-    opacity: 0.8;
-  }
-`;
-
-const SortSelect = styled.select`
-  width: 100%;
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
-  background: ${theme.colors.control.background};
-  border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
-  color: ${theme.colors.white};
-  font-size: ${theme.fontSize.sm};
-  cursor: pointer;
-  transition: all ${theme.transitions.fast};
-  appearance: none;
-
-  &:hover {
-    background: ${theme.colors.control.backgroundHover};
-    border-color: ${theme.colors.control.borderHover};
-  }
-
-  &:focus {
-    outline: none;
-    border-color: ${theme.colors.control.borderHover};
-  }
-
-  option {
-    background: ${theme.colors.popover.background};
-    color: ${theme.colors.white};
-  }
-`;
-
-const ClearFiltersButton = styled.button`
-  padding: ${theme.spacing.xs} ${theme.spacing.md};
-  background: ${theme.colors.control.background};
-  border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
-  color: ${theme.colors.muted.foreground};
-  font-size: ${theme.fontSize.xs};
-  cursor: pointer;
-  transition: all ${theme.transitions.fast};
-  margin-top: auto;
-
-  &:hover {
-    background: ${theme.colors.control.backgroundHover};
-    color: ${theme.colors.white};
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-`;
 
 const SearchIconSvg = () => (
   <svg viewBox="0 0 24 24">

--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import type { ProviderId } from '@/types/domain';
@@ -13,12 +12,12 @@ interface FilterSidebarProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
 
-  collectionType: 'playlists' | 'albums';
-  onCollectionTypeChange: (type: 'playlists' | 'albums') => void;
+  viewMode: 'playlists' | 'albums';
+  onViewModeChange: (type: 'playlists' | 'albums') => void;
 
   enabledProviderIds: ProviderId[];
   selectedProviderIds: ProviderId[];
-  onProviderFilterChange: (providerIds: ProviderId[]) => void;
+  onProviderToggle: (provider: ProviderId) => void;
 
   showProviderFilter: boolean;
 
@@ -26,7 +25,7 @@ interface FilterSidebarProps {
   availableGenres: string[];
   /** Currently selected genres (empty = all genres included). */
   selectedGenres: string[];
-  onGenreChange: (genres: string[]) => void;
+  onGenreToggle: (genre: string) => void;
 
   recentlyAdded: RecentlyAddedFilterOption;
   onRecentlyAddedChange: (value: RecentlyAddedFilterOption) => void;
@@ -35,6 +34,9 @@ interface FilterSidebarProps {
   setPlaylistSort: (v: PlaylistSortOption) => void;
   albumSort: AlbumSortOption;
   setAlbumSort: (v: AlbumSortOption) => void;
+
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
 }
 
 const SidebarContainer = styled.div`
@@ -185,34 +187,36 @@ const ToggleButton = styled.button<{ $active: boolean }>`
   }
 `;
 
-const ProviderCheckboxContainer = styled.label`
+const ChipList = styled.div`
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: ${theme.spacing.sm};
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
+`;
+
+const FilterChip = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? theme.colors.control.borderHover : theme.colors.control.border};
+  background: ${({ $active }) =>
+    $active ? theme.colors.control.backgroundHover : 'transparent'};
+  color: ${({ $active }) => ($active ? theme.colors.white : theme.colors.muted.foreground)};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${({ $active }) => ($active ? theme.fontWeight.semibold : theme.fontWeight.normal)};
   cursor: pointer;
-  border-radius: ${theme.borderRadius.md};
-  transition: background ${theme.transitions.fast};
+  transition: all ${theme.transitions.fast};
 
   &:hover {
-    background: ${theme.colors.control.background};
-  }
-`;
-
-const Checkbox = styled.input`
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  accent-color: ${theme.colors.spotify};
-`;
-
-const CheckboxLabel = styled.span`
-  font-size: ${theme.fontSize.sm};
-  color: ${theme.colors.muted.foreground};
-  transition: color ${theme.transitions.fast};
-
-  ${ProviderCheckboxContainer}:hover & {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
     color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
   }
 `;
 
@@ -290,53 +294,29 @@ const RECENTLY_ADDED_OPTIONS: { label: string; value: RecentlyAddedFilterOption 
 export const FilterSidebar = ({
   searchQuery,
   onSearchChange,
-  collectionType,
-  onCollectionTypeChange,
+  viewMode,
+  onViewModeChange,
   enabledProviderIds,
   selectedProviderIds,
-  onProviderFilterChange,
+  onProviderToggle,
   showProviderFilter,
   availableGenres,
   selectedGenres,
-  onGenreChange,
+  onGenreToggle,
   recentlyAdded,
   onRecentlyAddedChange,
   playlistSort,
   setPlaylistSort,
   albumSort,
   setAlbumSort,
+  hasActiveFilters,
+  onClearFilters,
 }: FilterSidebarProps) => {
-  const hasActiveFilters =
-    searchQuery !== '' ||
-    collectionType === 'albums' ||
-    selectedProviderIds.length > 0 ||
-    selectedGenres.length > 0 ||
-    (recentlyAdded !== 'all' && recentlyAdded !== undefined);
+  const isProviderActive = (provider: ProviderId): boolean =>
+    selectedProviderIds.length === 0 || selectedProviderIds.includes(provider);
 
-  const handleClearFilters = useCallback(() => {
-    onSearchChange('');
-    onCollectionTypeChange('playlists');
-    onProviderFilterChange([]);
-    onGenreChange([]);
-    onRecentlyAddedChange('all');
-  }, [onSearchChange, onCollectionTypeChange, onProviderFilterChange, onGenreChange, onRecentlyAddedChange]);
-
-  const handleProviderToggle = useCallback((provider: ProviderId) => {
-    if (selectedProviderIds.includes(provider)) {
-      const next = selectedProviderIds.filter((p) => p !== provider);
-      onProviderFilterChange(next.length === enabledProviderIds.length ? [] : next);
-    } else {
-      onProviderFilterChange([...selectedProviderIds, provider]);
-    }
-  }, [selectedProviderIds, enabledProviderIds, onProviderFilterChange]);
-
-  const handleGenreToggle = useCallback((genre: string) => {
-    if (selectedGenres.includes(genre)) {
-      onGenreChange(selectedGenres.filter((g) => g !== genre));
-    } else {
-      onGenreChange([...selectedGenres, genre]);
-    }
-  }, [selectedGenres, onGenreChange]);
+  const isGenreActive = (genre: string): boolean =>
+    selectedGenres.length === 0 || selectedGenres.includes(genre);
 
   return (
     <SidebarContainer>
@@ -369,14 +349,14 @@ export const FilterSidebar = ({
         <SectionTitle>Collection Type</SectionTitle>
         <ToggleGroup>
           <ToggleButton
-            $active={collectionType === 'playlists'}
-            onClick={() => onCollectionTypeChange('playlists')}
+            $active={viewMode === 'playlists'}
+            onClick={() => onViewModeChange('playlists')}
           >
             Playlists
           </ToggleButton>
           <ToggleButton
-            $active={collectionType === 'albums'}
-            onClick={() => onCollectionTypeChange('albums')}
+            $active={viewMode === 'albums'}
+            onClick={() => onViewModeChange('albums')}
           >
             Albums
           </ToggleButton>
@@ -386,52 +366,46 @@ export const FilterSidebar = ({
       {showProviderFilter && (
         <FilterSection>
           <SectionTitle>Providers</SectionTitle>
-          <div>
-            {enabledProviderIds.map((provider) => (
-              <ProviderCheckboxContainer key={provider}>
-                <Checkbox
-                  type="checkbox"
-                  checked={
-                    selectedProviderIds.length === 0 ||
-                    selectedProviderIds.includes(provider)
-                  }
-                  onChange={() => handleProviderToggle(provider)}
+          <ChipList>
+            {enabledProviderIds.map((provider) => {
+              const active = isProviderActive(provider);
+              return (
+                <FilterChip
+                  key={provider}
+                  type="button"
+                  $active={active}
+                  aria-pressed={active}
                   aria-label={`Filter by ${provider}`}
-                />
-                <CheckboxLabel>{provider}</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            ))}
-          </div>
+                  onClick={() => onProviderToggle(provider)}
+                >
+                  {provider}
+                </FilterChip>
+              );
+            })}
+          </ChipList>
         </FilterSection>
       )}
 
       {availableGenres.length > 0 && (
         <FilterSection>
           <SectionTitle>Genres</SectionTitle>
-          <div>
-            {selectedGenres.length > 0 && (
-              <ProviderCheckboxContainer>
-                <Checkbox
-                  type="checkbox"
-                  checked={false}
-                  onChange={() => onGenreChange([])}
-                  aria-label="Show all genres"
-                />
-                <CheckboxLabel>All genres</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            )}
-            {availableGenres.map((genre) => (
-              <ProviderCheckboxContainer key={genre}>
-                <Checkbox
-                  type="checkbox"
-                  checked={selectedGenres.length === 0 || selectedGenres.includes(genre)}
-                  onChange={() => handleGenreToggle(genre)}
+          <ChipList>
+            {availableGenres.map((genre) => {
+              const active = isGenreActive(genre);
+              return (
+                <FilterChip
+                  key={genre}
+                  type="button"
+                  $active={active}
+                  aria-pressed={active}
                   aria-label={`Filter by genre: ${genre}`}
-                />
-                <CheckboxLabel>{genre}</CheckboxLabel>
-              </ProviderCheckboxContainer>
-            ))}
-          </div>
+                  onClick={() => onGenreToggle(genre)}
+                >
+                  {genre}
+                </FilterChip>
+              );
+            })}
+          </ChipList>
         </FilterSection>
       )}
 
@@ -452,7 +426,7 @@ export const FilterSidebar = ({
 
       <FilterSection>
         <SectionTitle>Sort</SectionTitle>
-        {collectionType === 'playlists' ? (
+        {viewMode === 'playlists' ? (
           <SortSelect
             value={playlistSort}
             onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
@@ -476,7 +450,7 @@ export const FilterSidebar = ({
       </FilterSection>
 
       {hasActiveFilters && (
-        <ClearFiltersButton onClick={handleClearFilters}>
+        <ClearFiltersButton onClick={onClearFilters}>
           Clear Filters
         </ClearFiltersButton>
       )}

--- a/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
+++ b/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
@@ -9,17 +9,23 @@ function renderFilterSidebar(props = {}) {
   const defaultProps = {
     searchQuery: '',
     onSearchChange: vi.fn(),
-    collectionType: 'playlists' as const,
-    onCollectionTypeChange: vi.fn(),
+    viewMode: 'playlists' as const,
+    onViewModeChange: vi.fn(),
     enabledProviderIds: [] as const,
     selectedProviderIds: [] as const,
-    onProviderFilterChange: vi.fn(),
+    onProviderToggle: vi.fn(),
     showProviderFilter: false,
     availableGenres: [] as string[],
     selectedGenres: [] as string[],
-    onGenreChange: vi.fn(),
+    onGenreToggle: vi.fn(),
     recentlyAdded: 'all' as const,
     onRecentlyAddedChange: vi.fn(),
+    playlistSort: 'recently-added' as const,
+    setPlaylistSort: vi.fn(),
+    albumSort: 'recently-added' as const,
+    setAlbumSort: vi.fn(),
+    hasActiveFilters: false,
+    onClearFilters: vi.fn(),
     ...props,
   };
 
@@ -37,7 +43,7 @@ describe('FilterSidebar', () => {
 
   it('renders collection type toggle buttons', () => {
     // #given
-    renderFilterSidebar({ collectionType: 'playlists' });
+    renderFilterSidebar({ viewMode: 'playlists' });
 
     // #when
     const playlistsBtn = screen.getByRole('button', { name: 'Playlists' });
@@ -50,7 +56,7 @@ describe('FilterSidebar', () => {
 
   it('highlights active collection type', () => {
     // #given
-    renderFilterSidebar({ collectionType: 'albums' });
+    renderFilterSidebar({ viewMode: 'albums' });
 
     // #when
     const albumsBtn = screen.getByRole('button', { name: 'Albums' });
@@ -59,12 +65,12 @@ describe('FilterSidebar', () => {
     expect(albumsBtn).toBeInTheDocument();
   });
 
-  it('calls onCollectionTypeChange when clicking playlists button', () => {
+  it('calls onViewModeChange when clicking playlists button', () => {
     // #given
-    const onCollectionTypeChange = vi.fn();
+    const onViewModeChange = vi.fn();
     renderFilterSidebar({
-      collectionType: 'albums',
-      onCollectionTypeChange,
+      viewMode: 'albums',
+      onViewModeChange,
     });
 
     // #when
@@ -72,15 +78,15 @@ describe('FilterSidebar', () => {
     fireEvent.click(playlistsBtn);
 
     // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('playlists');
+    expect(onViewModeChange).toHaveBeenCalledWith('playlists');
   });
 
-  it('calls onCollectionTypeChange when clicking albums button', () => {
+  it('calls onViewModeChange when clicking albums button', () => {
     // #given
-    const onCollectionTypeChange = vi.fn();
+    const onViewModeChange = vi.fn();
     renderFilterSidebar({
-      collectionType: 'playlists',
-      onCollectionTypeChange,
+      viewMode: 'playlists',
+      onViewModeChange,
     });
 
     // #when
@@ -88,7 +94,7 @@ describe('FilterSidebar', () => {
     fireEvent.click(albumsBtn);
 
     // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('albums');
+    expect(onViewModeChange).toHaveBeenCalledWith('albums');
   });
 
   it('does not render provider filter when showProviderFilter is false', () => {
@@ -105,7 +111,7 @@ describe('FilterSidebar', () => {
     expect(providers).toHaveLength(0);
   });
 
-  it('renders provider filter checkboxes when showProviderFilter is true', () => {
+  it('renders provider filter chips when showProviderFilter is true', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -114,38 +120,34 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify');
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox');
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox).toBeInTheDocument();
-    expect(dropboxCheckbox).toBeInTheDocument();
+    expect(spotifyChip).toBeInTheDocument();
+    expect(dropboxChip).toBeInTheDocument();
   });
 
-  it('toggles provider when clicking provider checkbox', () => {
+  it('calls onProviderToggle with provider id when clicking a provider chip', () => {
     // #given
-    const onProviderFilterChange = vi.fn();
+    const onProviderToggle = vi.fn();
     renderFilterSidebar({
       showProviderFilter: true,
       enabledProviderIds: ['spotify', 'dropbox'],
       selectedProviderIds: [],
-      onProviderFilterChange,
+      onProviderToggle,
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify');
-    fireEvent.click(spotifyCheckbox);
+    fireEvent.click(screen.getByLabelText('Filter by spotify'));
 
     // #then
-    expect(onProviderFilterChange).toHaveBeenCalled();
+    expect(onProviderToggle).toHaveBeenCalledWith('spotify');
   });
 
-  it('does not render Clear Filters button when no filters are active', () => {
+  it('does not render Clear Filters button when hasActiveFilters is false', () => {
     // #given
-    renderFilterSidebar({
-      collectionType: 'playlists',
-      selectedProviderIds: [],
-    });
+    renderFilterSidebar({ hasActiveFilters: false });
 
     // #when
     const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
@@ -154,12 +156,9 @@ describe('FilterSidebar', () => {
     expect(clearBtn).not.toBeInTheDocument();
   });
 
-  it('renders Clear Filters button when collection type is albums', () => {
+  it('renders Clear Filters button when hasActiveFilters is true', () => {
     // #given
-    renderFilterSidebar({
-      collectionType: 'albums',
-      selectedProviderIds: [],
-    });
+    renderFilterSidebar({ hasActiveFilters: true });
 
     // #when
     const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
@@ -168,41 +167,22 @@ describe('FilterSidebar', () => {
     expect(clearBtn).toBeInTheDocument();
   });
 
-  it('renders Clear Filters button when providers are filtered', () => {
+  it('calls onClearFilters when clicking Clear Filters', () => {
     // #given
+    const onClearFilters = vi.fn();
     renderFilterSidebar({
-      collectionType: 'playlists',
-      selectedProviderIds: ['spotify'],
+      hasActiveFilters: true,
+      onClearFilters,
     });
 
     // #when
-    const clearBtn = screen.queryByRole('button', { name: 'Clear Filters' });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Filters' }));
 
     // #then
-    expect(clearBtn).toBeInTheDocument();
+    expect(onClearFilters).toHaveBeenCalled();
   });
 
-  it('resets filters to default when clicking Clear Filters', () => {
-    // #given
-    const onCollectionTypeChange = vi.fn();
-    const onProviderFilterChange = vi.fn();
-    renderFilterSidebar({
-      collectionType: 'albums',
-      selectedProviderIds: ['spotify'],
-      onCollectionTypeChange,
-      onProviderFilterChange,
-    });
-
-    // #when
-    const clearBtn = screen.getByRole('button', { name: 'Clear Filters' });
-    fireEvent.click(clearBtn);
-
-    // #then
-    expect(onCollectionTypeChange).toHaveBeenCalledWith('playlists');
-    expect(onProviderFilterChange).toHaveBeenCalledWith([]);
-  });
-
-  it('checks providers by default when no filter is active', () => {
+  it('shows every provider chip as active when no filter is set', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -211,15 +191,15 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify') as HTMLInputElement;
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox') as HTMLInputElement;
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox.checked).toBe(true);
-    expect(dropboxCheckbox.checked).toBe(true);
+    expect(spotifyChip).toHaveAttribute('aria-pressed', 'true');
+    expect(dropboxChip).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('only checks selected providers when filter is active', () => {
+  it('shows only selected provider chips as active when filter is non-empty', () => {
     // #given
     renderFilterSidebar({
       showProviderFilter: true,
@@ -228,12 +208,74 @@ describe('FilterSidebar', () => {
     });
 
     // #when
-    const spotifyCheckbox = screen.getByLabelText('Filter by spotify') as HTMLInputElement;
-    const dropboxCheckbox = screen.getByLabelText('Filter by dropbox') as HTMLInputElement;
+    const spotifyChip = screen.getByLabelText('Filter by spotify');
+    const dropboxChip = screen.getByLabelText('Filter by dropbox');
 
     // #then
-    expect(spotifyCheckbox.checked).toBe(true);
-    expect(dropboxCheckbox.checked).toBe(false);
+    expect(spotifyChip).toHaveAttribute('aria-pressed', 'true');
+    expect(dropboxChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows every genre chip as active when no genre is selected', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: [],
+    });
+
+    // #when
+    const rockChip = screen.getByLabelText('Filter by genre: rock');
+    const popChip = screen.getByLabelText('Filter by genre: pop');
+
+    // #then
+    expect(rockChip).toHaveAttribute('aria-pressed', 'true');
+    expect(popChip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows only selected genre chips as active when filter is non-empty', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: ['rock'],
+    });
+
+    // #when
+    const rockChip = screen.getByLabelText('Filter by genre: rock');
+    const popChip = screen.getByLabelText('Filter by genre: pop');
+
+    // #then
+    expect(rockChip).toHaveAttribute('aria-pressed', 'true');
+    expect(popChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onGenreToggle with genre when clicking a genre chip', () => {
+    // #given
+    const onGenreToggle = vi.fn();
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: [],
+      onGenreToggle,
+    });
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Filter by genre: rock'));
+
+    // #then
+    expect(onGenreToggle).toHaveBeenCalledWith('rock');
+  });
+
+  it('does not render an "All genres" pseudo-row when a genre is selected', () => {
+    // #given
+    renderFilterSidebar({
+      availableGenres: ['rock', 'pop'],
+      selectedGenres: ['rock'],
+    });
+
+    // #when
+    const allGenres = screen.queryByLabelText('Show all genres');
+
+    // #then
+    expect(allGenres).not.toBeInTheDocument();
   });
 
   it('renders recently added section with all time options', () => {
@@ -257,25 +299,5 @@ describe('FilterSidebar', () => {
 
     // #then
     expect(onRecentlyAddedChange).toHaveBeenCalledWith('30-days');
-  });
-
-  it('shows Clear Filters button when recently added is not all', () => {
-    // #given
-    renderFilterSidebar({ recentlyAdded: '7-days' });
-
-    // #then
-    expect(screen.getByRole('button', { name: 'Clear Filters' })).toBeInTheDocument();
-  });
-
-  it('resets recently added when clicking Clear Filters', () => {
-    // #given
-    const onRecentlyAddedChange = vi.fn();
-    renderFilterSidebar({ recentlyAdded: '7-days', onRecentlyAddedChange });
-
-    // #when
-    fireEvent.click(screen.getByRole('button', { name: 'Clear Filters' }));
-
-    // #then
-    expect(onRecentlyAddedChange).toHaveBeenCalledWith('all');
   });
 });

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -27,9 +27,11 @@ export interface LibraryBrowsingContextValue {
   availableGenres: string[];
   selectedGenres: string[];
   setSelectedGenres: (v: string[]) => void;
+  handleGenreToggle: (genre: string) => void;
   recentlyAddedFilter: RecentlyAddedFilterOption;
   setRecentlyAddedFilter: (v: RecentlyAddedFilterOption) => void;
   hasActiveFilters: boolean;
+  handleClearFilters: () => void;
 }
 
 export interface LibraryPinContextValue {

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type * as React from 'react';
+import * as React from 'react';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
@@ -71,12 +71,6 @@ export interface LibraryDataContextValue {
   activeDescriptor: ProviderDescriptor | null;
 }
 
-export type LibraryContextValue =
-  LibraryBrowsingContextValue &
-  LibraryPinContextValue &
-  LibraryActionsContextValue &
-  LibraryDataContextValue;
-
 const LibraryBrowsingContext = createContext<LibraryBrowsingContextValue | null>(null);
 const LibraryPinContext = createContext<LibraryPinContextValue | null>(null);
 const LibraryActionsContext = createContext<LibraryActionsContextValue | null>(null);
@@ -119,10 +113,24 @@ export function useLibraryData(): LibraryDataContextValue {
   return ctx;
 }
 
-export function useLibraryContext(): LibraryContextValue {
-  const browsing = useLibraryBrowsingContext();
-  const pins = useLibraryPins();
-  const actions = useLibraryActions();
-  const data = useLibraryData();
-  return { ...browsing, ...pins, ...actions, ...data };
+export function LibraryProviders({ values, children }: {
+  values: {
+    browsing: LibraryBrowsingContextValue;
+    pin: LibraryPinContextValue;
+    actions: LibraryActionsContextValue;
+    data: LibraryDataContextValue;
+  };
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <LibraryDataProvider value={values.data}>
+      <LibraryBrowsingProvider value={values.browsing}>
+        <LibraryPinProvider value={values.pin}>
+          <LibraryActionsProvider value={values.actions}>
+            {children}
+          </LibraryActionsProvider>
+        </LibraryPinProvider>
+      </LibraryBrowsingProvider>
+    </LibraryDataProvider>
+  );
 }

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -94,13 +94,14 @@ export function LibraryMainContent(): React.JSX.Element {
     albumSort,
     setAlbumSort,
     providerFilters,
-    setProviderFilters,
     handleProviderToggle,
     availableGenres,
     selectedGenres,
-    setSelectedGenres,
+    handleGenreToggle,
     recentlyAddedFilter,
     setRecentlyAddedFilter,
+    hasActiveFilters,
+    handleClearFilters,
   } = useLibraryBrowsingContext();
   const { onLibraryRefresh, isLibraryRefreshing } = useLibraryActions();
   const { inDrawer, showProviderBadges, enabledProviderIds } = useLibraryData();
@@ -112,21 +113,23 @@ export function LibraryMainContent(): React.JSX.Element {
         <FilterSidebar
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          collectionType={viewMode}
-          onCollectionTypeChange={setViewMode}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
           enabledProviderIds={enabledProviderIds}
           selectedProviderIds={providerFilters}
-          onProviderFilterChange={setProviderFilters}
+          onProviderToggle={handleProviderToggle}
           showProviderFilter={showProviderBadges}
           availableGenres={availableGenres}
           selectedGenres={selectedGenres}
-          onGenreChange={setSelectedGenres}
+          onGenreToggle={handleGenreToggle}
           recentlyAdded={recentlyAddedFilter}
           onRecentlyAddedChange={setRecentlyAddedFilter}
           playlistSort={playlistSort}
           setPlaylistSort={setPlaylistSort}
           albumSort={albumSort}
           setAlbumSort={setAlbumSort}
+          hasActiveFilters={hasActiveFilters}
+          onClearFilters={handleClearFilters}
         />
         <MainContent>
           {viewMode === 'playlists' && <PlaylistGrid />}

--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -115,6 +115,273 @@ function albumNames(result: { current: ReturnType<typeof useLibraryRoot> }): str
   return result.current.pinValue.unpinnedAlbums.map((a) => a.name);
 }
 
+describe('useLibraryRoot behavioral coverage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockIsMobile.current = false;
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  describe('combined filter interactions', () => {
+    it('applies provider, genre, and recently-added filters together on albums', () => {
+      // #given
+      const recent = new Date(Date.now() - 3 * 86_400_000).toISOString();
+      const old = new Date(Date.now() - 60 * 86_400_000).toISOString();
+      setLibrarySync(
+        [],
+        [
+          makeAlbumInfo({ id: 'a-1', name: 'Spotify Rock Recent',  provider: 'spotify',  genres: ['Rock'],   added_at: recent }),
+          makeAlbumInfo({ id: 'a-2', name: 'Spotify Rock Old',     provider: 'spotify',  genres: ['Rock'],   added_at: old }),
+          makeAlbumInfo({ id: 'a-3', name: 'Spotify Jazz Recent',  provider: 'spotify',  genres: ['Jazz'],   added_at: recent }),
+          makeAlbumInfo({ id: 'a-4', name: 'Dropbox Rock Recent',  provider: 'dropbox',  genres: ['Rock'],   added_at: recent }),
+        ],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when — provider=spotify, genre=Rock, recently-added=7-days
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['spotify']);
+        result.current.browsingValue.setSelectedGenres(['Rock']);
+        result.current.browsingValue.setRecentlyAddedFilter('7-days');
+      });
+
+      // #then — only the one item matching all three filters survives
+      expect(albumNames(result)).toEqual(['Spotify Rock Recent']);
+    });
+
+    it('applies provider and recently-added filters together on playlists', () => {
+      // #given
+      const recent = new Date(Date.now() - 2 * 86_400_000).toISOString();
+      const old = new Date(Date.now() - 60 * 86_400_000).toISOString();
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Spotify Recent',  provider: 'spotify',  added_at: recent }),
+          makePlaylistInfo({ id: 'p-2', name: 'Spotify Old',     provider: 'spotify',  added_at: old }),
+          makePlaylistInfo({ id: 'p-3', name: 'Dropbox Recent',  provider: 'dropbox',  added_at: recent }),
+        ],
+        [],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when — provider=spotify AND recently-added=7-days
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['spotify']);
+        result.current.browsingValue.setRecentlyAddedFilter('7-days');
+      });
+
+      // #then — only the spotify + recent playlist passes both filters
+      expect(playlistNames(result)).toEqual(['Spotify Recent']);
+    });
+  });
+
+  describe('mobile provider filter bypass', () => {
+    beforeEach(() => {
+      mockIsMobile.current = true;
+    });
+
+    it('shows items from all providers when isMobile is true, even when providerFilters is set', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-1', name: 'Spotify Playlist', provider: 'spotify' }),
+          makePlaylistInfo({ id: 'p-2', name: 'Dropbox Playlist', provider: 'dropbox' }),
+        ],
+        [
+          makeAlbumInfo({ id: 'a-1', name: 'Spotify Album', provider: 'spotify' }),
+          makeAlbumInfo({ id: 'a-2', name: 'Dropbox Album', provider: 'dropbox' }),
+        ],
+      );
+      const { result } = renderLibraryRoot();
+
+      // #when — set a provider filter that would exclude dropbox on desktop
+      act(() => {
+        result.current.browsingValue.setProviderFilters(['spotify']);
+      });
+
+      // #then — both providers' items appear in playlists and albums
+      expect(playlistNames(result).sort()).toEqual(['Dropbox Playlist', 'Spotify Playlist']);
+      expect(albumNames(result).sort()).toEqual(['Dropbox Album', 'Spotify Album']);
+    });
+  });
+
+  describe('error messaging', () => {
+    it('surfaces libraryError mentioning the active provider name when all collections are empty and load is complete', () => {
+      // #given — all counts are 0 and initial load is done
+      mockUseLibrarySync.mockReturnValue({
+        playlists: [],
+        albums: [],
+        likedSongsCount: 0,
+        likedSongsPerProvider: [],
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        isLikedSongsSyncing: false,
+        lastSyncTimestamp: Date.now(),
+        syncError: null,
+        refreshNow: vi.fn(),
+        removeCollection: vi.fn(),
+      });
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then — error string names the active provider
+      expect(typeof result.current.statusContentProps.error).toBe('string');
+      expect(result.current.statusContentProps.error).toContain('Spotify');
+    });
+
+    it('does not surface libraryError before initial load completes', () => {
+      // #given — load still in progress
+      mockUseLibrarySync.mockReturnValue({
+        playlists: [],
+        albums: [],
+        likedSongsCount: 0,
+        likedSongsPerProvider: [],
+        isInitialLoadComplete: false,
+        isSyncing: true,
+        isLikedSongsSyncing: false,
+        lastSyncTimestamp: null,
+        syncError: null,
+        refreshNow: vi.fn(),
+        removeCollection: vi.fn(),
+      });
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then — no error yet
+      expect(result.current.statusContentProps.error).toBeNull();
+    });
+  });
+
+  describe('pin composition', () => {
+    it('pinned playlist appears in pinnedPlaylists and not in unpinnedPlaylists', () => {
+      // #given
+      setLibrarySync(
+        [
+          makePlaylistInfo({ id: 'p-pinned', name: 'Pinned Playlist', provider: 'spotify' }),
+          makePlaylistInfo({ id: 'p-free',   name: 'Free Playlist',   provider: 'spotify' }),
+        ],
+        [],
+      );
+      mockUsePinnedItems.mockReturnValue({
+        pinnedPlaylistIds: ['p-pinned'],
+        pinnedAlbumIds: [],
+        isPlaylistPinned: (id: string) => id === 'p-pinned',
+        isAlbumPinned: () => false,
+        togglePinPlaylist: vi.fn(),
+        togglePinAlbum: vi.fn(),
+        canPinMorePlaylists: true,
+        canPinMoreAlbums: true,
+      });
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      const pinnedNames = result.current.pinValue.pinnedPlaylists.map((p) => p.name);
+      const unpinnedNames = result.current.pinValue.unpinnedPlaylists.map((p) => p.name);
+      expect(pinnedNames).toContain('Pinned Playlist');
+      expect(unpinnedNames).not.toContain('Pinned Playlist');
+      expect(unpinnedNames).toContain('Free Playlist');
+    });
+
+    it('pinned album appears in pinnedAlbums and not in unpinnedAlbums', () => {
+      // #given
+      setLibrarySync(
+        [],
+        [
+          makeAlbumInfo({ id: 'a-pinned', name: 'Pinned Album',  provider: 'spotify' }),
+          makeAlbumInfo({ id: 'a-free',   name: 'Free Album',    provider: 'spotify' }),
+        ],
+      );
+      mockUsePinnedItems.mockReturnValue({
+        pinnedPlaylistIds: [],
+        pinnedAlbumIds: ['a-pinned'],
+        isPlaylistPinned: () => false,
+        isAlbumPinned: (id: string) => id === 'a-pinned',
+        togglePinPlaylist: vi.fn(),
+        togglePinAlbum: vi.fn(),
+        canPinMorePlaylists: true,
+        canPinMoreAlbums: true,
+      });
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      const pinnedNames = result.current.pinValue.pinnedAlbums.map((a) => a.name);
+      const unpinnedNames = result.current.pinValue.unpinnedAlbums.map((a) => a.name);
+      expect(pinnedNames).toContain('Pinned Album');
+      expect(unpinnedNames).not.toContain('Pinned Album');
+      expect(unpinnedNames).toContain('Free Album');
+    });
+  });
+
+  describe('liked songs provider resolution', () => {
+    it('resolves to the single provider when only one provider has liked songs', () => {
+      // #given
+      const onPlaylistSelect = vi.fn();
+      mockUseLibrarySync.mockReturnValue({
+        playlists: [],
+        albums: [],
+        likedSongsCount: 5,
+        likedSongsPerProvider: [{ provider: 'spotify' as const, count: 5 }],
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        isLikedSongsSyncing: false,
+        lastSyncTimestamp: Date.now(),
+        syncError: null,
+        refreshNow: vi.fn(),
+        removeCollection: vi.fn(),
+      });
+      const { result } = renderHook(() =>
+        useLibraryRoot({ onPlaylistSelect, inDrawer: false }),
+      );
+
+      // #when — click liked songs without specifying a provider
+      act(() => {
+        result.current.actionsValue.onLikedSongsClick(undefined);
+      });
+
+      // #then — routed to liked-songs with the single provider resolved
+      expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', 'spotify');
+    });
+
+    it('passes undefined provider when multiple providers have liked songs', () => {
+      // #given
+      const onPlaylistSelect = vi.fn();
+      mockUseLibrarySync.mockReturnValue({
+        playlists: [],
+        albums: [],
+        likedSongsCount: 10,
+        likedSongsPerProvider: [
+          { provider: 'spotify' as const, count: 5 },
+          { provider: 'dropbox' as const, count: 5 },
+        ],
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        isLikedSongsSyncing: false,
+        lastSyncTimestamp: Date.now(),
+        syncError: null,
+        refreshNow: vi.fn(),
+        removeCollection: vi.fn(),
+      });
+      const { result } = renderHook(() =>
+        useLibraryRoot({ onPlaylistSelect, inDrawer: false }),
+      );
+
+      // #when — click liked songs without specifying a provider
+      act(() => {
+        result.current.actionsValue.onLikedSongsClick(undefined);
+      });
+
+      // #then — provider remains undefined (unified route)
+      expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', undefined);
+    });
+  });
+});
+
 describe('useLibraryRoot grid behavior', () => {
   beforeEach(() => {
     window.localStorage.clear();

--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -348,7 +348,43 @@ describe('useLibraryRoot behavioral coverage', () => {
       expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', 'spotify');
     });
 
-    it('passes undefined provider when multiple providers have liked songs', () => {
+    it('routes through unified path when unified liked is active', () => {
+      // #given
+      const onPlaylistSelect = vi.fn();
+      mockUseLibrarySync.mockReturnValue({
+        playlists: [],
+        albums: [],
+        likedSongsCount: 10,
+        likedSongsPerProvider: [
+          { provider: 'spotify' as const, count: 5 },
+          { provider: 'dropbox' as const, count: 5 },
+        ],
+        isInitialLoadComplete: true,
+        isSyncing: false,
+        isLikedSongsSyncing: false,
+        lastSyncTimestamp: Date.now(),
+        syncError: null,
+        refreshNow: vi.fn(),
+        removeCollection: vi.fn(),
+      });
+      mockUseUnifiedLikedTracks.mockReturnValue({
+        isUnifiedLikedActive: true,
+        totalCount: 10,
+      });
+      const { result } = renderHook(() =>
+        useLibraryRoot({ onPlaylistSelect, inDrawer: false }),
+      );
+
+      // #when — click liked songs without specifying a provider
+      act(() => {
+        result.current.actionsValue.onLikedSongsClick(undefined);
+      });
+
+      // #then — provider is undefined (unified route)
+      expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', undefined);
+    });
+
+    it('falls back to active provider when multiple providers and unified inactive', () => {
       // #given
       const onPlaylistSelect = vi.fn();
       mockUseLibrarySync.mockReturnValue({
@@ -376,8 +412,8 @@ describe('useLibraryRoot behavioral coverage', () => {
         result.current.actionsValue.onLikedSongsClick(undefined);
       });
 
-      // #then — provider remains undefined (unified route)
-      expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', undefined);
+      // #then — ambiguous branch falls back to active descriptor id (logged via debug)
+      expect(onPlaylistSelect).toHaveBeenCalledWith('liked-songs', 'Liked Songs', 'spotify');
     });
   });
 });

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -47,6 +47,7 @@ export const LibraryPage = React.memo(function LibraryPage({
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
+    saveErrorToast,
   } = useLibraryRoot({
     onPlaylistSelect,
     onAddToQueue,
@@ -73,6 +74,7 @@ export const LibraryPage = React.memo(function LibraryPage({
             {albumPopoverPortal}
             {playlistPopoverPortal}
             {confirmDeletePortal}
+            {saveErrorToast}
           </CardContent>
           {footer}
           {onNavigateToPlayer && (
@@ -121,6 +123,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
+    saveErrorToast,
   } = useLibraryRoot({
     onPlaylistSelect,
     onAddToQueue,
@@ -142,6 +145,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
         {albumPopoverPortal}
         {playlistPopoverPortal}
         {confirmDeletePortal}
+        {saveErrorToast}
       </DrawerContentWrapper>
     </LibraryProviders>
   );

--- a/src/components/PlaylistSelection/index.tsx
+++ b/src/components/PlaylistSelection/index.tsx
@@ -9,12 +9,7 @@ import {
 } from './styled';
 import { LibraryStatusContent } from './LibraryStatusContent';
 import { LibraryMainContent } from './LibraryMainContent';
-import {
-  LibraryBrowsingProvider,
-  LibraryPinProvider,
-  LibraryActionsProvider,
-  LibraryDataProvider,
-} from './LibraryContext';
+import { LibraryProviders } from './LibraryContext';
 import { useLibraryRoot } from './useLibraryRoot';
 import { LibraryMiniPlayer } from './LibraryMiniPlayer';
 
@@ -61,10 +56,7 @@ export const LibraryPage = React.memo(function LibraryPage({
   });
 
   return (
-    <LibraryDataProvider value={dataValue}>
-    <LibraryBrowsingProvider value={browsingValue}>
-    <LibraryPinProvider value={pinValue}>
-    <LibraryActionsProvider value={actionsValue}>
+    <LibraryProviders values={{ browsing: browsingValue, pin: pinValue, actions: actionsValue, data: dataValue }}>
       <PageContainer $overlay>
         <PageSelectionCard $maxWidth={maxWidth} $overlay>
           <CardContent
@@ -88,10 +80,7 @@ export const LibraryPage = React.memo(function LibraryPage({
           )}
         </PageSelectionCard>
       </PageContainer>
-    </LibraryActionsProvider>
-    </LibraryPinProvider>
-    </LibraryBrowsingProvider>
-    </LibraryDataProvider>
+    </LibraryProviders>
   );
 });
 
@@ -146,10 +135,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
   });
 
   return (
-    <LibraryDataProvider value={dataValue}>
-    <LibraryBrowsingProvider value={browsingValue}>
-    <LibraryPinProvider value={pinValue}>
-    <LibraryActionsProvider value={actionsValue}>
+    <LibraryProviders values={{ browsing: browsingValue, pin: pinValue, actions: actionsValue, data: dataValue }}>
       <DrawerContentWrapper>
         <LibraryStatusContent {...statusContentProps} />
         {showMainContent && <LibraryMainContent />}
@@ -157,10 +143,7 @@ export const DrawerLibrary = React.memo(function DrawerLibrary({
         {playlistPopoverPortal}
         {confirmDeletePortal}
       </DrawerContentWrapper>
-    </LibraryActionsProvider>
-    </LibraryPinProvider>
-    </LibraryBrowsingProvider>
-    </LibraryDataProvider>
+    </LibraryProviders>
   );
 });
 

--- a/src/components/PlaylistSelection/popoverOptions.ts
+++ b/src/components/PlaylistSelection/popoverOptions.ts
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import type { ProviderId } from '@/types/domain';
+import type { ProviderDescriptor } from '@/types/providers';
+import {
+  PlayIcon,
+  AddToQueueIcon,
+  HeartIcon,
+  ICON_MAP,
+  DiscogsIcon,
+  SpotifyIcon,
+  RemoveFromLibraryIcon,
+  AddToLibraryIcon,
+  TrashIcon,
+} from '../controls/TrackInfoPopover';
+
+export type PopoverOption = { label: string; icon: React.ReactNode; onClick: () => void };
+
+export function buildBaseCollectionOptions(params: {
+  collectionName: string;
+  onPlay: () => void;
+  onQueue: (() => void) | undefined;
+}): PopoverOption[] {
+  const { collectionName, onPlay, onQueue } = params;
+  const options: PopoverOption[] = [
+    {
+      label: `Play ${collectionName}`,
+      icon: React.createElement(PlayIcon),
+      onClick: onPlay,
+    },
+  ];
+
+  if (onQueue) {
+    options.push({
+      label: 'Add to Queue',
+      icon: React.createElement(AddToQueueIcon),
+      onClick: onQueue,
+    });
+  }
+
+  return options;
+}
+
+export function buildLikedOptions(params: {
+  collectionId: string;
+  collectionName: string;
+  collectionProvider: ProviderId | undefined;
+  descriptor: ProviderDescriptor | null | undefined;
+  likedLoading: boolean;
+  onPlayLiked: ((collectionId: string, collectionName: string, collectionProvider: ProviderId | undefined) => void) | undefined;
+  onQueueLiked: ((collectionId: string, collectionName: string) => void) | undefined;
+}): PopoverOption[] {
+  const {
+    collectionId,
+    collectionName,
+    collectionProvider,
+    descriptor,
+    likedLoading,
+    onPlayLiked,
+    onQueueLiked,
+  } = params;
+
+  const canSaveTrack = descriptor?.capabilities.hasSaveTrack && !!descriptor.catalog.isTrackSaved;
+  const options: PopoverOption[] = [];
+
+  if (canSaveTrack && onPlayLiked && descriptor) {
+    options.push({
+      label: likedLoading ? 'Loading…' : 'Play Liked',
+      icon: React.createElement(HeartIcon),
+      onClick: () => {
+        if (!likedLoading) onPlayLiked(collectionId, collectionName, collectionProvider);
+      },
+    });
+  }
+
+  if (canSaveTrack && onQueueLiked && descriptor) {
+    options.push({
+      label: likedLoading ? 'Loading…' : 'Queue Liked',
+      icon: React.createElement(HeartIcon),
+      onClick: () => {
+        if (!likedLoading) onQueueLiked(collectionId, collectionName);
+      },
+    });
+  }
+
+  return options;
+}
+
+export function buildSaveAlbumOption(params: {
+  albumId: string;
+  albumName: string;
+  albumArtists: string;
+  albumImages: { url: string }[];
+  albumReleaseDate: string | undefined;
+  albumTotalTracks: number | undefined;
+  albumUri: string | undefined;
+  albumProvider: ProviderId | undefined;
+  albumSaved: boolean | null;
+  descriptor: ProviderDescriptor | null | undefined;
+  onToggleSave: (currentlySaved: boolean) => void;
+}): PopoverOption[] {
+  const {
+    albumSaved,
+    descriptor,
+    onToggleSave,
+  } = params;
+
+  if (!descriptor?.capabilities.hasSaveAlbum || !descriptor.catalog.setAlbumSaved || albumSaved === null) {
+    return [];
+  }
+
+  return [{
+    label: albumSaved ? 'Remove from Library' : 'Add to Library',
+    icon: albumSaved ? React.createElement(RemoveFromLibraryIcon) : React.createElement(AddToLibraryIcon),
+    onClick: () => onToggleSave(albumSaved),
+  }];
+}
+
+export function buildExternalLinkOptions(params: {
+  albumName: string;
+  albumArtists: string;
+  descriptor: ProviderDescriptor | null | undefined;
+}): PopoverOption[] {
+  const { albumName, albumArtists, descriptor } = params;
+  const capabilities = descriptor?.capabilities;
+  const ExternalIcon = descriptor?.getExternalUrl ? DiscogsIcon : SpotifyIcon;
+
+  if (!(capabilities?.hasExternalLink ?? true)) return [];
+
+  const externalUrls = descriptor?.getExternalUrls?.({
+    type: 'album',
+    name: albumName,
+    artistName: albumArtists,
+  });
+
+  if (externalUrls) {
+    return externalUrls.map((entry) => {
+      const IconComponent = ICON_MAP[entry.icon] ?? DiscogsIcon;
+      return {
+        label: `Search ${entry.label}`,
+        icon: React.createElement(IconComponent),
+        onClick: () => void window.open(entry.url, '_blank', 'noopener,noreferrer'),
+      };
+    });
+  }
+
+  const providerName = capabilities?.externalLinkLabel?.replace('Open in ', '') ?? descriptor?.name ?? 'External';
+  const albumUrl = descriptor?.getExternalUrl
+    ? descriptor.getExternalUrl({ type: 'album', name: albumName, artistName: albumArtists })
+    : undefined;
+
+  if (albumUrl) {
+    return [{
+      label: `View album on ${providerName}`,
+      icon: React.createElement(ExternalIcon),
+      onClick: () => void window.open(albumUrl, '_blank', 'noopener,noreferrer'),
+    }];
+  }
+
+  return [];
+}
+
+export function buildDeletePlaylistOption(params: {
+  playlistId: string;
+  playlistName: string;
+  provider: ProviderId | undefined;
+  canDelete: boolean;
+  onDelete: (id: string, name: string, provider: ProviderId | undefined) => void;
+}): PopoverOption[] {
+  const { playlistId, playlistName, provider, canDelete, onDelete } = params;
+  if (!canDelete) return [];
+
+  return [{
+    label: 'Delete Playlist',
+    icon: React.createElement(TrashIcon),
+    onClick: () => onDelete(playlistId, playlistName, provider),
+  }];
+}

--- a/src/components/PlaylistSelection/useAlbumSavedStatus.ts
+++ b/src/components/PlaylistSelection/useAlbumSavedStatus.ts
@@ -1,0 +1,91 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AlbumInfo } from '../../services/spotify';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { logLibrary } from '@/lib/debugLog';
+import type { ItemPopoverState } from './useItemPopover';
+
+export interface UseAlbumSavedStatusReturn {
+  albumSaved: boolean | null;
+  saveError: string | null;
+  clearSaveError: () => void;
+  buildToggleSaveHandler: (album: AlbumInfo, descriptor: ProviderDescriptor | null | undefined) => (() => void) | null;
+}
+
+export function useAlbumSavedStatus(
+  popover: ItemPopoverState,
+  activeDescriptor: ProviderDescriptor | null,
+  getDescriptor: (id: ProviderId) => ProviderDescriptor | undefined,
+): UseAlbumSavedStatusReturn {
+  const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (popover?.kind !== 'album') {
+      setAlbumSaved(null);
+      return;
+    }
+    const descriptor = popover.album.provider
+      ? getDescriptor(popover.album.provider)
+      : activeDescriptor;
+    if (!descriptor?.capabilities.hasSaveAlbum || !descriptor.catalog.isAlbumSaved) {
+      setAlbumSaved(null);
+      return;
+    }
+    let cancelled = false;
+    descriptor.catalog.isAlbumSaved(popover.album.id).then((saved) => {
+      if (!cancelled) setAlbumSaved(saved);
+    }).catch((err) => {
+      logLibrary('isAlbumSaved check failed', err);
+      if (!cancelled) setAlbumSaved(null);
+    });
+    return () => { cancelled = true; };
+  }, [popover, activeDescriptor, getDescriptor]);
+
+  const buildToggleSaveHandler = useCallback((
+    album: AlbumInfo,
+    descriptor: ProviderDescriptor | null | undefined,
+  ): (() => void) | null => {
+    const catalog = descriptor?.catalog;
+    if (!descriptor?.capabilities.hasSaveAlbum || !catalog?.setAlbumSaved || albumSaved === null) {
+      return null;
+    }
+    const currentlySaved = albumSaved;
+    return () => {
+      setAlbumSaved(!currentlySaved);
+      catalog.setAlbumSaved!(album.id, !currentlySaved).then(() => {
+        if (currentlySaved) {
+          librarySyncEngine.optimisticRemoveAlbum(album.id).catch((err) => {
+            logLibrary('optimisticRemoveAlbum failed', err);
+          });
+        } else {
+          librarySyncEngine.optimisticAddAlbum({
+            id: album.id,
+            name: album.name,
+            artists: album.artists,
+            images: album.images ?? [],
+            release_date: album.release_date ?? '',
+            total_tracks: album.total_tracks ?? 0,
+            uri: album.uri ?? `spotify:album:${album.id}`,
+            added_at: new Date().toISOString(),
+            provider: album.provider,
+          }).catch((err) => {
+            logLibrary('optimisticAddAlbum failed', err);
+          });
+        }
+      }).catch((err) => {
+        logLibrary('setAlbumSaved failed', err);
+        setAlbumSaved(currentlySaved);
+        setSaveError(currentlySaved ? 'Failed to remove album from library.' : 'Failed to add album to library.');
+      });
+    };
+  }, [albumSaved]);
+
+  return {
+    albumSaved,
+    saveError,
+    clearSaveError: useCallback(() => setSaveError(null), []),
+    buildToggleSaveHandler,
+  };
+}

--- a/src/components/PlaylistSelection/useDeleteCollectionFlow.tsx
+++ b/src/components/PlaylistSelection/useDeleteCollectionFlow.tsx
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import * as React from 'react';
+import type { ProviderId } from '@/types/domain';
+import type { ProviderDescriptor } from '@/types/providers';
+import { isSavedPlaylistId, extractPlaylistPath } from '@/constants/playlist';
+import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
+import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+
+type DeleteTarget = { id: string; name: string; provider?: ProviderId };
+
+export interface UseDeleteCollectionFlowReturn {
+  openDelete: (id: string, name: string, provider: ProviderId | undefined) => void;
+  confirmDeletePortal: React.ReactNode;
+}
+
+export function useDeleteCollectionFlow(
+  getDescriptor: (id: ProviderId) => ProviderDescriptor | undefined,
+  activeDescriptor: ProviderDescriptor | null,
+  removeCollection: (id: string) => void,
+): UseDeleteCollectionFlowReturn {
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  const openDelete = useCallback((id: string, name: string, provider: ProviderId | undefined) => {
+    setDeleteTarget({ id, name, provider });
+  }, []);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget) return;
+    const provider = deleteTarget.provider ?? activeDescriptor?.id;
+    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
+    if (!descriptor?.catalog.deleteCollection) return;
+
+    const collectionId = isSavedPlaylistId(deleteTarget.id)
+      ? extractPlaylistPath(deleteTarget.id)
+      : deleteTarget.id;
+
+    await descriptor.catalog.deleteCollection(collectionId, 'playlist');
+    removeCollection(deleteTarget.id);
+    setDeleteTarget(null);
+    window.dispatchEvent(new CustomEvent(LIBRARY_REFRESH_EVENT, { detail: { providerId: provider } }));
+  }, [deleteTarget, activeDescriptor, getDescriptor, removeCollection]);
+
+  const handleDeleteClose = useCallback(() => setDeleteTarget(null), []);
+
+  const confirmDeletePortal = deleteTarget ? React.createElement(ConfirmDeleteDialog, {
+    name: deleteTarget.name,
+    onConfirm: handleDeleteConfirm,
+    onClose: handleDeleteClose,
+  }) : null;
+
+  return { openDelete, confirmDeletePortal };
+}

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -1,34 +1,23 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
-import { LIKED_SONGS_ID, isAlbumId, isSavedPlaylistId, extractPlaylistPath, resolvePlaylistRef } from '@/constants/playlist';
-import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
-import { toAlbumPlaylistId } from '@/constants/playlist';
-import TrackInfoPopover, {
-  SpotifyIcon,
-  PlayIcon,
-  DiscogsIcon,
-  AddToLibraryIcon,
-  RemoveFromLibraryIcon,
-  AddToQueueIcon,
-  HeartIcon,
-  TrashIcon,
-  ICON_MAP,
-} from '../controls/TrackInfoPopover';
-import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+import { LIKED_SONGS_ID, isAlbumId, toAlbumPlaylistId } from '@/constants/playlist';
+import TrackInfoPopover from '../controls/TrackInfoPopover';
 import Toast from '../Toast';
-import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
-import { logLibrary } from '@/lib/debugLog';
-
-type PopoverOption = { label: string; icon: React.ReactNode; onClick: () => void };
-
-type ItemPopoverState =
-  | { kind: 'album'; album: AlbumInfo; rect: DOMRect }
-  | { kind: 'playlist'; playlist: PlaylistInfo; rect: DOMRect }
-  | null;
+import { useItemPopover } from './useItemPopover';
+import { useLikedTracksActions } from './useLikedTracksActions';
+import { useDeleteCollectionFlow } from './useDeleteCollectionFlow';
+import { useAlbumSavedStatus } from './useAlbumSavedStatus';
+import {
+  buildBaseCollectionOptions,
+  buildLikedOptions,
+  buildSaveAlbumOption,
+  buildExternalLinkOptions,
+  buildDeletePlaylistOption,
+} from './popoverOptions';
 
 interface UseItemActionsProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -40,24 +29,6 @@ interface UseItemActionsProps {
   removeCollection: (id: string) => void;
 }
 
-async function fetchLikedTracksForCollection(
-  collectionId: string,
-  descriptor: ProviderDescriptor,
-): Promise<MediaTrack[]> {
-  const providerId = descriptor.id;
-  const { id, kind } = resolvePlaylistRef(collectionId, providerId);
-  const collectionRef = { provider: providerId, kind, id } as const;
-  const allTracks = await descriptor.catalog.listTracks(collectionRef);
-
-  if (!descriptor.catalog.isTrackSaved) return [];
-
-  const savedResults = await Promise.all(
-    allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false))
-  );
-
-  return allTracks.filter((_, i) => savedResults[i]);
-}
-
 export function useItemActions({
   onPlaylistSelect,
   onAddToQueue,
@@ -67,119 +38,34 @@ export function useItemActions({
   getDescriptor,
   removeCollection,
 }: UseItemActionsProps) {
-  const [popover, setPopover] = useState<ItemPopoverState>(null);
-  const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string; provider?: ProviderId } | null>(null);
-  const [likedLoading, setLikedLoading] = useState(false);
+  const { popover, openAlbum, openPlaylist, close: closePopover } = useItemPopover();
+  const { albumSaved, saveError, clearSaveError, buildToggleSaveHandler } = useAlbumSavedStatus(popover, activeDescriptor, getDescriptor);
+  const { openDelete, confirmDeletePortal } = useDeleteCollectionFlow(getDescriptor, activeDescriptor, removeCollection);
 
-  useEffect(() => {
-    if (popover?.kind !== 'album') {
-      setAlbumSaved(null);
-      return;
-    }
-    const descriptor = popover.album.provider
-      ? getDescriptor(popover.album.provider)
-      : activeDescriptor;
-    if (!descriptor?.capabilities.hasSaveAlbum || !descriptor.catalog.isAlbumSaved) {
-      setAlbumSaved(null);
-      return;
-    }
-    let cancelled = false;
-    descriptor.catalog.isAlbumSaved(popover.album.id).then((saved) => {
-      if (!cancelled) setAlbumSaved(saved);
-    }).catch((err) => {
-      logLibrary('isAlbumSaved check failed', err);
-      if (!cancelled) setAlbumSaved(null);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [popover, activeDescriptor, getDescriptor]);
+  const albumDescriptor = popover?.kind === 'album'
+    ? (popover.album.provider ? getDescriptor(popover.album.provider) : activeDescriptor)
+    : null;
 
-  function handlePlaylistContextMenu(playlist: PlaylistInfo, event: React.MouseEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    setPopover({ kind: 'playlist', playlist, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
-  }
+  const playlistDescriptor = popover?.kind === 'playlist'
+    ? (() => {
+        const provider = popover.playlist.provider ?? activeDescriptor?.id;
+        return provider ? getDescriptor(provider) : activeDescriptor;
+      })()
+    : null;
 
-  function handleAlbumContextMenu(album: AlbumInfo, event: React.MouseEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    setPopover({ kind: 'album', album, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
-  }
+  const { likedLoading, handlePlayLiked, handleQueueLiked } = useLikedTracksActions(
+    popover?.kind === 'album' ? albumDescriptor : playlistDescriptor,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
+  );
 
-  const closePopover = useCallback(() => {
-    setPopover(null);
-  }, []);
+  const handlePlaylistContextMenu = useCallback((playlist: PlaylistInfo, event: React.MouseEvent) => {
+    openPlaylist(playlist, event);
+  }, [openPlaylist]);
 
-  function buildCollectionPopoverOptions(params: {
-    collectionId: string;
-    collectionName: string;
-    collectionProvider: ProviderId | undefined;
-    descriptor: ProviderDescriptor | null | undefined;
-    onPlay: () => void;
-    onQueue: (() => void) | undefined;
-  }): PopoverOption[] {
-    const { collectionId, collectionName, collectionProvider, descriptor, onPlay, onQueue } = params;
-    const canSaveTrack = descriptor?.capabilities.hasSaveTrack && !!descriptor.catalog.isTrackSaved;
-
-    const options: PopoverOption[] = [
-      {
-        label: `Play ${collectionName}`,
-        icon: React.createElement(PlayIcon),
-        onClick: onPlay,
-      },
-    ];
-
-    if (onQueue) {
-      options.push({
-        label: 'Add to Queue',
-        icon: React.createElement(AddToQueueIcon),
-        onClick: onQueue,
-      });
-    }
-
-    if (canSaveTrack && onPlayLikedTracks && descriptor) {
-      options.push({
-        label: likedLoading ? 'Loading…' : 'Play Liked',
-        icon: React.createElement(HeartIcon),
-        onClick: () => {
-          if (likedLoading) return;
-          setLikedLoading(true);
-          fetchLikedTracksForCollection(collectionId, descriptor)
-            .then((likedTracks) => {
-              if (likedTracks.length > 0) {
-                return onPlayLikedTracks(likedTracks, collectionId, collectionName, collectionProvider);
-              }
-            })
-            .catch((err) => { console.error('[PlayLiked] Failed:', err); })
-            .finally(() => { setLikedLoading(false); });
-        },
-      });
-    }
-
-    if (canSaveTrack && onQueueLikedTracks && descriptor) {
-      options.push({
-        label: likedLoading ? 'Loading…' : 'Queue Liked',
-        icon: React.createElement(HeartIcon),
-        onClick: () => {
-          if (likedLoading) return;
-          setLikedLoading(true);
-          fetchLikedTracksForCollection(collectionId, descriptor)
-            .then((likedTracks) => {
-              if (likedTracks.length > 0) {
-                onQueueLikedTracks(likedTracks, collectionName);
-              }
-            })
-            .catch((err) => { console.error('[QueueLiked] Failed:', err); })
-            .finally(() => { setLikedLoading(false); });
-        },
-      });
-    }
-
-    return options;
-  }
+  const handleAlbumContextMenu = useCallback((album: AlbumInfo, event: React.MouseEvent) => {
+    openAlbum(album, event);
+  }, [openAlbum]);
 
   const buildPlaylistPopoverOptions = useCallback(() => {
     if (popover?.kind !== 'playlist') return [];
@@ -187,139 +73,82 @@ export function useItemActions({
     const provider = playlist.provider ?? activeDescriptor?.id;
     const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
 
-    const options = buildCollectionPopoverOptions({
+    const options = buildBaseCollectionOptions({
+      collectionName: playlist.name,
+      onPlay: () => onPlaylistSelect(playlist.id, playlist.name, playlist.provider),
+      onQueue: onAddToQueue ? () => onAddToQueue(playlist.id, playlist.name, playlist.provider) : undefined,
+    });
+
+    options.push(...buildLikedOptions({
       collectionId: playlist.id,
       collectionName: playlist.name,
       collectionProvider: playlist.provider,
       descriptor,
-      onPlay: () => onPlaylistSelect(playlist.id, playlist.name, playlist.provider),
-      onQueue: onAddToQueue
-        ? () => onAddToQueue(playlist.id, playlist.name, playlist.provider)
-        : undefined,
-    });
+      likedLoading,
+      onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
+      onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
+    }));
 
     const canDelete = descriptor?.capabilities.hasDeleteCollection &&
       descriptor.catalog.deleteCollection &&
       playlist.id !== LIKED_SONGS_ID &&
       !isAlbumId(playlist.id);
 
-    if (canDelete) {
-      options.push({
-        label: 'Delete Playlist',
-        icon: React.createElement(TrashIcon),
-        onClick: () => setDeleteTarget({ id: playlist.id, name: playlist.name, provider }),
-      });
-    }
+    options.push(...buildDeletePlaylistOption({
+      playlistId: playlist.id,
+      playlistName: playlist.name,
+      provider,
+      canDelete: !!canDelete,
+      onDelete: openDelete,
+    }));
 
     return options;
-  }, [popover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading]);
+  }, [popover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading, handlePlayLiked, handleQueueLiked, openDelete]);
 
   const buildAlbumPopoverOptions = useCallback(() => {
     if (popover?.kind !== 'album') return [];
     const album = popover.album;
     const descriptor = album.provider ? getDescriptor(album.provider) : activeDescriptor;
-    const capabilities = descriptor?.capabilities;
-    const catalog = descriptor?.catalog;
-    const ExternalIcon = descriptor?.getExternalUrl ? DiscogsIcon : SpotifyIcon;
     const albumCollectionId = toAlbumPlaylistId(album.id);
 
-    const options = buildCollectionPopoverOptions({
+    const options = buildBaseCollectionOptions({
+      collectionName: album.name,
+      onPlay: () => onPlaylistSelect(albumCollectionId, album.name, album.provider),
+      onQueue: onAddToQueue ? () => onAddToQueue(albumCollectionId, album.name, album.provider) : undefined,
+    });
+
+    options.push(...buildLikedOptions({
       collectionId: albumCollectionId,
       collectionName: album.name,
       collectionProvider: album.provider,
       descriptor,
-      onPlay: () => onPlaylistSelect(albumCollectionId, album.name, album.provider),
-      onQueue: onAddToQueue
-        ? () => onAddToQueue(albumCollectionId, album.name, album.provider)
-        : undefined,
-    });
+      likedLoading,
+      onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
+      onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
+    }));
 
-    if (capabilities?.hasSaveAlbum && catalog?.setAlbumSaved && albumSaved !== null) {
-      const saved = albumSaved;
-      options.push({
-        label: saved ? 'Remove from Library' : 'Add to Library',
-        icon: saved ? React.createElement(RemoveFromLibraryIcon) : React.createElement(AddToLibraryIcon),
-        onClick: () => {
-          setAlbumSaved(!saved);
-          catalog.setAlbumSaved!(album.id, !saved).then(() => {
-            if (saved) {
-              librarySyncEngine.optimisticRemoveAlbum(album.id).catch((err) => {
-                logLibrary('optimisticRemoveAlbum failed', err);
-              });
-            } else {
-              librarySyncEngine.optimisticAddAlbum({
-                id: album.id,
-                name: album.name,
-                artists: album.artists,
-                images: album.images ?? [],
-                release_date: album.release_date ?? '',
-                total_tracks: album.total_tracks ?? 0,
-                uri: album.uri ?? `spotify:album:${album.id}`,
-                added_at: new Date().toISOString(),
-                provider: album.provider,
-              }).catch((err) => {
-                logLibrary('optimisticAddAlbum failed', err);
-              });
-            }
-          }).catch((err) => {
-            logLibrary('setAlbumSaved failed', err);
-            setAlbumSaved(saved);
-            setSaveError(saved ? 'Failed to remove album from library.' : 'Failed to add album to library.');
-          });
-        },
-      });
-    }
+    options.push(...buildSaveAlbumOption({
+      albumId: album.id,
+      albumName: album.name,
+      albumArtists: album.artists,
+      albumImages: album.images ?? [],
+      albumReleaseDate: album.release_date,
+      albumTotalTracks: album.total_tracks,
+      albumUri: album.uri,
+      albumProvider: album.provider,
+      albumSaved,
+      descriptor,
+      onToggleSave: buildToggleSaveHandler(album, descriptor) ?? (() => undefined),
+    }));
 
-    if (capabilities?.hasExternalLink ?? true) {
-      const externalUrls = descriptor?.getExternalUrls?.({
-        type: 'album',
-        name: album.name,
-        artistName: album.artists,
-      });
-      if (externalUrls) {
-        for (const entry of externalUrls) {
-          const IconComponent = ICON_MAP[entry.icon] ?? DiscogsIcon;
-          options.push({
-            label: `Search ${entry.label}`,
-            icon: React.createElement(IconComponent),
-            onClick: () => void window.open(entry.url, '_blank', 'noopener,noreferrer'),
-          });
-        }
-      } else {
-        const providerName = capabilities?.externalLinkLabel?.replace('Open in ', '') ?? descriptor?.name ?? 'External';
-        const albumUrl = descriptor?.getExternalUrl
-          ? descriptor.getExternalUrl({ type: 'album', name: album.name, artistName: album.artists })
-          : undefined;
-        if (albumUrl) {
-          options.push({
-            label: `View album on ${providerName}`,
-            icon: React.createElement(ExternalIcon),
-            onClick: () => void window.open(albumUrl, '_blank', 'noopener,noreferrer'),
-          });
-        }
-      }
-    }
+    options.push(...buildExternalLinkOptions({
+      albumName: album.name,
+      albumArtists: album.artists,
+      descriptor,
+    }));
 
     return options;
-  }, [popover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading]);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteTarget) return;
-    const provider = deleteTarget.provider ?? activeDescriptor?.id;
-    const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
-    if (!descriptor?.catalog.deleteCollection) return;
-
-    const collectionId = isSavedPlaylistId(deleteTarget.id)
-      ? extractPlaylistPath(deleteTarget.id)
-      : deleteTarget.id;
-
-    await descriptor.catalog.deleteCollection(collectionId, 'playlist');
-    removeCollection(deleteTarget.id);
-    setDeleteTarget(null);
-    window.dispatchEvent(new CustomEvent(LIBRARY_REFRESH_EVENT, { detail: { providerId: provider } }));
-  }, [deleteTarget, activeDescriptor, getDescriptor, removeCollection]);
-
-  const handleDeleteClose = useCallback(() => setDeleteTarget(null), []);
+  }, [popover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading, handlePlayLiked, handleQueueLiked, buildToggleSaveHandler]);
 
   const albumPopoverPortal = popover?.kind === 'album' ? createPortal(
     React.createElement(TrackInfoPopover, {
@@ -341,15 +170,9 @@ export function useItemActions({
     document.body,
   ) : null;
 
-  const confirmDeletePortal = deleteTarget ? React.createElement(ConfirmDeleteDialog, {
-    name: deleteTarget.name,
-    onConfirm: handleDeleteConfirm,
-    onClose: handleDeleteClose,
-  }) : null;
-
   const saveErrorToast = saveError ? React.createElement(Toast, {
     message: saveError,
-    onDismiss: () => setSaveError(null),
+    onDismiss: clearSaveError,
   }) : null;
 
   return {

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -19,19 +19,16 @@ import TrackInfoPopover, {
   ICON_MAP,
 } from '../controls/TrackInfoPopover';
 import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+import Toast from '../Toast';
 import { LIBRARY_REFRESH_EVENT } from '@/hooks/useLibrarySync';
+import { logLibrary } from '@/lib/debugLog';
 
 type PopoverOption = { label: string; icon: React.ReactNode; onClick: () => void };
 
-type AlbumPopoverState = {
-  album: AlbumInfo;
-  rect: DOMRect;
-} | null;
-
-type PlaylistPopoverState = {
-  playlist: PlaylistInfo;
-  rect: DOMRect;
-} | null;
+type ItemPopoverState =
+  | { kind: 'album'; album: AlbumInfo; rect: DOMRect }
+  | { kind: 'playlist'; playlist: PlaylistInfo; rect: DOMRect }
+  | null;
 
 interface UseItemActionsProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -70,55 +67,50 @@ export function useItemActions({
   getDescriptor,
   removeCollection,
 }: UseItemActionsProps) {
-  const [albumPopover, setAlbumPopover] = useState<AlbumPopoverState>(null);
-  const [playlistPopover, setPlaylistPopover] = useState<PlaylistPopoverState>(null);
+  const [popover, setPopover] = useState<ItemPopoverState>(null);
   const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string; provider?: ProviderId } | null>(null);
   const [likedLoading, setLikedLoading] = useState(false);
 
   useEffect(() => {
-    if (!albumPopover) {
+    if (popover?.kind !== 'album') {
       setAlbumSaved(null);
       return;
     }
-    const descriptor = albumPopover.album.provider
-      ? getDescriptor(albumPopover.album.provider)
+    const descriptor = popover.album.provider
+      ? getDescriptor(popover.album.provider)
       : activeDescriptor;
     if (!descriptor?.capabilities.hasSaveAlbum || !descriptor.catalog.isAlbumSaved) {
       setAlbumSaved(null);
       return;
     }
     let cancelled = false;
-    descriptor.catalog.isAlbumSaved(albumPopover.album.id).then((saved) => {
+    descriptor.catalog.isAlbumSaved(popover.album.id).then((saved) => {
       if (!cancelled) setAlbumSaved(saved);
-    }).catch(() => {
+    }).catch((err) => {
+      logLibrary('isAlbumSaved check failed', err);
       if (!cancelled) setAlbumSaved(null);
     });
     return () => {
       cancelled = true;
     };
-  }, [albumPopover, activeDescriptor, getDescriptor]);
+  }, [popover, activeDescriptor, getDescriptor]);
 
   function handlePlaylistContextMenu(playlist: PlaylistInfo, event: React.MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    setPlaylistPopover({
-      playlist,
-      rect: new DOMRect(event.clientX, event.clientY, 0, 0),
-    });
+    setPopover({ kind: 'playlist', playlist, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
   }
 
   function handleAlbumContextMenu(album: AlbumInfo, event: React.MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    setAlbumPopover({
-      album,
-      rect: new DOMRect(event.clientX, event.clientY, 0, 0),
-    });
+    setPopover({ kind: 'album', album, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
   }
 
-  const closePlaylistPopover = useCallback(() => {
-    setPlaylistPopover(null);
+  const closePopover = useCallback(() => {
+    setPopover(null);
   }, []);
 
   function buildCollectionPopoverOptions(params: {
@@ -190,8 +182,8 @@ export function useItemActions({
   }
 
   const buildPlaylistPopoverOptions = useCallback(() => {
-    if (!playlistPopover) return [];
-    const playlist = playlistPopover.playlist;
+    if (popover?.kind !== 'playlist') return [];
+    const playlist = popover.playlist;
     const provider = playlist.provider ?? activeDescriptor?.id;
     const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
 
@@ -220,15 +212,11 @@ export function useItemActions({
     }
 
     return options;
-  }, [playlistPopover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading]);
-
-  const closeAlbumPopover = useCallback(() => {
-    setAlbumPopover(null);
-  }, []);
+  }, [popover, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, activeDescriptor, getDescriptor, likedLoading]);
 
   const buildAlbumPopoverOptions = useCallback(() => {
-    if (!albumPopover) return [];
-    const album = albumPopover.album;
+    if (popover?.kind !== 'album') return [];
+    const album = popover.album;
     const descriptor = album.provider ? getDescriptor(album.provider) : activeDescriptor;
     const capabilities = descriptor?.capabilities;
     const catalog = descriptor?.catalog;
@@ -252,9 +240,12 @@ export function useItemActions({
         label: saved ? 'Remove from Library' : 'Add to Library',
         icon: saved ? React.createElement(RemoveFromLibraryIcon) : React.createElement(AddToLibraryIcon),
         onClick: () => {
+          setAlbumSaved(!saved);
           catalog.setAlbumSaved!(album.id, !saved).then(() => {
             if (saved) {
-              librarySyncEngine.optimisticRemoveAlbum(album.id).catch(() => {});
+              librarySyncEngine.optimisticRemoveAlbum(album.id).catch((err) => {
+                logLibrary('optimisticRemoveAlbum failed', err);
+              });
             } else {
               librarySyncEngine.optimisticAddAlbum({
                 id: album.id,
@@ -266,9 +257,15 @@ export function useItemActions({
                 uri: album.uri ?? `spotify:album:${album.id}`,
                 added_at: new Date().toISOString(),
                 provider: album.provider,
-              }).catch(() => {});
+              }).catch((err) => {
+                logLibrary('optimisticAddAlbum failed', err);
+              });
             }
-          }).catch(() => {});
+          }).catch((err) => {
+            logLibrary('setAlbumSaved failed', err);
+            setAlbumSaved(saved);
+            setSaveError(saved ? 'Failed to remove album from library.' : 'Failed to add album to library.');
+          });
         },
       });
     }
@@ -304,7 +301,7 @@ export function useItemActions({
     }
 
     return options;
-  }, [albumPopover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading]);
+  }, [popover, albumSaved, getDescriptor, activeDescriptor, onPlaylistSelect, onAddToQueue, onPlayLikedTracks, onQueueLikedTracks, likedLoading]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;
@@ -324,21 +321,21 @@ export function useItemActions({
 
   const handleDeleteClose = useCallback(() => setDeleteTarget(null), []);
 
-  const albumPopoverPortal = albumPopover ? createPortal(
+  const albumPopoverPortal = popover?.kind === 'album' ? createPortal(
     React.createElement(TrackInfoPopover, {
       type: 'album',
-      anchorRect: albumPopover.rect,
-      onClose: closeAlbumPopover,
+      anchorRect: popover.rect,
+      onClose: closePopover,
       options: buildAlbumPopoverOptions(),
     }),
     document.body,
   ) : null;
 
-  const playlistPopoverPortal = playlistPopover ? createPortal(
+  const playlistPopoverPortal = popover?.kind === 'playlist' ? createPortal(
     React.createElement(TrackInfoPopover, {
       type: 'playlist',
-      anchorRect: playlistPopover.rect,
-      onClose: closePlaylistPopover,
+      anchorRect: popover.rect,
+      onClose: closePopover,
       options: buildPlaylistPopoverOptions(),
     }),
     document.body,
@@ -350,11 +347,17 @@ export function useItemActions({
     onClose: handleDeleteClose,
   }) : null;
 
+  const saveErrorToast = saveError ? React.createElement(Toast, {
+    message: saveError,
+    onDismiss: () => setSaveError(null),
+  }) : null;
+
   return {
     handlePlaylistContextMenu,
     handleAlbumContextMenu,
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
+    saveErrorToast,
   };
 }

--- a/src/components/PlaylistSelection/useItemPopover.ts
+++ b/src/components/PlaylistSelection/useItemPopover.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback } from 'react';
+import * as React from 'react';
+import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
+
+export type ItemPopoverState =
+  | { kind: 'album'; album: AlbumInfo; rect: DOMRect }
+  | { kind: 'playlist'; playlist: PlaylistInfo; rect: DOMRect }
+  | null;
+
+export interface UseItemPopoverReturn {
+  popover: ItemPopoverState;
+  openAlbum: (album: AlbumInfo, event: React.MouseEvent) => void;
+  openPlaylist: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  close: () => void;
+}
+
+export function useItemPopover(): UseItemPopoverReturn {
+  const [popover, setPopover] = useState<ItemPopoverState>(null);
+
+  const openAlbum = useCallback((album: AlbumInfo, event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setPopover({ kind: 'album', album, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
+  }, []);
+
+  const openPlaylist = useCallback((playlist: PlaylistInfo, event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setPopover({ kind: 'playlist', playlist, rect: new DOMRect(event.clientX, event.clientY, 0, 0) });
+  }, []);
+
+  const close = useCallback(() => setPopover(null), []);
+
+  return { popover, openAlbum, openPlaylist, close };
+}

--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -13,7 +13,7 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
 
   const [searchQuery, setSearchQuery] = useLocalStorage<string>(
     'vorbis-player-library-search',
-    '',
+    initialSearchQuery ?? '',
   );
 
   const [playlistSort, setPlaylistSort] = useLocalStorage<PlaylistSortOption>(
@@ -39,18 +39,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     'vorbis-player-library-recently-added',
     'all',
   );
-
-  useEffect(() => {
-    if (initialSearchQuery !== undefined) {
-      setSearchQuery(initialSearchQuery);
-    }
-  }, [initialSearchQuery]);
-
-  useEffect(() => {
-    if (initialViewMode) {
-      setViewMode(initialViewMode);
-    }
-  }, [initialViewMode]);
 
   useEffect(() => {
     if (viewMode === 'playlists' && artistFilter !== '') {

--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -40,7 +40,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     'all',
   );
 
-  // Sync when initial props change (e.g., drawer re-opened with new filter)
   useEffect(() => {
     if (initialSearchQuery !== undefined) {
       setSearchQuery(initialSearchQuery);
@@ -53,29 +52,49 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     }
   }, [initialViewMode]);
 
-  // Clear artist filter when switching away from albums view
   useEffect(() => {
-    if (viewMode === 'playlists') {
-      if (artistFilter !== '') {
-        setArtistFilter('');
-      }
+    if (viewMode === 'playlists' && artistFilter !== '') {
+      setArtistFilter('');
     }
   }, [viewMode, artistFilter]);
 
   const handleProviderToggle = useCallback((provider: ProviderId) => {
     setProviderFilters((prev) => {
       if (prev.length === 0) {
-        // First toggle: activate only this provider (deactivate others)
         return [provider];
       }
+      if (prev.length === 1 && prev[0] === provider) {
+        return [];
+      }
       if (prev.includes(provider)) {
-        const next = prev.filter((p) => p !== provider);
-        // If removing last filter, return to "all" (empty = no filter)
-        return next;
+        return prev.filter((p) => p !== provider);
       }
       return [...prev, provider];
     });
-  }, []);
+  }, [setProviderFilters]);
+
+  const handleGenreToggle = useCallback((genre: string) => {
+    setSelectedGenres((prev) => {
+      if (prev.length === 0) {
+        return [genre];
+      }
+      if (prev.length === 1 && prev[0] === genre) {
+        return [];
+      }
+      if (prev.includes(genre)) {
+        return prev.filter((g) => g !== genre);
+      }
+      return [...prev, genre];
+    });
+  }, [setSelectedGenres]);
+
+  const handleClearFilters = useCallback(() => {
+    setSearchQuery('');
+    setArtistFilter('');
+    setProviderFilters([]);
+    setSelectedGenres([]);
+    setRecentlyAddedFilter('all');
+  }, [setSearchQuery, setProviderFilters, setSelectedGenres, setRecentlyAddedFilter]);
 
   const hasActiveFilters =
     searchQuery !== '' ||
@@ -100,8 +119,10 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     handleProviderToggle,
     selectedGenres,
     setSelectedGenres,
+    handleGenreToggle,
     recentlyAddedFilter,
     setRecentlyAddedFilter,
     hasActiveFilters,
+    handleClearFilters,
   };
 }

--- a/src/components/PlaylistSelection/useLibraryContextValues.ts
+++ b/src/components/PlaylistSelection/useLibraryContextValues.ts
@@ -1,0 +1,216 @@
+import { useMemo } from 'react';
+import * as React from 'react';
+import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+import type {
+  LibraryBrowsingContextValue,
+  LibraryPinContextValue,
+  LibraryActionsContextValue,
+  LibraryDataContextValue,
+} from './LibraryContext';
+
+type BrowsingState = Omit<LibraryBrowsingContextValue, 'availableGenres'>;
+
+interface LikedSongsEntry {
+  provider: ProviderId;
+  count: number;
+}
+
+interface UseLibraryContextValuesParams {
+  browsingState: BrowsingState;
+  availableGenres: string[];
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  isPlaylistPinned: (id: string) => boolean;
+  canPinMorePlaylists: boolean;
+  isAlbumPinned: (id: string) => boolean;
+  canPinMoreAlbums: boolean;
+  onPinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  onPinAlbumClick: (id: string, event: React.MouseEvent) => void;
+  onPlaylistClick: (playlist: PlaylistInfo) => void;
+  onPlaylistContextMenu: (playlist: PlaylistInfo, event: React.MouseEvent) => void;
+  onLikedSongsClick: (provider?: ProviderId) => void;
+  onAlbumClick: (album: AlbumInfo) => void;
+  onAlbumContextMenu: (album: AlbumInfo, event: React.MouseEvent) => void;
+  onArtistClick: (artistName: string, event: React.MouseEvent) => void;
+  onLibraryRefresh?: () => void;
+  isLibraryRefreshing?: boolean;
+  inDrawer: boolean;
+  swipeZoneRef?: React.RefObject<HTMLDivElement>;
+  albums: AlbumInfo[];
+  isInitialLoadComplete: boolean;
+  showProviderBadges: boolean;
+  enabledProviderIds: ProviderId[];
+  likedSongsPerProvider: LikedSongsEntry[];
+  likedSongsCount: number;
+  isLikedSongsSyncing: boolean;
+  isUnifiedLikedActive: boolean;
+  unifiedLikedCount: number;
+  activeDescriptor: ProviderDescriptor | null;
+}
+
+export interface LibraryContextValuesResult {
+  browsingValue: LibraryBrowsingContextValue;
+  pinValue: LibraryPinContextValue;
+  actionsValue: LibraryActionsContextValue;
+  dataValue: LibraryDataContextValue;
+}
+
+export function useLibraryContextValues({
+  browsingState,
+  availableGenres,
+  pinnedPlaylists,
+  unpinnedPlaylists,
+  pinnedAlbums,
+  unpinnedAlbums,
+  isPlaylistPinned,
+  canPinMorePlaylists,
+  isAlbumPinned,
+  canPinMoreAlbums,
+  onPinPlaylistClick,
+  onPinAlbumClick,
+  onPlaylistClick,
+  onPlaylistContextMenu,
+  onLikedSongsClick,
+  onAlbumClick,
+  onAlbumContextMenu,
+  onArtistClick,
+  onLibraryRefresh,
+  isLibraryRefreshing,
+  inDrawer,
+  swipeZoneRef,
+  albums,
+  isInitialLoadComplete,
+  showProviderBadges,
+  enabledProviderIds,
+  likedSongsPerProvider,
+  likedSongsCount,
+  isLikedSongsSyncing,
+  isUnifiedLikedActive,
+  unifiedLikedCount,
+  activeDescriptor,
+}: UseLibraryContextValuesParams): LibraryContextValuesResult {
+  const browsingValue: LibraryBrowsingContextValue = useMemo(
+    () => ({
+      viewMode: browsingState.viewMode,
+      setViewMode: browsingState.setViewMode,
+      searchQuery: browsingState.searchQuery,
+      setSearchQuery: browsingState.setSearchQuery,
+      playlistSort: browsingState.playlistSort,
+      setPlaylistSort: browsingState.setPlaylistSort,
+      albumSort: browsingState.albumSort,
+      setAlbumSort: browsingState.setAlbumSort,
+      artistFilter: browsingState.artistFilter,
+      setArtistFilter: browsingState.setArtistFilter,
+      providerFilters: browsingState.providerFilters,
+      setProviderFilters: browsingState.setProviderFilters,
+      handleProviderToggle: browsingState.handleProviderToggle,
+      availableGenres,
+      selectedGenres: browsingState.selectedGenres,
+      setSelectedGenres: browsingState.setSelectedGenres,
+      handleGenreToggle: browsingState.handleGenreToggle,
+      recentlyAddedFilter: browsingState.recentlyAddedFilter,
+      setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
+      hasActiveFilters: browsingState.hasActiveFilters,
+      handleClearFilters: browsingState.handleClearFilters,
+    }),
+    [
+      browsingState.viewMode,
+      browsingState.searchQuery,
+      browsingState.playlistSort,
+      browsingState.albumSort,
+      browsingState.artistFilter,
+      browsingState.providerFilters,
+      availableGenres,
+      browsingState.selectedGenres,
+      browsingState.recentlyAddedFilter,
+      browsingState.hasActiveFilters,
+    ]
+  );
+
+  const pinValue: LibraryPinContextValue = useMemo(
+    () => ({
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      onPinPlaylistClick,
+      onPinAlbumClick,
+    }),
+    [
+      pinnedPlaylists,
+      unpinnedPlaylists,
+      pinnedAlbums,
+      unpinnedAlbums,
+      isPlaylistPinned,
+      canPinMorePlaylists,
+      isAlbumPinned,
+      canPinMoreAlbums,
+      onPinPlaylistClick,
+      onPinAlbumClick,
+    ]
+  );
+
+  const actionsValue: LibraryActionsContextValue = useMemo(
+    () => ({
+      onPlaylistClick,
+      onPlaylistContextMenu,
+      onLikedSongsClick,
+      onAlbumClick,
+      onAlbumContextMenu,
+      onArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    }),
+    [
+      onPlaylistClick,
+      onPlaylistContextMenu,
+      onLikedSongsClick,
+      onAlbumClick,
+      onAlbumContextMenu,
+      onArtistClick,
+      onLibraryRefresh,
+      isLibraryRefreshing,
+    ]
+  );
+
+  const dataValue: LibraryDataContextValue = useMemo(
+    () => ({
+      inDrawer,
+      swipeZoneRef,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      activeDescriptor,
+    }),
+    [
+      inDrawer,
+      swipeZoneRef,
+      albums,
+      isInitialLoadComplete,
+      showProviderBadges,
+      enabledProviderIds,
+      likedSongsPerProvider,
+      likedSongsCount,
+      isLikedSongsSyncing,
+      isUnifiedLikedActive,
+      unifiedLikedCount,
+      activeDescriptor,
+    ]
+  );
+
+  return { browsingValue, pinValue, actionsValue, dataValue };
+}

--- a/src/components/PlaylistSelection/useLibraryHandlers.ts
+++ b/src/components/PlaylistSelection/useLibraryHandlers.ts
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
+import { logQueue } from '@/lib/debugLog';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
+
+interface LikedSongsEntry {
+  provider: ProviderId;
+  count: number;
+}
+
+interface UseLibraryHandlersParams {
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  isUnifiedLikedActive: boolean;
+  likedSongsPerProvider: LikedSongsEntry[];
+  activeDescriptor: ProviderDescriptor | null | undefined;
+  togglePinPlaylist: (id: string) => void;
+  togglePinAlbum: (id: string) => void;
+  setArtistFilter: (artistName: string) => void;
+}
+
+export interface LibraryHandlers {
+  handlePlaylistClick: (playlist: PlaylistInfo) => void;
+  handleAlbumClick: (album: AlbumInfo) => void;
+  handleLikedSongsClick: (provider?: ProviderId) => void;
+  handlePinPlaylistClick: (id: string, event: React.MouseEvent) => void;
+  handlePinAlbumClick: (id: string, event: React.MouseEvent) => void;
+  handleArtistClick: (artistName: string, event: React.MouseEvent) => void;
+}
+
+export function useLibraryHandlers({
+  onPlaylistSelect,
+  isUnifiedLikedActive,
+  likedSongsPerProvider,
+  activeDescriptor,
+  togglePinPlaylist,
+  togglePinAlbum,
+  setArtistFilter,
+}: UseLibraryHandlersParams): LibraryHandlers {
+  function handlePlaylistClick(playlist: PlaylistInfo): void {
+    logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
+    onPlaylistSelect(playlist.id, playlist.name, playlist.provider);
+  }
+
+  function handleAlbumClick(album: AlbumInfo): void {
+    logQueue('selected album: %s (%s)', album.name, album.id);
+    onPlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
+  }
+
+  function handleLikedSongsClick(provider?: ProviderId): void {
+    if (provider !== undefined) {
+      logQueue('liked songs click: explicit provider %s', provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, provider);
+      return;
+    }
+
+    if (isUnifiedLikedActive) {
+      logQueue('liked songs click: unified path');
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, undefined);
+      return;
+    }
+
+    if (likedSongsPerProvider.length === 1) {
+      logQueue('liked songs click: single provider %s', likedSongsPerProvider[0].provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, likedSongsPerProvider[0].provider);
+      return;
+    }
+
+    logQueue(
+      'liked songs click: ambiguous — %d providers, unified inactive; falling back to active provider',
+      likedSongsPerProvider.length,
+    );
+    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, activeDescriptor?.id);
+  }
+
+  function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    togglePinPlaylist(id);
+  }
+
+  function handlePinAlbumClick(id: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    togglePinAlbum(id);
+  }
+
+  function handleArtistClick(artistName: string, event: React.MouseEvent): void {
+    event.stopPropagation();
+    setArtistFilter(artistName);
+  }
+
+  return {
+    handlePlaylistClick,
+    handleAlbumClick,
+    handleLikedSongsClick,
+    handlePinPlaylistClick,
+    handlePinAlbumClick,
+    handleArtistClick,
+  };
+}

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -90,6 +90,7 @@ export function useLibraryRoot({
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
+    saveErrorToast,
   } = useItemActions({
     onPlaylistSelect,
     onAddToQueue,
@@ -376,5 +377,6 @@ export function useLibraryRoot({
     albumPopoverPortal,
     playlistPopoverPortal,
     confirmDeletePortal,
+    saveErrorToast,
   };
 }

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -197,8 +197,29 @@ export function useLibraryRoot({
   }
 
   function handleLikedSongsClick(provider?: ProviderId): void {
-    const resolvedProvider = provider ?? (likedSongsPerProvider.length === 1 ? likedSongsPerProvider[0].provider : undefined);
-    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
+    if (provider !== undefined) {
+      logQueue('liked songs click: explicit provider %s', provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, provider);
+      return;
+    }
+
+    if (isUnifiedLikedActive) {
+      logQueue('liked songs click: unified path');
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, undefined);
+      return;
+    }
+
+    if (likedSongsPerProvider.length === 1) {
+      logQueue('liked songs click: single provider %s', likedSongsPerProvider[0].provider);
+      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, likedSongsPerProvider[0].provider);
+      return;
+    }
+
+    logQueue(
+      'liked songs click: ambiguous — %d providers, unified inactive; falling back to active provider',
+      likedSongsPerProvider.length,
+    );
+    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, activeDescriptor?.id);
   }
 
   function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -259,9 +259,11 @@ export function useLibraryRoot({
       availableGenres,
       selectedGenres: browsingState.selectedGenres,
       setSelectedGenres: browsingState.setSelectedGenres,
+      handleGenreToggle: browsingState.handleGenreToggle,
       recentlyAddedFilter: browsingState.recentlyAddedFilter,
       setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
       hasActiveFilters: browsingState.hasActiveFilters,
+      handleClearFilters: browsingState.handleClearFilters,
     }),
     [
       browsingState.viewMode,

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -1,31 +1,17 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import * as React from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useLibrarySync } from '../../hooks/useLibrarySync';
-import {
-  filterPlaylistsOnly,
-  sortPlaylistSubgroup,
-  filterAlbumsOnly,
-  sortAlbumSubgroup,
-  buildLibraryViewWithPins,
-  getAvailableGenres,
-  matchesRecentlyAddedFilter,
-} from '../../utils/playlistFilters';
 import { usePinnedItems } from '../../hooks/usePinnedItems';
-import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
-import { logQueue } from '@/lib/debugLog';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
-import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import { useLibraryBrowsing } from './useLibraryBrowsing';
 import { useItemActions } from './useItemActions';
-import type {
-  LibraryBrowsingContextValue,
-  LibraryPinContextValue,
-  LibraryActionsContextValue,
-  LibraryDataContextValue,
-} from './LibraryContext';
+import { useLibraryViews } from './useLibraryViews';
+import { useLibraryStatus } from './useLibraryStatus';
+import { useLibraryContextValues } from './useLibraryContextValues';
+import { useLibraryHandlers } from './useLibraryHandlers';
 
 interface UseLibraryRootParams {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -70,19 +56,7 @@ export function useLibraryRoot({
     removeCollection,
   } = useLibrarySync();
 
-  const [loginError, setLoginError] = useState<string | null>(null);
-
   const browsingState = useLibraryBrowsing(initialSearchQuery, initialViewMode);
-
-  const {
-    searchQuery,
-    playlistSort,
-    albumSort,
-    artistFilter,
-    providerFilters,
-    selectedGenres,
-    recentlyAddedFilter,
-  } = browsingState;
 
   const {
     handlePlaylistContextMenu,
@@ -114,259 +88,87 @@ export function useLibraryRoot({
   } = usePinnedItems();
 
   const maxWidth = useMemo(() => {
-    if (isMobile) {
-      return Math.min(viewport.width * 0.95, 400);
-    }
-    if (isTablet) {
-      return Math.min(viewport.width * 0.8, 500);
-    }
+    if (isMobile) return Math.min(viewport.width * 0.95, 400);
+    if (isTablet) return Math.min(viewport.width * 0.8, 500);
     return Math.min(viewport.width * 0.6, 600);
   }, [viewport.width, isMobile, isTablet]);
 
-  const ignoreProviderFilters = isMobile;
+  const { pinnedPlaylists, unpinnedPlaylists, pinnedAlbums, unpinnedAlbums, availableGenres } = useLibraryViews({
+    playlists,
+    albums,
+    searchQuery: browsingState.searchQuery,
+    playlistSort: browsingState.playlistSort,
+    albumSort: browsingState.albumSort,
+    artistFilter: browsingState.artistFilter,
+    providerFilters: browsingState.providerFilters,
+    selectedGenres: browsingState.selectedGenres,
+    recentlyAddedFilter: browsingState.recentlyAddedFilter,
+    pinnedPlaylistIds,
+    pinnedAlbumIds,
+    ignoreProviderFilters: isMobile,
+  });
 
-  const playlistLibraryView = useMemo(() => {
-    let items = playlists;
-    if (!ignoreProviderFilters && providerFilters.length > 0) {
-      items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
-    }
-    let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((p) => matchesRecentlyAddedFilter(p.added_at, recentlyAddedFilter));
-    }
-    return buildLibraryViewWithPins(
-      filtered,
-      pinnedPlaylistIds,
-      (p) => p.id,
-      (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
-    );
-  }, [playlists, searchQuery, playlistSort, providerFilters, ignoreProviderFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
+  const { showMainContent, statusContentProps } = useLibraryStatus({
+    activeDescriptor,
+    enabledProviderIds,
+    getDescriptor,
+    playlistsCount: playlists.length,
+    albumsCount: albums.length,
+    likedSongsCount,
+    isInitialLoadComplete,
+  });
 
-  const pinnedPlaylists = playlistLibraryView.pinned;
-  const unpinnedPlaylists = playlistLibraryView.unpinned;
+  const {
+    handlePlaylistClick,
+    handleAlbumClick,
+    handleLikedSongsClick,
+    handlePinPlaylistClick,
+    handlePinAlbumClick,
+    handleArtistClick,
+  } = useLibraryHandlers({
+    onPlaylistSelect,
+    isUnifiedLikedActive,
+    likedSongsPerProvider,
+    activeDescriptor,
+    togglePinPlaylist,
+    togglePinAlbum,
+    setArtistFilter: browsingState.setArtistFilter,
+  });
 
-  const albumLibraryView = useMemo(() => {
-    let items = albums;
-    if (!ignoreProviderFilters && providerFilters.length > 0) {
-      items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
-    }
-    let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((a) => matchesRecentlyAddedFilter(a.added_at, recentlyAddedFilter));
-    }
-    return buildLibraryViewWithPins(
-      filtered,
-      pinnedAlbumIds,
-      (a) => a.id,
-      (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
-    );
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, ignoreProviderFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
-
-  const pinnedAlbums = albumLibraryView.pinned;
-  const unpinnedAlbums = albumLibraryView.unpinned;
-
-  const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
-
-  const isAuthenticated = useMemo(
-    () =>
-      enabledProviderIds.some(id => getDescriptor(id)?.auth.isAuthenticated()) ||
-      (activeDescriptor?.auth.isAuthenticated() ?? false),
-    [activeDescriptor, enabledProviderIds, getDescriptor]
-  );
-
-  const isLoading = false;
-
-  const libraryError = useMemo(() => {
-    if (!isInitialLoadComplete) return null;
-    if (playlists.length === 0 && albums.length === 0 && likedSongsCount === 0) {
-      const providerName = activeDescriptor?.name ?? 'your music service';
-      return `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`;
-    }
-    return null;
-  }, [isInitialLoadComplete, playlists.length, albums.length, likedSongsCount, activeDescriptor]);
-
-  const error = loginError ?? libraryError;
-
-  function handlePlaylistClick(playlist: PlaylistInfo): void {
-    logQueue('selected playlist: %s (%s)', playlist.name, playlist.id);
-    onPlaylistSelect(playlist.id, playlist.name, playlist.provider);
-  }
-
-  function handleAlbumClick(album: AlbumInfo): void {
-    logQueue('selected album: %s (%s)', album.name, album.id);
-    onPlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
-  }
-
-  function handleLikedSongsClick(provider?: ProviderId): void {
-    if (provider !== undefined) {
-      logQueue('liked songs click: explicit provider %s', provider);
-      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, provider);
-      return;
-    }
-
-    if (isUnifiedLikedActive) {
-      logQueue('liked songs click: unified path');
-      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, undefined);
-      return;
-    }
-
-    if (likedSongsPerProvider.length === 1) {
-      logQueue('liked songs click: single provider %s', likedSongsPerProvider[0].provider);
-      onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, likedSongsPerProvider[0].provider);
-      return;
-    }
-
-    logQueue(
-      'liked songs click: ambiguous — %d providers, unified inactive; falling back to active provider',
-      likedSongsPerProvider.length,
-    );
-    onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, activeDescriptor?.id);
-  }
-
-  function handlePinPlaylistClick(id: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    togglePinPlaylist(id);
-  }
-
-  function handlePinAlbumClick(id: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    togglePinAlbum(id);
-  }
-
-  function handleArtistClick(artistName: string, event: React.MouseEvent): void {
-    event.stopPropagation();
-    browsingState.setArtistFilter(artistName);
-  }
-
-  const hasAnyContent = playlists.length > 0 || albums.length > 0 || likedSongsCount > 0;
-  const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
-
-  const browsingValue: LibraryBrowsingContextValue = useMemo(
-    () => ({
-      viewMode: browsingState.viewMode,
-      setViewMode: browsingState.setViewMode,
-      searchQuery: browsingState.searchQuery,
-      setSearchQuery: browsingState.setSearchQuery,
-      playlistSort: browsingState.playlistSort,
-      setPlaylistSort: browsingState.setPlaylistSort,
-      albumSort: browsingState.albumSort,
-      setAlbumSort: browsingState.setAlbumSort,
-      artistFilter: browsingState.artistFilter,
-      setArtistFilter: browsingState.setArtistFilter,
-      providerFilters: browsingState.providerFilters,
-      setProviderFilters: browsingState.setProviderFilters,
-      handleProviderToggle: browsingState.handleProviderToggle,
-      availableGenres,
-      selectedGenres: browsingState.selectedGenres,
-      setSelectedGenres: browsingState.setSelectedGenres,
-      handleGenreToggle: browsingState.handleGenreToggle,
-      recentlyAddedFilter: browsingState.recentlyAddedFilter,
-      setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
-      hasActiveFilters: browsingState.hasActiveFilters,
-      handleClearFilters: browsingState.handleClearFilters,
-    }),
-    [
-      browsingState.viewMode,
-      browsingState.searchQuery,
-      browsingState.playlistSort,
-      browsingState.albumSort,
-      browsingState.artistFilter,
-      browsingState.providerFilters,
-      availableGenres,
-      browsingState.selectedGenres,
-      browsingState.recentlyAddedFilter,
-      browsingState.hasActiveFilters,
-    ]
-  );
-
-  const pinValue: LibraryPinContextValue = useMemo(
-    () => ({
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
-      onPinPlaylistClick: handlePinPlaylistClick,
-      onPinAlbumClick: handlePinAlbumClick,
-    }),
-    [
-      pinnedPlaylists,
-      unpinnedPlaylists,
-      pinnedAlbums,
-      unpinnedAlbums,
-      isPlaylistPinned,
-      canPinMorePlaylists,
-      isAlbumPinned,
-      canPinMoreAlbums,
-      handlePinPlaylistClick,
-      handlePinAlbumClick,
-    ]
-  );
-
-  const actionsValue: LibraryActionsContextValue = useMemo(
-    () => ({
-      onPlaylistClick: handlePlaylistClick,
-      onPlaylistContextMenu: handlePlaylistContextMenu,
-      onLikedSongsClick: handleLikedSongsClick,
-      onAlbumClick: handleAlbumClick,
-      onAlbumContextMenu: handleAlbumContextMenu,
-      onArtistClick: handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
-    }),
-    [
-      handlePlaylistClick,
-      handlePlaylistContextMenu,
-      handleLikedSongsClick,
-      handleAlbumClick,
-      handleAlbumContextMenu,
-      handleArtistClick,
-      onLibraryRefresh,
-      isLibraryRefreshing,
-    ]
-  );
-
-  const dataValue: LibraryDataContextValue = useMemo(
-    () => ({
-      inDrawer,
-      swipeZoneRef,
-      albums,
-      isInitialLoadComplete,
-      showProviderBadges,
-      enabledProviderIds,
-      likedSongsPerProvider,
-      likedSongsCount,
-      isLikedSongsSyncing,
-      isUnifiedLikedActive,
-      unifiedLikedCount,
-      activeDescriptor: activeDescriptor ?? null,
-    }),
-    [
-      inDrawer,
-      swipeZoneRef,
-      albums,
-      isInitialLoadComplete,
-      showProviderBadges,
-      enabledProviderIds,
-      likedSongsPerProvider,
-      likedSongsCount,
-      isLikedSongsSyncing,
-      isUnifiedLikedActive,
-      unifiedLikedCount,
-      activeDescriptor,
-    ]
-  );
-
-  const statusContentProps = {
-    isLoading,
-    isAuthenticated,
-    error,
+  const { browsingValue, pinValue, actionsValue, dataValue } = useLibraryContextValues({
+    browsingState,
+    availableGenres,
+    pinnedPlaylists,
+    unpinnedPlaylists,
+    pinnedAlbums,
+    unpinnedAlbums,
+    isPlaylistPinned,
+    canPinMorePlaylists,
+    isAlbumPinned,
+    canPinMoreAlbums,
+    onPinPlaylistClick: handlePinPlaylistClick,
+    onPinAlbumClick: handlePinAlbumClick,
+    onPlaylistClick: handlePlaylistClick,
+    onPlaylistContextMenu: handlePlaylistContextMenu,
+    onLikedSongsClick: handleLikedSongsClick,
+    onAlbumClick: handleAlbumClick,
+    onAlbumContextMenu: handleAlbumContextMenu,
+    onArtistClick: handleArtistClick,
+    onLibraryRefresh,
+    isLibraryRefreshing,
+    inDrawer,
+    swipeZoneRef,
+    albums,
+    isInitialLoadComplete,
+    showProviderBadges,
+    enabledProviderIds,
+    likedSongsPerProvider,
+    likedSongsCount,
+    isLikedSongsSyncing,
+    isUnifiedLikedActive,
+    unifiedLikedCount,
     activeDescriptor: activeDescriptor ?? null,
-    setError: setLoginError,
-  };
+  });
 
   return {
     browsingValue,

--- a/src/components/PlaylistSelection/useLibraryStatus.ts
+++ b/src/components/PlaylistSelection/useLibraryStatus.ts
@@ -1,0 +1,75 @@
+import { useMemo, useState } from 'react';
+import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
+
+interface UseLibraryStatusParams {
+  activeDescriptor: ProviderDescriptor | null | undefined;
+  enabledProviderIds: ProviderId[];
+  getDescriptor: (id: ProviderId) => ProviderDescriptor | undefined;
+  playlistsCount: number;
+  albumsCount: number;
+  likedSongsCount: number;
+  isInitialLoadComplete: boolean;
+}
+
+export interface LibraryStatusResult {
+  isAuthenticated: boolean;
+  error: string | null;
+  showMainContent: boolean;
+  statusContentProps: {
+    isLoading: boolean;
+    isAuthenticated: boolean;
+    error: string | null;
+    activeDescriptor: ProviderDescriptor | null;
+    setError: (value: string | null) => void;
+  };
+}
+
+export function useLibraryStatus({
+  activeDescriptor,
+  enabledProviderIds,
+  getDescriptor,
+  playlistsCount,
+  albumsCount,
+  likedSongsCount,
+  isInitialLoadComplete,
+}: UseLibraryStatusParams): LibraryStatusResult {
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const isAuthenticated = useMemo(
+    () =>
+      enabledProviderIds.some(id => getDescriptor(id)?.auth.isAuthenticated()) ||
+      (activeDescriptor?.auth.isAuthenticated() ?? false),
+    [activeDescriptor, enabledProviderIds, getDescriptor]
+  );
+
+  const libraryError = useMemo(() => {
+    if (!isInitialLoadComplete) return null;
+    if (playlistsCount === 0 && albumsCount === 0 && likedSongsCount === 0) {
+      const providerName = activeDescriptor?.name ?? 'your music service';
+      return `No playlists, albums, or liked songs found. Please add some music to ${providerName} first.`;
+    }
+    return null;
+  }, [isInitialLoadComplete, playlistsCount, albumsCount, likedSongsCount, activeDescriptor]);
+
+  const error = loginError ?? libraryError;
+
+  const isLoading = false;
+  const hasAnyContent = playlistsCount > 0 || albumsCount > 0 || likedSongsCount > 0;
+  const showMainContent = isAuthenticated && !error && (hasAnyContent || (!isLoading && !isInitialLoadComplete));
+
+  const statusContentProps = {
+    isLoading,
+    isAuthenticated,
+    error,
+    activeDescriptor: activeDescriptor ?? null,
+    setError: setLoginError,
+  };
+
+  return {
+    isAuthenticated,
+    error,
+    showMainContent,
+    statusContentProps,
+  };
+}

--- a/src/components/PlaylistSelection/useLibraryViews.ts
+++ b/src/components/PlaylistSelection/useLibraryViews.ts
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import {
+  filterPlaylistsOnly,
+  sortPlaylistSubgroup,
+  filterAlbumsOnly,
+  sortAlbumSubgroup,
+  buildLibraryViewWithPins,
+  getAvailableGenres,
+  matchesRecentlyAddedFilter,
+  type PlaylistSortOption,
+  type AlbumSortOption,
+  type RecentlyAddedFilterOption,
+} from '../../utils/playlistFilters';
+import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
+import type { ProviderId } from '@/types/domain';
+
+interface UseLibraryViewsParams {
+  playlists: PlaylistInfo[];
+  albums: AlbumInfo[];
+  searchQuery: string;
+  playlistSort: PlaylistSortOption;
+  albumSort: AlbumSortOption;
+  artistFilter: string;
+  providerFilters: ProviderId[];
+  selectedGenres: string[];
+  recentlyAddedFilter: RecentlyAddedFilterOption;
+  pinnedPlaylistIds: string[];
+  pinnedAlbumIds: string[];
+  ignoreProviderFilters: boolean;
+}
+
+export interface LibraryViewsResult {
+  pinnedPlaylists: PlaylistInfo[];
+  unpinnedPlaylists: PlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  unpinnedAlbums: AlbumInfo[];
+  availableGenres: string[];
+}
+
+export function useLibraryViews({
+  playlists,
+  albums,
+  searchQuery,
+  playlistSort,
+  albumSort,
+  artistFilter,
+  providerFilters,
+  selectedGenres,
+  recentlyAddedFilter,
+  pinnedPlaylistIds,
+  pinnedAlbumIds,
+  ignoreProviderFilters,
+}: UseLibraryViewsParams): LibraryViewsResult {
+  const playlistLibraryView = useMemo(() => {
+    let items = playlists;
+    if (!ignoreProviderFilters && providerFilters.length > 0) {
+      items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
+    }
+    let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
+    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
+      filtered = filtered.filter((p) => matchesRecentlyAddedFilter(p.added_at, recentlyAddedFilter));
+    }
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedPlaylistIds,
+      (p) => p.id,
+      (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
+    );
+  }, [playlists, searchQuery, playlistSort, providerFilters, ignoreProviderFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
+
+  const albumLibraryView = useMemo(() => {
+    let items = albums;
+    if (!ignoreProviderFilters && providerFilters.length > 0) {
+      items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
+    }
+    let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
+    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
+      filtered = filtered.filter((a) => matchesRecentlyAddedFilter(a.added_at, recentlyAddedFilter));
+    }
+    return buildLibraryViewWithPins(
+      filtered,
+      pinnedAlbumIds,
+      (a) => a.id,
+      (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
+    );
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, ignoreProviderFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
+
+  const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
+
+  return {
+    pinnedPlaylists: playlistLibraryView.pinned,
+    unpinnedPlaylists: playlistLibraryView.unpinned,
+    pinnedAlbums: albumLibraryView.pinned,
+    unpinnedAlbums: albumLibraryView.unpinned,
+    availableGenres,
+  };
+}

--- a/src/components/PlaylistSelection/useLikedTracksActions.ts
+++ b/src/components/PlaylistSelection/useLikedTracksActions.ts
@@ -1,0 +1,73 @@
+import { useState, useCallback } from 'react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { ProviderDescriptor } from '@/types/providers';
+import { resolvePlaylistRef } from '@/constants/playlist';
+import { logLibrary } from '@/lib/debugLog';
+
+async function fetchLikedTracksForCollection(
+  collectionId: string,
+  descriptor: ProviderDescriptor,
+): Promise<MediaTrack[]> {
+  const providerId = descriptor.id;
+  const { id, kind } = resolvePlaylistRef(collectionId, providerId);
+  const collectionRef = { provider: providerId, kind, id } as const;
+  const allTracks = await descriptor.catalog.listTracks(collectionRef);
+
+  if (!descriptor.catalog.isTrackSaved) return [];
+
+  const savedResults = await Promise.all(
+    allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false))
+  );
+
+  return allTracks.filter((_, i) => savedResults[i]);
+}
+
+export interface UseLikedTracksActionsReturn {
+  likedLoading: boolean;
+  handlePlayLiked: (
+    collectionId: string,
+    collectionName: string,
+    collectionProvider: ProviderId | undefined,
+  ) => void;
+  handleQueueLiked: (collectionId: string, collectionName: string) => void;
+}
+
+export function useLikedTracksActions(
+  descriptor: ProviderDescriptor | null | undefined,
+  onPlayLikedTracks: ((tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>) | undefined,
+  onQueueLikedTracks: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined,
+): UseLikedTracksActionsReturn {
+  const [likedLoading, setLikedLoading] = useState(false);
+
+  const handlePlayLiked = useCallback((
+    collectionId: string,
+    collectionName: string,
+    collectionProvider: ProviderId | undefined,
+  ) => {
+    if (!descriptor || !onPlayLikedTracks || likedLoading) return;
+    setLikedLoading(true);
+    fetchLikedTracksForCollection(collectionId, descriptor)
+      .then((likedTracks) => {
+        if (likedTracks.length > 0) {
+          return onPlayLikedTracks(likedTracks, collectionId, collectionName, collectionProvider);
+        }
+      })
+      .catch((err) => { logLibrary('[PlayLiked] Failed:', err); })
+      .finally(() => { setLikedLoading(false); });
+  }, [descriptor, onPlayLikedTracks, likedLoading]);
+
+  const handleQueueLiked = useCallback((collectionId: string, collectionName: string) => {
+    if (!descriptor || !onQueueLikedTracks || likedLoading) return;
+    setLikedLoading(true);
+    fetchLikedTracksForCollection(collectionId, descriptor)
+      .then((likedTracks) => {
+        if (likedTracks.length > 0) {
+          onQueueLikedTracks(likedTracks, collectionName);
+        }
+      })
+      .catch((err) => { logLibrary('[QueueLiked] Failed:', err); })
+      .finally(() => { setLikedLoading(false); });
+  }, [descriptor, onQueueLikedTracks, likedLoading]);
+
+  return { likedLoading, handlePlayLiked, handleQueueLiked };
+}

--- a/src/components/__tests__/PlaylistSelection.test.tsx
+++ b/src/components/__tests__/PlaylistSelection.test.tsx
@@ -203,7 +203,7 @@ describe('PlaylistSelection', () => {
   });
 
   it('Liked Songs item is present with LIKED_SONGS_ID', () => {
-    // #given
+    // #given — likedSongsPerProvider is empty and unified is inactive: resolves to active provider
     const { onPlaylistSelect } = renderLibraryPage();
 
     // #when
@@ -211,7 +211,7 @@ describe('PlaylistSelection', () => {
 
     // #then
     expect(screen.getByText('Liked Songs')).toBeTruthy();
-    expect(onPlaylistSelect).toHaveBeenCalledWith(LIKED_SONGS_ID, 'Liked Songs', undefined);
+    expect(onPlaylistSelect).toHaveBeenCalledWith(LIKED_SONGS_ID, 'Liked Songs', 'spotify');
   });
 
 });


### PR DESCRIPTION
## Summary

Desktop library polish sweep: hardened filter semantics, split oversized hooks into focused modules, removed derived-state effects, and extracted styled components. Closes #984–#999.

## PRs included

- #1000 refactor(library): tidy LibraryContext exports and provider nesting
- #1001 fix(library): harden useItemActions error handling and types
- #1002 test(library): cover useLibraryRoot filter combinations and edge cases
- #1003 fix(library): make liked-songs provider resolution explicit
- #1004 fix(library): unify and repair desktop filter semantics
- #1005 test(library): align liked-songs provider resolution tests with #997 semantics
- #1006 refactor(library): remove derived-state effects from useLibraryBrowsing
- #1007 cleanup(library): extract FilterSidebar styled components to sibling module
- #1008 refactor(library): split useItemActions into focused hooks
- #1009 refactor(library): split useLibraryRoot into focused hooks

## Test plan

- [ ] CI typecheck + test suite passes
- [ ] Desktop library: provider chip filtering, genre/recently-added filters, search, sort all function
- [ ] Mobile library overlay: search + sort still bypass provider filters
- [ ] Liked Songs resolution: unified-active and ambiguous-fallback branches behave as specified
- [ ] Album/playlist context menus: add-to-queue, play-next, delete flows work