### PR TITLE
fix(a11y): replace hardcoded focus outline with two-tone halo

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -117,19 +117,12 @@ input[type="range"]::-moz-range-track {
   }
 }
 
-/* WCAG 2.4.7 Focus Visible — keyboard navigation only */
+/* WCAG 2.4.7 Focus Visible — keyboard navigation only.
+   Two-tone halo renders via box-shadow so it follows each component's
+   border-radius and meets 3:1 contrast against any background. */
 :focus-visible {
-  outline: 2px solid #646cff;
-  outline-offset: 2px;
-}
-
-button:focus-visible,
-[role="button"]:focus-visible,
-a:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible,
-[tabindex]:focus-visible {
-  outline: 2px solid #646cff;
-  outline-offset: 2px;
+  outline: none;
+  box-shadow:
+    0 0 0 2px rgba(0, 0, 0, 0.9),
+    0 0 0 4px rgba(255, 255, 255, 0.9);
 }


### PR DESCRIPTION
## Summary
Replaces the hardcoded purple (`#646cff`) `:focus-visible` outline with a two-tone black+white `box-shadow` halo.

## Why
- Outline color was hardcoded (not themed) and looked visually out of place.
- 2px outline + 2px offset did not align cleanly on rounded components (noticeable on the library search input).
- The dynamically-derived accent color cannot guarantee 3:1 contrast against arbitrary backgrounds, which WCAG 1.4.11 requires for non-text focus indicators.

## Approach
Two-tone (black 2px + white 2px) `box-shadow` ring. This pattern is used by GitHub Primer, Radix, and Atlassian for exactly this reason — the black+white pair guarantees contrast against any background, and `box-shadow` follows each component's `border-radius` natively (no alignment gap).

Also collapses the redundant element-specific block since the universal `:focus-visible` rule already covers it.

## Test plan
- [ ] Tab through library search, filter chips, BottomBar controls — halo is visible against dark and light surfaces
- [ ] Focus ring follows rounded corners (search input, chips, album tiles)
- [ ] No visual regression on non-focused state