### PR TITLE
fix(zen): restrict track radio popover to normal mode only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ test-results/
 playwright/capture/output/
 playwright/capture/.auth-state.json
 playwright/capture/.chrome-profile/
+
+# Claude Code sessionkit handoff docs
+.sessionkit/

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -5,7 +5,6 @@ import AlbumArt from '@/components/AlbumArt';
 import AlbumArtQuickSwapBack from '@/components/AlbumArtQuickSwapBack';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
 import { ProviderBadge } from '@/components/ProviderBadge';
-import { TrackRadioPopover } from '@/components/controls/TrackRadioPopover';
 import { useColorContext } from '@/contexts/ColorContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useProviderContext } from '@/contexts/ProviderContext';
@@ -24,25 +23,6 @@ const ZenProviderBadgeInline = styled.span`
   margin-left: ${({ theme }) => theme.spacing.sm};
   position: relative;
   top: -1px;
-`;
-
-const ZenTrackNameTrigger = styled.button`
-  display: inline;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  color: inherit;
-  text-shadow: inherit;
-  cursor: pointer;
-  pointer-events: auto;
-
-  &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.colors.white};
-    outline-offset: 2px;
-    border-radius: ${({ theme }) => theme.borderRadius.sm};
-  }
 `;
 
 interface AlbumArtBounds {
@@ -74,8 +54,6 @@ interface AlbumArtSectionProps {
   canSaveTrack: boolean;
   onLikeToggle: () => void;
   flipToggleRef?: React.MutableRefObject<(() => void) | null>;
-  isRadioAvailable?: boolean;
-  onStartRadio?: () => void;
 }
 
 export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
@@ -100,8 +78,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   canSaveTrack,
   onLikeToggle,
   flipToggleRef,
-  isRadioAvailable,
-  onStartRadio,
 }) => {
   const { connectedProviderIds } = useProviderContext();
 
@@ -141,7 +117,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
 
   const [isFlipped, setIsFlipped] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const [radioPopoverAnchor, setRadioPopoverAnchor] = useState<DOMRect | null>(null);
   const flipContainerRef = useRef<HTMLDivElement>(null);
   const albumArtContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -225,23 +200,9 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   useEffect(() => {
     if (!zenModeEnabled) {
       setIsHovered(false);
-      setRadioPopoverAnchor(null);
     }
   }, [zenModeEnabled]);
 
-  const handleTrackNameClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    if (!onStartRadio || !isRadioAvailable) return;
-    setRadioPopoverAnchor(e.currentTarget.getBoundingClientRect());
-  }, [onStartRadio, isRadioAvailable]);
-
-  const handleCloseRadioPopover = useCallback(() => {
-    setRadioPopoverAnchor(null);
-  }, []);
-
-  const handlePlayRadio = useCallback(() => {
-    onStartRadio?.();
-  }, [onStartRadio]);
 
   useEffect(() => {
     if (!isFlipped) return;
@@ -394,13 +355,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
       </CardContent>
       <ZenTrackInfo $zenMode={zenModeEnabled}>
         <ZenTrackName $isMobile={isMobile} $isTablet={isTablet}>
-          {currentTrack?.name && zenModeEnabled && isRadioAvailable && onStartRadio ? (
-            <ZenTrackNameTrigger type="button" onClick={handleTrackNameClick}>
-              {currentTrack.name}
-            </ZenTrackNameTrigger>
-          ) : (
-            currentTrack?.name
-          )}
+          {currentTrack?.name}
           {zenModeEnabled && connectedProviderIds.length > 1 && currentTrackProvider != null && (
             <ZenProviderBadgeInline>
               <ProviderBadge providerId={currentTrackProvider} iconOnly />
@@ -411,14 +366,6 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
           <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
         )}
       </ZenTrackInfo>
-      {zenModeEnabled && radioPopoverAnchor && currentTrack?.name && (
-        <TrackRadioPopover
-          trackName={currentTrack.name}
-          anchorRect={radioPopoverAnchor}
-          onClose={handleCloseRadioPopover}
-          onPlayRadio={handlePlayRadio}
-        />
-      )}
     </>
   );
 });

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -206,8 +206,6 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
             canSaveTrack={canSaveTrack}
             onLikeToggle={handleLikeToggle}
             flipToggleRef={flipToggleRef}
-            isRadioAvailable={isRadioAvailable}
-            onStartRadio={handlers.onStartRadio}
           />
           <PlayerControlsSection
             currentTrack={currentTrack}


### PR DESCRIPTION
Track name click should only trigger the radio popover in normal mode, not in zen mode. Removed the radio popover trigger, handlers, and related state from AlbumArtSection, and cleaned up the props passed from index.tsx.