### PR TITLE
fix(switch): restore pill shape on SwitchTrack

### DIFF
--- a/src/components/controls/Switch.tsx
+++ b/src/components/controls/Switch.tsx
@@ -23,7 +23,7 @@ const SwitchTrack = styled.button<{ $on: boolean; $disabled?: boolean; $variant:
   position: relative;
   width: 36px;
   height: 20px;
-  border-radius: ${({ theme }) => theme.borderRadius.flat};
+  border-radius: ${({ theme }) => theme.borderRadius.full};
   border: none;
   padding: 0;
   cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};


### PR DESCRIPTION
## Summary

The flat-design swarm (#1044, part of epic #1040) flattened the `SwitchTrack` component's border-radius along with other \"chips and pill shapes\" called out in AC#5 of the epic. But `Switch` is a toggle control, not a chip or badge — the pill shape is functional (it wraps a circular knob that slides left/right), not decorative.

With a flat track and a circular knob, the component now looks visually broken: the knob's curvature doesn't match the square corners of the track.

## Fix

Revert `SwitchTrack` border-radius from `theme.borderRadius.flat` to `theme.borderRadius.full` so the track stays pill-shaped.

## Test plan

- [ ] Visually inspect any `Switch` in the app (AppSettingsMenu toggle, VisualEffectsMenu toggles, provider setup enable/disable toggle) — track is pill-shaped again
- [ ] Knob still circular and slides between left (off) and right (on) positions

## Follow-up

Epic #1040 AC#5 ('Chip and badge elements are sharp rectangles') is intentionally scoped to chips and badges only — Switch tracks are explicitly out of scope. Updating the CLAUDE.md Flat-design section to clarify this is being handled separately.