### PR TITLE
feat(auth): auto-disconnect provider and show toast on unrecoverable 401

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -192,7 +192,7 @@ const AudioPlayerComponent = () => {
     onReorderQueue: handlers.handleReorderQueue,
   }), [handlers, handleAlbumPlay, handlePlaylistSelect, handleOpenQuickAccessPanel]);
 
-  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt } = useProviderContext();
+  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();
   // Setup is needed when no provider has been chosen yet and none are connected,
   // or when the active provider isn't authenticated and no other enabled provider is either.
   // connectedProviderIds is the subset of enabledProviderIds with valid auth.
@@ -398,6 +398,9 @@ const AudioPlayerComponent = () => {
             onDismiss={dismissReconnectPrompt}
             persistent
           />
+        )}
+        {disconnectToast && !reconnectPrompt && (
+          <Toast message={disconnectToast} onDismiss={dismissDisconnectToast} />
         )}
         {needsSetup && (
           <>

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -60,6 +60,11 @@ interface ProviderContextValue {
   acceptReconnectPrompt: () => void;
   /** Dismiss the reconnect prompt without reconnecting. */
   dismissReconnectPrompt: () => void;
+
+  /** Auto-dismiss toast shown immediately when a provider is disconnected due to an unrecoverable 401. */
+  disconnectToast: string | null;
+  /** Dismiss the disconnect toast. */
+  dismissDisconnectToast: () => void;
 }
 
 const ProviderContext =
@@ -162,6 +167,10 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   // ── Session-expired reconnect prompt ─────────────────────────────────
   const [reconnectPrompt, setReconnectPrompt] = useState<{ providerId: ProviderId; message: string } | null>(null);
 
+  // ── Disconnect toast (auto-dismiss) ──────────────────────────────────
+  const [disconnectToast, setDisconnectToast] = useState<string | null>(null);
+  const dismissDisconnectToast = useCallback(() => setDisconnectToast(null), []);
+
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
       const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
@@ -176,6 +185,7 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
           message: `Your ${name} session has expired. Tap to reconnect.`,
         };
       });
+      setDisconnectToast(`${name} disconnected — session expired.`);
       setAuthRevision(prev => prev + 1);
     };
 
@@ -301,10 +311,12 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       reconnectPrompt,
       acceptReconnectPrompt,
       dismissReconnectPrompt,
+      disconnectToast,
+      dismissDisconnectToast,
     }),
     // authRevision triggers re-evaluation when a popup completes OAuth
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, authRevision],
+    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast, authRevision],
   );
 
   return (


### PR DESCRIPTION
## Summary

- When a mid-session token refresh fails with 400/401, `ProviderContext` now shows an auto-dismiss toast: `"{Provider name} disconnected — session expired."`
- `connectedProviderIds` already reacted to `SESSION_EXPIRED_EVENT` via `authRevision` — no store changes needed
- The existing persistent reconnect prompt (`"Your {name} session has expired. Tap to reconnect."`) is preserved; the new toast is suppressed while that prompt is visible to avoid duplicate notifications
- Transient 5xx/network error paths in both Spotify and Dropbox adapters are unchanged

## Test plan

- [ ] TypeScript: `npx tsc -b --noEmit` passes
- [ ] Tests: `npm run test:run` — 1036 tests pass
- [ ] Manual: revoke a Spotify token mid-session — toast appears then auto-dismisses; reconnect prompt follows
- [ ] Manual: revoke a Dropbox token mid-session — same behaviour

Closes #1098