### PR TITLE
refactor(inputs): flatten inputs and custom focus-ring radii

### DIFF
--- a/src/components/LibraryDrawer/FilterSidebar.styled.ts
+++ b/src/components/LibraryDrawer/FilterSidebar.styled.ts
@@ -43,7 +43,7 @@ export const SearchInputWrapper = styled.div`
   position: relative;
   background: ${theme.colors.control.background};
   border: 1px solid ${theme.colors.control.border};
-  border-radius: ${theme.borderRadius.md};
+  border-radius: ${theme.borderRadius.flat};
   padding: 0 ${theme.spacing.sm};
   transition: all ${theme.transitions.fast};
 
@@ -167,7 +167,7 @@ export const FilterChip = styled.button<{ $active: boolean }>`
   display: inline-flex;
   align-items: center;
   padding: ${theme.spacing.xs} ${theme.spacing.md};
-  border-radius: 999px;
+  border-radius: ${theme.borderRadius.flat};
   border: 1px solid
     ${({ $active }) =>
       $active ? theme.colors.control.borderHover : theme.colors.control.border};
@@ -254,7 +254,7 @@ export const RecentlyPlayedThumbnail = styled.div`
   flex-shrink: 0;
   width: 24px;
   height: 24px;
-  border-radius: ${theme.borderRadius.sm};
+  border-radius: ${theme.borderRadius.md};
   overflow: hidden;
   background: ${theme.colors.control.borderHover};
   display: flex;

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -37,11 +37,7 @@ const StyledLikeButton = styled.button<{
     if ($isTablet) return theme.spacing.sm;
     return theme.spacing.sm;
   }};
-  border-radius: ${({ $isMobile, $isTablet }) => {
-    if ($isMobile) return theme.borderRadius.sm;
-    if ($isTablet) return theme.borderRadius.md;
-    return theme.borderRadius.md;
-  }};
+  border-radius: ${theme.borderRadius.flat};
   position: relative;
 
   .heart-icon-wrapper {

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -53,7 +53,7 @@ const LoadingCard = styled(Card)<{ backgroundImage?: string; standalone?: boolea
   right: 0;
   bottom: 0;
   overflow: hidden;
-  border-radius: 1.25rem;
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   border: 1px solid ${({ theme }) => theme.colors.border};
   box-shadow: ${({ theme }) => theme.shadows.albumArt};
 
@@ -66,7 +66,7 @@ const LoadingCard = styled(Card)<{ backgroundImage?: string; standalone?: boolea
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
-      border-radius: 1.25rem;
+      border-radius: ${theme.borderRadius.flat};
       z-index: 0;
     }
 
@@ -76,7 +76,7 @@ const LoadingCard = styled(Card)<{ backgroundImage?: string; standalone?: boolea
       inset: 0;
       background: ${theme.colors.card.overlay};
       backdrop-filter: blur(24px);
-      border-radius: 1.25rem;
+      border-radius: ${theme.borderRadius.flat};
       z-index: 1;
     }
   ` : `
@@ -149,7 +149,7 @@ const ProgressBar = styled.div`
   width: 200px;
   height: 3px;
   background: ${({ theme }) => theme.colors.control.background};
-  border-radius: 1.5px;
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
   margin-top: 1.5rem;
   position: relative;
   overflow: hidden;

