### PR TITLE
feat(controls): disabled state, truncation & polish for TrackRadioPopover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 - `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
 - Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated.
 - Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
+- **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
 
 #### Provider Implementation Details
 

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -8,6 +8,8 @@ interface PopoverOption {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
+  disabled?: boolean;
+  title?: string;
 }
 
 interface TrackInfoPopoverProps {
@@ -51,28 +53,32 @@ const PopoverContainer = styled.div<{ $x: number; $y: number }>`
   }
 `;
 
-const OptionButton = styled.button`
+const OptionButton = styled.button<{ $disabled?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.625rem;
   width: 100%;
+  min-height: 44px;
   padding: ${({ theme }) => theme.spacing.sm} ${theme.spacing.lg};
   background: none;
   border: none;
-  color: ${({ theme }) => theme.colors.foreground};
+  color: ${({ theme, $disabled }) => ($disabled ? theme.colors.muted.foreground : theme.colors.foreground)};
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   transition: background ${({ theme }) => theme.transitions.fast} ease;
   white-space: nowrap;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.control.background};
+    background: ${({ theme, $disabled }) =>
+      $disabled ? 'transparent' : theme.colors.control.background};
   }
 
   &:active {
-    background: ${({ theme }) => theme.colors.control.backgroundHover};
+    background: ${({ theme, $disabled }) =>
+      $disabled ? 'transparent' : theme.colors.control.backgroundHover};
   }
 
   svg {
@@ -106,7 +112,11 @@ function TrackInfoPopover({ options, anchorRect, onClose }: TrackInfoPopoverProp
         {options.map((option, index) => (
           <OptionButton
             key={index}
+            $disabled={option.disabled}
+            aria-disabled={option.disabled ? 'true' : undefined}
+            title={option.title}
             onClick={() => {
+              if (option.disabled) return;
               option.onClick();
               onClose();
             }}

--- a/src/components/controls/TrackRadioPopover.tsx
+++ b/src/components/controls/TrackRadioPopover.tsx
@@ -1,11 +1,23 @@
 import TrackInfoPopover from './TrackInfoPopover';
 import { RadioIcon } from '../icons/QuickActionIcons';
 
+const DEFAULT_TRUNCATE_LEN = 32;
+const DEFAULT_DISABLED_REASON =
+  'Radio is unavailable. Configure VITE_LASTFM_API_KEY.';
+
+export function truncateTrackName(name: string, maxLen = DEFAULT_TRUNCATE_LEN): string {
+  if (maxLen <= 0) return '';
+  if (name.length <= maxLen) return name;
+  return `${name.slice(0, maxLen).trimEnd()}…`;
+}
+
 export interface TrackRadioPopoverProps {
   trackName: string;
   anchorRect: DOMRect | null;
   onClose: () => void;
   onPlayRadio: () => void;
+  isAvailable?: boolean;
+  disabledReason?: string;
 }
 
 export function TrackRadioPopover({
@@ -13,7 +25,13 @@ export function TrackRadioPopover({
   anchorRect,
   onClose,
   onPlayRadio,
+  isAvailable = true,
+  disabledReason = DEFAULT_DISABLED_REASON,
 }: TrackRadioPopoverProps): JSX.Element {
+  const truncated = truncateTrackName(trackName);
+  const label = `Play ${truncated} Radio`;
+  const title = isAvailable ? trackName : disabledReason;
+
   return (
     <TrackInfoPopover
       type="radio"
@@ -21,9 +39,11 @@ export function TrackRadioPopover({
       onClose={onClose}
       options={[
         {
-          label: `Play ${trackName} Radio`,
+          label,
           icon: <RadioIcon />,
           onClick: onPlayRadio,
+          disabled: !isAvailable,
+          title,
         },
       ]}
     />

--- a/src/components/controls/__tests__/TrackRadioPopover.test.tsx
+++ b/src/components/controls/__tests__/TrackRadioPopover.test.tsx
@@ -1,0 +1,265 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import {
+  TrackRadioPopover,
+  truncateTrackName,
+} from '../TrackRadioPopover';
+
+function makeAnchorRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  const base = {
+    x: 100,
+    y: 200,
+    left: 100,
+    top: 200,
+    right: 140,
+    bottom: 220,
+    width: 40,
+    height: 20,
+    toJSON: () => ({}),
+  };
+  return { ...base, ...overrides } as DOMRect;
+}
+
+interface RenderOverrides {
+  trackName?: string;
+  anchorRect?: DOMRect | null;
+  onClose?: () => void;
+  onPlayRadio?: () => void;
+  isAvailable?: boolean;
+  disabledReason?: string;
+}
+
+function renderPopover(overrides: RenderOverrides = {}) {
+  const props = {
+    trackName: overrides.trackName ?? 'Dreams',
+    anchorRect:
+      overrides.anchorRect === undefined ? makeAnchorRect() : overrides.anchorRect,
+    onClose: overrides.onClose ?? vi.fn(),
+    onPlayRadio: overrides.onPlayRadio ?? vi.fn(),
+    isAvailable: overrides.isAvailable,
+    disabledReason: overrides.disabledReason,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <TrackRadioPopover {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('truncateTrackName', () => {
+  it('returns the input unchanged when below the default limit', () => {
+    // #given
+    const name = 'Short Track';
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe('Short Track');
+  });
+
+  it('returns the input unchanged when exactly at the default limit', () => {
+    // #given
+    const name = 'a'.repeat(32);
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe(name);
+    expect(result).toHaveLength(32);
+  });
+
+  it('truncates with an ellipsis when longer than the default limit', () => {
+    // #given
+    const name = 'a'.repeat(33);
+
+    // #when
+    const result = truncateTrackName(name);
+
+    // #then
+    expect(result).toBe(`${'a'.repeat(32)}…`);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('respects a custom maxLen', () => {
+    // #given
+    const name = 'abcdefghij';
+
+    // #when
+    const result = truncateTrackName(name, 5);
+
+    // #then
+    expect(result).toBe('abcde…');
+  });
+
+  it('strips trailing whitespace before the ellipsis', () => {
+    // #given
+    const name = 'hello world more text here';
+
+    // #when
+    const result = truncateTrackName(name, 6);
+
+    // #then
+    expect(result).toBe('hello…');
+    expect(result).not.toContain(' …');
+  });
+
+  it('returns an empty string when given an empty string', () => {
+    // #when
+    const result = truncateTrackName('');
+
+    // #then
+    expect(result).toBe('');
+  });
+
+  it('returns an empty string when maxLen is zero or negative', () => {
+    // #when / #then
+    expect(truncateTrackName('anything', 0)).toBe('');
+    expect(truncateTrackName('anything', -1)).toBe('');
+  });
+});
+
+describe('TrackRadioPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Play {trackName} Radio" option when available', () => {
+    // #when
+    renderPopover({ trackName: 'Dreams' });
+
+    // #then
+    expect(screen.getByText('Play Dreams Radio')).toBeInTheDocument();
+  });
+
+  it('renders the option when isAvailable is omitted (defaults to true)', () => {
+    // #when
+    renderPopover({ trackName: 'Dreams', isAvailable: undefined });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play Dreams Radio/ });
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('truncates long track names in the visible label', () => {
+    // #given
+    const longName = 'A'.repeat(40);
+
+    // #when
+    renderPopover({ trackName: longName });
+
+    // #then
+    const truncated = `${'A'.repeat(32)}…`;
+    expect(screen.getByText(`Play ${truncated} Radio`)).toBeInTheDocument();
+  });
+
+  it('preserves the full track name in the title attribute when available', () => {
+    // #given
+    const longName = 'A'.repeat(40);
+
+    // #when
+    renderPopover({ trackName: longName });
+
+    // #then
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('title', longName);
+  });
+
+  it('fires onPlayRadio and onClose when the option is clicked', () => {
+    // #given
+    const onPlayRadio = vi.fn();
+    const onClose = vi.fn();
+    renderPopover({ onPlayRadio, onClose });
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: /Play .* Radio/ }));
+
+    // #then
+    expect(onPlayRadio).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire onPlayRadio when isAvailable is false', () => {
+    // #given
+    const onPlayRadio = vi.fn();
+    const onClose = vi.fn();
+    renderPopover({ onPlayRadio, onClose, isAvailable: false });
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: /Play .* Radio/ }));
+
+    // #then
+    expect(onPlayRadio).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('marks the option as aria-disabled when isAvailable is false', () => {
+    // #when
+    renderPopover({ isAvailable: false });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('surfaces the default disabled reason via the title attribute when disabled', () => {
+    // #when
+    renderPopover({ isAvailable: false });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute(
+      'title',
+      'Radio is unavailable. Configure VITE_LASTFM_API_KEY.',
+    );
+  });
+
+  it('surfaces a custom disabledReason via the title attribute when disabled', () => {
+    // #given
+    const disabledReason = 'Please sign in to use radio.';
+
+    // #when
+    renderPopover({ isAvailable: false, disabledReason });
+
+    // #then
+    const button = screen.getByRole('button', { name: /Play .* Radio/ });
+    expect(button).toHaveAttribute('title', disabledReason);
+  });
+
+  it('renders nothing when anchorRect is null', () => {
+    // #when
+    const { container } = renderPopover({ anchorRect: null });
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('button', { name: /Play .* Radio/ })).toBeNull();
+  });
+
+  it('closes when the Escape key is pressed', () => {
+    // #given
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+
+    // #when
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // #then
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not close on unrelated keydown events', () => {
+    // #given
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+
+    // #when
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    // #then
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #888
Closes #889
Closes #890

Part of epic #893. Stacked on #885.

## What changed
- Extended `PopoverOption` in `TrackInfoPopover` with optional `disabled` and `title` fields.
- `OptionButton` now renders a disabled variant: dimmed via `opacity`, `cursor: not-allowed`, suppressed hover/active backgrounds, muted foreground color. Also enforces a 44px minimum tap target for mobile.
- Disabled options no-op on click and set `aria-disabled` for assistive tech; HTML `title` passed through for tooltip context.
- Added pure `truncateTrackName(name, maxLen = 32)` helper, exported named from `TrackRadioPopover.tsx` for unit testing (#891).
- `TrackRadioPopover` now truncates long track names in its label with ellipsis and exposes the full untruncated name via the `title` attribute.
- New `isAvailable` (default `true`) and `disabledReason` props let callers wire in `useRadio().isRadioAvailable` to render the option disabled with an explanatory tooltip.

## Testing
- `npx tsc -b --noEmit` clean
- `npm run test:run` all 1017 tests pass
- Unit tests for the truncation helper are scheduled as #891

Closes #891
Closes #892