### PR TITLE
refactor(zen): animate ZenTrackInfo via grid-template-rows

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/constants/zenAnimation';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { VisualizerStyle } from '@/types/visualizer';
-import { FlipInner, ZenTrackInfo, ZenTrackName, ZenTrackArtist } from './styled';
+import { FlipInner, ZenTrackInfo, ZenTrackInfoInner, ZenTrackName, ZenTrackArtist } from './styled';
 
 const ZEN_TRACK_INFO_WILL_CHANGE_FALLBACK_MS =
   ZEN_TRACK_INFO_ENTER_OPACITY_DURATION + ZEN_TRACK_INFO_ENTER_OPACITY_DELAY + 100;
@@ -131,7 +131,7 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
   useTransitionWillChange(
     zenTrackInfoRef,
     zenModeEnabled,
-    'opacity, max-height',
+    'opacity, grid-template-rows',
     ZEN_TRACK_INFO_WILL_CHANGE_FALLBACK_MS,
   );
 
@@ -369,17 +369,19 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
         </div>
       </CardContent>
       <ZenTrackInfo $zenMode={zenModeEnabled} ref={zenTrackInfoRef}>
-        <ZenTrackName $isMobile={isMobile} $isTablet={isTablet}>
-          {currentTrack?.name}
-          {zenModeEnabled && connectedProviderIds.length > 1 && currentTrackProvider != null && (
-            <ZenProviderBadgeInline>
-              <ProviderBadge providerId={currentTrackProvider} iconOnly />
-            </ZenProviderBadgeInline>
+        <ZenTrackInfoInner>
+          <ZenTrackName $isMobile={isMobile} $isTablet={isTablet}>
+            {currentTrack?.name}
+            {zenModeEnabled && connectedProviderIds.length > 1 && currentTrackProvider != null && (
+              <ZenProviderBadgeInline>
+                <ProviderBadge providerId={currentTrackProvider} iconOnly />
+              </ZenProviderBadgeInline>
+            )}
+          </ZenTrackName>
+          {currentTrack?.artists && (
+            <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
           )}
-        </ZenTrackName>
-        {currentTrack?.artists && (
-          <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
-        )}
+        </ZenTrackInfoInner>
       </ZenTrackInfo>
     </>
   );

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -119,20 +119,22 @@ export const ZenControlsInner = styled.div`
 export const ZenTrackInfo = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$zenMode'].includes(prop),
 })<{ $zenMode: boolean }>`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-template-rows: ${({ $zenMode }) => $zenMode ? '1fr' : '0fr'};
   text-align: center;
   pointer-events: none;
   margin-top: ${({ theme }) => theme.spacing.sm};
   padding: 0 ${({ theme }) => theme.spacing.md};
-  overflow: hidden;
   opacity: ${({ $zenMode }) => $zenMode ? 1 : 0};
-  max-height: ${({ $zenMode }) => $zenMode ? '5rem' : '0'};
   transition: ${({ $zenMode }) => $zenMode
-    ? `opacity ${ZEN_TRACK_INFO_ENTER_OPACITY_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_OPACITY_DELAY}ms, max-height ${ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_HEIGHT_DELAY}ms`
-    : `opacity ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease, max-height ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease`
+    ? `opacity ${ZEN_TRACK_INFO_ENTER_OPACITY_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_OPACITY_DELAY}ms, grid-template-rows ${ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_HEIGHT_DELAY}ms`
+    : `opacity ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease, grid-template-rows ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease`
   };
+`;
+
+export const ZenTrackInfoInner = styled.div`
+  min-height: 0;
+  overflow: hidden;
 `;
 
 export const ZenTrackName = styled.div.withConfig({


### PR DESCRIPTION
Closes #864

Refactors `ZenTrackInfo` to use the `grid-template-rows: 0fr / 1fr` pattern already established by `ZenControlsWrapper`, replacing the `max-height: 0 / 5rem` hack. The animation now runs over the actual content height instead of a fixed `5rem` range, matching the perceived animation speed to the visible transition.

## Changes
- `ZenTrackInfo` — `display: grid;` + `grid-template-rows` transition; `max-height` removed.
- New `ZenTrackInfoInner` styled component with `min-height: 0; overflow: hidden;`.
- `AlbumArtSection.tsx` wraps `ZenTrackInfo` children in the new inner wrapper.
- `useTransitionWillChange` call on `ZenTrackInfo` updated to reference `grid-template-rows` instead of `max-height`.

## Stacked on #1089
This PR targets `worktree-agent-863` as its base. GitHub will retarget to `develop` as each upstream PR merges.

## Verification
- `npx tsc -b --noEmit` passes
- `npm run lint` passes (pre-existing errors only, none introduced)
- `npm run test:run` passes (1036 tests)
- `npm run build` succeeds