### PR TITLE
feat(controls): integrate TrackRadioPopover into TrackInfo

### DIFF
--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -314,6 +314,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
                     onPrevious={onPrevious}
                     onArtistBrowse={onArtistBrowse}
                     onAlbumPlay={onAlbumPlay}
+                    onPlayRadio={isRadioAvailable ? onStartRadio : undefined}
                     currentTrackProvider={currentTrackProvider}
                   />
                 </ProfiledComponent>

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -23,6 +23,7 @@ interface SpotifyPlayerControlsProps {
   onToggleLike?: () => void;
   onArtistBrowse?: (artistName: string) => void;
   onAlbumPlay?: (albumId: string, albumName: string) => void;
+  onPlayRadio?: () => void;
   currentTrackProvider?: ProviderId;
 }
 
@@ -38,6 +39,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   onToggleLike: propOnToggleLike,
   onArtistBrowse,
   onAlbumPlay,
+  onPlayRadio,
   currentTrackProvider,
 }) => {
   // Get responsive sizing information
@@ -85,6 +87,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         isTablet={isTablet}
         onArtistBrowse={onArtistBrowse}
         onAlbumPlay={onAlbumPlay}
+        onPlayRadio={onPlayRadio}
       />
 
       <div style={{ display: 'flex', justifyContent: 'center', width: '100%', gap: '0.5rem' }}>

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -5,6 +5,7 @@ import { useProviderContext } from '../../contexts/ProviderContext';
 import { librarySyncEngine } from '../../services/cache/librarySyncEngine';
 import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 import TrackInfoPopover, { LibraryIcon, SpotifyIcon, PlayIcon, DiscogsIcon, AddToLibraryIcon, RemoveFromLibraryIcon, ICON_MAP } from './TrackInfoPopover';
+import TrackRadioPopover from './TrackRadioPopover';
 
 interface TrackInfoProps {
     track: {
@@ -20,6 +21,7 @@ interface TrackInfoProps {
     isTablet: boolean;
     onArtistBrowse?: (artistName: string) => void;
     onAlbumPlay?: (albumId: string, albumName: string) => void;
+    onPlayRadio?: () => void;
 }
 
 // Custom comparison function for memo optimization
@@ -36,16 +38,18 @@ const areTrackInfoPropsEqual = (
         prevProps.isMobile === nextProps.isMobile &&
         prevProps.isTablet === nextProps.isTablet &&
         prevProps.onArtistBrowse === nextProps.onArtistBrowse &&
-        prevProps.onAlbumPlay === nextProps.onAlbumPlay
+        prevProps.onAlbumPlay === nextProps.onAlbumPlay &&
+        prevProps.onPlayRadio === nextProps.onPlayRadio
     );
 };
 
 type PopoverState =
     | { type: 'artist'; artistName: string; artistUrl: string; rect: DOMRect }
     | { type: 'album'; albumId: string; albumName: string; rect: DOMRect }
+    | { type: 'radio'; trackName: string; rect: DOMRect }
     | null;
 
-const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBrowse, onAlbumPlay }) => {
+const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBrowse, onAlbumPlay, onPlayRadio }) => {
     const [popover, setPopover] = useState<PopoverState>(null);
     const [albumSaved, setAlbumSaved] = useState<boolean | null>(null);
     const artistRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -88,6 +92,21 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
         const rect = target.getBoundingClientRect();
         setPopover({ type: 'album', albumId: track.albumId, albumName: track.album, rect });
     }, [track?.albumId, track?.album]);
+
+    const handleTrackNameClick = useCallback((e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!track?.name || !onPlayRadio) return;
+        const target = e.currentTarget as HTMLElement;
+        const rect = target.getBoundingClientRect();
+        setPopover({ type: 'radio', trackName: track.name, rect });
+    }, [track?.name, onPlayRadio]);
+
+    const handlePlayRadio = useCallback(() => {
+        if (!onPlayRadio) return;
+        onPlayRadio();
+        setPopover(null);
+    }, [onPlayRadio]);
 
     const hasExternalLink = capabilities?.hasExternalLink ?? false;
     const providerName = capabilities?.externalLinkLabel?.replace('Open in ', '') ?? trackDescriptor?.name ?? 'External';
@@ -243,21 +262,45 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
     };
 
     const popoverContent = popover && createPortal(
-        <TrackInfoPopover
-            type={popover.type}
-            anchorRect={popover.rect}
-            onClose={closePopover}
-            options={popover.type === 'artist' ? buildArtistOptions() : buildAlbumOptions()}
-        />,
+        popover.type === 'radio' ? (
+            <TrackRadioPopover
+                trackName={popover.trackName}
+                anchorRect={popover.rect}
+                onClose={closePopover}
+                onPlayRadio={handlePlayRadio}
+            />
+        ) : (
+            <TrackInfoPopover
+                type={popover.type}
+                anchorRect={popover.rect}
+                onClose={closePopover}
+                options={popover.type === 'artist' ? buildArtistOptions() : buildAlbumOptions()}
+            />
+        ),
         document.body
     );
+
+    const trackNameContent = track?.name || 'No track selected';
+    const isTrackNameClickable = Boolean(onPlayRadio && track?.name);
 
     return (
         <>
             <TrackInfoOnlyRow $compact={isMobile || isTablet}>
-                <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
-                    {track?.name || 'No track selected'}
-                </PlayerTrackName>
+                {isTrackNameClickable ? (
+                    <PlayerTrackName
+                        as="button"
+                        type="button"
+                        onClick={handleTrackNameClick}
+                        $isMobile={isMobile}
+                        $isTablet={isTablet}
+                    >
+                        {trackNameContent}
+                    </PlayerTrackName>
+                ) : (
+                    <PlayerTrackName $isMobile={isMobile} $isTablet={isTablet}>
+                        {trackNameContent}
+                    </PlayerTrackName>
+                )}
                 {track?.album && (
                     <PlayerTrackAlbum>{renderAlbum()}</PlayerTrackAlbum>
                 )}

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -85,6 +85,17 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
   position: relative;
   z-index: 11;
   text-shadow: ${({ theme }) => theme.shadows.textMd};
+
+  /* Reset button-specific styles when rendered as a button (as="button") */
+  &:where(button) {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    text-align: inherit;
+    cursor: pointer;
+  }
 `;
 
 export const PlayerTrackAlbum = styled.div`


### PR DESCRIPTION
Closes #886

Part of epic #893. Stacked on #1063 (#885).

## What changed
- Added optional `onPlayRadio` prop to `TrackInfo`.
- Extended `TrackInfo`'s popover state machine with a `'radio'` variant; clicking the track name opens `TrackRadioPopover` anchored to the name's `DOMRect`. Selecting "Play <track> Radio" invokes `onPlayRadio` and closes the popover.
- Track name renders as a `<button>` (via `as="button"`) only when `onPlayRadio` is provided, so idle/no-handler behavior is unchanged. Added a scoped button-reset inside `PlayerTrackName` to preserve the visual layout when rendered as a button.
- Threaded `onStartRadio` (gated by `isRadioAvailable`) from `PlayerControlsSection` through `SpotifyPlayerControls` into `TrackInfo` as `onPlayRadio`.

## Scope
Normal (non-zen) mode only. Zen-mode integration is #887. No changes to `AlbumArtSection` or zen-specific files. No disabled-state/tooltip (#888), truncation (#889), extra styling (#890), or tests (#891).

## Testing
- `npx tsc -b --noEmit` clean
- `npm run test:run` — 1017/1017 passing
- `npm run build` clean