--- a/src/components/PlaylistSelection/LibraryMiniPlayer.tsx
+++ b/src/components/PlaylistSelection/LibraryMiniPlayer.tsx
@@ -88,7 +88,7 @@ const Bars = styled.div<{ $paused: boolean }>`
     width: 3px;
     height: 100%;
     background: ${theme.colors.muted.foreground};
-    border-radius: 1px;
+    border-radius: ${theme.borderRadius.flat};
     transform-origin: bottom;
     animation: ${equalize} 0.8s ease-in-out infinite;
     animation-play-state: ${({ $paused }) => ($paused ? 'paused' : 'running')};

--- a/src/components/__tests__/flatDesignInvariants.test.tsx
+++ b/src/components/__tests__/flatDesignInvariants.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for the flat-design migration (epic #1040, issue #1038).
+ *
+ * Asserts that surfaces explicitly preserved by the flat-design rules in
+ * CLAUDE.md retain a non-zero border-radius after the sweep:
+ *
+ *   - `AlbumArt` uses theme.borderRadius.xl
+ *   - `Switch` track uses theme.borderRadius.full (pill)
+ *   - `Switch` knob stays circular (border-radius: 50%)
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import Switch from '@/components/controls/Switch';
+import AlbumArt from '@/components/AlbumArt';
+import { makeTrack } from '@/test/fixtures';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  PlayerSizingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePlayerSizingContext: vi.fn(() => ({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    isTouchDevice: false,
+    hasPointerInput: true,
+    viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
+    dimensions: { width: 600, height: 600 },
+  })),
+}));
+
+vi.mock('@/hooks/useImageProcessingWorker', () => ({
+  useImageProcessingWorker: () => ({
+    processImage: vi.fn(() => new Promise(() => {})),
+  }),
+}));
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+describe('flat-design preserved surfaces', () => {
+  it('AlbumArt container retains the xl border-radius', () => {
+    // #given
+    const track = makeTrack();
+
+    // #when
+    const { container } = renderWithTheme(<AlbumArt currentTrack={track} />);
+    const albumArt = container.firstElementChild as HTMLElement;
+
+    // #then
+    expect(albumArt).toBeTruthy();
+    const computedRadius = window.getComputedStyle(albumArt).borderRadius;
+    expect(computedRadius).not.toBe('0px');
+    expect(computedRadius).not.toBe('');
+    expect(computedRadius).toBe(theme.borderRadius.xl);
+  });
+
+  it('Switch track keeps its pill shape via borderRadius.full', () => {
+    // #when
+    const { getByRole } = renderWithTheme(
+      <Switch on={false} onToggle={() => {}} ariaLabel="test" />,
+    );
+    const track = getByRole('switch');
+
+    // #then
+    const computedRadius = window.getComputedStyle(track).borderRadius;
+    expect(computedRadius).not.toBe('0px');
+    expect(computedRadius).toBe(theme.borderRadius.full);
+  });
+
+  it('Switch knob stays circular', () => {
+    // #when
+    const { getByRole } = renderWithTheme(
+      <Switch on={false} onToggle={() => {}} ariaLabel="test" />,
+    );
+    const knob = getByRole('switch').firstElementChild as HTMLElement;
+
+    // #then
+    expect(knob).toBeTruthy();
+    const computedRadius = window.getComputedStyle(knob).borderRadius;
+    expect(computedRadius).toBe('50%');
+  });
+});

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -159,7 +159,7 @@ export const ControlButton = styled.button.withConfig({
   touch-action: manipulation; /* Remove 300ms tap delay on iOS */
   transition: all 0.2s ease;
   padding: ${({ theme }) => theme.spacing.sm};
-  border-radius: ${({ theme }) => theme.borderRadius.md};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
 
   svg {
     width: 1.5rem;

--- a/src/components/styled/Drawer.tsx
+++ b/src/components/styled/Drawer.tsx
@@ -20,7 +20,7 @@ export const GripPill = styled.div`
   width: 40px;
   height: 4px;
   background: ${({ theme }) => theme.colors.control.backgroundHover};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.flat};
 `;
 
 export const SwipeHandle = styled.div`

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -17,7 +17,7 @@ export const buttonBase = css`
   align-items: center;
   justify-content: center;
   padding: ${theme.spacing.sm} ${theme.spacing.md};
-  border-radius: ${theme.borderRadius.lg};
+  border-radius: ${theme.borderRadius.flat};
   font-size: ${theme.fontSize.sm};
   font-weight: ${theme.fontWeight.medium};
   transition: ${theme.transitions.normal};
@@ -76,7 +76,7 @@ export const buttonGhost = css`
 export const cardBase = css`
   background-color: ${theme.colors.muted.background};
   border: 1px solid ${theme.colors.border};
-  border-radius: ${theme.borderRadius.md};
+  border-radius: ${theme.borderRadius.flat};
   padding: ${theme.spacing.sm};
   margin: ${theme.spacing.sm};
   margin-top: ${theme.spacing.md};
@@ -112,12 +112,12 @@ export const customScrollbar = css`
   
   &::-webkit-scrollbar-track {
     background: ${theme.colors.muted.background};
-    border-radius: ${theme.borderRadius.md};
+    border-radius: ${theme.borderRadius.flat};
   }
-  
+
   &::-webkit-scrollbar-thumb {
     background: ${theme.colors.gray[600]};
-    border-radius: ${theme.borderRadius.md};
+    border-radius: ${theme.borderRadius.flat};
   }
   
   &::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
Closes #1036

Part of flat-design epic #1040. Flattens text/search inputs and styled focus-ring radii on non-preserved components. Preserves Switch tracks, slider tracks paired with circular thumbs, AlbumArt, player panel, thumbnails, and 50% circles per CLAUDE.md flat-design rules.

Closes #1037
Closes #1038