### PR TITLE
perf(zen): consolidate max-width animation to PlayerStack (#860)

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -2,8 +2,6 @@ import React, { memo, useEffect, useState, useCallback, useMemo } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import { breatheBorderGlow } from '../styles/animations';
-import { ZEN_ART_DURATION, ZEN_ART_EASING, ZEN_ART_ENTER_DELAY, ZEN_ART_MARGIN_H, ZEN_ART_MARGIN_V, ZEN_ART_MARGIN_H_MOBILE, ZEN_ART_MARGIN_V_MOBILE } from '@/constants/zenAnimation';
-
 import AccentColorGlowOverlay, { DEFAULT_GLOW_RATE, DEFAULT_GLOW_INTENSITY } from './AccentColorGlowOverlay';
 import { hexToRgb } from '../utils/colorUtils';
 import { useImageProcessingWorker } from '../hooks/useImageProcessingWorker';
@@ -71,14 +69,7 @@ const AlbumArtContainer = styled.div.withConfig({
   border-radius: ${theme.borderRadius.xl};
   position: relative;
   width: 100%;
-  max-width: ${({ $zenMode }) => $zenMode
-    ? `min(calc(100vw - ${ZEN_ART_MARGIN_H}px), calc(100dvh - ${ZEN_ART_MARGIN_V}px))`
-    : `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - 120px))`
-  };
-  transition: ${({ $zenMode }) => $zenMode
-    ? `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms, box-shadow 0.5s ease, opacity 0.5s ease`
-    : `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}, box-shadow 0.5s ease, opacity 0.5s ease`
-  };
+  transition: box-shadow 0.5s ease, opacity 0.5s ease;
   aspect-ratio: 1;
   margin: 0 auto;
   overflow: hidden;
@@ -143,12 +134,6 @@ const AlbumArtContainer = styled.div.withConfig({
   opacity: ${({ $translucenceOpacity }) => $translucenceOpacity ?? 1};
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
-
-  @media (max-width: ${theme.breakpoints.lg}) {
-    ${({ $zenMode }) => $zenMode && `
-      max-width: min(calc(100vw - ${ZEN_ART_MARGIN_H_MOBILE}px), calc(100dvh - ${ZEN_ART_MARGIN_V_MOBILE}px));
-    `}
-  }
 `;
 
 const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): boolean => {

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -32,7 +32,6 @@ export const ContentWrapper = styled.div.withConfig({
   $zenMode?: boolean;
 }>`
   width: ${props => props.$zenMode ? '100%' : props.useFluidSizing ? '100%' : `${props.width}px`};
-  max-width: ${props => props.$zenMode ? '100%' : `${props.width}px`};
 
   margin: 0 auto;
   margin-bottom: ${props => props.$zenMode ? '0' : `${BOTTOM_BAR_HEIGHT}px`};
@@ -45,8 +44,7 @@ export const ContentWrapper = styled.div.withConfig({
 
   transition: width ${props => props.$zenMode ? `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms` : `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`},
             padding ${props => props.transitionDuration}ms ${props => props.transitionEasing},
-            padding-bottom ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING},
-            max-width ${props => props.$zenMode ? `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms` : `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`};
+            padding-bottom ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING};
 
   container-type: inline-size;
   container-name: player;


### PR DESCRIPTION
## Summary

Closes #860. Consolidates the zen-mode `max-width` animation so only `PlayerStack` owns it, reducing nested layout-triggering transitions from 3x to 1x per frame.

**Before**: `ContentWrapper` + `PlayerStack` + `AlbumArtContainer` each animated their own `max-width` with identical `ZEN_ART_DURATION` / `ZEN_ART_EASING`, triggering three independent layout recalcs per frame during zen toggles.

**After**: `PlayerStack` keeps the animated `max-width` (it's already the more restrictive constraint — includes `BOTTOM_BAR_HEIGHT`). `AlbumArtContainer` fills it via `width: 100%` + `aspect-ratio: 1`. `ContentWrapper` sizes itself via its existing `width` transition (non-zen `${width}px` vs zen `100%`).

### Changes

- **`src/components/AlbumArt.tsx`** — drop `AlbumArtContainer` `max-width` + its `max-width` transition entry. Drop the mobile `@media` block that was only overriding `max-width`. Drop unused `ZEN_ART_*` imports.
- **`src/components/PlayerContent/styled.ts`** — drop `ContentWrapper` `max-width` + its `max-width` transition entry. `width` transition preserved.

### Behavior note

Album art may render slightly smaller in narrow edge cases where `PlayerStack`'s bottom-bar-aware constraint was previously tighter than `AlbumArtContainer`'s — i.e. where the art was previously overlapping the bottom bar. This is a correctness improvement, not a regression.

### Unblocks

Prerequisite for #859 (replace `max-width` with `transform: scale()` for zen art transition).

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1036/1036 passing
- [x] Dev server boots clean (no compile errors)
- [ ] Manual visual check: toggle zen in/out on desktop — transition feels smoother, no size discontinuity
- [ ] Manual visual check: toggle zen in/out on mobile viewport — no regression
- [ ] Manual visual check: confirm album art doesn't overlap `BottomBar` on narrow/short viewports