### PR TITLE
feat(player): record collection loads into recently-played history

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -119,7 +119,7 @@ const AudioPlayerComponent = () => {
     (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => {
       if (name) collectionNameRef.current = name;
       collectionProviderRef.current = provider;
-      handlers.loadCollection(id, provider);
+      handlers.loadCollection(id, provider, name);
     },
     [handlers]
   );

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCollectionLoader } from '../useCollectionLoader';
 import { makeTrack } from '@/test/fixtures';
-import { LIKED_SONGS_ID } from '@/constants/playlist';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import type { MediaTrack } from '@/types/domain';
 
 function makeMediaTrack(id: string, addedAt?: number): MediaTrack {
@@ -30,6 +30,7 @@ describe('useCollectionLoader', () => {
   let mockGetDescriptor: ReturnType<typeof vi.fn>;
   let mockSpotifyHandlePlaylistSelect: ReturnType<typeof vi.fn>;
   let mockStopRadioBase: ReturnType<typeof vi.fn>;
+  let mockRecord: ReturnType<typeof vi.fn>;
   let mockActiveDescriptor: any;
   let mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
   let drivingProviderRef: React.MutableRefObject<string | null>;
@@ -46,6 +47,7 @@ describe('useCollectionLoader', () => {
     mockGetDescriptor = vi.fn();
     mockSpotifyHandlePlaylistSelect = vi.fn().mockResolvedValue([]);
     mockStopRadioBase = vi.fn();
+    mockRecord = vi.fn();
     mediaTracksRef = { current: [] };
     drivingProviderRef = { current: null };
     mockActiveDescriptor = { id: 'spotify' };
@@ -81,6 +83,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -141,6 +144,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -178,6 +182,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -216,6 +221,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -251,6 +257,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: true,
       })
     );
@@ -284,6 +291,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -325,6 +333,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -356,6 +365,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -390,6 +400,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -418,6 +429,7 @@ describe('useCollectionLoader', () => {
         playTrack: mockPlayTrack,
         spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
         stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
         radioStateIsActive: false,
       })
     );
@@ -428,5 +440,157 @@ describe('useCollectionLoader', () => {
 
     expect(trackCount).toBe(0);
     expect(mockSetIsLoading).not.toHaveBeenCalled();
+  });
+
+  it('calls record with the collection ref and name after a successful provider collection load', async () => {
+    // #given
+    const mockCatalog = {
+      listTracks: vi.fn().mockResolvedValue([makeMediaTrack('1'), makeMediaTrack('2')]),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection('playlist_123', undefined, 'My Playlist');
+    });
+
+    // #then
+    expect(mockRecord).toHaveBeenCalledOnce();
+    expect(mockRecord).toHaveBeenCalledWith(
+      { provider: 'spotify', kind: 'playlist', id: 'playlist_123' },
+      'My Playlist',
+    );
+  });
+
+  it('does not call record when the provider collection load fails', async () => {
+    // #given
+    const mockCatalog = {
+      listTracks: vi.fn().mockRejectedValue(new Error('Network error')),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection('playlist_123', undefined, 'My Playlist');
+    });
+
+    // #then
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('calls record with the liked kind and display name after a successful unified liked load', async () => {
+    // #given
+    const mockCatalog = {
+      listTracks: vi.fn().mockResolvedValue([makeMediaTrack('1', 1000)]),
+    };
+    mockGetDescriptor.mockReturnValue({
+      id: 'spotify',
+      catalog: mockCatalog,
+      capabilities: { hasLikedCollection: true },
+    });
+    mockActiveDescriptor.id = 'spotify';
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection(LIKED_SONGS_ID);
+    });
+
+    // #then
+    expect(mockRecord).toHaveBeenCalledOnce();
+    expect(mockRecord).toHaveBeenCalledWith(
+      { provider: 'spotify', kind: 'liked' },
+      LIKED_SONGS_NAME,
+    );
+  });
+
+  it('does not call record when the unified liked load returns no tracks', async () => {
+    // #given
+    mockGetDescriptor.mockReturnValue({
+      id: 'spotify',
+      catalog: { listTracks: vi.fn().mockResolvedValue([]) },
+      capabilities: { hasLikedCollection: true },
+    });
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection(LIKED_SONGS_ID);
+    });
+
+    // #then
+    expect(mockRecord).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -146,7 +146,7 @@ describe('useQueueManagement', () => {
     });
 
     // #then
-    expect(mockHandlePlaylistSelect).toHaveBeenCalledWith('playlist_id', undefined);
+    expect(mockHandlePlaylistSelect).toHaveBeenCalledWith('playlist_id', undefined, 'My Playlist');
     expect(response).toEqual({ added: 3, collectionName: 'My Playlist' });
   });
 

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
-import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import { LIKED_SONGS_ID, resolvePlaylistRef } from '@/constants/playlist';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
@@ -21,10 +21,11 @@ interface UseCollectionLoaderProps {
   spotifyHandlePlaylistSelect: (playlistId: string) => Promise<MediaTrack[]>;
   stopRadioBase: () => void;
   radioStateIsActive: boolean;
+  record: (ref: CollectionRef, name: string) => void;
 }
 
 interface UseCollectionLoaderReturn {
-  loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
+  loadCollection: (playlistId: string, provider?: ProviderId, name?: string) => Promise<number>;
   playTracksDirectly: (tracks: MediaTrack[], collectionId: string, provider?: ProviderId) => Promise<number>;
 }
 
