### PR TITLE
feat(controls): add TrackRadioPopover component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 - `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
 - Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated.
 - Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
+- **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
 
 #### Provider Implementation Details
 

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -5,6 +5,7 @@ import AlbumArt from '@/components/AlbumArt';
 import AlbumArtQuickSwapBack from '@/components/AlbumArtQuickSwapBack';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
 import { ProviderBadge } from '@/components/ProviderBadge';
+import { TrackRadioPopover } from '@/components/controls/TrackRadioPopover';
 import { useColorContext } from '@/contexts/ColorContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useProviderContext } from '@/contexts/ProviderContext';
@@ -23,6 +24,25 @@ const ZenProviderBadgeInline = styled.span`
   margin-left: ${({ theme }) => theme.spacing.sm};
   position: relative;
   top: -1px;
+`;
+
+const ZenTrackNameTrigger = styled.button`
+  display: inline;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-shadow: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.white};
+    outline-offset: 2px;
+    border-radius: ${({ theme }) => theme.borderRadius.sm};
+  }
 `;
 
 interface AlbumArtBounds {
@@ -54,6 +74,8 @@ interface AlbumArtSectionProps {
   canSaveTrack: boolean;
   onLikeToggle: () => void;
   flipToggleRef?: React.MutableRefObject<(() => void) | null>;
+  isRadioAvailable?: boolean;
+  onStartRadio?: () => void;
 }
 
 export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
@@ -78,6 +100,8 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   canSaveTrack,
   onLikeToggle,
   flipToggleRef,
+  isRadioAvailable,
+  onStartRadio,
 }) => {
   const { connectedProviderIds } = useProviderContext();
 
@@ -117,6 +141,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
 
   const [isFlipped, setIsFlipped] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const [radioPopoverAnchor, setRadioPopoverAnchor] = useState<DOMRect | null>(null);
   const flipContainerRef = useRef<HTMLDivElement>(null);
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -200,8 +225,23 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   useEffect(() => {
     if (!zenModeEnabled) {
       setIsHovered(false);
+      setRadioPopoverAnchor(null);
     }
   }, [zenModeEnabled]);
+
+  const handleTrackNameClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (!onStartRadio || !isRadioAvailable) return;
+    setRadioPopoverAnchor(e.currentTarget.getBoundingClientRect());
+  }, [onStartRadio, isRadioAvailable]);
+
+  const handleCloseRadioPopover = useCallback(() => {
+    setRadioPopoverAnchor(null);
+  }, []);
+
+  const handlePlayRadio = useCallback(() => {
+    onStartRadio?.();
+  }, [onStartRadio]);
 
   useEffect(() => {
     if (!isFlipped) return;
@@ -354,7 +394,13 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
       </CardContent>
       <ZenTrackInfo $zenMode={zenModeEnabled}>
         <ZenTrackName $isMobile={isMobile} $isTablet={isTablet}>
-          {currentTrack?.name}
+          {currentTrack?.name && zenModeEnabled && isRadioAvailable && onStartRadio ? (
+            <ZenTrackNameTrigger type="button" onClick={handleTrackNameClick}>
+              {currentTrack.name}
+            </ZenTrackNameTrigger>
+          ) : (
+            currentTrack?.name
+          )}
           {zenModeEnabled && connectedProviderIds.length > 1 && currentTrackProvider != null && (
             <ZenProviderBadgeInline>
               <ProviderBadge providerId={currentTrackProvider} iconOnly />
@@ -365,6 +411,14 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
         )}
       </ZenTrackInfo>
+      {zenModeEnabled && radioPopoverAnchor && currentTrack?.name && (
+        <TrackRadioPopover
+          trackName={currentTrack.name}
+          anchorRect={radioPopoverAnchor}
+          onClose={handleCloseRadioPopover}
+          onPlayRadio={handlePlayRadio}
+        />
+      )}
     </>
   );
 });

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -314,6 +314,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
                     onPrevious={onPrevious}
                     onArtistBrowse={onArtistBrowse}
                     onAlbumPlay={onAlbumPlay}
+                    onPlayRadio={isRadioAvailable ? onStartRadio : undefined}
                     currentTrackProvider={currentTrackProvider}
                   />
                 </ProfiledComponent>

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -206,6 +206,8 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
             canSaveTrack={canSaveTrack}
             onLikeToggle={handleLikeToggle}
             flipToggleRef={flipToggleRef}
+            isRadioAvailable={isRadioAvailable}
+            onStartRadio={handlers.onStartRadio}
           />
           <PlayerControlsSection
             currentTrack={currentTrack}

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -23,6 +23,7 @@ interface SpotifyPlayerControlsProps {
   onToggleLike?: () => void;
   onArtistBrowse?: (artistName: string) => void;
   onAlbumPlay?: (albumId: string, albumName: string) => void;
+  onPlayRadio?: () => void;
   currentTrackProvider?: ProviderId;
 }
 
@@ -38,6 +39,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   onToggleLike: propOnToggleLike,
   onArtistBrowse,
   onAlbumPlay,
+  onPlayRadio,
   currentTrackProvider,
 }) => {
   // Get responsive sizing information
@@ -85,6 +87,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         isTablet={isTablet}
         onArtistBrowse={onArtistBrowse}
         onAlbumPlay={onAlbumPlay}
+        onPlayRadio={onPlayRadio}
       />
 
       <div style={{ display: 'flex', justifyContent: 'center', width: '100%', gap: '0.5rem' }}>

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -5,6 +5,7 @@ import { useProviderContext } from '../../contexts/ProviderContext';
 import { librarySyncEngine } from '../../services/cache/librarySyncEngine';
 import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 import TrackInfoPopover, { LibraryIcon, SpotifyIcon, PlayIcon, DiscogsIcon, AddToLibraryIcon, RemoveFromLibraryIcon, ICON_MAP } from './TrackInfoPopover';
+import TrackRadioPopover from './TrackRadioPopover';
 
 interface TrackInfoProps {
     track: {
@@ -20,6 +21,7 @@ interface TrackInfoProps {
     isTablet: boolean;
     onArtistBrowse?: (artistName: string) => void;
     onAlbumPlay?: (albumId: string, albumName: string) => void;
+    onPlayRadio?: () => void;
 }
 
 // Custom comparison function for memo optimization
@@ -36,16 +38,18 @@ const areTrackInfoPropsEqual = (
         prevProps.isMobile === nextProps.isMobile &&
         prevProps.isTablet === nextProps.isTablet &&
         prevProps.onArtistBrowse === nextProps.onArtistBrowse &&
-        prevProps.onAlbumPlay === nextProps.onAlbumPlay
+        prevProps.onAlbumPlay === nextProps.onAlbumPlay &&
+        prevProps.onPlayRadio === nextProps.onPlayRadio
     );
 };
 
 type PopoverState =
     | { type: 'artist'; artistName: string; artistUrl: string; rect: DOMRect }
     | { type: 'album'; albumId: string; albumName: string; rect: DOMRect }
+    | { type: 'radio'; trackName: string; rect: DOMRect }
     | null;
 
-const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBrowse, onAlbumPlay }) => {
+const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBrowse, onAlbumPlay, onPlayRadio }) => {
     const [popover, setPopover] = useState<PopoverState>(null);
     const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
     const artistRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -88,6 +92,21 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
         const rect = target.getBoundingClientRect();
         setPopover({ type: 'album', albumId: track.albumId, albumName: track.album, rect });
     }, [track?.albumId, track?.album]);
+
+    const handleTrackNameClick = useCallback((e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!track?.name || !onPlayRadio) return;
+        const target = e.currentTarget as HTMLElement;
+        const rect = target.getBoundingClientRect();
+        setPopover({ type: 'radio', trackName: track.name, rect });
+    }, [track?.name, onPlayRadio]);
+
+    const handlePlayRadio = useCallback(() => {
+        if (!onPlayRadio) return;
+        onPlayRadio();
+        setPopover(null);
+    }, [onPlayRadio]);
 
     const hasExternalLink = capabilities?.hasExternalLink ?? false;
     const providerName = capabilities?.externalLinkLabel?.replace('Open in ', '') ?? trackDescriptor?.name ?? 'External';
@@ -243,21 +262,45 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
     };
 
     const popoverContent = popover && createPortal(
-        <TrackInfoPopover
-            type={popover.type}
-            anchorRect={popover.rect}
-            onClose={closePopover}
-            options={popover.type === 'artist' ? buildArtistOptions() : buildAlbumOptions()}
-        />,
+        popover.type === 'radio' ? (
+            <TrackRadioPopover
+                trackName={popover.trackName}
+                anchorRect={popover.rect}
+                onClose={closePopover}
+                onPlayRadio={handlePlayRadio}
+            />
+        ) : (
+            <TrackInfoPopover
+                type={popover.type}
+                anchorRect={popover.rect}
+                onClose={closePopover}
+                options={popover.type === 'artist' ? buildArtistOptions() : buildAlbumOptions()}
+            />
+        ),
         document.body
     );
+
+    const trackNameContent = track?.name || 'No track selected';
+    const isTrackNameClickable = Boolean(onPlayRadio && track?.name);
 
     return (
         <>
             <TrackInfoOnlyRow $compact={isMobile || isTablet}>
-                <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
-                    {track?.name || 'No track selected'}
-                </PlayerTrackName>
+                {isTrackNameClickable ? (
+                    <PlayerTrackName
+                        as="button"
+                        type="button"
+                        onClick={handleTrackNameClick}
+                        $isMobile={isMobile}
+                        $isTablet={isTablet}
+                    >
+                        {trackNameContent}
+                    </PlayerTrackName>
+                ) : (
+                    <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
+                        {trackNameContent}
+                    </PlayerTrackName>
+                )}
                 {track?.album && (
                     <PlayerTrackAlbum>{renderAlbum()}</PlayerTrackAlbum>
                 )}

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -8,6 +8,8 @@ interface PopoverOption {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
+  disabled?: boolean;
+  title?: string;
 }
 
 interface TrackInfoPopoverProps {
@@ -51,28 +53,32 @@ const PopoverContainer = styled.div<{ $x: number; $y: number }>`
   }
 `;
 
-const OptionButton = styled.button`
+const OptionButton = styled.button<{ $disabled?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.625rem;
   width: 100%;
+  min-height: 44px;
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: none;
   border: none;
-  color: ${({ theme }) => theme.colors.foreground};
+  color: ${({ theme, $disabled }) => ($disabled ? theme.colors.muted.foreground : theme.colors.foreground)};
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   transition: background ${({ theme }) => theme.transitions.fast} ease;
   white-space: nowrap;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.control.background};
