### PR TITLE
feat(library): add thumbnail icons to recently played list

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.styled.ts
+++ b/src/components/LibraryDrawer/FilterSidebar.styled.ts
@@ -225,7 +225,9 @@ export const RecentlyPlayedList = styled.div`
 `;
 
 export const RecentlyPlayedItem = styled.button`
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
   width: 100%;
   padding: ${theme.spacing.sm} ${theme.spacing.md};
   background: ${theme.colors.control.background};
@@ -236,9 +238,6 @@ export const RecentlyPlayedItem = styled.button`
   cursor: pointer;
   transition: all ${theme.transitions.fast};
   text-align: left;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 
   &:hover {
     background: ${theme.colors.control.backgroundHover};
@@ -249,6 +248,44 @@ export const RecentlyPlayedItem = styled.button`
   &:active {
     opacity: 0.8;
   }
+`;
+
+export const RecentlyPlayedThumbnail = styled.div`
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: ${theme.borderRadius.sm};
+  overflow: hidden;
+  background: ${theme.colors.control.borderHover};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: ${theme.colors.muted.foreground};
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+`;
+
+export const RecentlyPlayedLabel = styled.span`
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const ClearFiltersButton = styled.button`

--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -79,18 +79,13 @@ const PlaceholderThumbnailSvg = () => (
   </svg>
 );
 
-interface RecentlyPlayedThumbProps {
-  imageUrl?: string | null;
-  alt: string;
-}
-
-const RecentlyPlayedThumb = ({ imageUrl, alt }: RecentlyPlayedThumbProps) => {
+const RecentlyPlayedThumb = ({ imageUrl }: { imageUrl?: string | null }) => {
   const [errored, setErrored] = useState(false);
   const showImage = !!imageUrl && !errored;
   return (
-    <RecentlyPlayedThumbnail aria-hidden={showImage ? undefined : true}>
+    <RecentlyPlayedThumbnail aria-hidden>
       {showImage ? (
-        <img src={imageUrl} alt={alt} loading="lazy" onError={() => setErrored(true)} />
+        <img src={imageUrl} alt="" loading="lazy" onError={() => setErrored(true)} />
       ) : (
         <PlaceholderThumbnailSvg />
       )}
@@ -229,7 +224,7 @@ export const FilterSidebar = ({
                   onClick={() => onRecentlyPlayedSelect(entry)}
                   aria-label={`Play ${entry.name}`}
                 >
-                  <RecentlyPlayedThumb imageUrl={entry.imageUrl} alt="" />
+                  <RecentlyPlayedThumb imageUrl={entry.imageUrl} />
                   <RecentlyPlayedLabel>{entry.name}</RecentlyPlayedLabel>
                 </RecentlyPlayedItem>
               );

--- a/src/components/LibraryDrawer/FilterSidebar.tsx
+++ b/src/components/LibraryDrawer/FilterSidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { ProviderId } from '@/types/domain';
 import type {
   PlaylistSortOption,
@@ -21,6 +22,8 @@ import {
   ClearFiltersButton,
   RecentlyPlayedList,
   RecentlyPlayedItem,
+  RecentlyPlayedThumbnail,
+  RecentlyPlayedLabel,
 } from './FilterSidebar.styled';
 
 interface FilterSidebarProps {
@@ -67,6 +70,33 @@ const ClearIconSvg = () => (
     <line x1="6" y1="6" x2="18" y2="18" />
   </svg>
 );
+
+const PlaceholderThumbnailSvg = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M9 18V5l12-2v13" />
+    <circle cx="6" cy="18" r="3" />
+    <circle cx="18" cy="16" r="3" />
+  </svg>
+);
+
+interface RecentlyPlayedThumbProps {
+  imageUrl?: string | null;
+  alt: string;
+}
+
+const RecentlyPlayedThumb = ({ imageUrl, alt }: RecentlyPlayedThumbProps) => {
+  const [errored, setErrored] = useState(false);
+  const showImage = !!imageUrl && !errored;
+  return (
+    <RecentlyPlayedThumbnail aria-hidden={showImage ? undefined : true}>
+      {showImage ? (
+        <img src={imageUrl} alt={alt} loading="lazy" onError={() => setErrored(true)} />
+      ) : (
+        <PlaceholderThumbnailSvg />
+      )}
+    </RecentlyPlayedThumbnail>
+  );
+};
 
 export const FilterSidebar = ({
   searchQuery,
@@ -199,7 +229,8 @@ export const FilterSidebar = ({
                   onClick={() => onRecentlyPlayedSelect(entry)}
                   aria-label={`Play ${entry.name}`}
                 >
-                  {entry.name}
+                  <RecentlyPlayedThumb imageUrl={entry.imageUrl} alt="" />
+                  <RecentlyPlayedLabel>{entry.name}</RecentlyPlayedLabel>
                 </RecentlyPlayedItem>
               );
             })}

--- a/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
+++ b/src/components/LibraryDrawer/__tests__/FilterSidebar.test.tsx
@@ -329,6 +329,40 @@ describe('FilterSidebar', () => {
       expect(screen.queryByRole('button', { name: 'Play Playlist 5' })).not.toBeInTheDocument();
     });
 
+    it('renders a thumbnail image when an entry has an imageUrl', () => {
+      // #given
+      const withImage: RecentlyPlayedEntry[] = [{
+        ref: { provider: 'spotify', kind: 'playlist', id: 'p-img' },
+        name: 'With Cover',
+        imageUrl: 'https://cdn.example/cover.jpg',
+      }];
+
+      // #when
+      renderFilterSidebar({ recentlyPlayed: withImage });
+
+      // #then
+      const button = screen.getByRole('button', { name: 'Play With Cover' });
+      const img = button.querySelector('img');
+      expect(img).not.toBeNull();
+      expect(img?.getAttribute('src')).toBe('https://cdn.example/cover.jpg');
+    });
+
+    it('renders a placeholder when an entry has no imageUrl', () => {
+      // #given
+      const noImage: RecentlyPlayedEntry[] = [{
+        ref: { provider: 'spotify', kind: 'liked' },
+        name: 'No Cover',
+      }];
+
+      // #when
+      renderFilterSidebar({ recentlyPlayed: noImage });
+
+      // #then
+      const button = screen.getByRole('button', { name: 'Play No Cover' });
+      expect(button.querySelector('img')).toBeNull();
+      expect(button.querySelector('svg')).not.toBeNull();
+    });
+
     it('calls onRecentlyPlayedSelect with the entry when a shortcut is clicked', () => {
       // #given
       const onRecentlyPlayedSelect = vi.fn();

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -478,6 +478,47 @@ describe('useCollectionLoader', () => {
     expect(mockRecord).toHaveBeenCalledWith(
       { provider: 'spotify', kind: 'playlist', id: 'playlist_123' },
       'My Playlist',
+      null,
+    );
+  });
+
+  it('forwards the first track image as imageUrl when calling record', async () => {
+    // #given
+    const trackWithImage: MediaTrack = { ...makeMediaTrack('1'), image: 'https://cdn.example/cover.jpg' };
+    const mockCatalog = {
+      listTracks: vi.fn().mockResolvedValue([trackWithImage, makeMediaTrack('2')]),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection('playlist_123', undefined, 'My Playlist');
+    });
+
+    // #then
+    expect(mockRecord).toHaveBeenCalledWith(
+      { provider: 'spotify', kind: 'playlist', id: 'playlist_123' },
+      'My Playlist',
+      'https://cdn.example/cover.jpg',
     );
   });
 
@@ -556,6 +597,7 @@ describe('useCollectionLoader', () => {
     expect(mockRecord).toHaveBeenCalledWith(
       { provider: 'spotify', kind: 'liked' },
       LIKED_SONGS_NAME,
+      null,
     );
   });
 

--- a/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
+++ b/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
@@ -114,6 +114,52 @@ describe('useRecentlyPlayedCollections', () => {
     expect(JSON.parse(lastCall![1] as string)[0]).toEqual({ ref, name: 'My Playlist' });
   });
 
+  it('records and persists the imageUrl when provided', () => {
+    // #given
+    const ref = makeRef();
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'My Playlist', 'https://example.com/cover.jpg');
+    });
+
+    // #then
+    expect(result.current.history[0]).toEqual({
+      ref,
+      name: 'My Playlist',
+      imageUrl: 'https://example.com/cover.jpg',
+    });
+  });
+
+  it('omits imageUrl when not provided', () => {
+    // #given
+    const ref = makeRef();
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'My Playlist');
+    });
+
+    // #then
+    expect(result.current.history[0]).not.toHaveProperty('imageUrl');
+  });
+
+  it('omits imageUrl when null is passed', () => {
+    // #given
+    const ref = makeRef();
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+
+    // #when
+    act(() => {
+      result.current.record(ref, 'My Playlist', null);
+    });
+
+    // #then
+    expect(result.current.history[0]).not.toHaveProperty('imageUrl');
+  });
+
   it('loads persisted history from localStorage on init', () => {
     // #given
     const ref = makeRef();

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -21,7 +21,7 @@ interface UseCollectionLoaderProps {
   spotifyHandlePlaylistSelect: (playlistId: string) => Promise<MediaTrack[]>;
   stopRadioBase: () => void;
   radioStateIsActive: boolean;
-  record: (ref: CollectionRef, name: string) => void;
+  record: (ref: CollectionRef, name: string, imageUrl?: string | null) => void;
 }
 
 interface UseCollectionLoaderReturn {
@@ -116,6 +116,7 @@ export function useCollectionLoader({
         record(
           { provider: firstTrack.provider, kind: 'liked' },
           name ?? LIKED_SONGS_NAME,
+          firstTrack.image ?? null,
         );
       }
       return merged.length;
@@ -174,7 +175,7 @@ export function useCollectionLoader({
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
       await playTrack(0);
-      record(collectionRef, name ?? collectionId);
+      record(collectionRef, name ?? collectionId, list[0]?.image ?? null);
       return list.length;
     } catch (err) {
       return handleLoadError(err, 'Failed to load collection.');

--- a/src/hooks/useRecentlyPlayedCollections.ts
+++ b/src/hooks/useRecentlyPlayedCollections.ts
@@ -9,22 +9,24 @@ const MAX_ENTRIES = 5;
 export interface RecentlyPlayedEntry {
   ref: CollectionRef;
   name: string;
+  imageUrl?: string | null;
 }
 
 export interface UseRecentlyPlayedCollectionsResult {
   history: RecentlyPlayedEntry[];
-  record: (ref: CollectionRef, name: string) => void;
+  record: (ref: CollectionRef, name: string, imageUrl?: string | null) => void;
 }
 
 export function useRecentlyPlayedCollections(): UseRecentlyPlayedCollectionsResult {
   const [history, setHistory] = useLocalStorage<RecentlyPlayedEntry[]>(STORAGE_KEY, []);
 
   const record = useCallback(
-    (ref: CollectionRef, name: string) => {
+    (ref: CollectionRef, name: string, imageUrl?: string | null) => {
       const key = collectionRefToKey(ref);
       setHistory((prev) => {
         const filtered = prev.filter((entry) => collectionRefToKey(entry.ref) !== key);
-        return [{ ref, name }, ...filtered].slice(0, MAX_ENTRIES);
+        const entry: RecentlyPlayedEntry = imageUrl ? { ref, name, imageUrl } : { ref, name };
+        return [entry, ...filtered].slice(0, MAX_ENTRIES);
       });
     },
     [setHistory]


### PR DESCRIPTION
Closes #1019

## Summary

Render a 24px cover-art thumbnail beside each Recently Played entry in the desktop FilterSidebar so visually-similar collection names can be distinguished at a glance.

## Changes

- **`useRecentlyPlayedCollections`**: extend `RecentlyPlayedEntry` with optional `imageUrl`; accept it as third arg to `record(...)`. Backward-compatible — existing localStorage entries without `imageUrl` still work and render the placeholder.
- **`useCollectionLoader`**: forward the first track's `image` as the cover URL when calling `record(...)` from both the provider-collection and unified-liked-songs paths.
- **`FilterSidebar` + styled module**: add `RecentlyPlayedThumb` (24x24, theme `borderRadius.sm`, `spacing.sm` gap) with a music-note SVG placeholder when no `imageUrl` is available; falls back to placeholder on `<img>` error. Mobile (`MobileLibraryBottomBar`) is untouched.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — all my changes pass; 6 pre-existing failures on `develop` (useFilterState, PlaylistSelection) are unrelated
- [x] Added unit tests for imageUrl round-trip in `useRecentlyPlayedCollections`, image forwarding in `useCollectionLoader`, and thumbnail/placeholder rendering in `FilterSidebar`