### PR TITLE
test(visual): assert preserved surfaces retain rounded radii

### DIFF
--- a/src/components/__tests__/flatDesignInvariants.test.tsx
+++ b/src/components/__tests__/flatDesignInvariants.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for the flat-design migration (epic #1040, issue #1038).
+ *
+ * Asserts that surfaces explicitly preserved by the flat-design rules in
+ * CLAUDE.md retain a non-zero border-radius after the sweep:
+ *
+ *   - `AlbumArt` uses theme.borderRadius.xl
+ *   - `Switch` track uses theme.borderRadius.full (pill)
+ *   - `Switch` knob stays circular (border-radius: 50%)
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import Switch from '@/components/controls/Switch';
+import AlbumArt from '@/components/AlbumArt';
+import { makeTrack } from '@/test/fixtures';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  PlayerSizingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePlayerSizingContext: vi.fn(() => ({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    isTouchDevice: false,
+    hasPointerInput: true,
+    viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
+    dimensions: { width: 600, height: 600 },
+  })),
+}));
+
+vi.mock('@/hooks/useImageProcessingWorker', () => ({
+  useImageProcessingWorker: () => ({
+    processImage: vi.fn(() => new Promise(() => {})),
+  }),
+}));
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+describe('flat-design preserved surfaces', () => {
+  it('AlbumArt container retains the xl border-radius', () => {
+    // #given
+    const track = makeTrack();
+
+    // #when
+    const { container } = renderWithTheme(<AlbumArt currentTrack={track} />);
+    const albumArt = container.firstElementChild as HTMLElement;
+
+    // #then
+    expect(albumArt).toBeTruthy();
+    const computedRadius = window.getComputedStyle(albumArt).borderRadius;
+    expect(computedRadius).not.toBe('0px');
+    expect(computedRadius).not.toBe('');
+    expect(computedRadius).toBe(theme.borderRadius.xl);
+  });
+
+  it('Switch track keeps its pill shape via borderRadius.full', () => {
+    // #when
+    const { getByRole } = renderWithTheme(
+      <Switch on={false} onToggle={() => {}} ariaLabel="test" />,
+    );
+    const track = getByRole('switch');
+
+    // #then
+    const computedRadius = window.getComputedStyle(track).borderRadius;
+    expect(computedRadius).not.toBe('0px');
+    expect(computedRadius).toBe(theme.borderRadius.full);
+  });
+
+  it('Switch knob stays circular', () => {
+    // #when
+    const { getByRole } = renderWithTheme(
+      <Switch on={false} onToggle={() => {}} ariaLabel="test" />,
+    );
+    const knob = getByRole('switch').firstElementChild as HTMLElement;
+
+    // #then
+    expect(knob).toBeTruthy();
+    const computedRadius = window.getComputedStyle(knob).borderRadius;
+    expect(computedRadius).toBe('50%');
+  });
+});


### PR DESCRIPTION
Closes #1038

Part of flat-design epic #1040. Stacked on PR #1057 (#1037) and PR #1056 (#1036).

## Summary

Adds a single automated regression test asserting that surfaces explicitly preserved by the flat-design rules in `CLAUDE.md` retain a non-zero `border-radius` after the sweep:

- `AlbumArt` container uses `theme.borderRadius.xl` (12px)
- `Switch` track uses `theme.borderRadius.full` (pill)
- `Switch` knob stays circular (`border-radius: 50%`)

## Approach

Uses `window.getComputedStyle` on elements rendered inside a styled-components `ThemeProvider`. styled-components v6 injects CSS into the document head, and jsdom's `getComputedStyle` correctly resolves the `border-radius` declarations — no snapshot tooling required.

Mocks `usePlayerSizingContext` and `useImageProcessingWorker` so `AlbumArt` can mount without a full app shell (same pattern used by `LibraryNavigation.test.tsx`).

## Verification done

- \`npx tsc -b --noEmit\` — clean
- \`npm run test:run\` — 1012/1012 passing (3 new)
- Grep-verified preservation invariants before writing assertions:
  - \`AlbumArt.tsx\` still uses \`borderRadius.xl\`
  - \`PlayerContent/styled.ts\` still has non-zero radii on the panel beneath AlbumArt
  - \`Switch.tsx\` still uses \`borderRadius.full\` / \`50%\`

## Manual QA still required before release

This test covers the automatable slice of issue #1038. The full QA walkthrough from the issue checklist — visual verification across normal, zen, and mobile modes on the running dev server — must still be performed by a human before release.