### PR TITLE
refactor(thumbnails): use borderRadius.md for library tiles (#1035)

### DIFF
--- a/src/components/PlaylistSelection/LikedSongsCard.tsx
+++ b/src/components/PlaylistSelection/LikedSongsCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ProviderIcon from '../ProviderIcon';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
+import { theme } from '@/styles/theme';
 import type { ProviderId } from '@/types/domain';
 import {
   GridCardArtWrapper,
@@ -36,7 +37,7 @@ const HeartArt: React.FC<{ gradient: string; layout: 'grid' | 'list' }> = ({ gra
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    borderRadius: layout === 'list' ? '0.5rem' : undefined,
+    borderRadius: layout === 'list' ? theme.borderRadius.md : undefined,
     fontSize: layout === 'list' ? '1.5rem' : '3rem',
     color: 'white',
   }}>♥</div>

--- a/src/components/PlaylistSelection/styled.grids.ts
+++ b/src/components/PlaylistSelection/styled.grids.ts
@@ -50,7 +50,7 @@ export const GridCardArtWrapper = styled.div`
   position: relative;
   width: 100%;
   aspect-ratio: 1;
-  border-radius: 0.5rem;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
   overflow: hidden;
   background: linear-gradient(135deg, ${({ theme }) => theme.colors.gray[800]}, ${({ theme }) => theme.colors.gray[700]});
 
@@ -120,7 +120,7 @@ const PlaylistItem = styled.div`
 export const PlaylistImageWrapper = styled.div`
   width: 60px;
   height: 60px;
-  border-radius: 0.5rem;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
   overflow: hidden;
   background: linear-gradient(45deg, ${({ theme }) => theme.colors.gray[700]}, ${({ theme }) => theme.colors.gray[600]});
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Migrate library thumbnail wrappers to `theme.borderRadius.md` (6px) so "mini album art" echoes the hero `AlbumArt` (xl) without competing with it
- `GridCardArtWrapper` + `PlaylistImageWrapper`: `0.5rem` → `theme.borderRadius.md`
- `LikedSongsCard` `HeartArt` list-mode inline radius: `0.5rem` → `theme.borderRadius.md`
- Part of the **flat UI refactor** epic (#1040)

## Already on md (no change needed)
- `LibraryMiniPlayer` `Artwork` + `ArtworkPlaceholder`
- `MosaicThumbnail` uses \`border-radius: inherit\` and picks up the wrapper value

## Preserved
- `AlbumArt` stays at `borderRadius.xl`
- `ProviderBadge.IconWrapper` remains a 50% circle (functional, not a thumbnail image)

## Test plan
- [x] \`npx tsc -b --noEmit\` clean
- [x] \`npm run build\` clean
- [x] \`npm run test:run\` — 1009/1009 passing
- [ ] Manual visual check: grid tiles, list thumbnails, liked-songs heart art, mini-player art all show subtle rounded corners (md)

Closes #1035