### PR TITLE
feat(library): replace Recently Added filter with Recently Played section

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -375,7 +375,6 @@ const AudioPlayerComponent = () => {
                   localStorage.removeItem(STORAGE_KEYS.LIBRARY_SEARCH);
                   localStorage.removeItem(STORAGE_KEYS.LIBRARY_PROVIDER_FILTERS);
                   localStorage.removeItem(STORAGE_KEYS.LIBRARY_GENRES);
-                  localStorage.removeItem(STORAGE_KEYS.LIBRARY_RECENTLY_ADDED);
                   handleCloseQuickAccessPanel();
                   handlers.handleOpenLibrary();
                 }}

--- a/src/components/LibraryDrawer/FilterSidebar.styled.ts
+++ b/src/components/LibraryDrawer/FilterSidebar.styled.ts
@@ -210,6 +210,39 @@ export const SortSelect = styled.select`
   }
 `;
 
+export const RecentlyPlayedList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xs};
+`;
+
+export const RecentlyPlayedItem = styled.button`
+  display: block;
+  width: 100%;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: ${theme.colors.control.background};
+  border: 1px solid ${theme.colors.control.border};
+  border-radius: ${theme.borderRadius.md};
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+  transition: all ${theme.transitions.fast};
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    background: ${theme.colors.control.backgroundHover};
+    border-color: ${theme.colors.control.borderHover};
+    color: ${theme.colors.white};
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+`;
+
 export const ClearFiltersButton = styled.button`
   padding: ${theme.spacing.xs} ${theme.spacing.md};
   background: ${theme.colors.control.background};

