### PR TITLE
chore: gitignore .claude/HANDOFF.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist-ssr
 # Audio files
 public/audio/
 .claude/settings.local.json
+.claude/HANDOFF.md
 
 # Electron build outputs
 dist-electron/


### PR DESCRIPTION
## Summary
- Add `.claude/HANDOFF.md` to `.gitignore` to prevent session handoff docs from being committed.

## Test plan
- [x] Verify `.claude/HANDOFF.md` is ignored by `git status`