### PR TITLE
fix(auth): surface reconnect prompt when token refresh fails

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -192,7 +192,7 @@ const AudioPlayerComponent = () => {
     onReorderQueue: handlers.handleReorderQueue,
   }), [handlers, handleAlbumPlay, handlePlaylistSelect, handleOpenQuickAccessPanel]);
 
-  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification } = useProviderContext();
+  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt } = useProviderContext();
   // Setup is needed when no provider has been chosen yet and none are connected,
   // or when the active provider isn't authenticated and no other enabled provider is either.
   // connectedProviderIds is the subset of enabledProviderIds with valid auth.
@@ -389,6 +389,15 @@ const AudioPlayerComponent = () => {
         )}
         {fallthroughNotification && (
           <Toast message={fallthroughNotification} onDismiss={dismissFallthroughNotification} />
+        )}
+        {reconnectPrompt && (
+          <Toast
+            message={reconnectPrompt.message}
+            actionLabel="Reconnect"
+            onAction={acceptReconnectPrompt}
+            onDismiss={dismissReconnectPrompt}
+            persistent
+          />
         )}
         {needsSetup && (
           <>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -9,6 +9,8 @@ interface ToastProps {
   /** Optional text button (e.g. “View queue”) — does not dismiss on its own unless `onAction` does. */
   actionLabel?: string;
   onAction?: () => void;
+  /** When true, the toast does not auto-dismiss — the user must click the dismiss button or action. */
+  persistent?: boolean;
 }
 
 const slideIn = keyframes`
@@ -100,10 +102,11 @@ const DismissIcon = styled.button`
   }
 `;
 
-export default function Toast({ message, onDismiss, actionLabel, onAction }: ToastProps) {
+export default function Toast({ message, onDismiss, actionLabel, onAction, persistent = false }: ToastProps) {
   const [exiting, setExiting] = useState(false);
 
   useEffect(() => {
+    if (persistent) return;
     const displayDurationMs = 5000;
     const exitDurationMs = 300;
     const exitTimer = setTimeout(() => setExiting(true), displayDurationMs - exitDurationMs);
@@ -112,7 +115,7 @@ export default function Toast({ message, onDismiss, actionLabel, onAction }: Toa
       clearTimeout(exitTimer);
       clearTimeout(dismissTimer);
     };
-  }, [onDismiss]);
+  }, [onDismiss, persistent]);
 
   const handleDismiss = () => {
     setExiting(true);

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,1 +1,10 @@
 export const AUTH_COMPLETE_EVENT = 'vorbis-auth-complete';
+
+/**
+ * Dispatched on `window` when a provider's refresh token is rejected as
+ * permanently invalid (HTTP 400/401). Listeners should transition the
+ * provider to a disconnected state and surface a reconnect prompt.
+ *
+ * Event `detail` is `{ providerId: ProviderId }`.
+ */
+export const SESSION_EXPIRED_EVENT = 'vorbis-session-expired';

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -9,7 +9,7 @@ import '@/providers/spotify/spotifyProvider';
 import '@/providers/dropbox/dropboxProvider'; // conditionally registers if VITE_DROPBOX_CLIENT_ID is set
 import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 import { DROPBOX_AUTH_ERROR_EVENT } from '@/providers/dropbox/dropboxAuthAdapter';
-import { AUTH_COMPLETE_EVENT } from '@/constants/events';
+import { AUTH_COMPLETE_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { STORAGE_KEYS } from '@/constants/storage';
 
 type ProviderSwitchInterceptor = (
@@ -53,6 +53,13 @@ interface ProviderContextValue {
   fallthroughNotification: string | null;
   /** Dismiss the fallthrough notification. */
   dismissFallthroughNotification: () => void;
+
+  /** Reconnect prompt shown when a provider's refresh token is rejected (400/401). Persists until acted upon. */
+  reconnectPrompt: { providerId: ProviderId; message: string } | null;
+  /** Trigger the OAuth flow for the provider with a pending reconnect prompt. */
+  acceptReconnectPrompt: () => void;
+  /** Dismiss the reconnect prompt without reconnecting. */
+  dismissReconnectPrompt: () => void;
 }
 
 const ProviderContext =
@@ -151,6 +158,43 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   // ── Auto-fallthrough notification ─────────────────────────────────────
   const [fallthroughNotification, setFallthroughNotification] = useState<string | null>(null);
   const dismissFallthroughNotification = useCallback(() => setFallthroughNotification(null), []);
+
+  // ── Session-expired reconnect prompt ─────────────────────────────────
+  const [reconnectPrompt, setReconnectPrompt] = useState<{ providerId: ProviderId; message: string } | null>(null);
+
+  useEffect(() => {
+    const handleSessionExpired = (event: Event) => {
+      const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
+      const providerId = detail?.providerId;
+      if (!providerId) return;
+      const descriptor = providerRegistry.get(providerId);
+      const name = descriptor?.name ?? providerId;
+      setReconnectPrompt(prev => {
+        if (prev?.providerId === providerId) return prev;
+        return {
+          providerId,
+          message: `Your ${name} session has expired. Tap to reconnect.`,
+        };
+      });
+      setAuthRevision(prev => prev + 1);
+    };
+
+    window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+    return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+  }, []);
+
+  const dismissReconnectPrompt = useCallback(() => setReconnectPrompt(null), []);
+
+  const acceptReconnectPrompt = useCallback(() => {
+    setReconnectPrompt(current => {
+      if (!current) return null;
+      const descriptor = providerRegistry.get(current.providerId);
+      descriptor?.auth.beginLogin({ popup: true }).catch(error => {
+        console.warn('[ProviderContext] Failed to begin login for reconnect:', error);
+      });
+      return null;
+    });
+  }, []);
 
   // ── Active provider (for playback) ─────────────────────────────────────
   const needsProviderSelection =
@@ -254,10 +298,13 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       connectedProviderIds,
       fallthroughNotification,
       dismissFallthroughNotification,
+      reconnectPrompt,
+      acceptReconnectPrompt,
+      dismissReconnectPrompt,
     }),
     // authRevision triggers re-evaluation when a popup completes OAuth
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, authRevision],
+    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, authRevision],
   );
 
   return (

--- a/src/providers/dropbox/__tests__/dropboxAuthAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxAuthAdapter.test.ts
@@ -325,6 +325,56 @@ describe('DropboxAuthAdapter', () => {
       expect(result).toBeNull();
       expect(localStorageMock.getItem('vorbis-player-dropbox-refresh-token')).toBe('my-refresh');
     });
+
+    it('emits SESSION_EXPIRED_EVENT on 401 (invalid grant)', async () => {
+      // #given
+      const adapter = await freshAdapter({
+        'vorbis-player-dropbox-token': 'old-token',
+        'vorbis-player-dropbox-refresh-token': 'my-refresh',
+      });
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      }));
+
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      await adapter.refreshAccessToken();
+
+      // #then
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('single-flights concurrent refresh calls into one fetch', async () => {
+      // #given
+      const adapter = await freshAdapter({
+        'vorbis-player-dropbox-token': 'old-token',
+        'vorbis-player-dropbox-refresh-token': 'my-refresh',
+      });
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'fresh-token', expires_in: 3600 }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      // #when
+      const [a, b, c] = await Promise.all([
+        adapter.refreshAccessToken(),
+        adapter.refreshAccessToken(),
+        adapter.refreshAccessToken(),
+      ]);
+
+      // #then
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(a).toBe('fresh-token');
+      expect(b).toBe('fresh-token');
+      expect(c).toBe('fresh-token');
+    });
   });
 
   describe('logout', () => {

--- a/src/providers/dropbox/dropboxAuthAdapter.ts
+++ b/src/providers/dropbox/dropboxAuthAdapter.ts
@@ -6,10 +6,19 @@
 import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { resetPlaylistsFolderCache } from './dropboxPlaylistStorage';
 import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
 
 export const DROPBOX_AUTH_ERROR_EVENT = 'vorbis-dropbox-auth-error';
+
+function notifyDropboxSessionExpired(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(DROPBOX_AUTH_ERROR_EVENT));
+  window.dispatchEvent(
+    new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'dropbox' } }),
+  );
+}
 
 function getDropboxClientId(): string {
   return import.meta.env.VITE_DROPBOX_CLIENT_ID ?? '';
@@ -51,6 +60,7 @@ export class DropboxAuthAdapter implements AuthProvider {
   private accessToken: string | null = null;
   private refreshToken: string | null = null;
   private tokenExpiresAt: number | null = null;
+  private refreshInFlight: Promise<string | null> | null = null;
 
   constructor() {
     this.accessToken = localStorage.getItem(STORAGE_KEYS.DROPBOX_TOKEN);
@@ -214,11 +224,22 @@ export class DropboxAuthAdapter implements AuthProvider {
     if (!this.accessToken && !this.refreshToken) return;
     console.warn('[DropboxAuth] Persistent 401 after token refresh — logging out');
     this.logout();
-    window.dispatchEvent(new CustomEvent(DROPBOX_AUTH_ERROR_EVENT));
+    notifyDropboxSessionExpired();
   }
 
-  /** Refresh the access token using the stored refresh token. */
+  /** Refresh the access token using the stored refresh token. Single-flight: concurrent callers share one request. */
   async refreshAccessToken(): Promise<string | null> {
+    if (this.refreshInFlight) {
+      return this.refreshInFlight;
+    }
+
+    this.refreshInFlight = this.performRefresh().finally(() => {
+      this.refreshInFlight = null;
+    });
+    return this.refreshInFlight;
+  }
+
+  private async performRefresh(): Promise<string | null> {
     if (!this.refreshToken || !getDropboxClientId()) return null;
 
     const body = new URLSearchParams({
@@ -235,7 +256,6 @@ export class DropboxAuthAdapter implements AuthProvider {
         body: body.toString(),
       });
     } catch (error) {
-      // Network error — preserve refresh token for future retry.
       console.warn('[DropboxAuth] Token refresh network error:', error);
       this.clearAccessToken();
       return null;
@@ -244,10 +264,9 @@ export class DropboxAuthAdapter implements AuthProvider {
     if (!response.ok) {
       console.warn('[DropboxAuth] Token refresh failed:', response.status);
       if (response.status === 400 || response.status === 401) {
-        // Invalid or revoked grant — full logout.
         this.logout();
+        notifyDropboxSessionExpired();
       } else {
-        // Transient failure — clear access token but keep refresh token for retry.
         this.clearAccessToken();
       }
       return null;

--- a/src/services/__tests__/spotifyAuth.test.ts
+++ b/src/services/__tests__/spotifyAuth.test.ts
@@ -205,6 +205,108 @@ describe('SpotifyAuth', () => {
       // #when / #then
       await expect(auth.refreshAccessToken()).rejects.toThrow('Token refresh failed');
     });
+
+    it('logs out and emits SESSION_EXPIRED_EVENT on 401 refresh', async () => {
+      // #given
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+
+      mockFetchResponse({}, 401);
+
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      await expect(auth.refreshAccessToken()).rejects.toThrow('Token refresh failed');
+
+      // #then
+      expect(localStorage.removeItem).toHaveBeenCalledWith('spotify_token');
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('logs out and emits SESSION_EXPIRED_EVENT on 400 refresh', async () => {
+      // #given
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+
+      mockFetchResponse({}, 400);
+
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      await expect(auth.refreshAccessToken()).rejects.toThrow('Token refresh failed');
+
+      // #then
+      expect(localStorage.removeItem).toHaveBeenCalledWith('spotify_token');
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('preserves refresh token on 5xx (transient) — no logout, no event', async () => {
+      // #given
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+
+      mockFetchResponse({}, 500);
+
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      await expect(auth.refreshAccessToken()).rejects.toThrow('Token refresh failed');
+
+      // #then
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith('spotify_token');
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).not.toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('single-flights concurrent refresh calls into one fetch', async () => {
+      // #given
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+
+      mockFetchResponse({
+        access_token: 'new-token',
+        refresh_token: 'new-refresh',
+        expires_in: 3600,
+      });
+
+      // #when
+      const [a, b, c] = await Promise.all([
+        auth.refreshAccessToken(),
+        auth.refreshAccessToken(),
+        auth.refreshAccessToken(),
+      ]);
+
+      // #then
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(a).toBeUndefined();
+      expect(b).toBeUndefined();
+      expect(c).toBeUndefined();
+    });
   });
 
   describe('handleAuthCallback', () => {

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -1,4 +1,5 @@
 import type { TokenData } from './types';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 
 const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 
@@ -30,6 +31,7 @@ const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 class SpotifyAuth {
   private tokenData: TokenData | null = null;
+  private refreshInFlight: Promise<void> | null = null;
 
   constructor() {
     this.loadTokenFromStorage();
@@ -140,6 +142,17 @@ class SpotifyAuth {
   }
 
   public async refreshAccessToken(): Promise<void> {
+    if (this.refreshInFlight) {
+      return this.refreshInFlight;
+    }
+
+    this.refreshInFlight = this.performRefresh().finally(() => {
+      this.refreshInFlight = null;
+    });
+    return this.refreshInFlight;
+  }
+
+  private async performRefresh(): Promise<void> {
     if (!this.tokenData?.refresh_token) {
       throw new Error('No refresh token available');
     }
@@ -159,6 +172,10 @@ class SpotifyAuth {
     });
 
     if (!response.ok) {
+      if (response.status === 400 || response.status === 401) {
+        this.logout();
+        this.notifySessionExpired();
+      }
       throw new Error(`Token refresh failed: ${response.statusText}`);
     }
 
@@ -168,6 +185,13 @@ class SpotifyAuth {
       refresh_token: data.refresh_token || this.tokenData.refresh_token,
       expires_at: Date.now() + data.expires_in * 1000,
     });
+  }
+
+  private notifySessionExpired(): void {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(
+      new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+    );
   }
 
   public async ensureValidToken(): Promise<string> {


### PR DESCRIPTION
Closes #1061

## What changed

- Introduced a shared `SESSION_EXPIRED_EVENT` fired when a provider's stored refresh token is rejected as permanently invalid (HTTP 400/401).
- **Spotify (`src/services/spotify/auth.ts`)**: classify 400/401 on `/api/token` refresh as session expiry. Clear tokens, emit the event, then throw. Preserve the refresh token on 5xx/network errors.
- **Dropbox (`src/providers/dropbox/dropboxAuthAdapter.ts`)**: emit the same `SESSION_EXPIRED_EVENT` on 400/401 (already performs full logout). Kept existing `DROPBOX_AUTH_ERROR_EVENT` for back-compat.
- **Single-flight refresh** on both providers: concurrent callers share one in-flight refresh promise, so only one logout + notification fires per expired session.
- **Reconnect prompt in `ProviderContext`**: listens for `SESSION_EXPIRED_EVENT` and exposes `reconnectPrompt`, `acceptReconnectPrompt`, and `dismissReconnectPrompt`. `AudioPlayer` renders the prompt as a persistent `Toast` with a "Reconnect" action that triggers the provider's OAuth popup.
- **`Toast`** gains a `persistent` prop so auth prompts don't auto-dismiss while the user is away from the screen.

## Testing

- `npx tsc -b --noEmit` — no new errors (pre-existing `html2canvas` type error unchanged).
- `npm run test:run` — all 1017 tests pass.
- New unit tests cover:
  - Spotify 400 and 401 paths (logout + event emission)
  - Spotify 5xx path (refresh token preserved, no event)
  - Spotify single-flight (3 concurrent calls → 1 fetch)
  - Dropbox 401 path emits `SESSION_EXPIRED_EVENT`
  - Dropbox single-flight (3 concurrent calls → 1 fetch)
- `npm run build` succeeds.