### PR TITLE
fix(library): resolve recently-played thumbnails from library cache

### DIFF
--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -10,12 +10,14 @@ const {
   mockUseUnifiedLikedTracks,
   mockUseProviderContext,
   mockUsePinnedItems,
+  mockUseRecentlyPlayedCollections,
 } = vi.hoisted(() => ({
   mockIsMobile: { current: false },
   mockUseLibrarySync: vi.fn(),
   mockUseUnifiedLikedTracks: vi.fn(),
   mockUseProviderContext: vi.fn(),
   mockUsePinnedItems: vi.fn(),
+  mockUseRecentlyPlayedCollections: vi.fn(),
 }));
 
 vi.mock('@/contexts/PlayerSizingContext', () => ({
@@ -52,6 +54,10 @@ vi.mock('@/hooks/usePinnedItems', () => ({
   usePinnedItems: () => mockUsePinnedItems(),
 }));
 
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockUseRecentlyPlayedCollections(),
+}));
+
 import { useLibraryRoot } from '../useLibraryRoot';
 
 function setupDefaultMocks(): void {
@@ -79,6 +85,10 @@ function setupDefaultMocks(): void {
     togglePinAlbum: vi.fn(),
     canPinMorePlaylists: true,
     canPinMoreAlbums: true,
+  });
+  mockUseRecentlyPlayedCollections.mockReturnValue({
+    history: [],
+    record: vi.fn(),
   });
 }
 
@@ -566,6 +576,89 @@ describe('useLibraryRoot grid behavior', () => {
 
       // #then
       expect(playlistNames(result).sort()).toEqual(['Dropbox Mix', 'Spotify Mix']);
+    });
+  });
+
+  describe('recently played image enrichment', () => {
+    it('resolves imageUrl from cached playlists when history entry lacks one', () => {
+      // #given
+      mockUseRecentlyPlayedCollections.mockReturnValue({
+        record: vi.fn(),
+        history: ([
+          { ref: { provider: 'spotify', kind: 'playlist', id: 'p-1' }, name: 'My Mix' },
+        ]),
+      });
+      setLibrarySync(
+        [makePlaylistInfo({ id: 'p-1', name: 'My Mix', provider: 'spotify', images: [{ url: 'https://example.com/p1.jpg', height: 300, width: 300 }] })],
+        [],
+      );
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      expect(result.current.browsingValue.recentlyPlayed[0].imageUrl).toBe('https://example.com/p1.jpg');
+    });
+
+    it('resolves imageUrl from cached albums for album history entries', () => {
+      // #given
+      mockUseRecentlyPlayedCollections.mockReturnValue({
+        record: vi.fn(),
+        history: ([
+          { ref: { provider: 'spotify', kind: 'album', id: 'a-1' }, name: 'OK Computer' },
+        ]),
+      });
+      setLibrarySync(
+        [],
+        [makeAlbumInfo({ id: 'a-1', name: 'OK Computer', provider: 'spotify', images: [{ url: 'https://example.com/a1.jpg', height: 300, width: 300 }] })],
+      );
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      expect(result.current.browsingValue.recentlyPlayed[0].imageUrl).toBe('https://example.com/a1.jpg');
+    });
+
+    it('preserves existing imageUrl without overwriting from cache', () => {
+      // #given
+      mockUseRecentlyPlayedCollections.mockReturnValue({
+        record: vi.fn(),
+        history: ([
+          {
+            ref: { provider: 'spotify', kind: 'playlist', id: 'p-1' },
+            name: 'My Mix',
+            imageUrl: 'https://example.com/stored.jpg',
+          },
+        ]),
+      });
+      setLibrarySync(
+        [makePlaylistInfo({ id: 'p-1', name: 'My Mix', provider: 'spotify', images: [{ url: 'https://example.com/fresh.jpg', height: 300, width: 300 }] })],
+        [],
+      );
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      expect(result.current.browsingValue.recentlyPlayed[0].imageUrl).toBe('https://example.com/stored.jpg');
+    });
+
+    it('leaves imageUrl undefined when no matching collection is cached', () => {
+      // #given
+      mockUseRecentlyPlayedCollections.mockReturnValue({
+        record: vi.fn(),
+        history: ([
+          { ref: { provider: 'spotify', kind: 'playlist', id: 'missing' }, name: 'Gone' },
+        ]),
+      });
+      setLibrarySync([], []);
+
+      // #when
+      const { result } = renderLibraryRoot();
+
+      // #then
+      expect(result.current.browsingValue.recentlyPlayed[0].imageUrl).toBeUndefined();
     });
   });
 });

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -59,7 +59,29 @@ export function useLibraryRoot({
   } = useLibrarySync();
 
   const browsingState = useLibraryBrowsing(initialSearchQuery, initialViewMode);
-  const { history: recentlyPlayed } = useRecentlyPlayedCollections();
+  const { history: recentlyPlayedRaw } = useRecentlyPlayedCollections();
+
+  const recentlyPlayed = useMemo<RecentlyPlayedEntry[]>(() => {
+    return recentlyPlayedRaw.map((entry) => {
+      if (entry.imageUrl) return entry;
+      const { ref } = entry;
+      if (ref.kind === 'playlist') {
+        const match = playlists.find(
+          (p) => p.id === ref.id && (p.provider ?? 'spotify') === ref.provider,
+        );
+        const imageUrl = match?.images?.[0]?.url;
+        return imageUrl ? { ...entry, imageUrl } : entry;
+      }
+      if (ref.kind === 'album') {
+        const match = albums.find(
+          (a) => a.id === ref.id && (a.provider ?? 'spotify') === ref.provider,
+        );
+        const imageUrl = match?.images?.[0]?.url;
+        return imageUrl ? { ...entry, imageUrl } : entry;
+      }
+      return entry;
+    });
+  }, [recentlyPlayedRaw, playlists, albums]);
 
   const handleRecentlyPlayedSelect = useCallback(
     (entry: RecentlyPlayedEntry) => {


### PR DESCRIPTION
Follow-up to #1020 (Closes #1019 properly).

## Problem
#1020 stored `firstTrack.image` as the thumbnail for each Recently Played entry. This was wrong in two ways:

1. **Playlists** — the first track's album cover is not the playlist cover. You'd see a random track's art instead of the playlist art.
2. **Async art resolution** — providers like Dropbox resolve artwork asynchronously. At the moment `record()` fires, `firstTrack.image` is often `undefined`, so the entry gets stored with no image and the placeholder renders forever.

Result: the Recently Played section showed generic music-note placeholders even for collections whose covers are visible elsewhere in the library.

## Fix
Enrich history entries at render time in `useLibraryRoot`:
- For `playlist` / `album` refs, look up the matching `MediaCollection` in `useLibrarySync`'s cached `playlists` / `albums` and use its `images[0].url`.
- Preserve any `imageUrl` already on the entry (so a future write-side fix can supply a more authoritative source).
- Leaves `liked` refs alone.

## Why this approach
The alternative was threading an `imageUrl` parameter through 10+ files (`onPlaylistSelect` → `handlePlaylistSelect` → `loadCollection` → `record`). The read-side enrichment is localized to one hook and works for entries that were already persisted without an image. A follow-up can tighten the write side if needed.

## Verification
- `npx tsc -b --noEmit` — clean
- Tests pass (4 new tests covering playlist / album / preserves-existing / missing-from-cache; 6 pre-existing failures on develop in `useFilterState` and `PlaylistSelection` are unrelated)

Closes #1019