### PR TITLE
docs(flat-design): exempt functional controls from flattening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ The player uses a deliberately flat visual language. Rules:
 - **All other rectangular surfaces** use `theme.borderRadius.flat` (`0`) — cards, drawers, menus, list items, modals, etc.
 - **Circles** (`border-radius: 50%`) stay circular everywhere (icon buttons, avatar-style elements).
 - **Thumbnails** (library tiles, mini album art) use `theme.borderRadius.md` (6 px).
+- **Functional controls whose shape is part of their mechanics** keep their original rounding. In practice this means pill-shaped toggle tracks (`Switch`) and any slider track whose knob is circular — flattening them would leave the circular thumb clipping against square corners. Treat the `Switch` component (`src/components/controls/Switch.tsx`) as the reference: track = `borderRadius.full`, knob = `border-radius: 50%`.
 
 When adding new UI surfaces, default to `borderRadius.flat` unless the element is explicitly one of the exceptions above. Do not introduce new ad-hoc radius values.
 


### PR DESCRIPTION
## Summary

- Clarify the flat-design rule in `CLAUDE.md` so functional controls (toggle switch tracks, slider tracks with circular thumbs) stay rounded — flattening them causes the circular knob to clip against square corners.
- Update deferred swarm issues #1036, #1037, #1038 bodies with the same clarification so their agents don't re-flatten `Switch`.

## Context

The initial flat-design swarm (PR #1044 / issue #1032) flattened `SwitchTrack` along with other pill shapes per epic AC#5 ('chips and badges become sharp rectangles'). PR #1051 reverted it. This PR captures the governing exemption so we don't rediscover the issue later.

## Test plan

- [ ] `CLAUDE.md` rendered on GitHub shows the new bullet in the **Flat design** section
- [ ] Issues #1036, #1037, #1038 show a **Clarification (post-swarm-1)** footer with the exemption