+    background: ${({ theme, $disabled }) =>
+      $disabled ? 'transparent' : theme.colors.control.background};
   }
 
   &:active {
-    background: ${({ theme }) => theme.colors.control.backgroundHover};
+    background: ${({ theme, $disabled }) =>
+      $disabled ? 'transparent' : theme.colors.control.backgroundHover};
   }
 
   svg {
@@ -106,7 +112,11 @@ function TrackInfoPopover({ options, anchorRect, onClose }: TrackInfoPopoverProp
         {options.map((option, index) => (
           <OptionButton
             key={index}
+            $disabled={option.disabled}
+            aria-disabled={option.disabled ? 'true' : undefined}
+            title={option.title}
             onClick={() => {
+              if (option.disabled) return;
               option.onClick();
               onClose();
             }}

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 import { theme } from '../../styles/theme';
 
-type PopoverType = 'artist' | 'album' | 'playlist';
+type PopoverType = 'artist' | 'album' | 'playlist' | 'radio';
 
 interface PopoverOption {
   label: string;

--- a/src/components/controls/TrackRadioPopover.tsx
+++ b/src/components/controls/TrackRadioPopover.tsx
@@ -1,11 +1,23 @@
 import TrackInfoPopover from './TrackInfoPopover';
 import { RadioIcon } from '../icons/QuickActionIcons';
 
+const DEFAULT_TRUNCATE_LEN = 32;
+const DEFAULT_DISABLED_REASON =
+  'Radio is unavailable. Configure VITE_LASTFM_API_KEY.';
+
+export function truncateTrackName(name: string, maxLen = DEFAULT_TRUNCATE_LEN): string {
+  if (maxLen <= 0) return '';
+  if (name.length <= maxLen) return name;
+  return `${name.slice(0, maxLen).trimEnd()}…`;
+}
+
 export interface TrackRadioPopoverProps {
   trackName: string;
   anchorRect: DOMRect | null;
   onClose: () => void;
   onPlayRadio: () => void;
+  isAvailable?: boolean;
+  disabledReason?: string;
 }
 
 export function TrackRadioPopover({
@@ -13,7 +25,13 @@ export function TrackRadioPopover({
   anchorRect,
   onClose,
   onPlayRadio,
+  isAvailable = true,
+  disabledReason = DEFAULT_DISABLED_REASON,
 }: TrackRadioPopoverProps): JSX.Element {
+  const truncated = truncateTrackName(trackName);
+  const label = `Play ${truncated} Radio`;
+  const title = isAvailable ? trackName : disabledReason;
+
   return (
     <TrackInfoPopover
       type="radio"
@@ -21,9 +39,11 @@ export function TrackRadioPopover({
       onClose={onClose}
       options={[
         {
-          label: `Play ${trackName} Radio`,
+          label,
           icon: <RadioIcon />,
           onClick: onPlayRadio,
+          disabled: !isAvailable,
+          title,
         },
       ]}
     />

--- a/src/components/controls/TrackRadioPopover.tsx
+++ b/src/components/controls/TrackRadioPopover.tsx
@@ -1,0 +1,33 @@
+import TrackInfoPopover from './TrackInfoPopover';
+import { RadioIcon } from '../icons/QuickActionIcons';
+
+export interface TrackRadioPopoverProps {
+  trackName: string;
+  anchorRect: DOMRect | null;
+  onClose: () => void;
+  onPlayRadio: () => void;
+}
+
+export function TrackRadioPopover({
+  trackName,
+  anchorRect,
+  onClose,
+  onPlayRadio,
+}: TrackRadioPopoverProps): JSX.Element {
+  return (
+    <TrackInfoPopover
+      type="radio"
+      anchorRect={anchorRect}
+      onClose={onClose}
+      options={[
+        {
+          label: `Play ${trackName} Radio`,
+          icon: <RadioIcon />,
+          onClick: onPlayRadio,
+        },
+      ]}
+    />
+  );
+}
+
+export default TrackRadioPopover;

--- a/src/components/controls/__tests__/TrackRadioPopover.test.tsx
+++ b/src/components/controls/__tests__/TrackRadioPopover.test.tsx
@@ -1,0 +1,265 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import {
+  TrackRadioPopover,
+  truncateTrackName,
+} from '../TrackRadioPopover';
+
+function makeAnchorRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  const base = {
+    x: 100,
+    y: 200,
+    left: 100,
+    top: 200,
+    right: 140,
+    bottom: 220,
+    width: 40,
+    height: 20,
+    toJSON: () => ({}),
+  };
+  return { ...base, ...overrides } as DOMRect;
+}
+
+interface RenderOverrides {
+  trackName?: string;
+  anchorRect?: DOMRect | null;
+  onClose?: () => void;
+  onPlayRadio?: () => void;
+  isAvailable?: boolean;
+  disabledReason?: string;
+}
+
+function renderPopover(overrides: RenderOverrides = {}) {
+  const props = {
+    trackName: overrides.trackName ?? 'Dreams',
+    anchorRect:
+      overrides.anchorRect === undefined ? makeAnchorRect() : overrides.anchorRect,
+    onClose: overrides.onClose ?? vi.fn(),
+    onPlayRadio: overrides.onPlayRadio ?? vi.fn(),
+    isAvailable: overrides.isAvailable,
+    disabledReason: overrides.disabledReason,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <TrackRadioPopover {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('truncateTrackName', () => {
+  it('returns the input unchanged when below the default limit', () => {
+    // #given
+    const name = 'Short Track';
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe('Short Track');
+  });
+
+  it('returns the input unchanged when exactly at the default limit', () => {
+    // #given
+    const name = 'a'.repeat(32);
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe(name);
+    expect(result).toHaveLength(32);
+  });
+
+  it('truncates with an ellipsis when longer than the default limit', () => {
+    // #given
+    const name = 'a'.repeat(33);
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe(`${'a'.repeat(32)}…`);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('respects a custom maxLen', () => {
+    // #given
+    const name = 'abcdefghij';
+
+    // #when
+    const result = truncateTrackName(name, 5);
+
+    // #then
+    expect(result).toBe('abcde…');
+  });
+
+  it('strips trailing whitespace before the ellipsis', () => {
+    // #given
+    const name = 'hello world more text here';
+
+    // #when
+    const result = truncateTrackName(name, 6);
+
+    // #then
+    expect(result).toBe('hello…');
+    expect(result).not.toContain(' …');
+  });
+
+  it('returns an empty string when given an empty string', () => {
+    // #when
+    const result = truncateTrackName('');
+
+    // #then
+    expect(result).toBe('');
+  });
+
+  it('returns an empty string when maxLen is zero or negative', () => {
+    // #when / #then
+    expect(truncateTrackName('anything', 0)).toBe('');
+    expect(truncateTrackName('anything', -1)).toBe('');
+  });
+});
+
+describe('TrackRadioPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Play {trackName} Radio" option when available', () => {
+    // #when
+    renderPopover({ trackName: 'Dreams' });
+
+    // #then
+    expect(screen.getByText('Play Dreams Radio')).toBeInTheDocument();
+  });
+
+  it('renders the option when isAvailable is omitted (defaults to true)', () => {
+    // #when
+    renderPopover({ trackName: 'Dreams', isAvailable: undefined });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play Dreams Radio/ });
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('truncates long track names in the visible label', () => {
+    // #given
+    const longName = 'A'.repeat(40);
+
+    // #when
+    renderPopover({ trackName: longName });
+
+    // #then
+    const truncated = `${'A'.repeat(32)}…`;
+    expect(screen.getByText(`Play ${truncated} Radio`)).toBeInTheDocument();
+  });
+
+  it('preserves the full track name in the title attribute when available', () => {
+    // #given
+    const longName = 'A'.repeat(40);
+
+    // #when
+    renderPopover({ trackName: longName });
+
+    // #then
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('title', longName);
+  });
+
+  it('fires onPlayRadio and onClose when the option is clicked', () => {
+    // #given
+    const onPlayRadio = vi.fn();
+    const onClose = vi.fn();
+    renderPopover({ onPlayRadio, onClose });
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: /Play .* Radio/ }));
+
+    // #then
+    expect(onPlayRadio).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire onPlayRadio when isAvailable is false', () => {
+    // #given
+    const onPlayRadio = vi.fn();
+    const onClose = vi.fn();
+    renderPopover({ onPlayRadio, onClose, isAvailable: false });
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: /Play .* Radio/ }));
+
+    // #then
+    expect(onPlayRadio).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('marks the option as aria-disabled when isAvailable is false', () => {
+    // #when
+    renderPopover({ isAvailable: false });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('surfaces the default disabled reason via the title attribute when disabled', () => {
+    // #when
+    renderPopover({ isAvailable: false });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute(
+      'title',
+      'Radio is unavailable. Configure VITE_LASTFM_API_KEY.',
+    );
+  });
+
+  it('surfaces a custom disabledReason via the title attribute when disabled', () => {
+    // #given
+    const disabledReason = 'Please sign in to use radio.';
+
+    // #when
+    renderPopover({ isAvailable: false, disabledReason });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute('title', disabledReason);
+  });
+
+  it('renders nothing when anchorRect is null', () => {
+    // #when
+    const { container } = renderPopover({ anchorRect: null });
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('button', { name: /Play .* Radio/ })).toBeNull();
+  });
+
+  it('closes when the Escape key is pressed', () => {
+    // #given
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+
+    // #when
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // #then
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not close on unrelated keydown events', () => {
+    // #given
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+
+    // #when
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    // #then
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -85,6 +85,17 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
   position: relative;
   z-index: 11;
   text-shadow: ${({ theme }) => theme.shadows.textMd};
+
+  /* Reset button-specific styles when rendered as a button (as="button") */
+  &:where(button) {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    text-align: inherit;
+    cursor: pointer;
+  }
 `;
 
 export const PlayerTrackAlbum = styled.div`


### PR DESCRIPTION
Closes #885

Part of epic #893.

## What changed

- Extends `TrackInfoPopover` `PopoverType` union with `'radio'`.
- Adds `TrackRadioPopover` — a thin wrapper around `TrackInfoPopover` that takes `trackName`, `anchorRect`, `onClose`, `onPlayRadio` and renders a single "Play {trackName} Radio" option with `RadioIcon` (already defined in `QuickActionIcons`).

### Architectural decision

Chose to wrap (not inline) the generic popover: keeps the "Play {trackName} Radio" option construction in one place and mirrors how the issue framed it (`TrackRadioPopover component`). The underlying `TrackInfoPopover` stayed generic — it now accepts `'radio'` in its discriminator but otherwise unchanged. Consumers in #886 / #887 will pass `onPlayRadio` as a callback, keeping radio-generation logic (`useRadio` / `radioService`) out of this component.

## Scope

This PR lands only the popover component. Integration into `TrackInfo` (#886) and zen mode (#887), disabled-state / tooltip (#888), truncation (#889), styling polish (#890), tests (#891), and docs (#892) are all separate follow-ups in the epic.

## Testing

- `npx tsc -b --noEmit` clean
- `npm run test:run` — 1017/1017 pass (11s)
- No new tests added (reserved for #891)

Closes #888
Closes #889
Closes #890
Closes #891
Closes #892
Closes #886
Closes #887