### PR TITLE
test(provider-settings): add component tests for provider toggle and disconnect dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,17 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 
 **Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`). Both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection`.
 
+**Provider toggle (Music Sources section in settings)**:
+- Each provider row has a single on/off toggle — there is no separate Reconnect button.
+- `enabledProviderIds` — localStorage-persisted set of providers the user has opted into.
+- `connectedProviderIds` — derived set: `enabledProviderIds` ∩ authenticated providers. Used by cross-provider features (Unified Liked Songs, radio resolver).
+- Toggle-OFF: opens `ProviderDisconnectDialog` showing the provider name and count of queued tracks that will be removed. Confirming calls `logout()`, removes the provider from `enabledProviderIds`, and cleans up queue/playback state. The last enabled provider's toggle is disabled to prevent a zero-provider state.
+- Toggle-ON when already authenticated: silently adds to `enabledProviderIds`.
+- Toggle-ON when not authenticated: calls `beginLogin({ popup: true })` immediately. The provider is added to `enabledProviderIds` only after the OAuth popup reports success via `AUTH_COMPLETE_EVENT`.
+- OAuth cancel/failure: toggle reverts; a toast shows `"Couldn't connect to {provider}. Try again."`.
+- Mid-session unrecoverable 401: `logout()` is called automatically; a toast shows `"{Provider} disconnected — session expired."`.
+- Implementation: `src/components/VisualEffectsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
+
 **Unified playback across providers**:
 - Queue items are represented as provider-agnostic `MediaTrack` records and can mix Spotify + Dropbox tracks in one queue.
 - Provider model:
@@ -131,12 +142,12 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
   - `useProviderPlayback` resolves provider per index (`track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback).
   - `usePlayerLogic` owns control actions and playback-state synchronization using `getDrivingProviderId()`.
   - `useAutoAdvance` advances based on events from the current driving provider.
