### PR TITLE
test(provider): verify disconnected providers excluded from liked songs and radio

### DIFF
--- a/src/hooks/__tests__/useUnifiedLikedTracks.test.ts
+++ b/src/hooks/__tests__/useUnifiedLikedTracks.test.ts
@@ -223,6 +223,33 @@ describe('useUnifiedLikedTracks', () => {
     });
   });
 
+  it('excludes enabled-but-disconnected providers from the merged result', async () => {
+    // #given - spotify is connected, dropbox is enabled but not in connectedProviderIds
+    const spotifyTracks = [makeTrack('s1', 'spotify', 2000)];
+    const dropboxTracks = [makeTrack('d1', 'dropbox', 1000)];
+    mockConnectedProviderIds.push('spotify'); // only spotify is connected
+    const spotifyDesc = makeDescriptor('spotify', spotifyTracks);
+    const dropboxDesc = makeDescriptor('dropbox', dropboxTracks);
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return spotifyDesc;
+      if (id === 'dropbox') return dropboxDesc;
+      return undefined;
+    });
+    mockRegistryGet.mockImplementation((id: string) => {
+      if (id === 'spotify') return spotifyDesc;
+      if (id === 'dropbox') return dropboxDesc;
+      return undefined;
+    });
+
+    // #when - render hook with only one connected provider
+    const { result } = renderHook(() => useUnifiedLikedTracks());
+
+    // #then - unified mode inactive, no dropbox tracks fetched
+    expect(result.current.isUnifiedLikedActive).toBe(false);
+    expect(result.current.unifiedTracks).toEqual([]);
+    expect(vi.mocked(dropboxDesc.catalog.listTracks)).not.toHaveBeenCalled();
+  });
+
   it('serves cached data immediately on subsequent hook mounts', async () => {
     // #given - set up providers
     const spotifyTracks = [makeTrack('s1', 'spotify', 2000)];

--- a/src/services/__tests__/radioPipeline.test.ts
+++ b/src/services/__tests__/radioPipeline.test.ts
@@ -228,6 +228,53 @@ describe('runRadioPipeline', () => {
       expect(result!.queue.some((t) => t.id === 'resolved-1')).toBe(true);
     });
 
+    it('skips unauthenticated search providers silently', async () => {
+      // #given
+      const seedTrack = makeMediaTrack({ id: 'seed-1', name: 'Creep', artists: 'Radiohead' });
+      const catalogTrack = makeMediaTrack({ id: 'rec-1', name: 'Karma Police', artists: 'Radiohead' });
+      const resolvedTrack = makeMediaTrack({ id: 'resolved-1', name: 'Missing Song', artists: 'Missing Artist' });
+      const catalogProvider = makeCatalogProvider([catalogTrack]);
+
+      const unauthenticatedProvider = makeProviderDescriptor({
+        capabilities: { hasSaveTrack: false, hasExternalLink: false, hasLikedCollection: false, hasTrackSearch: true },
+        auth: {
+          providerId: 'spotify',
+          isAuthenticated: vi.fn().mockReturnValue(false),
+          getAccessToken: vi.fn(),
+          beginLogin: vi.fn(),
+          handleCallback: vi.fn(),
+          logout: vi.fn(),
+        },
+        catalog: {
+          providerId: 'spotify',
+          listCollections: vi.fn().mockResolvedValue([]),
+          listTracks: vi.fn().mockResolvedValue([]),
+          searchTrack: vi.fn().mockResolvedValue(resolvedTrack),
+        },
+      });
+
+      const generateQueue = vi.fn().mockResolvedValue(
+        makeRadioResult({
+          queue: [catalogTrack],
+          unmatchedSuggestions: [{ name: 'Missing Song', artist: 'Missing Artist', matchScore: 0.5 }],
+        }),
+      );
+
+      // #when
+      const result = await runRadioPipeline({
+        seedTrack,
+        catalogProvider,
+        searchProviders: [unauthenticatedProvider],
+        onProgress,
+        generateQueue,
+      });
+
+      // #then - disconnected provider is not used for resolution
+      expect(result).not.toBeNull();
+      expect(result!.queue.some((t) => t.id === 'resolved-1')).toBe(false);
+      expect(vi.mocked(unauthenticatedProvider.catalog.searchTrack)).not.toHaveBeenCalled();
+    });
+
     it('does not add resolved tracks that duplicate existing queue entries by artists||name', async () => {
       // #given
       const seedTrack = makeMediaTrack({ id: 'seed-1', name: 'Creep', artists: 'Radiohead' });


### PR DESCRIPTION
Closes #1099

## Summary

- Audited `useUnifiedLikedTracks` — already uses `connectedProviderIds` (not `enabledProviderIds`), so disconnected providers are correctly excluded from Unified Liked Songs
- Audited `useRadioSession` and `radioPipeline` — already filters `searchProviders` by `auth.isAuthenticated()`, so disconnected Spotify is already skipped silently
- Added explicit test in `useUnifiedLikedTracks.test.ts`: an enabled-but-disconnected provider is excluded from the merge and its `listTracks` is never called
- Added explicit test in `radioPipeline.test.ts`: an unauthenticated search provider is skipped and `searchTrack` is never invoked

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (1038 tests, +2 new)
- [x] New test: `useUnifiedLikedTracks` excludes enabled-but-disconnected providers
- [x] New test: `radioPipeline` skips unauthenticated search providers silently