--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -1,10 +1,10 @@
 import type { ProviderId } from '@/types/domain';
 import type {
-  RecentlyAddedFilterOption,
   PlaylistSortOption,
   AlbumSortOption,
 } from '@/utils/playlistFilters';
 import { PLAYLIST_SORT_LABELS, ALBUM_SORT_LABELS } from '@/utils/playlistFilters';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 import {
   SidebarContainer,
   FilterSection,
@@ -19,6 +19,8 @@ import {
   FilterChip,
   SortSelect,
   ClearFiltersButton,
+  RecentlyPlayedList,
+  RecentlyPlayedItem,
 } from './FilterSidebar.styled';
 
 interface FilterSidebarProps {
@@ -40,8 +42,8 @@ interface FilterSidebarProps {
   selectedGenres: string[];
   onGenreToggle: (genre: string) => void;
 
-  recentlyAdded: RecentlyAddedFilterOption;
-  onRecentlyAddedChange: (value: RecentlyAddedFilterOption) => void;
+  recentlyPlayed: RecentlyPlayedEntry[];
+  onRecentlyPlayedSelect: (entry: RecentlyPlayedEntry) => void;
 
   playlistSort: PlaylistSortOption;
   setPlaylistSort: (v: PlaylistSortOption) => void;
@@ -66,13 +68,6 @@ const ClearIconSvg = () => (
   </svg>
 );
 
-const RECENTLY_ADDED_OPTIONS: { label: string; value: RecentlyAddedFilterOption }[] = [
-  { label: 'All time', value: 'all' },
-  { label: 'Last 7 days', value: '7-days' },
-  { label: 'Last 30 days', value: '30-days' },
-  { label: 'Last year', value: '1-year' },
-];
-
 export const FilterSidebar = ({
   searchQuery,
   onSearchChange,
@@ -85,8 +80,8 @@ export const FilterSidebar = ({
   availableGenres,
   selectedGenres,
   onGenreToggle,
-  recentlyAdded,
-  onRecentlyAddedChange,
+  recentlyPlayed,
+  onRecentlyPlayedSelect,
   playlistSort,
   setPlaylistSort,
   albumSort,
@@ -191,20 +186,26 @@ export const FilterSidebar = ({
         </FilterSection>
       )}
 
-      <FilterSection>
-        <SectionTitle>Recently Added</SectionTitle>
-        <ToggleGroup>
-          {RECENTLY_ADDED_OPTIONS.map(({ label, value }) => (
-            <ToggleButton
-              key={value}
-              $active={(recentlyAdded ?? 'all') === value}
-              onClick={() => onRecentlyAddedChange(value)}
-            >
-              {label}
-            </ToggleButton>
-          ))}
-        </ToggleGroup>
-      </FilterSection>
+      {recentlyPlayed.length > 0 && (
+        <FilterSection>
+          <SectionTitle>Recently Played</SectionTitle>
+          <RecentlyPlayedList>
+            {recentlyPlayed.slice(0, 5).map((entry) => {
+              const key = `${entry.ref.provider}:${entry.ref.kind}:${entry.ref.kind === 'liked' ? '' : entry.ref.id}`;
+              return (
+                <RecentlyPlayedItem
+                  key={key}
+                  type="button"
+                  onClick={() => onRecentlyPlayedSelect(entry)}
+                  aria-label={`Play ${entry.name}`}
+                >
+                  {entry.name}
+                </RecentlyPlayedItem>
+              );
+            })}
+          </RecentlyPlayedList>
+        </FilterSection>
+      )}
 
       <FilterSection>
         <SectionTitle>Sort</SectionTitle>

--- a/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
+++ b/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import { FilterSidebar } from '../FilterSidebar';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 
 function renderFilterSidebar(props = {}) {
   const defaultProps = {
@@ -18,8 +19,8 @@ function renderFilterSidebar(props = {}) {
     availableGenres: [] as string[],
     selectedGenres: [] as string[],
     onGenreToggle: vi.fn(),
-    recentlyAdded: 'all' as const,
-    onRecentlyAddedChange: vi.fn(),
+    recentlyPlayed: [] as RecentlyPlayedEntry[],
+    onRecentlyPlayedSelect: vi.fn(),
     playlistSort: 'recently-added' as const,
     setPlaylistSort: vi.fn(),
     albumSort: 'recently-added' as const,
@@ -278,26 +279,66 @@ describe('FilterSidebar', () => {
     expect(allGenres).not.toBeInTheDocument();
   });
 
-  it('renders recently added section with all time options', () => {
-    // #when
-    renderFilterSidebar({ recentlyAdded: 'all' });
+  describe('Recently Played section', () => {
+    const entries: RecentlyPlayedEntry[] = [
+      { ref: { provider: 'spotify', kind: 'playlist', id: 'p-1' }, name: 'Chill Mix' },
+      { ref: { provider: 'dropbox', kind: 'album', id: 'a-1' }, name: 'Rumours' },
+      { ref: { provider: 'spotify', kind: 'liked' }, name: 'Liked Songs' },
+    ];
 
-    // #then
-    expect(screen.getByRole('button', { name: 'All time' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Last 7 days' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Last 30 days' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Last year' })).toBeInTheDocument();
-  });
+    it('does not render the section when history is empty', () => {
+      // #when
+      renderFilterSidebar({ recentlyPlayed: [] });
 
-  it('calls onRecentlyAddedChange when clicking a time range option', () => {
-    // #given
-    const onRecentlyAddedChange = vi.fn();
-    renderFilterSidebar({ recentlyAdded: 'all', onRecentlyAddedChange });
+      // #then
+      expect(screen.queryByText('Recently Played')).not.toBeInTheDocument();
+    });
 
-    // #when
-    fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+    it('renders the section header when history has entries', () => {
+      // #when
+      renderFilterSidebar({ recentlyPlayed: entries });
 
-    // #then
-    expect(onRecentlyAddedChange).toHaveBeenCalledWith('30-days');
+      // #then
+      expect(screen.getByText('Recently Played')).toBeInTheDocument();
+    });
+
+    it('renders one clickable shortcut per entry (up to 5)', () => {
+      // #when
+      renderFilterSidebar({ recentlyPlayed: entries });
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Play Chill Mix' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Play Rumours' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Play Liked Songs' })).toBeInTheDocument();
+    });
+
+    it('caps the rendered list at 5 entries', () => {
+      // #given
+      const six: RecentlyPlayedEntry[] = Array.from({ length: 6 }, (_, i) => ({
+        ref: { provider: 'spotify', kind: 'playlist', id: `p-${i}` },
+        name: `Playlist ${i}`,
+      }));
+
+      // #when
+      renderFilterSidebar({ recentlyPlayed: six });
+
+      // #then
+      for (let i = 0; i < 5; i++) {
+        expect(screen.getByRole('button', { name: `Play Playlist ${i}` })).toBeInTheDocument();
+      }
+      expect(screen.queryByRole('button', { name: 'Play Playlist 5' })).not.toBeInTheDocument();
+    });
+
+    it('calls onRecentlyPlayedSelect with the entry when a shortcut is clicked', () => {
+      // #given
+      const onRecentlyPlayedSelect = vi.fn();
+      renderFilterSidebar({ recentlyPlayed: entries, onRecentlyPlayedSelect });
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: 'Play Chill Mix' }));
+
+      // #then
+      expect(onRecentlyPlayedSelect).toHaveBeenCalledWith(entries[0]);
+    });
   });
 });

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
-import type { PlaylistSortOption, AlbumSortOption, RecentlyAddedFilterOption } from '@/utils/playlistFilters';
+import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 
 interface LikedSongsEntry {
   provider: ProviderId;
@@ -28,8 +29,8 @@ export interface LibraryBrowsingContextValue {
   selectedGenres: string[];
   setSelectedGenres: (v: string[]) => void;
   handleGenreToggle: (genre: string) => void;
-  recentlyAddedFilter: RecentlyAddedFilterOption;
-  setRecentlyAddedFilter: (v: RecentlyAddedFilterOption) => void;
+  recentlyPlayed: RecentlyPlayedEntry[];
+  onRecentlyPlayedSelect: (entry: RecentlyPlayedEntry) => void;
   hasActiveFilters: boolean;
   handleClearFilters: () => void;
 }

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -98,8 +98,8 @@ export function LibraryMainContent(): React.JSX.Element {
     availableGenres,
     selectedGenres,
     handleGenreToggle,
-    recentlyAddedFilter,
-    setRecentlyAddedFilter,
+    recentlyPlayed,
+    onRecentlyPlayedSelect,
     hasActiveFilters,
     handleClearFilters,
   } = useLibraryBrowsingContext();
@@ -122,8 +122,8 @@ export function LibraryMainContent(): React.JSX.Element {
           availableGenres={availableGenres}
           selectedGenres={selectedGenres}
           onGenreToggle={handleGenreToggle}
-          recentlyAdded={recentlyAddedFilter}
-          onRecentlyAddedChange={setRecentlyAddedFilter}
+          recentlyPlayed={recentlyPlayed}
+          onRecentlyPlayedSelect={onRecentlyPlayedSelect}
           playlistSort={playlistSort}
           setPlaylistSort={setPlaylistSort}
           albumSort={albumSort}

--- a/src/components/PlaylistSelection/__tests__/MobileLibraryBottomBar.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/MobileLibraryBottomBar.test.tsx
@@ -11,7 +11,6 @@ import {
 import type {
   AlbumSortOption,
   PlaylistSortOption,
-  RecentlyAddedFilterOption,
 } from '@/utils/playlistFilters';
 import type { ProviderId } from '@/types/domain';
 
@@ -36,8 +35,6 @@ function BrowsingStateHarness({
   const [artistFilter, setArtistFilter] = useState<string>('');
   const [providerFilters, setProviderFilters] = useState<ProviderId[]>([]);
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
-  const [recentlyAddedFilter, setRecentlyAddedFilter] =
-    useState<RecentlyAddedFilterOption>('all');
 
   const value: LibraryBrowsingContextValue = {
     viewMode,
@@ -56,9 +53,11 @@ function BrowsingStateHarness({
     availableGenres: [],
     selectedGenres,
     setSelectedGenres,
-    recentlyAddedFilter,
-    setRecentlyAddedFilter,
+    handleGenreToggle: () => undefined,
+    recentlyPlayed: [],
+    onRecentlyPlayedSelect: () => undefined,
     hasActiveFilters: false,
+    handleClearFilters: () => undefined,
   };
 
   return (

--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -124,54 +124,26 @@ describe('useLibraryRoot behavioral coverage', () => {
   });
 
   describe('combined filter interactions', () => {
-    it('applies provider, genre, and recently-added filters together on albums', () => {
+    it('applies provider and genre filters together on albums', () => {
       // #given
-      const recent = new Date(Date.now() - 3 * 86_400_000).toISOString();
-      const old = new Date(Date.now() - 60 * 86_400_000).toISOString();
       setLibrarySync(
         [],
         [
-          makeAlbumInfo({ id: 'a-1', name: 'Spotify Rock Recent',  provider: 'spotify',  genres: ['Rock'],   added_at: recent }),
-          makeAlbumInfo({ id: 'a-2', name: 'Spotify Rock Old',     provider: 'spotify',  genres: ['Rock'],   added_at: old }),
-          makeAlbumInfo({ id: 'a-3', name: 'Spotify Jazz Recent',  provider: 'spotify',  genres: ['Jazz'],   added_at: recent }),
-          makeAlbumInfo({ id: 'a-4', name: 'Dropbox Rock Recent',  provider: 'dropbox',  genres: ['Rock'],   added_at: recent }),
+          makeAlbumInfo({ id: 'a-1', name: 'Spotify Rock',   provider: 'spotify',  genres: ['Rock'] }),
+          makeAlbumInfo({ id: 'a-2', name: 'Spotify Jazz',   provider: 'spotify',  genres: ['Jazz'] }),
+          makeAlbumInfo({ id: 'a-3', name: 'Dropbox Rock',   provider: 'dropbox',  genres: ['Rock'] }),
         ],
       );
       const { result } = renderLibraryRoot();
 
-      // #when — provider=spotify, genre=Rock, recently-added=7-days
+      // #when — provider=spotify AND genre=Rock
       act(() => {
         result.current.browsingValue.setProviderFilters(['spotify']);
         result.current.browsingValue.setSelectedGenres(['Rock']);
-        result.current.browsingValue.setRecentlyAddedFilter('7-days');
       });
 
-      // #then — only the one item matching all three filters survives
-      expect(albumNames(result)).toEqual(['Spotify Rock Recent']);
-    });
-
-    it('applies provider and recently-added filters together on playlists', () => {
-      // #given
-      const recent = new Date(Date.now() - 2 * 86_400_000).toISOString();
-      const old = new Date(Date.now() - 60 * 86_400_000).toISOString();
-      setLibrarySync(
-        [
-          makePlaylistInfo({ id: 'p-1', name: 'Spotify Recent',  provider: 'spotify',  added_at: recent }),
-          makePlaylistInfo({ id: 'p-2', name: 'Spotify Old',     provider: 'spotify',  added_at: old }),
-          makePlaylistInfo({ id: 'p-3', name: 'Dropbox Recent',  provider: 'dropbox',  added_at: recent }),
-        ],
-        [],
-      );
-      const { result } = renderLibraryRoot();
-
-      // #when — provider=spotify AND recently-added=7-days
-      act(() => {
-        result.current.browsingValue.setProviderFilters(['spotify']);
-        result.current.browsingValue.setRecentlyAddedFilter('7-days');
-      });
-
-      // #then — only the spotify + recent playlist passes both filters
-      expect(playlistNames(result)).toEqual(['Spotify Recent']);
+      // #then — only the item matching both filters survives
+      expect(albumNames(result)).toEqual(['Spotify Rock']);
     });
   });
 

--- a/src/components/PlaylistSelection/useLibraryBrowsing.ts
+++ b/src/components/PlaylistSelection/useLibraryBrowsing.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
-import type { PlaylistSortOption, AlbumSortOption, RecentlyAddedFilterOption } from '@/utils/playlistFilters';
+import type { PlaylistSortOption, AlbumSortOption } from '@/utils/playlistFilters';
 import type { ProviderId } from '@/types/domain';
 
 type ViewMode = 'playlists' | 'albums';
@@ -34,10 +34,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
   const [selectedGenres, setSelectedGenres] = useLocalStorage<string[]>(
     'vorbis-player-library-genres',
     [],
-  );
-  const [recentlyAddedFilter, setRecentlyAddedFilter] = useLocalStorage<RecentlyAddedFilterOption>(
-    'vorbis-player-library-recently-added',
-    'all',
   );
 
   useEffect(() => {
@@ -81,15 +77,13 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     setArtistFilter('');
     setProviderFilters([]);
     setSelectedGenres([]);
-    setRecentlyAddedFilter('all');
-  }, [setSearchQuery, setProviderFilters, setSelectedGenres, setRecentlyAddedFilter]);
+  }, [setSearchQuery, setProviderFilters, setSelectedGenres]);
 
   const hasActiveFilters =
     searchQuery !== '' ||
     artistFilter !== '' ||
     providerFilters.length > 0 ||
-    selectedGenres.length > 0 ||
-    (recentlyAddedFilter !== 'all' && recentlyAddedFilter !== undefined);
+    selectedGenres.length > 0;
 
   return {
     viewMode,
@@ -108,8 +102,6 @@ export function useLibraryBrowsing(initialSearchQuery?: string, initialViewMode?
     selectedGenres,
     setSelectedGenres,
     handleGenreToggle,
-    recentlyAddedFilter,
-    setRecentlyAddedFilter,
     hasActiveFilters,
     handleClearFilters,
   };

--- a/src/components/PlaylistSelection/useLibraryContextValues.ts
+++ b/src/components/PlaylistSelection/useLibraryContextValues.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 import type {
   LibraryBrowsingContextValue,
   LibraryPinContextValue,
@@ -10,7 +11,7 @@ import type {
   LibraryDataContextValue,
 } from './LibraryContext';
 
-type BrowsingState = Omit<LibraryBrowsingContextValue, 'availableGenres'>;
+type BrowsingState = Omit<LibraryBrowsingContextValue, 'availableGenres' | 'recentlyPlayed' | 'onRecentlyPlayedSelect'>;
 
 interface LikedSongsEntry {
   provider: ProviderId;
@@ -20,6 +21,8 @@ interface LikedSongsEntry {
 interface UseLibraryContextValuesParams {
   browsingState: BrowsingState;
   availableGenres: string[];
+  recentlyPlayed: RecentlyPlayedEntry[];
+  onRecentlyPlayedSelect: (entry: RecentlyPlayedEntry) => void;
   pinnedPlaylists: PlaylistInfo[];
   unpinnedPlaylists: PlaylistInfo[];
   pinnedAlbums: AlbumInfo[];
@@ -62,6 +65,8 @@ export interface LibraryContextValuesResult {
 export function useLibraryContextValues({
   browsingState,
   availableGenres,
+  recentlyPlayed,
+  onRecentlyPlayedSelect,
   pinnedPlaylists,
   unpinnedPlaylists,
   pinnedAlbums,
@@ -112,8 +117,8 @@ export function useLibraryContextValues({
       selectedGenres: browsingState.selectedGenres,
       setSelectedGenres: browsingState.setSelectedGenres,
       handleGenreToggle: browsingState.handleGenreToggle,
-      recentlyAddedFilter: browsingState.recentlyAddedFilter,
-      setRecentlyAddedFilter: browsingState.setRecentlyAddedFilter,
+      recentlyPlayed,
+      onRecentlyPlayedSelect,
       hasActiveFilters: browsingState.hasActiveFilters,
       handleClearFilters: browsingState.handleClearFilters,
     }),
@@ -126,7 +131,8 @@ export function useLibraryContextValues({
       browsingState.providerFilters,
       availableGenres,
       browsingState.selectedGenres,
-      browsingState.recentlyAddedFilter,
+      recentlyPlayed,
+      onRecentlyPlayedSelect,
       browsingState.hasActiveFilters,
     ]
   );

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -1,10 +1,12 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useLibrarySync } from '../../hooks/useLibrarySync';
 import { usePinnedItems } from '../../hooks/usePinnedItems';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
+import { useRecentlyPlayedCollections, type RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, toAlbumPlaylistId } from '../../constants/playlist';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import { useLibraryBrowsing } from './useLibraryBrowsing';
 import { useItemActions } from './useItemActions';
@@ -57,6 +59,23 @@ export function useLibraryRoot({
   } = useLibrarySync();
 
   const browsingState = useLibraryBrowsing(initialSearchQuery, initialViewMode);
+  const { history: recentlyPlayed } = useRecentlyPlayedCollections();
+
+  const handleRecentlyPlayedSelect = useCallback(
+    (entry: RecentlyPlayedEntry) => {
+      const { ref, name } = entry;
+      if (ref.kind === 'liked') {
+        onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, ref.provider);
+        return;
+      }
+      if (ref.kind === 'album') {
+        onPlaylistSelect(toAlbumPlaylistId(ref.id), name, ref.provider);
+        return;
+      }
+      onPlaylistSelect(ref.id, name, ref.provider);
+    },
+    [onPlaylistSelect],
+  );
 
   const {
     handlePlaylistContextMenu,
@@ -102,7 +121,6 @@ export function useLibraryRoot({
     artistFilter: browsingState.artistFilter,
     providerFilters: browsingState.providerFilters,
     selectedGenres: browsingState.selectedGenres,
-    recentlyAddedFilter: browsingState.recentlyAddedFilter,
     pinnedPlaylistIds,
     pinnedAlbumIds,
     ignoreProviderFilters: isMobile,
@@ -138,6 +156,8 @@ export function useLibraryRoot({
   const { browsingValue, pinValue, actionsValue, dataValue } = useLibraryContextValues({
     browsingState,
     availableGenres,
+    recentlyPlayed,
+    onRecentlyPlayedSelect: handleRecentlyPlayedSelect,
     pinnedPlaylists,
     unpinnedPlaylists,
     pinnedAlbums,

--- a/src/components/PlaylistSelection/useLibraryViews.ts
+++ b/src/components/PlaylistSelection/useLibraryViews.ts
@@ -6,10 +6,8 @@ import {
   sortAlbumSubgroup,
   buildLibraryViewWithPins,
   getAvailableGenres,
-  matchesRecentlyAddedFilter,
   type PlaylistSortOption,
   type AlbumSortOption,
-  type RecentlyAddedFilterOption,
 } from '../../utils/playlistFilters';
 import type { PlaylistInfo, AlbumInfo } from '../../services/spotify';
 import type { ProviderId } from '@/types/domain';
@@ -23,7 +21,6 @@ interface UseLibraryViewsParams {
   artistFilter: string;
   providerFilters: ProviderId[];
   selectedGenres: string[];
-  recentlyAddedFilter: RecentlyAddedFilterOption;
   pinnedPlaylistIds: string[];
   pinnedAlbumIds: string[];
   ignoreProviderFilters: boolean;
@@ -46,7 +43,6 @@ export function useLibraryViews({
   artistFilter,
   providerFilters,
   selectedGenres,
-  recentlyAddedFilter,
   pinnedPlaylistIds,
   pinnedAlbumIds,
   ignoreProviderFilters,
@@ -56,34 +52,28 @@ export function useLibraryViews({
     if (!ignoreProviderFilters && providerFilters.length > 0) {
       items = items.filter((p) => p.provider && providerFilters.includes(p.provider));
     }
-    let filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((p) => matchesRecentlyAddedFilter(p.added_at, recentlyAddedFilter));
-    }
+    const filtered = filterPlaylistsOnly(items, searchQuery, selectedGenres);
     return buildLibraryViewWithPins(
       filtered,
       pinnedPlaylistIds,
       (p) => p.id,
       (subgroup) => sortPlaylistSubgroup(subgroup, playlistSort)
     );
-  }, [playlists, searchQuery, playlistSort, providerFilters, ignoreProviderFilters, pinnedPlaylistIds, selectedGenres, recentlyAddedFilter]);
+  }, [playlists, searchQuery, playlistSort, providerFilters, ignoreProviderFilters, pinnedPlaylistIds, selectedGenres]);
 
   const albumLibraryView = useMemo(() => {
     let items = albums;
     if (!ignoreProviderFilters && providerFilters.length > 0) {
       items = items.filter((a) => a.provider && providerFilters.includes(a.provider));
     }
-    let filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
-    if (recentlyAddedFilter && recentlyAddedFilter !== 'all') {
-      filtered = filtered.filter((a) => matchesRecentlyAddedFilter(a.added_at, recentlyAddedFilter));
-    }
+    const filtered = filterAlbumsOnly(items, searchQuery, 'all', artistFilter, selectedGenres);
     return buildLibraryViewWithPins(
       filtered,
       pinnedAlbumIds,
       (a) => a.id,
       (subgroup) => sortAlbumSubgroup(subgroup, albumSort)
     );
-  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, ignoreProviderFilters, pinnedAlbumIds, selectedGenres, recentlyAddedFilter]);
+  }, [albums, searchQuery, albumSort, artistFilter, providerFilters, ignoreProviderFilters, pinnedAlbumIds, selectedGenres]);
 
   const availableGenres = useMemo(() => getAvailableGenres(albums), [albums]);
 

--- a/src/components/__tests__/LibraryNavigation.test.tsx
+++ b/src/components/__tests__/LibraryNavigation.test.tsx
@@ -4,7 +4,7 @@
  * Covers:
  *  B. Library open/close — BottomBar's onBackToLibrary triggers library open;
  *     library closes when onCloseLibrary / onNavigateToPlayer is invoked.
- *  C. Filter reset on QAP open — the onBrowseLibrary handler removes the four
+ *  C. Filter reset on QAP open — the onBrowseLibrary handler removes the three
  *     library filter keys from localStorage before opening the library.
  */
 
@@ -202,7 +202,6 @@ describe('Library open/close via onCloseLibrary', () => {
  *     localStorage.removeItem(STORAGE_KEYS.LIBRARY_SEARCH);
  *     localStorage.removeItem(STORAGE_KEYS.LIBRARY_PROVIDER_FILTERS);
  *     localStorage.removeItem(STORAGE_KEYS.LIBRARY_GENRES);
- *     localStorage.removeItem(STORAGE_KEYS.LIBRARY_RECENTLY_ADDED);
  *     handleCloseQuickAccessPanel();
  *     handlers.handleOpenLibrary();
  *   }}
@@ -212,7 +211,6 @@ function makeBrowseLibraryHandler(onOpenLibrary: () => void) {
     localStorage.removeItem(STORAGE_KEYS.LIBRARY_SEARCH);
     localStorage.removeItem(STORAGE_KEYS.LIBRARY_PROVIDER_FILTERS);
     localStorage.removeItem(STORAGE_KEYS.LIBRARY_GENRES);
-    localStorage.removeItem(STORAGE_KEYS.LIBRARY_RECENTLY_ADDED);
     onOpenLibrary();
   };
 }
@@ -261,20 +259,7 @@ describe('Filter reset on QAP open (onBrowseLibrary)', () => {
     expect(removeItem).toHaveBeenCalledWith(STORAGE_KEYS.LIBRARY_GENRES);
   });
 
-  it('removes LIBRARY_RECENTLY_ADDED from localStorage before opening the library', () => {
-    // #given
-    const removeItem = vi.spyOn(localStorage, 'removeItem');
-    const onOpenLibrary = vi.fn();
-    const handler = makeBrowseLibraryHandler(onOpenLibrary);
-
-    // #when
-    handler();
-
-    // #then
-    expect(removeItem).toHaveBeenCalledWith(STORAGE_KEYS.LIBRARY_RECENTLY_ADDED);
-  });
-
-  it('removes all four filter keys and then calls onOpenLibrary', () => {
+  it('removes all three filter keys and then calls onOpenLibrary', () => {
     // #given
     const callOrder: string[] = [];
     const removeItem = vi.spyOn(localStorage, 'removeItem').mockImplementation((key) => {
@@ -286,8 +271,8 @@ describe('Filter reset on QAP open (onBrowseLibrary)', () => {
     // #when
     handler();
 
-    // #then — all four removes happen before the library open
-    expect(removeItem).toHaveBeenCalledTimes(4);
+    // #then — all three removes happen before the library open
+    expect(removeItem).toHaveBeenCalledTimes(3);
     expect(onOpenLibrary).toHaveBeenCalledOnce();
 
     const openIdx = callOrder.indexOf('openLibrary');
@@ -295,7 +280,6 @@ describe('Filter reset on QAP open (onBrowseLibrary)', () => {
       callOrder.indexOf(`remove:${STORAGE_KEYS.LIBRARY_SEARCH}`),
       callOrder.indexOf(`remove:${STORAGE_KEYS.LIBRARY_PROVIDER_FILTERS}`),
       callOrder.indexOf(`remove:${STORAGE_KEYS.LIBRARY_GENRES}`),
-      callOrder.indexOf(`remove:${STORAGE_KEYS.LIBRARY_RECENTLY_ADDED}`),
     ];
     expect(Math.max(...removeIndices)).toBeLessThan(openIdx);
   });

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -36,7 +36,6 @@ export const STORAGE_KEYS = {
   LIBRARY_SEARCH: 'vorbis-player-library-search',
   LIBRARY_PROVIDER_FILTERS: 'vorbis-player-library-provider-filters',
   LIBRARY_GENRES: 'vorbis-player-library-genres',
-  LIBRARY_RECENTLY_ADDED: 'vorbis-player-library-recently-added',
   PINNED_PLAYLISTS: 'vorbis-player-pinned-playlists',
   PINNED_ALBUMS: 'vorbis-player-pinned-albums',
 

--- a/src/utils/playlistFilters.ts
+++ b/src/utils/playlistFilters.ts
@@ -22,7 +22,7 @@ export type AlbumSortOption =
  *
  * Each field is optional — omitting it means "no filter applied" for that dimension.
  * The filter pipeline applies each non-empty filter in sequence:
- *   provider → collectionType → genres → recentlyAdded → searchQuery
+ *   provider → collectionType → genres → searchQuery
  */
 export interface FilterState {
   /** Only include items from these providers. Empty array = all providers. */
@@ -31,13 +31,9 @@ export interface FilterState {
   collectionType?: 'playlists' | 'albums';
   /** Only include items tagged with at least one of these genres. Empty array = all genres. */
   genres?: string[];
-  /** Only include items added within this time window. 'all' or undefined = no restriction. */
-  recentlyAdded?: 'all' | '7-days' | '30-days' | '1-year';
   /** Full-text search across title, artist, album. Empty string = no restriction. */
   searchQuery?: string;
 }
-
-export type RecentlyAddedFilterOption = FilterState['recentlyAdded'];
 
 export const PLAYLIST_SORT_LABELS: Record<PlaylistSortOption, string> = {
   'recently-added': 'Recently Added',
@@ -148,21 +144,6 @@ function matchesYearFilter(year: number | null, filter: YearFilterOption): boole
   return year >= decadeStart && year < decadeStart + 10;
 }
 
-/**
- * Resolve the cutoff epoch ms for a recently-added time range.
- * Returns 0 for 'all' or undefined (no restriction).
- */
-function recentlyAddedCutoffMs(timeRange: FilterState['recentlyAdded']): number {
-  if (!timeRange || timeRange === 'all') return 0;
-  const now = Date.now();
-  const MS_PER_DAY = 86_400_000;
-  switch (timeRange) {
-    case '7-days':  return now - 7 * MS_PER_DAY;
-    case '30-days': return now - 30 * MS_PER_DAY;
-    case '1-year':  return now - 365 * MS_PER_DAY;
-  }
-}
-
 // ============================================================
 // UNIFIED FILTER HELPERS
 // ============================================================
@@ -189,21 +170,6 @@ export function matchesGenreFilter(itemGenres: string[] | undefined, selectedGen
   if (selectedGenres.length === 0) return true;
   if (!itemGenres || itemGenres.length === 0) return false;
   return selectedGenres.some(g => itemGenres.includes(g));
-}
-
-/**
- * Returns true when the item was added within the given time range,
- * or when the time range is 'all' / undefined (no restriction).
- */
-export function matchesRecentlyAddedFilter(
-  addedAt: string | number | undefined,
-  timeRange: FilterState['recentlyAdded']
-): boolean {
-  const cutoff = recentlyAddedCutoffMs(timeRange);
-  if (cutoff === 0) return true;
-  const ts = parseAddedAt(addedAt);
-  if (ts === 0) return false;
-  return ts >= cutoff;
 }
 
 /**
@@ -242,22 +208,17 @@ export function getAvailableGenres(items: Array<{ genres?: string[] }>): string[
 
 /**
  * Apply a FilterState to a MediaTrack array.
- * Pipeline: provider → genres → recentlyAdded → searchQuery
+ * Pipeline: provider → genres → searchQuery
  */
 export function applyFilters(items: MediaTrack[], filterState: FilterState): MediaTrack[] {
-  const { provider, genres, recentlyAdded, searchQuery } = filterState;
+  const { provider, genres, searchQuery } = filterState;
   const activeProvider = provider && provider.length > 0 ? provider : null;
   const activeGenres   = genres && genres.length > 0 ? genres : null;
-  const activeCutoff   = recentlyAddedCutoffMs(recentlyAdded);
   const activeQuery    = searchQuery ? normalizeText(searchQuery) : null;
 
   return items.filter(track => {
     if (activeProvider && !activeProvider.includes(track.provider)) return false;
     if (activeGenres && !matchesGenreFilter((track as MediaTrack & { genres?: string[] }).genres, activeGenres)) return false;
-    if (activeCutoff > 0) {
-      const ts = typeof track.addedAt === 'number' ? track.addedAt : 0;
-      if (ts === 0 || ts < activeCutoff) return false;
-    }
     if (activeQuery) {
       if (
         !normalizeText(track.name).includes(activeQuery) &&
@@ -271,18 +232,16 @@ export function applyFilters(items: MediaTrack[], filterState: FilterState): Med
 
 /**
  * Apply a FilterState to an AlbumInfo array.
- * Pipeline: provider → genres → recentlyAdded → searchQuery
+ * Pipeline: provider → genres → searchQuery
  */
 export function applyAlbumFilters(albums: AlbumInfo[], filterState: FilterState): AlbumInfo[] {
-  const { provider, genres, recentlyAdded, searchQuery } = filterState;
+  const { provider, genres, searchQuery } = filterState;
   const activeProvider = provider && provider.length > 0 ? provider : null;
   const activeGenres   = genres && genres.length > 0 ? genres : null;
-  const activeCutoff   = recentlyAddedCutoffMs(recentlyAdded);
 
   return albums.filter(album => {
     if (activeProvider && !matchesProviderFilter(album.provider, activeProvider)) return false;
     if (activeGenres && !matchesGenreFilter((album as AlbumInfo & { genres?: string[] }).genres, activeGenres)) return false;
-    if (activeCutoff > 0 && !matchesRecentlyAddedFilter(album.added_at, recentlyAdded)) return false;
     if (!matchesSearch(album, searchQuery ?? '')) return false;
     return true;
   });


### PR DESCRIPTION
Closes #962
Closes #963

Replaces the desktop library's 'Recently Added' date-range filter with a 'Recently Played' section rendering up to 5 clickable shortcuts from useRecentlyPlayedCollections. The old filter plumbing (prop, hook state, filter logic, constant, storage key, QAP cleanup) is fully removed. Mobile overlay unchanged.