### PR TITLE
feat(library): force shuffle for All Music on load and append

### DIFF
--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -1,3 +1,5 @@
+import type { CollectionRef } from '@/types/domain';
+
 /** Prefix used when encoding an album ID as a playlist selection ID */
 export const ALBUM_ID_PREFIX = 'album:';
 
@@ -9,6 +11,14 @@ export const LIKED_SONGS_NAME = 'Liked Songs';
 
 /** Special playlist ID representing the radio queue */
 export const RADIO_PLAYLIST_ID = 'radio';
+
+/** Pin-list identifier for the Dropbox "All Music" aggregate collection. */
+export const ALL_MUSIC_PIN_ID = 'dropbox-all-music';
+
+/** Returns true when the ref points at the Dropbox "All Music" aggregate (folder with empty id). */
+export function isAllMusicRef(ref: CollectionRef): boolean {
+  return ref.provider === 'dropbox' && ref.kind === 'folder' && 'id' in ref && ref.id === '';
+}
 
 /** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row, Dropbox "All Music" uses id ''). */
 export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, '']);

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -601,6 +601,90 @@ describe('useCollectionLoader', () => {
     );
   });
 
+  it('forces shuffle when loading Dropbox All Music even when global shuffleEnabled is false', async () => {
+    // #given — All Music is addressed as dropbox folder with empty id; provide an ordered list we can detect re-ordering on
+    const tracks = Array.from({ length: 20 }, (_, i) => makeMediaTrack(String(i + 1)));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(tracks) };
+    const dropboxDescriptor = {
+      id: 'dropbox' as const,
+      catalog: mockCatalog,
+      playback: { pause: vi.fn() },
+    };
+    mockGetDescriptor.mockReturnValue(dropboxDescriptor);
+    mockActiveDescriptor = { id: 'dropbox', playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — loadCollection with empty id (All Music ref)
+    await act(async () => {
+      await result.current.loadCollection('', 'dropbox');
+    });
+
+    // #then — originalTracks preserves order; tracks is a permutation that is not guaranteed to equal input order
+    expect(mockSetOriginalTracks).toHaveBeenCalledWith(tracks);
+    const emittedTracks = mockSetTracks.mock.calls[0][0] as MediaTrack[];
+    expect(emittedTracks).toHaveLength(tracks.length);
+    expect(emittedTracks.map(t => t.id).sort((a, b) => Number(a) - Number(b))).toEqual(tracks.map(t => t.id));
+    // With 20 items a Fisher-Yates shuffle reordering equalling the original is vanishingly unlikely
+    const identical = emittedTracks.every((t, i) => t.id === tracks[i].id);
+    expect(identical).toBe(false);
+  });
+
+  it('does not force-shuffle non-All-Music Dropbox folder collections when shuffleEnabled is false', async () => {
+    // #given — regression guard: a normal dropbox folder (non-empty id) must keep catalog order
+    const tracks = Array.from({ length: 20 }, (_, i) => makeMediaTrack(String(i + 1)));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(tracks) };
+    const dropboxDescriptor = {
+      id: 'dropbox' as const,
+      catalog: mockCatalog,
+      playback: { pause: vi.fn() },
+    };
+    mockGetDescriptor.mockReturnValue(dropboxDescriptor);
+    mockActiveDescriptor = { id: 'dropbox', playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — a specific album/folder path, not All Music
+    await act(async () => {
+      await result.current.loadCollection('/Music/Artist/Album', 'dropbox');
+    });
+
+    // #then — tracks should be in input (catalog) order
+    expect(mockSetTracks).toHaveBeenCalledWith(tracks);
+  });
+
   it('does not call record when the unified liked load returns no tracks', async () => {
     // #given
     mockGetDescriptor.mockReturnValue({

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -150,6 +150,77 @@ describe('useQueueManagement', () => {
     expect(response).toEqual({ added: 3, collectionName: 'My Playlist' });
   });
 
+  it('handleAddToQueue shuffles Dropbox All Music tracks before appending', async () => {
+    // #given — existing queue + All Music ref ('' id, dropbox folder) returning a large ordered list
+    mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+    const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+    const incoming = Array.from({ length: 20 }, (_, i) => makeMediaTrack(`n${i + 1}`));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(incoming) };
+    const dropboxDescriptor = { id: 'dropbox' as const, catalog: mockCatalog, playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: dropboxDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when — empty playlist id resolves to All Music (dropbox/folder/'')
+    await act(async () => {
+      await result.current.handleAddToQueue('');
+    });
+
+    // #then — setTracks updater yields a shuffled permutation of the incoming tracks appended to the existing queue
+    expect(mockSetTracks).toHaveBeenCalledWith(expect.any(Function));
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: MediaTrack[]) => MediaTrack[];
+    const appended = tracksUpdater([makeMediaTrack('a'), makeMediaTrack('b')]);
+    expect(appended).toHaveLength(22);
+    expect(appended[0].id).toBe('a');
+    expect(appended[1].id).toBe('b');
+    const appendedIds = appended.slice(2).map(t => t.id);
+    expect(appendedIds.slice().sort()).toEqual(incoming.map(t => t.id).slice().sort());
+    const orderPreserved = appendedIds.every((id, i) => id === incoming[i].id);
+    expect(orderPreserved).toBe(false);
+  });
+
+  it('handleAddToQueue preserves catalog order when appending a non-All-Music Dropbox folder', async () => {
+    // #given — regression guard for shuffle-by-default semantics
+    mediaTracksRef.current = [makeMediaTrack('a')];
+    const tracks = [makeTrack({ id: 'a' })];
+    const incoming = Array.from({ length: 20 }, (_, i) => makeMediaTrack(`n${i + 1}`));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(incoming) };
+    const dropboxDescriptor = { id: 'dropbox' as const, catalog: mockCatalog, playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: dropboxDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when — non-empty folder id (not All Music)
+    await act(async () => {
+      await result.current.handleAddToQueue('/Music/Artist/Album');
+    });
+
+    // #then — appended portion preserves incoming order
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: MediaTrack[]) => MediaTrack[];
+    const appended = tracksUpdater([makeMediaTrack('a')]);
+    expect(appended.slice(1).map(t => t.id)).toEqual(incoming.map(t => t.id));
+  });
+
   it('handleAddToQueue appends tracks to an existing queue without resetting currentTrackIndex', async () => {
     // #given
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import { LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvePlaylistRef } from '@/constants/playlist';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
@@ -66,9 +66,10 @@ export function useCollectionLoader({
     return clearWithError(err instanceof Error ? err.message : fallbackMessage);
   }, [clearWithError]);
 
-  const applyTracks = useCallback((tracks: MediaTrack[]) => {
+  const applyTracks = useCallback((tracks: MediaTrack[], options?: { forceShuffle?: boolean }) => {
     setOriginalTracks(tracks);
-    if (shuffleEnabled) {
+    const shouldShuffle = shuffleEnabled || options?.forceShuffle === true;
+    if (shouldShuffle) {
       const indices = shuffleArray(tracks.map((_, i) => i));
       const shuffled = indices.map(i => tracks[i]);
       mediaTracksRef.current = shuffled;
@@ -171,7 +172,7 @@ export function useCollectionLoader({
 
       if (list.length === 0) return clearWithError('No tracks found in this collection.');
 
-      applyTracks(list);
+      applyTracks(list, { forceShuffle: isAllMusicRef(collectionRef) });
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
       await playTrack(0);

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -2,8 +2,9 @@ import { useCallback, useRef } from 'react';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import { resolvePlaylistRef } from '@/constants/playlist';
+import { isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { logQueue } from '@/lib/debugLog';
+import { shuffleArray } from '@/utils/shuffleArray';
 import {
   appendMediaTracks,
   moveItemInArray,
@@ -78,7 +79,8 @@ export function useQueueManagement({
         const catalog = targetDescriptor.catalog;
         const { id: collectionId, kind: collectionKind } = resolvePlaylistRef(playlistId, targetProviderId);
         const collectionRef = { provider: targetProviderId, kind: collectionKind, id: collectionId } as const;
-        const newMediaTracks = await catalog.listTracks(collectionRef);
+        const fetchedTracks = await catalog.listTracks(collectionRef);
+        const newMediaTracks = isAllMusicRef(collectionRef) ? shuffleArray(fetchedTracks) : fetchedTracks;
 
         const existingIds = new Set(tracksRef.current.map((t) => t.id));
         const uniqueNewTracks = newMediaTracks.filter((t) => !existingIds.has(t.id));


### PR DESCRIPTION
## Summary
- Adds `ALL_MUSIC_PIN_ID` and `isAllMusicRef()` to `src/constants/playlist.ts`
- Forces shuffle in `useCollectionLoader` when loading All Music, without mutating global `shuffleEnabled`
- Forces shuffle in `useQueueManagement.handleAddToQueue` when appending All Music

## Test plan
- Unit tests verify forced shuffle on load (global shuffle OFF) and on append
- Regression guard confirms other collections still respect global toggle
- `npm run test:run` and `npx tsc -b --noEmit` pass

Closes #1090