### PR TITLE
fix(zen): replace paddingTop jump with transform translateY on AlbumArtSection

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -317,7 +317,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
         zIndex: 2,
         minHeight: 0,
         alignItems: 'center',
-        paddingTop: zenModeEnabled ? '0' : (isMobile ? '0.25rem' : '0.5rem')
+        transform: zenModeEnabled ? 'translateY(0)' : `translateY(${isMobile ? '0.25rem' : '0.5rem'})`
       }}>
         <div ref={flipContainerRef} style={{ width: '100%', position: 'relative' }} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
           <GestureLayer


### PR DESCRIPTION
Closes #862

## Summary
Replaces the layout-triggering `paddingTop` toggle in `AlbumArtSection.tsx` with a GPU-composited `transform: translateY()`. Removes the instant jump at the start of every zen transition — the translate is now eligible for the surrounding element's existing transitions.

No existing `transform` was set on this element, so there is no composition conflict.

## Test plan
- [ ] Toggle zen mode on desktop, verify no padding jump at start of transition
- [ ] Toggle zen mode on mobile, verify no jump (smaller 0.25rem offset)
- [ ] Confirm album art final resting positions match previous behavior in both zen on/off states