-- Unified liked songs can merge liked tracks from all connected providers and sort by `addedAt`.
+- Unified liked songs can merge liked tracks from all connected providers (`connectedProviderIds`) and sort by `addedAt`.
 
 **Radio generation**:
 - Radio is a one-shot action (not a sticky toggle) that builds a playlist from the current track.
 - `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
-- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated.
+- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated and Spotify is in `connectedProviderIds`.
 - Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
 - **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 
 ## Features
 
-- **Multi-Provider Support** — Stream from Spotify or your personal Dropbox music library
+- **Multi-Provider Support** — Stream from Spotify or your personal Dropbox music library; enable/disable providers via a single toggle in settings (requires re-auth when not yet connected; disabling removes that provider's tracks from the queue)
 - **Unified Cross-Provider Playback** — Keep playback controls consistent across mixed Spotify + Dropbox queues
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet

--- a/src/components/VisualEffectsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/VisualEffectsMenu/__tests__/SourcesSections.test.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeProviderDescriptor, makeMediaTrack } from '@/test/fixtures';
+import type { ProviderDescriptor } from '@/types/providers';
+
+// ── Context mocks ──────────────────────────────────────────────────────────
+
+const mockToggleProvider = vi.fn();
+const mockSetTracks = vi.fn();
+const mockSetOriginalTracks = vi.fn();
+const mockSetCurrentTrackIndex = vi.fn();
+
+const mockRegistry = {
+  getAll: vi.fn<[], ProviderDescriptor[]>(() => []),
+  get: vi.fn<[string], ProviderDescriptor | undefined>(() => undefined),
+  has: vi.fn(() => true),
+};
+
+let mockEnabledProviderIds: string[] = ['spotify', 'dropbox'];
+let mockTracks: ReturnType<typeof makeMediaTrack>[] = [];
+let mockCurrentTrackIndex = 0;
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    registry: mockRegistry,
+    enabledProviderIds: mockEnabledProviderIds,
+    toggleProvider: mockToggleProvider,
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: vi.fn(() => ({
+    tracks: mockTracks,
+    setTracks: mockSetTracks,
+    setOriginalTracks: mockSetOriginalTracks,
+  })),
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrackIndex: mockCurrentTrackIndex,
+    setCurrentTrackIndex: mockSetCurrentTrackIndex,
+  })),
+}));
+
+vi.mock('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: vi.fn((key: string, defaultValue: unknown) => [defaultValue, vi.fn()]),
+}));
+
+// Import after mocks are set up
+import { MusicSourcesSection } from '../SourcesSections';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+function makeSpotifyDescriptor(authOverrides?: Partial<ProviderDescriptor['auth']>): ProviderDescriptor {
+  return makeProviderDescriptor({
+    id: 'spotify',
+    name: 'Spotify',
+    auth: {
+      ...makeProviderDescriptor().auth,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      ...authOverrides,
+    },
+  });
+}
+
+function makeDropboxDescriptor(authOverrides?: Partial<ProviderDescriptor['auth']>): ProviderDescriptor {
+  return makeProviderDescriptor({
+    id: 'dropbox' as 'spotify',
+    name: 'Dropbox',
+    auth: {
+      ...makeProviderDescriptor().auth,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      ...authOverrides,
+    },
+  });
+}
+
+describe('MusicSourcesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnabledProviderIds = ['spotify', 'dropbox'];
+    mockTracks = [];
+    mockCurrentTrackIndex = 0;
+    mockRegistry.getAll.mockReturnValue([]);
+    mockRegistry.get.mockReturnValue(undefined);
+  });
+
+  describe('toggle-off: disconnect dialog flow', () => {
+    it('opens ProviderDisconnectDialog when an enabled provider toggle is turned off', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      const spotifyToggle = screen.getByLabelText('Disable Spotify');
+      fireEvent.click(spotifyToggle);
+
+      // #then
+      expect(screen.getByText('Disconnect Spotify')).toBeInTheDocument();
+    });
+
+    it('calls descriptor.auth.logout() and toggleProvider when dialog is confirmed', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+      expect(screen.getByText('Disconnect Spotify')).toBeInTheDocument();
+
+      // #when
+      fireEvent.click(screen.getByText('Disconnect'));
+
+      // #then
+      expect(spotifyDesc.auth.logout).toHaveBeenCalledOnce();
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
+    });
+
+    it('closes the dialog and leaves state unchanged when Cancel is clicked', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockReturnValue(spotifyDesc);
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
+      expect(spotifyDesc.auth.logout).not.toHaveBeenCalled();
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('shows affected-track count in disconnect dialog when provider has queued tracks', () => {
+      // #given
+      const spotifyTrack1 = makeMediaTrack({ id: 'track-1', provider: 'spotify' });
+      const spotifyTrack2 = makeMediaTrack({ id: 'track-2', provider: 'spotify' });
+      const dropboxTrack = makeMediaTrack({ id: 'track-3', provider: 'dropbox' as 'spotify' });
+      mockTracks = [spotifyTrack1, spotifyTrack2, dropboxTrack];
+
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then
+      expect(screen.getByText(/remove 2 queued tracks/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('toggle-on: silent enable when authenticated', () => {
+    it('calls toggleProvider directly without opening a popup when provider is already authenticated', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(true) });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
+      expect(spotifyDesc.auth.beginLogin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggle-on: unauthenticated provider login', () => {
+    it('calls descriptor.auth.beginLogin when provider is not authenticated', async () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // Stub window.open to simulate a popup that never closes
+      const mockPopup = { closed: false } as Window;
+      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then
+      await waitFor(() => {
+        expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
+      });
+    });
+  });
+
+  describe('toggle-on: OAuth cancellation/failure', () => {
+    it('shows error toast when beginLogin promise rejects', async () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockRejectedValue(new Error('popup blocked'));
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // window.open returns null to simulate blocked popup, triggering the error path
+      vi.spyOn(window, 'open').mockReturnValue(null);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then — toast appears with the correct copy
+      await waitFor(() => {
+        expect(screen.getByText(/Couldn't connect to Spotify/i)).toBeInTheDocument();
+      });
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('shows error toast and does not enable the provider when the popup is dismissed (closed without completing OAuth)', async () => {
+      // #given — provider not yet authenticated, beginLogin opens a popup that closes immediately
+      const isAuthenticated = vi.fn().mockReturnValue(false);
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // The popup window is immediately closed (user dismissed the OAuth popup)
+      const mockPopup = { closed: true } as Window;
+      // Use Object.defineProperty to bypass any lingering spy on window.open
+      const mockPopupObj = { closed: true };
+      const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
+      Object.defineProperty(window, 'open', {
+        value: () => mockPopupObj,
+        writable: true,
+        configurable: true,
+      });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockImplementation(async () => {
+        window.open('https://accounts.spotify.com/authorize', '_blank');
+      });
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+      await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
+
+      // #then — poll detects closed popup within 500ms and shows the error toast
+      await waitFor(
+        () => {
+          expect(screen.getByText(/Couldn't connect to Spotify/i)).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+
+      // Restore original window.open property descriptor
+      if (originalDescriptor) {
+        Object.defineProperty(window, 'open', originalDescriptor);
+      }
+    });
+  });
+
+  describe('last-enabled guard', () => {
+    it('disables the toggle for the sole remaining enabled provider', () => {
+      // #given — only one provider is enabled
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.getByLabelText('Disable Spotify')).toBeDisabled();
+    });
+
+    it('does not disable the toggle when multiple providers are enabled', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.getByLabelText('Disable Spotify')).not.toBeDisabled();
+    });
+  });
+
+  describe('Reconnect button', () => {
+    it('has no Reconnect button in the rendered DOM', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.queryByRole('button', { name: /reconnect/i })).not.toBeInTheDocument();
+      expect(screen.queryByText(/reconnect/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/ProviderDisconnectDialog.test.tsx
+++ b/src/components/__tests__/ProviderDisconnectDialog.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import ProviderDisconnectDialog from '../ProviderDisconnectDialog';
+
+function renderDialog(overrides?: {
+  providerName?: string;
+  affectedQueueCount?: number;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) {
+  const props = {
+    providerName: 'Spotify',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <ProviderDisconnectDialog {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('ProviderDisconnectDialog', () => {
+  describe('content rendering', () => {
+    it('renders the provider name in title and body', () => {
+      // #given / #when
+      renderDialog({ providerName: 'Dropbox' });
+
+      // #then
+      expect(screen.getByText('Disconnect Dropbox')).toBeInTheDocument();
+      expect(screen.getByText(/disconnect.*Dropbox/i)).toBeInTheDocument();
+    });
+
+    it('renders the affected-queue count line when count is positive', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 5 });
+
+      // #then
+      expect(screen.getByText(/remove 5 queued tracks/i)).toBeInTheDocument();
+    });
+
+    it('uses singular "track" when affected count is 1', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 1 });
+
+      // #then
+      expect(screen.getByText(/remove 1 queued track\./i)).toBeInTheDocument();
+    });
+
+    it('hides the count line when affectedQueueCount is 0', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 0 });
+
+      // #then
+      expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+    });
+
+    it('hides the count line when affectedQueueCount is undefined', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: undefined });
+
+      // #then
+      expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('button interactions', () => {
+    it('calls onCancel when Cancel is clicked', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('calls onConfirm when Disconnect is clicked', () => {
+      // #given
+      const onConfirm = vi.fn();
+      renderDialog({ onConfirm });
+
+      // #when
+      fireEvent.click(screen.getByText('Disconnect'));
+
+      // #then
+      expect(onConfirm).toHaveBeenCalledOnce();
+    });
+
+    it('calls onCancel when the overlay backdrop is clicked', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+      // Dialog is portalled to document.body — query the overlay from there
+      const overlay = document.body.querySelector('[style]') ?? document.body.firstElementChild as HTMLElement;
+      // The overlay is the fixed-position div wrapping the dialog box
+      const dialogBox = screen.getByRole('dialog');
+      const overlayEl = dialogBox.parentElement as HTMLElement;
+
+      // #when
+      fireEvent.click(overlayEl);
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('calls onCancel when Escape is pressed on the overlay', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+      const dialogBox = screen.getByRole('dialog');
+      const overlayEl = dialogBox.parentElement as HTMLElement;
+
+      // #when
+      fireEvent.keyDown(overlayEl, { key: 'Escape' });
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('destructive button styling', () => {
+    it('Disconnect button has $destructive prop applied', () => {
+      // #given / #when
+      renderDialog();
+      const disconnectButton = screen.getByText('Disconnect');
+
+      // #then — $destructive renders red background via styled-components
+      expect(disconnectButton).toHaveStyle({ background: 'rgba(239, 68, 68, 0.85)' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ProviderDisconnectDialog.test.tsx` with 10 tests covering all dialog behaviors (content rendering, button interactions, ESC key, destructive styling)
- Adds `SourcesSections.test.tsx` with 11 tests covering toggle-off/dialog flow, toggle-on (authenticated + unauthenticated + OAuth failure), last-enabled guard, and Reconnect button absence
- All tests use `// #given`, `// #when`, `// #then` BDD markers

## Test plan
- [ ] `npm run test:run` passes (1057 tests, 0 failures)
- [ ] `npx tsc -b --noEmit` clean

Closes #1100

Closes #1101