@@ -41,6 +42,7 @@ export function useCollectionLoader({
   spotifyHandlePlaylistSelect,
   stopRadioBase,
   radioStateIsActive,
+  record,
 }: UseCollectionLoaderProps): UseCollectionLoaderReturn {
   const { setError, setIsLoading, setSelectedPlaylistId, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef } = trackOps;
 
@@ -79,7 +81,7 @@ export function useCollectionLoader({
     setIsLoading(false);
   }, [shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, setCurrentTrackIndex, setIsLoading]);
 
-  const loadUnifiedLiked = useCallback(async (playlistId: string): Promise<number> => {
+  const loadUnifiedLiked = useCallback(async (playlistId: string, name?: string): Promise<number> => {
     beginLoad(playlistId);
     try {
       const descriptorMap = new Map(
@@ -111,6 +113,10 @@ export function useCollectionLoader({
         }
         queueSnapshot('Unified Liked loaded', merged, mediaTracksRef.current.length, 0);
         await playTrack(0);
+        record(
+          { provider: firstTrack.provider, kind: 'liked' },
+          name ?? LIKED_SONGS_NAME,
+        );
       }
       return merged.length;
     } catch (err) {
@@ -119,7 +125,7 @@ export function useCollectionLoader({
   }, [
     beginLoad, clearWithError, handleLoadError, applyTracks,
     connectedProviderIds, getDescriptor, activeDescriptor,
-    setActiveProviderId, drivingProviderRef, mediaTracksRef, playTrack,
+    setActiveProviderId, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
 
   const loadContextPlayback = useCallback(async (
@@ -144,7 +150,7 @@ export function useCollectionLoader({
   }, [drivingProviderRef, mediaTracksRef, setIsLoading, spotifyHandlePlaylistSelect]);
 
   const loadProviderCollection = useCallback(async (
-    playlistId: string, targetDescriptor: ProviderDescriptor,
+    playlistId: string, targetDescriptor: ProviderDescriptor, name?: string,
   ): Promise<number> => {
     const providerId = targetDescriptor.id;
 
@@ -168,23 +174,24 @@ export function useCollectionLoader({
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
       await playTrack(0);
+      record(collectionRef, name ?? collectionId);
       return list.length;
     } catch (err) {
       return handleLoadError(err, 'Failed to load collection.');
     }
   }, [
     activeDescriptor, beginLoad, clearWithError, handleLoadError,
-    applyTracks, loadContextPlayback, drivingProviderRef, mediaTracksRef, playTrack,
+    applyTracks, loadContextPlayback, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
 
   const loadCollection = useCallback(
-    async (playlistId: string, provider?: ProviderId): Promise<number> => {
+    async (playlistId: string, provider?: ProviderId, name?: string): Promise<number> => {
       logQueue('loadCollection called — playlistId=%s provider=%s', playlistId, provider ?? 'active');
 
       if (radioStateIsActive) stopRadioBase();
 
       if (playlistId === LIKED_SONGS_ID && !provider && isUnifiedLikedActive) {
-        return loadUnifiedLiked(playlistId);
+        return loadUnifiedLiked(playlistId, name);
       }
 
       const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
@@ -195,7 +202,7 @@ export function useCollectionLoader({
       }
 
       if (targetDescriptor) {
-        return loadProviderCollection(playlistId, targetDescriptor);
+        return loadProviderCollection(playlistId, targetDescriptor, name);
       }
 
       return 0;

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -20,6 +20,7 @@ import { useQueueManagement } from './useQueueManagement';
 import { useCollectionLoader } from './useCollectionLoader';
 import { usePlaybackSubscription } from './usePlaybackSubscription';
 import { useRadioSession } from './useRadioSession';
+import { useRecentlyPlayedCollections } from './useRecentlyPlayedCollections';
 import type { RadioProgress } from '@/types/radio';
 
 export function usePlayerLogic() {
@@ -116,6 +117,8 @@ export function usePlayerLogic() {
     shuffleEnabled,
   });
 
+  const { record } = useRecentlyPlayedCollections();
+
   // Initialize collection loader
   const { loadCollection, playTracksDirectly } = useCollectionLoader({
     trackOps,
@@ -130,6 +133,7 @@ export function usePlayerLogic() {
     spotifyHandlePlaylistSelect,
     stopRadioBase,
     radioStateIsActive: radioState.isActive,
+    record,
   });
 
   useAutoAdvance({ tracks, currentTrackIndex, playTrack, enabled: true, currentPlaybackProviderRef: drivingProviderRef });

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -17,7 +17,7 @@ interface UseQueueManagementProps {
   tracks: MediaTrack[];
   currentTrackIndex: number;
   shuffleEnabled: boolean;
-  loadCollection: (playlistId: string, provider?: ProviderId) => Promise<number>;
+  loadCollection: (playlistId: string, provider?: ProviderId, name?: string) => Promise<number>;
   handleBackToLibrary: () => void;
   activeDescriptor: ProviderDescriptor | undefined;
   getDescriptor: (providerId: ProviderId) => ProviderDescriptor | undefined;
@@ -62,7 +62,7 @@ export function useQueueManagement({
 
       if (isQueueEmpty) {
         logQueue('handleAddToQueue — queue empty, delegating to loadCollection');
-        const loaded = await loadCollection(playlistId, provider);
+        const loaded = await loadCollection(playlistId, provider, collectionName);
         if (loaded > 0) {
           return { added: loaded, collectionName };
         }


### PR DESCRIPTION
Closes #961

Wires `useRecentlyPlayedCollections.record()` into the collection-load convergence point so every successful load (playlist select, album play, unified liked songs) appends to the history. Failed loads are not recorded.

- `useCollectionLoader` accepts a `record` callback and optional `name` on `loadCollection`
- `usePlayerLogic` instantiates `useRecentlyPlayedCollections` and passes `record` down
- `AudioPlayer.handlePlaylistSelect` threads the display name through
- `useQueueManagement` passes `collectionName` when delegating to `loadCollection` on an empty queue
- 4 new tests cover success and failure paths for both provider collections and unified liked