### PR TITLE
fix(providers): surface active provider on session-expired screen

### DIFF
--- a/src/components/ProviderSetupScreen.tsx
+++ b/src/components/ProviderSetupScreen.tsx
@@ -136,6 +136,8 @@ const StatusBadge = styled.span<{ $status: 'connected' | 'expired' | 'idle' }>`
 `;
 
 const ConnectButton = styled.button<{ $accentColor: string }>`
+  appearance: none;
+  -webkit-appearance: none;
   padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.md};
   background: ${({ $accentColor }) => $accentColor};
   color: #fff;
@@ -312,10 +314,20 @@ export default function ProviderSetupScreen({ onOpenSettings, onOpenLibrary }: P
     );
   }
 
-  // All-expired reconnect screen: show each previously-enabled provider with status
+  // All-expired reconnect screen: show each previously-enabled provider with status.
   // The auto-fallthrough in ProviderContext handles the partial-expiry case,
   // so we only reach here when ALL enabled providers are expired.
-  const enabledProviders = providers.filter(p => enabledProviderIds.includes(p.id));
+  //
+  // The active provider is surfaced first even if it isn't in enabledProviderIds —
+  // otherwise a user who disabled their active provider after its session expired
+  // would see a "reconnect" card for a provider they weren't trying to use.
+  const expiredProviders = useMemo(() => {
+    const inEnabled = providers.filter(p => enabledProviderIds.includes(p.id));
+    if (activeDescriptor && !enabledProviderIds.includes(activeDescriptor.id)) {
+      return [activeDescriptor, ...inEnabled];
+    }
+    return inEnabled;
+  }, [providers, enabledProviderIds, activeDescriptor]);
 
   return (
     <Wrapper>
@@ -329,12 +341,12 @@ export default function ProviderSetupScreen({ onOpenSettings, onOpenLibrary }: P
           )}
         </CardHeader>
         <Subtitle>
-          {enabledProviders.length > 1
+          {expiredProviders.length > 1
             ? 'Your provider sessions have expired. Reconnect to continue listening.'
             : `Your ${activeDescriptor?.name ?? 'provider'} session has expired. Reconnect to continue listening.`}
         </Subtitle>
         <ProviderGrid>
-          {enabledProviders.map((descriptor) => {
+          {expiredProviders.map((descriptor) => {
             const meta = PROVIDER_META[descriptor.id] ?? { icon: '\u266A', accentColor: '#646cff', note: '' };
             const isAuthenticated = descriptor.auth.isAuthenticated();
             return (

--- a/src/components/__tests__/ProviderSetupScreen.test.tsx
+++ b/src/components/__tests__/ProviderSetupScreen.test.tsx
@@ -296,5 +296,44 @@ describe('ProviderSetupScreen', () => {
         screen.getByText(/Your Spotify session has expired/)
       ).toBeInTheDocument();
     });
+
+    it('surfaces the active provider even when it is not in enabledProviderIds', () => {
+      // #given — user was playing Spotify, disabled it, then its session expired
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+        activeDescriptor: spotifyDesc,
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+        enabledProviderIds: ['dropbox'],
+      });
+
+      // #when
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then — Spotify card is rendered so the user can reconnect the provider they were using
+      expect(screen.getByText('Spotify')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox')).toBeInTheDocument();
+      expect(screen.getAllByText('Reconnect')).toHaveLength(2);
+    });
+
+    it('does not duplicate the active provider when it is already in enabledProviderIds', () => {
+      // #given
+      const spotifyDesc = makeProviderDescriptor({ id: 'spotify', name: 'Spotify' });
+      const dropboxDesc = makeProviderDescriptor({ id: 'dropbox' as 'spotify', name: 'Dropbox' });
+      mockProviderContextValue = buildProviderContext({
+        chosenProviderId: 'spotify',
+        activeDescriptor: spotifyDesc,
+        registry: { getAll: () => [spotifyDesc, dropboxDesc] },
+        enabledProviderIds: ['spotify', 'dropbox'],
+      });
+
+      // #when
+      render(<Wrapper><ProviderSetupScreen /></Wrapper>);
+
+      // #then — exactly one card per provider, no duplicates
+      expect(screen.getAllByText('Spotify')).toHaveLength(1);
+      expect(screen.getAllByText('Dropbox')).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
Closes #1052

## Problems

Two bugs on the `ProviderSetupScreen` "Session Expired" branch:

1. **Wrong provider surfaced.** The expired-session card list was derived by filtering registered providers to `enabledProviderIds`. If a user had disabled the provider they were trying to use after its session expired, the overlay rendered a "Connect to \<other provider\>" card for a provider they weren't trying to use.
2. **Reconnect button rendered as a white rectangle on some platforms.** The `<button>` inherited browser UA chrome (Safari/iOS button bezel, macOS `buttonface` fill), visually replacing the styled background and making the white label text unreadable.

## Fixes

1. `ProviderSetupScreen.tsx` — derive the expired-session list as `activeDescriptor ∪ enabledProviderIds`, surfacing the active provider first when it isn't in the enabled set. Deduped so the active provider never appears twice.
2. `ProviderSetupScreen.tsx` — `ConnectButton` now sets `appearance: none; -webkit-appearance: none;` so the declared `background: accentColor` renders reliably across Safari/iOS/macOS.

## Tests

Two new cases in `ProviderSetupScreen.test.tsx`:

- `surfaces the active provider even when it is not in enabledProviderIds`
- `does not duplicate the active provider when it is already in enabledProviderIds`

All 20 tests pass in the `ProviderSetupScreen` suite; 1011/1011 pass in the full suite; `npx tsc -b --noEmit` and `npm run build` are clean.

## Acceptance criteria (from #1052)

- ✅ When a playback action fails due to the active provider's auth being missing, the overlay points the user at that provider even if it's outside `enabledProviderIds`.
- ✅ The Connect/Reconnect button renders with visible contrasting text on its accent-colored background across browsers.
- ➖ Criterion 3 (skip overlay entirely after auto-fallthrough succeeds) — already handled by existing `needsSetup` logic in `AudioPlayer.tsx`: when fallthrough produces a connected provider, `connectedProviderIds.length > 0` and the overlay does not render; only the toast is shown.

## Coordination note

`ProviderSetupScreen.tsx` is also modified on `epic/1040-flat-design` (styling-only: four `border-radius` declarations flip to `theme.borderRadius.flat`). These two PRs touch different lines but the same file — expect a small manual merge when the epic lands.