### PR TITLE
fix(a11y): move search focus ring to wrapper with soft halo

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.styled.ts
+++ b/src/components/LibraryDrawer/FilterSidebar.styled.ts
@@ -50,6 +50,10 @@ export const SearchInputWrapper = styled.div`
   &:focus-within {
     border-color: ${theme.colors.control.borderHover};
     background: ${theme.colors.control.backgroundHover};
+    box-shadow:
+      0 0 0 2px rgba(0, 0, 0, 0.9),
+      0 0 0 4px rgba(255, 255, 255, 0.85),
+      0 0 12px 0 rgba(255, 255, 255, 0.35);
   }
 `;
 
@@ -82,6 +86,10 @@ export const SearchInput = styled.input`
   font-size: ${theme.fontSize.sm};
   color: ${theme.colors.white};
   min-width: 0;
+
+  &:focus-visible {
+    box-shadow: none;
+  }
 
   &::placeholder {
     color: ${theme.colors.muted.foreground};

--- a/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
+++ b/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
@@ -36,6 +36,10 @@ const SearchInputWrapper = styled.div`
   &:focus-within {
     border-color: ${theme.colors.control.borderHover};
     background: ${theme.colors.control.backgroundHover};
+    box-shadow:
+      0 0 0 2px rgba(0, 0, 0, 0.9),
+      0 0 0 4px rgba(255, 255, 255, 0.85),
+      0 0 12px 0 rgba(255, 255, 255, 0.35);
   }
 `;
 
@@ -68,6 +72,10 @@ const SearchInput = styled.input`
   font-size: ${theme.fontSize.sm};
   color: ${theme.colors.white};
   min-width: 0;
+
+  &:focus-visible {
+    box-shadow: none;
+  }
 
   &::placeholder {
     color: ${theme.colors.muted.foreground};


### PR DESCRIPTION
## Summary
- Moves the focus ring from the inner `<input>` to the rounded `SearchInputWrapper` via `:focus-within`, so it follows the wrapper's border-radius instead of clipping through it
- Softens the two-tone ring with a small outer glow so it reads as a halo rather than a hard rectangle
- Suppresses the inner input's global `:focus-visible` shadow to avoid double rings
- Applies the fix to both desktop (`FilterSidebar`) and mobile (`MobileLibraryBottomBar`) search boxes since they share the wrapper pattern

## Why
The previous global `:focus-visible` rule put a 2px/2px ring on the `<input>` itself, which has no border-radius and sits inside the wrapper's padding — the effect was a sharp white rectangle visibly inset from the rounded container.

## Test plan
- [ ] Focus the library search on desktop — ring follows the rounded wrapper, soft halo
- [ ] Focus the mobile library overlay search — same treatment
- [ ] Other focusable controls (buttons, chips) still show the global two-tone ring