### PR TITLE
perf(zen): use transform scale for zen art transition

### DIFF
--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -119,17 +119,23 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
     const nextWidth = el.offsetWidth;
     lastStackWidthRef.current = nextWidth;
 
-    if (prevWidth === null || prevWidth === 0 || nextWidth === 0 || reducedMotion) {
+    const resetTransform = () => {
       el.style.transition = 'none';
       el.style.transform = '';
+    };
+
+    if (prevWidth === null || prevWidth <= 0 || nextWidth <= 0 || reducedMotion) {
+      resetTransform();
       return;
     }
 
     const ratio = prevWidth / nextWidth;
-    if (Math.abs(ratio - 1) < 0.001) return;
+    if (Math.abs(ratio - 1) < 0.001) {
+      resetTransform();
+      return;
+    }
 
     const enterDelay = zenModeEnabled ? ZEN_ART_ENTER_DELAY : 0;
-
     el.style.transition = 'none';
     el.style.transform = `scale(${ratio})`;
     void el.offsetWidth;

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -1,10 +1,16 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 import { useLikeTrack } from '@/hooks/useLikeTrack';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { STORAGE_KEYS } from '@/constants/storage';
+import {
+  ZEN_ART_DURATION,
+  ZEN_ART_EASING,
+  ZEN_ART_ENTER_DELAY,
+} from '@/constants/zenAnimation';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState, RadioProgress } from '@/types/radio';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
@@ -79,12 +85,15 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
   const { zenModeEnabled, setZenModeEnabled, setShowVisualEffects } = useVisualEffectsContext();
   const { dimensions, useFluidSizing, padding, transitionDuration, transitionEasing, isMobile, isTablet, hasPointerInput, isTouchDevice } = usePlayerSizingContext();
   const { isLiked, isLikePending, handleLikeToggle, canSaveTrack } = useLikeTrack(currentTrack?.id, currentTrack?.provider);
+  const reducedMotion = useReducedMotion();
 
   const [qapEnabled] = useQapEnabled();
 
   const controlsRef = useRef<HTMLDivElement>(null);
   const stableControlsHeightRef = useRef<number>(220);
   const flipToggleRef = useRef<(() => void) | null>(null);
+  const playerStackRef = useRef<HTMLDivElement>(null);
+  const lastStackWidthRef = useRef<number | null>(null);
 
   useEffect(() => {
     const el = controlsRef.current;
@@ -99,6 +108,42 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
     const observer = new ResizeObserver(update);
     observer.observe(el);
     update();
+    return () => observer.disconnect();
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = playerStackRef.current;
+    if (!el) return;
+
+    const prevWidth = lastStackWidthRef.current;
+    const nextWidth = el.offsetWidth;
+    lastStackWidthRef.current = nextWidth;
+
+    if (prevWidth === null || prevWidth === 0 || nextWidth === 0 || reducedMotion) {
+      el.style.transition = 'none';
+      el.style.transform = '';
+      return;
+    }
+
+    const ratio = prevWidth / nextWidth;
+    if (Math.abs(ratio - 1) < 0.001) return;
+
+    const enterDelay = zenModeEnabled ? ZEN_ART_ENTER_DELAY : 0;
+
+    el.style.transition = 'none';
+    el.style.transform = `scale(${ratio})`;
+    void el.offsetWidth;
+    el.style.transition = `transform ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${enterDelay}ms`;
+    el.style.transform = 'scale(1)';
+  }, [zenModeEnabled, reducedMotion]);
+
+  useEffect(() => {
+    const el = playerStackRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      lastStackWidthRef.current = el.offsetWidth;
+    });
+    observer.observe(el);
     return () => observer.disconnect();
   }, []);
 
@@ -183,7 +228,7 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
       onClick={handleZenExitClick}
     >
       <PlayerContainer>
-        <PlayerStack $zenMode={zenModeEnabled}>
+        <PlayerStack $zenMode={zenModeEnabled} ref={playerStackRef}>
           <AlbumArtSection
             currentTrack={currentTrack}
             currentTrackProvider={currentTrackProvider}

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -74,11 +74,12 @@ export const PlayerStack = styled.div.withConfig({
     : `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - ${120 + BOTTOM_BAR_HEIGHT}px))`
   };
   margin: 0 auto;
-  /* Entering zen: art grows after controls fade out (300ms delay). Exiting zen: art shrinks immediately. */
-  transition: ${({ $zenMode }) => $zenMode
-    ? `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms`
-    : `max-width ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`
-  };
+  /*
+   * Size is switched instantly via max-width (no transition). A FLIP transform
+   * in PlayerContent/index.tsx produces the visual resize on the compositor so
+   * no layout-triggering property animates per frame.
+   */
+  transform-origin: top center;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.lg}) {
     ${({ $zenMode }) => $zenMode && `

--- a/src/components/__tests__/PlayerContent.test.tsx
+++ b/src/components/__tests__/PlayerContent.test.tsx
@@ -74,6 +74,10 @@ vi.mock('@/hooks/useLikeTrack', () => ({
   })),
 }));
 
+vi.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: vi.fn(() => false),
+}));
+
 vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
   useUnifiedLikedTracks: vi.fn(() => ({
     isUnifiedLikedActive: false,


### PR DESCRIPTION
Closes #859

Replaces the `max-width` animation on `PlayerStack` with a GPU-composited `transform: scale()` FLIP so the zen-mode art resize no longer triggers layout on every frame.

## Approach

`PlayerStack`'s `max-width` switches instantly between the normal and zen values (no CSS transition). A `useLayoutEffect` in `PlayerContent/index.tsx` runs a FLIP on each `zenModeEnabled` change:

1. Read the element's new `offsetWidth` after React commits.
2. Compute `ratio = prevWidth / nextWidth` from the width stored in a ref.
3. Apply `transform: scale(ratio)` with `transition: none` and force a reflow so the browser commits the starting state.
4. Re-enable the transition and set `transform: scale(1)`, producing a compositor-only animation.

A `ResizeObserver` keeps the stored width in sync with viewport changes between toggles so a mid-session window resize doesn't corrupt the next ratio. `useReducedMotion` bypasses the animation.

## Changes

- `src/components/PlayerContent/styled.ts` — `PlayerStack` drops the `max-width` transition and adds `transform-origin: top center` so the art shrinks toward its normal-mode resting position.
- `src/components/PlayerContent/index.tsx` — ref on `PlayerStack`, FLIP `useLayoutEffect`, resize observer, reduced-motion bypass.
- `src/components/__tests__/PlayerContent.test.tsx` — mock `useReducedMotion` so the jsdom test env (no `matchMedia`) still renders the component.

## Verification

- `npx tsc -b --noEmit` passes
- `npm run lint` clean (no new warnings/errors in touched files)
- `npm run test:run` — 1044/1044 passing
- `npm run build` succeeds