### PR TITLE
feat(hooks): add useRecentlyPlayedCollections hook

### DIFF
--- a/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
+++ b/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentlyPlayedCollections } from '../useRecentlyPlayedCollections';
+import type { CollectionRef } from '@/types/domain';
+
+const STORAGE_KEY = 'vorbis-player-recently-played';
+
+function makeRef(overrides: Partial<CollectionRef> = {}): CollectionRef {
+  return { provider: 'spotify', kind: 'playlist', id: 'playlist-1', ...overrides } as CollectionRef;
+}
+
+describe('useRecentlyPlayedCollections', () => {
+  beforeEach(() => {
+    window.localStorage.getItem = vi.fn().mockReturnValue(null);
+    window.localStorage.setItem = vi.fn();
+  });
+
+  it('starts with an empty history', () => {
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #then
+    expect(result.current.history).toEqual([]);
+  });
+
+  it('records a new entry at the front of history', () => {
+    // #given
+    const ref = makeRef();
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'My Playlist');
+    });
+
+    // #then
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0]).toEqual({ ref, name: 'My Playlist' });
+  });
+
+  it('places the newest entry first when multiple are recorded', () => {
+    // #given
+    const ref1 = makeRef({ id: 'playlist-1' });
+    const ref2 = makeRef({ id: 'playlist-2' });
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref1, 'First');
+    });
+    act(() => {
+      result.current.record(ref2, 'Second');
+    });
+
+    // #then
+    expect(result.current.history[0]).toEqual({ ref: ref2, name: 'Second' });
+    expect(result.current.history[1]).toEqual({ ref: ref1, name: 'First' });
+  });
+
+  it('moves a duplicate entry to the top without adding a second copy', () => {
+    // #given
+    const ref = makeRef({ id: 'playlist-1' });
+    const otherRef = makeRef({ id: 'playlist-2' });
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    act(() => {
+      result.current.record(ref, 'First');
+    });
+    act(() => {
+      result.current.record(otherRef, 'Other');
+    });
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'First (revisited)');
+    });
+
+    // #then
+    expect(result.current.history).toHaveLength(2);
+    expect(result.current.history[0]).toEqual({ ref, name: 'First (revisited)' });
+    expect(result.current.history[1]).toEqual({ ref: otherRef, name: 'Other' });
+  });
+
+  it('caps history at 5 entries, dropping the oldest', () => {
+    // #given
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      for (let i = 1; i <= 6; i++) {
+        result.current.record(makeRef({ id: `playlist-${i}` }), `Playlist ${i}`);
+      }
+    });
+
+    // #then
+    expect(result.current.history).toHaveLength(5);
+    expect(result.current.history[0].ref).toMatchObject({ id: 'playlist-6' });
+    expect(result.current.history[4].ref).toMatchObject({ id: 'playlist-2' });
+  });
+
+  it('persists history under the correct localStorage key', () => {
+    // #given
+    const ref = makeRef();
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'My Playlist');
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expect.any(String)
+    );
+    const storedCall = vi.mocked(window.localStorage.setItem).mock.calls.find(
+      ([key]) => key === STORAGE_KEY
+    );
+    expect(storedCall).toBeDefined();
+    const stored = JSON.parse(storedCall![1] as string);
+    expect(stored[0]).toEqual({ ref, name: 'My Playlist' });
+  });
+
+  it('loads persisted history from localStorage on init', () => {
+    // #given
+    const ref = makeRef();
+    const stored = JSON.stringify([{ ref, name: 'Persisted Playlist' }]);
+    window.localStorage.getItem = vi.fn((key: string) => {
+      if (key === STORAGE_KEY) return stored;
+      return null;
+    });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #then
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0]).toEqual({ ref, name: 'Persisted Playlist' });
+  });
+});

--- a/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
+++ b/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
@@ -109,16 +109,9 @@ describe('useRecentlyPlayedCollections', () => {
     });
 
     // #then
-    expect(window.localStorage.setItem).toHaveBeenCalledWith(
-      STORAGE_KEY,
-      expect.any(String)
-    );
-    const storedCall = vi.mocked(window.localStorage.setItem).mock.calls.find(
-      ([key]) => key === STORAGE_KEY
-    );
-    expect(storedCall).toBeDefined();
-    const stored = JSON.parse(storedCall![1] as string);
-    expect(stored[0]).toEqual({ ref, name: 'My Playlist' });
+    const lastCall = vi.mocked(window.localStorage.setItem).mock.lastCall;
+    expect(lastCall?.[0]).toBe(STORAGE_KEY);
+    expect(JSON.parse(lastCall![1] as string)[0]).toEqual({ ref, name: 'My Playlist' });
   });
 
   it('loads persisted history from localStorage on init', () => {

--- a/src/hooks/useRecentlyPlayedCollections.ts
+++ b/src/hooks/useRecentlyPlayedCollections.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import type { CollectionRef } from '@/types/domain';
+import { collectionRefToKey } from '@/types/domain';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+const STORAGE_KEY = 'vorbis-player-recently-played';
+const MAX_ENTRIES = 5;
+
+export interface RecentlyPlayedEntry {
+  ref: CollectionRef;
+  name: string;
+}
+
+export interface UseRecentlyPlayedCollectionsResult {
+  history: RecentlyPlayedEntry[];
+  record: (ref: CollectionRef, name: string) => void;
+}
+
+export function useRecentlyPlayedCollections(): UseRecentlyPlayedCollectionsResult {
+  const [history, setHistory] = useLocalStorage<RecentlyPlayedEntry[]>(STORAGE_KEY, []);
+
+  const record = useCallback(
+    (ref: CollectionRef, name: string) => {
+      const key = collectionRefToKey(ref);
+      setHistory((prev) => {
+        const filtered = prev.filter((entry) => collectionRefToKey(entry.ref) !== key);
+        return [{ ref, name }, ...filtered].slice(0, MAX_ENTRIES);
+      });
+    },
+    [setHistory]
+  );
+
+  return { history, record };
+}


### PR DESCRIPTION
Closes #960

Adds a new hook that stores up to 5 recently-played collections in localStorage under `vorbis-player-recently-played`, deduped by provider+kind+id, newest first. Foundational for the Recently Played feature epic (#965).