### PR TITLE
refactor(library): flatten library surfaces and chip components (#1027)

### DIFF
--- a/src/components/LibraryProviderBar.tsx
+++ b/src/components/LibraryProviderBar.tsx
@@ -58,7 +58,7 @@ const ConnectButton = styled.button`
   color: ${TOGGLE_ON_COLOR};
   background: none;
   border: 1px solid ${TOGGLE_ON_COLOR}40;
-  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   padding: 2px 8px;
   cursor: pointer;
   transition: background 0.15s ease;

--- a/src/components/PlaylistSelection/LibraryMainContent.tsx
+++ b/src/components/PlaylistSelection/LibraryMainContent.tsx
@@ -60,7 +60,7 @@ const ProviderChip = styled.button<{ $active: boolean }>`
   gap: ${theme.spacing.xs};
   flex-shrink: 0;
   padding: ${theme.spacing.xs} ${theme.spacing.md};
-  border-radius: 999px;
+  border-radius: ${theme.borderRadius.flat};
   border: 1px solid
     ${({ $active }) =>
       $active ? theme.colors.control.borderHover : theme.colors.control.border};

--- a/src/components/PlaylistSelection/LibraryStatusContent.tsx
+++ b/src/components/PlaylistSelection/LibraryStatusContent.tsx
@@ -50,7 +50,7 @@ export function LibraryStatusContent({
               border: 'none',
               padding: `${theme.spacing.lg} ${theme.spacing.xl}`,
               fontSize: theme.fontSize.base,
-              borderRadius: theme.borderRadius.lg,
+              borderRadius: theme.borderRadius.flat,
               cursor: 'pointer',
               transition: `background ${theme.transitions.fast} ease`
             }}

--- a/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
+++ b/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
@@ -28,7 +28,7 @@ const SearchInputWrapper = styled.div`
   min-width: 0;
   background: ${theme.colors.control.background};
   border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
+  border-radius: ${theme.borderRadius.flat};
   padding: 0 ${theme.spacing.sm};
   min-height: ${MIN_TAP_TARGET};
   transition: all ${theme.transitions.fast};
@@ -117,7 +117,7 @@ const SortSelect = styled.select`
   padding: ${theme.spacing.sm} ${theme.spacing.md};
   background: ${theme.colors.control.background};
   border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
+  border-radius: ${theme.borderRadius.flat};
   color: ${theme.colors.white};
   font-size: ${theme.fontSize.sm};
   cursor: pointer;

--- a/src/components/PlaylistSelection/styled.controls.ts
+++ b/src/components/PlaylistSelection/styled.controls.ts
@@ -84,7 +84,7 @@ export const SelectDropdown = styled.select`
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: ${({ theme }) => theme.colors.control.background};
   border: 1px solid ${({ theme }) => theme.colors.control.borderHover};
-  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   color: ${({ theme }) => theme.colors.white};
   font-size: ${({ theme }) => theme.fontSize.sm};
   cursor: pointer;
@@ -164,7 +164,7 @@ export const ClearButton = styled.button`
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: ${({ theme }) => theme.colors.control.background};
   border: 1px solid ${({ theme }) => theme.colors.control.borderHover};
-  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   color: ${({ theme }) => theme.colors.muted.foreground};
   font-size: ${({ theme }) => theme.fontSize.sm};
   cursor: pointer;

--- a/src/components/PlaylistSelection/styled.grids.ts
+++ b/src/components/PlaylistSelection/styled.grids.ts
@@ -36,7 +36,7 @@ const GridCard = styled.div`
   display: flex;
   flex-direction: column;
   cursor: pointer;
-  border-radius: 0.5rem;
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   transition: transform 0.15s ease, background 0.15s ease;
   min-width: 0;
 
@@ -106,7 +106,7 @@ const PlaylistItem = styled.div`
   padding: ${({ theme }) => theme.spacing.md};
   background: ${({ theme }) => theme.colors.control.background};
   border: 1px solid ${({ theme }) => theme.colors.control.border};
-  border-radius: ${({ theme }) => theme.borderRadius.xl};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   cursor: pointer;
   transition: all ${({ theme }) => theme.transitions.fast} ease;
 

--- a/src/components/PlaylistSelection/styled.layout.ts
+++ b/src/components/PlaylistSelection/styled.layout.ts
@@ -26,7 +26,7 @@ export const PageSelectionCard = styled(Card)<{ $maxWidth: number; $overlay?: bo
   background: ${theme.colors.muted.background};
   backdrop-filter: blur(12px);
   border: ${({ $overlay }) => ($overlay ? 'none' : `1px solid ${theme.colors.control.border}`)};
-  border-radius: ${({ $overlay }) => ($overlay ? '0' : '1.25rem')};
+  border-radius: ${theme.borderRadius.flat};
   box-shadow: ${({ $overlay }) => ($overlay ? 'none' : theme.shadows.albumArt)};
   display: flex;
   flex-direction: column;

--- a/src/components/ProviderBadge.tsx
+++ b/src/components/ProviderBadge.tsx
@@ -13,7 +13,7 @@ const BadgeContainer = styled.div.withConfig({
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
-  border-radius: ${({ theme }) => theme.borderRadius.full};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   padding: ${({ $iconOnly }) => $iconOnly ? '4px' : '3px 8px 3px 4px'};
   pointer-events: none;
   user-select: none;

--- a/src/components/styled/FilterChips.tsx
+++ b/src/components/styled/FilterChips.tsx
@@ -23,7 +23,7 @@ export const Chip = styled.button<{ $active?: boolean }>`
   gap: ${theme.spacing.xs};
   padding: ${theme.spacing.xs} ${theme.spacing.md};
   min-height: 36px;
-  border-radius: ${theme.borderRadius.full};
+  border-radius: ${theme.borderRadius.flat};
   border: 1px solid ${({ $active }) =>
     $active ? theme.colors.accent : theme.colors.control.borderHover};
   background: ${({ $active }) =>
@@ -59,7 +59,7 @@ export const SearchChipWrapper = styled.div<{ $expanded: boolean }>`
   display: inline-flex;
   align-items: center;
   min-height: 36px;
-  border-radius: ${theme.borderRadius.full};
+  border-radius: ${theme.borderRadius.flat};
   border: 1px solid ${({ $expanded }) =>
     $expanded ? theme.colors.accent : theme.colors.control.borderHover};
   background: ${({ $expanded }) =>
@@ -118,7 +118,7 @@ export const SortDropdown = styled.div`
   min-width: 180px;
   background: ${theme.colors.popover.background};
   border: 1px solid ${theme.colors.popover.border};
-  border-radius: ${theme.borderRadius.lg};
+  border-radius: ${theme.borderRadius.flat};
   box-shadow: ${theme.shadows.popover};
   padding: ${theme.spacing.xs} 0;
   overflow: hidden;
@@ -156,7 +156,7 @@ export const ArtistListPopover = styled.div`
   overflow-y: auto;
   background: ${theme.colors.popover.background};
   border: 1px solid ${theme.colors.popover.border};
-  border-radius: ${theme.borderRadius.lg};
+  border-radius: ${theme.borderRadius.flat};
   box-shadow: ${theme.shadows.popover};
   padding: ${theme.spacing.xs} 0;
   scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- Migrates library browser chips, badges, cards, and dropdowns to `theme.borderRadius.flat`
- Converts `ProviderBadge`, `FilterChips.Chip`, `SearchChipWrapper`, and `LibraryMainContent.ProviderChip` from pill (`full`/`999px`) to rectangle (`flat`)
- Flattens surrounding surfaces: `PageSelectionCard`, `GridCard`, `PlaylistItem`, `SelectDropdown`, `ClearButton`, `ConnectButton`, `SortDropdown`, `ArtistListPopover`, `MobileLibraryBottomBar` search/sort controls
- Part of the **flat UI refactor** epic (#1040)

## Preserved (per epic rules)
- `AlbumArt` and the player panel beneath it (still `borderRadius.xl`)
- `Switch` tracks and any slider tracks paired with circular thumbs
- All `border-radius: 50%` circles (icon buttons, status dots, spinners)
- Library thumbnail images — `GridCardArtWrapper`, `PlaylistImageWrapper`, `LibraryMiniPlayer` artwork, `LikedSongsCard` synthetic thumbnail — deferred to #1035

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1009/1009 passing
- [ ] Manual visual check: library tiles, provider chips, filter chips, mobile search bar, connect button all sharp-cornered; thumbnails and circles unchanged

Closes #1027