### PR TITLE
feat(library): add AllMusicCard with shuffle branding to playlist grid

### DIFF
--- a/src/components/PlaylistSelection/AllMusicCard.tsx
+++ b/src/components/PlaylistSelection/AllMusicCard.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+import {
+  GridCardArtWrapper,
+  GridCardTextArea,
+  GridCardTitle,
+  GridCardSubtitle,
+  PlaylistImageWrapper,
+  PlaylistInfoDiv,
+  PlaylistName,
+  PlaylistDetails,
+  PinButton,
+  PinnableListItem,
+  GridCardPinOverlay,
+  PinnableGridCard,
+  TabSpinner,
+} from './styled';
+import { allMusicAsPlaylistInfo, getLikedSongsGradient } from './playlistUtils';
+import { PinIcon } from './utils';
+import { useLibraryPins, useLibraryActions } from './LibraryContext';
+
+const ALL_MUSIC_TITLE = 'All Music';
+
+interface AllMusicCardProps {
+  layout: 'grid' | 'list';
+  count: number;
+}
+
+const ShuffleArt: React.FC<{ gradient: string; layout: 'grid' | 'list' }> = ({ gradient, layout }) => {
+  const glyphSize = layout === 'list' ? 28 : 64;
+  return (
+    <div
+      data-testid="all-music-art"
+      style={{
+        background: gradient,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        borderRadius: layout === 'list' ? '0.5rem' : undefined,
+        color: 'white',
+      }}
+    >
+      <svg
+        data-testid="all-music-shuffle-glyph"
+        width={glyphSize}
+        height={glyphSize}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M16 3h5v5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M4 20 21 3"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M21 16v5h-5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15 15l6 6"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M4 4l5 5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
+};
+
+const AllMusicCard: React.FC<AllMusicCardProps> = React.memo(function AllMusicCard({ layout, count }) {
+  const { isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
+  const { onPlaylistContextMenu } = useLibraryActions();
+
+  const allMusicPinned = isPlaylistPinned(ALL_MUSIC_PIN_ID);
+  const gradient = getLikedSongsGradient('dropbox');
+
+  const subtitleText = count > 0 ? `${count} tracks • Shuffled` : null;
+  const subtitle = subtitleText ?? <TabSpinner />;
+
+  const openPopover = (e: React.MouseEvent) =>
+    onPlaylistContextMenu(allMusicAsPlaylistInfo(), e);
+
+  if (layout === 'grid') {
+    return (
+      <PinnableGridCard
+        key="all-music"
+        onClick={openPopover}
+        onContextMenu={openPopover}
+      >
+        <GridCardArtWrapper style={{ position: 'relative' }}>
+          <ShuffleArt gradient={gradient} layout="grid" />
+          <GridCardPinOverlay
+            $isPinned={allMusicPinned}
+            onClick={(e) => onPinPlaylistClick(ALL_MUSIC_PIN_ID, e)}
+          >
+            <PinIcon filled={allMusicPinned} />
+          </GridCardPinOverlay>
+        </GridCardArtWrapper>
+        <GridCardTextArea>
+          <GridCardTitle>{ALL_MUSIC_TITLE}</GridCardTitle>
+          <GridCardSubtitle>{subtitle}</GridCardSubtitle>
+        </GridCardTextArea>
+      </PinnableGridCard>
+    );
+  }
+
+  return (
+    <PinnableListItem key="all-music" onClick={openPopover} onContextMenu={openPopover}>
+      <PlaylistImageWrapper>
+        <ShuffleArt gradient={gradient} layout="list" />
+      </PlaylistImageWrapper>
+      <PlaylistInfoDiv>
+        <PlaylistName>{ALL_MUSIC_TITLE}</PlaylistName>
+        <PlaylistDetails>{subtitle}</PlaylistDetails>
+      </PlaylistInfoDiv>
+      <PinButton
+        $isPinned={allMusicPinned}
+        $disabled={!canPinMorePlaylists && !allMusicPinned}
+        onClick={(e) => onPinPlaylistClick(ALL_MUSIC_PIN_ID, e)}
+        title={allMusicPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (12)')}
+        aria-label={allMusicPinned ? 'Unpin All Music' : 'Pin All Music to top'}
+      >
+        <PinIcon filled={allMusicPinned} />
+      </PinButton>
+    </PinnableListItem>
+  );
+});
+
+export { AllMusicCard };

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -71,6 +71,8 @@ export interface LibraryDataContextValue {
   isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
+  /** Track count for the Dropbox "All Music" aggregate row. 0 when Dropbox is disabled. */
+  allMusicCount: number;
   activeDescriptor: ProviderDescriptor | null;
 }
 

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { PlaylistInfo } from '../../services/spotify';
-import { LIKED_SONGS_ID } from '@/constants/playlist';
+import { ALL_MUSIC_PIN_ID, LIKED_SONGS_ID } from '@/constants/playlist';
 import ProviderIcon from '../ProviderIcon';
 import { PlaylistTypeIcon } from '../icons/QuickActionIcons';
 import {
@@ -26,14 +26,16 @@ import {
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 import { useLibraryBrowsingContext, useLibraryPins, useLibraryActions, useLibraryData } from './LibraryContext';
 import { LikedSongsCard } from './LikedSongsCard';
+import { AllMusicCard } from './AllMusicCard';
 
 export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const { hasActiveFilters, searchQuery, providerFilters } = useLibraryBrowsingContext();
   const { pinnedPlaylists, unpinnedPlaylists, isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
   const { onPlaylistContextMenu } = useLibraryActions();
-  const { inDrawer, likedSongsPerProvider, likedSongsCount, isUnifiedLikedActive, unifiedLikedCount, isInitialLoadComplete, showProviderBadges } = useLibraryData();
+  const { inDrawer, likedSongsPerProvider, likedSongsCount, isUnifiedLikedActive, unifiedLikedCount, isInitialLoadComplete, showProviderBadges, allMusicCount, enabledProviderIds } = useLibraryData();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
+  const allMusicPinned = isPlaylistPinned(ALL_MUSIC_PIN_ID);
 
   const filteredLikedSongsPerProvider = providerFilters.length > 0
     ? likedSongsPerProvider.filter(e => providerFilters.includes(e.provider))
@@ -53,6 +55,11 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
       ))
     : <LikedSongsCard layout={layout} count={effectiveLikedCount} />
   );
+
+  const dropboxEnabled = enabledProviderIds.includes('dropbox');
+  const passesProviderFilter = providerFilters.length === 0 || providerFilters.includes('dropbox');
+  const showAllMusic = dropboxEnabled && passesProviderFilter && (allMusicCount > 0 || !isInitialLoadComplete);
+  const allMusicItem = showAllMusic && <AllMusicCard layout={layout} count={allMusicCount} />;
 
   const renderPlaylistGrid = (playlist: PlaylistInfo) => {
     const pinned = isPlaylistPinned(playlist.id);
@@ -123,7 +130,9 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   };
 
   const renderFn = inDrawer ? renderPlaylistGrid : renderPlaylistList;
-  const hasPinnedSection = pinnedPlaylists.length > 0 || (likedSongsPinned && showLikedSongs && !hasActiveFilters);
+  const hasPinnedSection = pinnedPlaylists.length > 0
+    || (likedSongsPinned && showLikedSongs && !hasActiveFilters)
+    || (allMusicPinned && showAllMusic && !hasActiveFilters);
 
   const filteredPlaylistsCount = pinnedPlaylists.length + unpinnedPlaylists.length;
   const emptyState = filteredPlaylistsCount === 0 && likedSongsCount === 0 && isInitialLoadComplete && (
@@ -137,9 +146,11 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const Grid = inDrawer ? MobileGrid : PlaylistGridDiv;
   return (
     <Grid $inDrawer={inDrawer ? undefined : false}>
+      {!hasActiveFilters && allMusicPinned && allMusicItem}
       {!hasActiveFilters && likedSongsPinned && likedSongsItem}
       {pinnedPlaylists.map(renderFn)}
       {hasPinnedSection && <PinnedSectionLabel key="__pin-sep">Pinned</PinnedSectionLabel>}
+      {(hasActiveFilters || !allMusicPinned) && allMusicItem}
       {(hasActiveFilters || !likedSongsPinned) && likedSongsItem}
       {unpinnedPlaylists.map(renderFn)}
       {emptyState}

--- a/src/components/PlaylistSelection/__tests__/AllMusicCard.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/AllMusicCard.test.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { AllMusicCard } from '../AllMusicCard';
+import {
+  LibraryActionsProvider,
+  LibraryDataProvider,
+  LibraryPinProvider,
+  type LibraryActionsContextValue,
+  type LibraryDataContextValue,
+  type LibraryPinContextValue,
+} from '../LibraryContext';
+import { ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+import { PinnedItemsProvider, usePinnedItemsContext } from '@/contexts/PinnedItemsContext';
+import { setPins, UNIFIED_PROVIDER } from '@/services/settings/pinnedItemsStorage';
+
+interface HarnessOverrides {
+  isPinned?: boolean;
+  canPinMore?: boolean;
+  onPlaylistContextMenu?: LibraryActionsContextValue['onPlaylistContextMenu'];
+  onPinPlaylistClick?: LibraryPinContextValue['onPinPlaylistClick'];
+}
+
+function renderWithContext(
+  layout: 'grid' | 'list',
+  count: number,
+  overrides: HarnessOverrides = {},
+): { onPlaylistContextMenu: ReturnType<typeof vi.fn>; onPinPlaylistClick: ReturnType<typeof vi.fn> } {
+  const onPlaylistContextMenu = vi.fn();
+  const onPinPlaylistClick = vi.fn();
+
+  const data: LibraryDataContextValue = {
+    inDrawer: layout === 'grid',
+    albums: [],
+    isInitialLoadComplete: true,
+    showProviderBadges: false,
+    enabledProviderIds: ['dropbox'],
+    likedSongsPerProvider: [],
+    likedSongsCount: 0,
+    isLikedSongsSyncing: false,
+    isUnifiedLikedActive: false,
+    unifiedLikedCount: 0,
+    allMusicCount: count,
+    activeDescriptor: null,
+  };
+
+  const pin: LibraryPinContextValue = {
+    pinnedPlaylists: [],
+    unpinnedPlaylists: [],
+    pinnedAlbums: [],
+    unpinnedAlbums: [],
+    isPlaylistPinned: (id: string) => (overrides.isPinned ?? false) && id === ALL_MUSIC_PIN_ID,
+    canPinMorePlaylists: overrides.canPinMore ?? true,
+    isAlbumPinned: () => false,
+    canPinMoreAlbums: true,
+    onPinPlaylistClick: overrides.onPinPlaylistClick ?? onPinPlaylistClick,
+    onPinAlbumClick: vi.fn(),
+  };
+
+  const actions: LibraryActionsContextValue = {
+    onPlaylistClick: vi.fn(),
+    onPlaylistContextMenu: overrides.onPlaylistContextMenu ?? onPlaylistContextMenu,
+    onLikedSongsClick: vi.fn(),
+    onAlbumClick: vi.fn(),
+    onAlbumContextMenu: vi.fn(),
+    onArtistClick: vi.fn(),
+  };
+
+  render(
+    <ThemeProvider theme={theme}>
+      <LibraryDataProvider value={data}>
+        <LibraryPinProvider value={pin}>
+          <LibraryActionsProvider value={actions}>
+            <AllMusicCard layout={layout} count={count} />
+          </LibraryActionsProvider>
+        </LibraryPinProvider>
+      </LibraryDataProvider>
+    </ThemeProvider>,
+  );
+
+  return { onPlaylistContextMenu, onPinPlaylistClick };
+}
+
+describe('AllMusicCard', () => {
+  describe('grid layout', () => {
+    it('renders the title, "{N} tracks • Shuffled" subtitle, and shuffle glyph', () => {
+      // #when
+      renderWithContext('grid', 248);
+
+      // #then
+      expect(screen.getByText('All Music')).toBeInTheDocument();
+      expect(screen.getByText('248 tracks • Shuffled')).toBeInTheDocument();
+      expect(screen.getByTestId('all-music-shuffle-glyph')).toBeInTheDocument();
+    });
+
+    it('renders the branded art container with a linear-gradient background', () => {
+      // #when
+      renderWithContext('grid', 5);
+
+      // #then
+      const art = screen.getByTestId('all-music-art');
+      const style = art.getAttribute('style') ?? '';
+      expect(style.toLowerCase()).toContain('linear-gradient');
+    });
+
+    it('opens the playlist popover when the card is clicked', () => {
+      // #when
+      const { onPlaylistContextMenu } = renderWithContext('grid', 10);
+      fireEvent.click(screen.getByText('All Music'));
+
+      // #then
+      expect(onPlaylistContextMenu).toHaveBeenCalledTimes(1);
+      const playlistArg = onPlaylistContextMenu.mock.calls[0][0];
+      expect(playlistArg).toMatchObject({ id: '', name: 'All Music', provider: 'dropbox' });
+    });
+  });
+
+  describe('list layout', () => {
+    it('renders the title, "{N} tracks • Shuffled" subtitle, and shuffle glyph', () => {
+      // #when
+      renderWithContext('list', 12);
+
+      // #then
+      expect(screen.getByText('All Music')).toBeInTheDocument();
+      expect(screen.getByText('12 tracks • Shuffled')).toBeInTheDocument();
+      expect(screen.getByTestId('all-music-shuffle-glyph')).toBeInTheDocument();
+    });
+
+    it('exposes a pin button labelled for All Music', () => {
+      // #when
+      renderWithContext('list', 12, { isPinned: false });
+
+      // #then
+      expect(screen.getByRole('button', { name: /pin all music to top/i })).toBeInTheDocument();
+    });
+
+    it('switches the pin button label to "Unpin All Music" when pinned', () => {
+      // #when
+      renderWithContext('list', 12, { isPinned: true });
+
+      // #then
+      expect(screen.getByRole('button', { name: /unpin all music/i })).toBeInTheDocument();
+    });
+
+    it('invokes onPinPlaylistClick with ALL_MUSIC_PIN_ID when the pin button is clicked', () => {
+      // #when
+      const { onPinPlaylistClick } = renderWithContext('list', 12);
+      fireEvent.click(screen.getByRole('button', { name: /pin all music to top/i }));
+
+      // #then
+      expect(onPinPlaylistClick).toHaveBeenCalledTimes(1);
+      expect(onPinPlaylistClick.mock.calls[0][0]).toBe(ALL_MUSIC_PIN_ID);
+    });
+  });
+});
+
+function PinHarness({ onState }: { onState: (state: { ids: string[]; togglePin: (id: string) => void }) => void }) {
+  const { pinnedPlaylistIds, togglePinPlaylist } = usePinnedItemsContext();
+  React.useEffect(() => {
+    onState({ ids: pinnedPlaylistIds, togglePin: togglePinPlaylist });
+  }, [pinnedPlaylistIds, togglePinPlaylist, onState]);
+  return null;
+}
+
+describe('AllMusicCard pin persistence', () => {
+  beforeEach(async () => {
+    await setPins(UNIFIED_PROVIDER, 'playlists', []);
+    await setPins(UNIFIED_PROVIDER, 'albums', []);
+  });
+
+  it('persists ALL_MUSIC_PIN_ID across remounts via the pinned-items store', async () => {
+    // #given — simulate a previous session pinning All Music
+    await setPins(UNIFIED_PROVIDER, 'playlists', [ALL_MUSIC_PIN_ID]);
+
+    // #when — fresh provider mount reads the persisted state
+    const states: Array<{ ids: string[]; togglePin: (id: string) => void }> = [];
+    render(
+      <PinnedItemsProvider>
+        <PinHarness onState={(s) => states.push(s)} />
+      </PinnedItemsProvider>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).toContain(ALL_MUSIC_PIN_ID);
+    });
+  });
+
+  it('toggling unpin removes ALL_MUSIC_PIN_ID from persisted state', async () => {
+    // #given
+    await setPins(UNIFIED_PROVIDER, 'playlists', [ALL_MUSIC_PIN_ID]);
+    const states: Array<{ ids: string[]; togglePin: (id: string) => void }> = [];
+    render(
+      <PinnedItemsProvider>
+        <PinHarness onState={(s) => states.push(s)} />
+      </PinnedItemsProvider>,
+    );
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).toContain(ALL_MUSIC_PIN_ID);
+    });
+
+    // #when
+    await act(async () => {
+      states.at(-1)?.togglePin(ALL_MUSIC_PIN_ID);
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).not.toContain(ALL_MUSIC_PIN_ID);
+    });
+  });
+});

--- a/src/components/PlaylistSelection/__tests__/AllMusicPlacement.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/AllMusicPlacement.test.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})) as unknown as typeof IntersectionObserver;
+
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { PlaylistGrid } from '../PlaylistGrid';
+import { AlbumGrid } from '../AlbumGrid';
+import {
+  LibraryActionsProvider,
+  LibraryBrowsingProvider,
+  LibraryDataProvider,
+  LibraryPinProvider,
+  type LibraryActionsContextValue,
+  type LibraryBrowsingContextValue,
+  type LibraryDataContextValue,
+  type LibraryPinContextValue,
+} from '../LibraryContext';
+import type { AlbumInfo } from '../../../services/spotify';
+
+const baseBrowsing: LibraryBrowsingContextValue = {
+  viewMode: 'playlists',
+  setViewMode: () => undefined,
+  searchQuery: '',
+  setSearchQuery: () => undefined,
+  playlistSort: 'recently-added',
+  setPlaylistSort: () => undefined,
+  albumSort: 'recently-added',
+  setAlbumSort: () => undefined,
+  artistFilter: '',
+  setArtistFilter: () => undefined,
+  providerFilters: [],
+  setProviderFilters: () => undefined,
+  handleProviderToggle: () => undefined,
+  availableGenres: [],
+  selectedGenres: [],
+  setSelectedGenres: () => undefined,
+  handleGenreToggle: () => undefined,
+  recentlyPlayed: [],
+  onRecentlyPlayedSelect: () => undefined,
+  hasActiveFilters: false,
+  handleClearFilters: () => undefined,
+};
+
+const baseActions: LibraryActionsContextValue = {
+  onPlaylistClick: vi.fn(),
+  onPlaylistContextMenu: vi.fn(),
+  onLikedSongsClick: vi.fn(),
+  onAlbumClick: vi.fn(),
+  onAlbumContextMenu: vi.fn(),
+  onArtistClick: vi.fn(),
+};
+
+const basePin: LibraryPinContextValue = {
+  pinnedPlaylists: [],
+  unpinnedPlaylists: [],
+  pinnedAlbums: [],
+  unpinnedAlbums: [],
+  isPlaylistPinned: () => false,
+  canPinMorePlaylists: true,
+  isAlbumPinned: () => false,
+  canPinMoreAlbums: true,
+  onPinPlaylistClick: vi.fn(),
+  onPinAlbumClick: vi.fn(),
+};
+
+const baseData: LibraryDataContextValue = {
+  inDrawer: false,
+  albums: [],
+  isInitialLoadComplete: true,
+  showProviderBadges: false,
+  enabledProviderIds: ['dropbox'],
+  likedSongsPerProvider: [],
+  likedSongsCount: 0,
+  isLikedSongsSyncing: false,
+  isUnifiedLikedActive: false,
+  unifiedLikedCount: 0,
+  allMusicCount: 250,
+  activeDescriptor: null,
+};
+
+function renderGrid(
+  Component: React.ComponentType,
+  data: Partial<LibraryDataContextValue> = {},
+  pin: Partial<LibraryPinContextValue> = {},
+  browsing: Partial<LibraryBrowsingContextValue> = {},
+) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <LibraryDataProvider value={{ ...baseData, ...data }}>
+        <LibraryBrowsingProvider value={{ ...baseBrowsing, ...browsing }}>
+          <LibraryPinProvider value={{ ...basePin, ...pin }}>
+            <LibraryActionsProvider value={baseActions}>
+              <Component />
+            </LibraryActionsProvider>
+          </LibraryPinProvider>
+        </LibraryBrowsingProvider>
+      </LibraryDataProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('PlaylistGrid placement of AllMusicCard', () => {
+  it('renders AllMusicCard inside the playlist grid when Dropbox is enabled', () => {
+    // #when
+    renderGrid(PlaylistGrid);
+
+    // #then
+    expect(screen.getByText('All Music')).toBeInTheDocument();
+    expect(screen.getByText('250 tracks • Shuffled')).toBeInTheDocument();
+  });
+
+  it('places AllMusicCard before any other entry (top anchor slot, before Liked Songs and pinned playlists)', () => {
+    // #when
+    renderGrid(PlaylistGrid, {
+      likedSongsCount: 7,
+      likedSongsPerProvider: [{ provider: 'dropbox', count: 7 }],
+    });
+
+    // #then — All Music heading appears before Liked Songs in document order
+    const allMusic = screen.getByText('All Music');
+    const liked = screen.getByText('Liked Songs');
+    expect(allMusic.compareDocumentPosition(liked) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('hides AllMusicCard when Dropbox is not in enabledProviderIds', () => {
+    // #when
+    renderGrid(PlaylistGrid, { enabledProviderIds: ['spotify'] });
+
+    // #then
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+
+  it('hides AllMusicCard when Dropbox is excluded by provider filter chip', () => {
+    // #when
+    renderGrid(PlaylistGrid, undefined, undefined, { providerFilters: ['spotify'] });
+
+    // #then
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+});
+
+describe('AlbumGrid does not render All Music', () => {
+  const dropboxAlbum: AlbumInfo = {
+    id: '/Artist/Abbey Road',
+    name: 'Abbey Road',
+    artists: 'The Beatles',
+    images: [],
+    release_date: '1969',
+    total_tracks: 17,
+    uri: '',
+    provider: 'dropbox',
+  };
+
+  it('renders only real albums even though All Music is fed via context data', () => {
+    // #when
+    renderGrid(
+      AlbumGrid,
+      { albums: [dropboxAlbum] },
+      { unpinnedAlbums: [dropboxAlbum] },
+    );
+
+    // #then
+    expect(screen.getByText('Abbey Road')).toBeInTheDocument();
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-state message when no real albums are present', () => {
+    // #when
+    const { container } = renderGrid(AlbumGrid);
+
+    // #then
+    expect(within(container).queryByText('All Music')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PlaylistSelection/playlistUtils.ts
+++ b/src/components/PlaylistSelection/playlistUtils.ts
@@ -31,3 +31,16 @@ export function likedSongsAsPlaylistInfo(provider?: ProviderId): PlaylistInfo {
     provider,
   };
 }
+
+/** Minimal playlist row for the Dropbox "All Music" aggregate — used to open the playlist popover. */
+export function allMusicAsPlaylistInfo(): PlaylistInfo {
+  return {
+    id: '',
+    name: 'All Music',
+    description: null,
+    images: [],
+    tracks: null,
+    owner: null,
+    provider: 'dropbox',
+  };
+}

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
-import { LIKED_SONGS_ID, isAlbumId, toAlbumPlaylistId } from '@/constants/playlist';
+import { LIKED_SONGS_ID, isAlbumId, isAllMusicPlaylist, toAlbumPlaylistId } from '@/constants/playlist';
 import TrackInfoPopover from '../controls/TrackInfoPopover';
 import Toast from '../Toast';
 import { useItemPopover } from './useItemPopover';
@@ -79,17 +79,22 @@ export function useItemActions({
       onQueue: onAddToQueue ? () => onAddToQueue(playlist.id, playlist.name, playlist.provider) : undefined,
     });
 
-    options.push(...buildLikedOptions({
-      collectionId: playlist.id,
-      collectionName: playlist.name,
-      collectionProvider: playlist.provider,
-      descriptor,
-      likedLoading,
-      onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
-      onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
-    }));
+    const isAllMusic = isAllMusicPlaylist(playlist);
 
-    const canDelete = descriptor?.capabilities.hasDeleteCollection &&
+    if (!isAllMusic) {
+      options.push(...buildLikedOptions({
+        collectionId: playlist.id,
+        collectionName: playlist.name,
+        collectionProvider: playlist.provider,
+        descriptor,
+        likedLoading,
+        onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
+        onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
+      }));
+    }
+
+    const canDelete = !isAllMusic &&
+      descriptor?.capabilities.hasDeleteCollection &&
       descriptor.catalog.deleteCollection &&
       playlist.id !== LIKED_SONGS_ID &&
       !isAlbumId(playlist.id);

--- a/src/components/PlaylistSelection/useLibraryContextValues.ts
+++ b/src/components/PlaylistSelection/useLibraryContextValues.ts
@@ -52,6 +52,7 @@ interface UseLibraryContextValuesParams {
   isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
+  allMusicCount: number;
   activeDescriptor: ProviderDescriptor | null;
 }
 
@@ -96,6 +97,7 @@ export function useLibraryContextValues({
   isLikedSongsSyncing,
   isUnifiedLikedActive,
   unifiedLikedCount,
+  allMusicCount,
   activeDescriptor,
 }: UseLibraryContextValuesParams): LibraryContextValuesResult {
   const browsingValue: LibraryBrowsingContextValue = useMemo(
@@ -200,6 +202,7 @@ export function useLibraryContextValues({
       isLikedSongsSyncing,
       isUnifiedLikedActive,
       unifiedLikedCount,
+      allMusicCount,
       activeDescriptor,
     }),
     [
@@ -214,6 +217,7 @@ export function useLibraryContextValues({
       isLikedSongsSyncing,
       isUnifiedLikedActive,
       unifiedLikedCount,
+      allMusicCount,
       activeDescriptor,
     ]
   );

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -53,6 +53,7 @@ export function useLibraryRoot({
     albums,
     likedSongsCount,
     likedSongsPerProvider,
+    allMusicCount,
     isInitialLoadComplete,
     isLikedSongsSyncing,
     removeCollection,
@@ -209,6 +210,7 @@ export function useLibraryRoot({
     isLikedSongsSyncing,
     isUnifiedLikedActive,
     unifiedLikedCount,
+    allMusicCount,
     activeDescriptor: activeDescriptor ?? null,
   });
 

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -10,11 +10,23 @@ export const LIKED_SONGS_NAME = 'Liked Songs';
 /** Special playlist ID representing the radio queue */
 export const RADIO_PLAYLIST_ID = 'radio';
 
-/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row, Dropbox "All Music" uses id ''). */
-export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, '']);
+/**
+ * Pin identifier for the Dropbox "All Music" aggregate row.
+ * Distinct from the underlying collection id (`''`) so the pin survives
+ * even if the catalog representation of All Music changes.
+ */
+export const ALL_MUSIC_PIN_ID = 'dropbox-all-music';
 
-/** Album IDs that stay in catalog order and are not reordered by library sort (Dropbox aggregate uses id ''). */
-export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set(['']);
+/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row). */
+export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID]);
+
+/** Album IDs that stay in catalog order and are not reordered by library sort. */
+export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set();
+
+/** Returns true when the playlist info represents the Dropbox "All Music" aggregate row. */
+export function isAllMusicPlaylist(playlist: { id: string; provider?: string }): boolean {
+  return playlist.id === '' && playlist.provider === 'dropbox';
+}
 
 /** Check whether a playlist selection ID represents an album */
 export function isAlbumId(playlistId: string): boolean {

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -24,6 +24,8 @@ interface UseLibrarySyncResult {
   likedSongsCount: number;
   /** Liked counts broken down by provider (for multi-provider liked songs cards). */
   likedSongsPerProvider: PerProviderLikedCount[];
+  /** Total track count for the Dropbox "All Music" aggregate row, or 0 when Dropbox is not enabled. */
+  allMusicCount: number;
   isInitialLoadComplete: boolean;
   isSyncing: boolean;
   /** True while liked counts from the synchronous cache seed are being verified by async sources. */
@@ -83,19 +85,33 @@ function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
   };
 }
 
-function splitCollections(collections: MediaCollection[]): { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[] } {
+/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
+function isAllMusicCollection(c: MediaCollection): boolean {
+  return c.provider === 'dropbox' && c.id === '';
+}
+
+function splitCollections(collections: MediaCollection[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  allMusicCount: number;
+} {
   const playlists: CachedPlaylistInfo[] = [];
   const albums: AlbumInfo[] = [];
   let playlistOrdinal = 0;
   let albumOrdinal = 0;
+  let allMusicCount = 0;
   for (const c of collections) {
+    if (isAllMusicCollection(c)) {
+      allMusicCount = c.trackCount ?? 0;
+      continue;
+    }
     if (c.kind === 'album') {
       albums.push(collectionToAlbumInfo(c, albumOrdinal++));
     } else {
       playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
     }
   }
-  return { playlists, albums };
+  return { playlists, albums, allMusicCount };
 }
 
 export function useLibrarySync(): UseLibrarySyncResult {
@@ -105,6 +121,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const [albums, setAlbums] = useState<AlbumInfo[]>([]);
   const [likedSongsCount, setLikedSongsCount] = useState(() => initialSnapshot.total);
   const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>(() => initialSnapshot.perProvider);
+  const [allMusicCount, setAllMusicCount] = useState(0);
   const [syncState, setSyncState] = useState<SyncState>({
     isInitialLoadComplete: false,
     isSyncing: false,
@@ -119,7 +136,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,
   });
-  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>>(new Map());
+  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
 
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
   const catalogProviderIds = enabledProviderIds.filter(id => id !== engineProviderId);
@@ -128,6 +145,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     const allPlaylists: CachedPlaylistInfo[] = [];
     const allAlbums: AlbumInfo[] = [];
     let totalLikedCount = 0;
+    let totalAllMusicCount = 0;
     const perProvider: PerProviderLikedCount[] = [];
 
     if (isEngineProviderEnabled && engineProviderId) {
@@ -144,6 +162,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
         allPlaylists.push(...data.playlists);
         allAlbums.push(...data.albums);
         totalLikedCount += data.likedCount;
+        totalAllMusicCount += data.allMusicCount;
         if (data.likedCount > 0) {
           perProvider.push({ provider: providerId, count: data.likedCount });
         }
@@ -154,6 +173,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     setAlbums(allAlbums);
     setLikedSongsCount(totalLikedCount);
     setLikedSongsPerProvider(perProvider);
+    setAllMusicCount(totalAllMusicCount);
   }, [isEngineProviderEnabled, engineProviderId, enabledProviderIds]);
 
   useEffect(() => {
@@ -212,7 +232,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       const catalog = descriptor?.catalog;
       const auth = descriptor?.auth;
       if (!catalog || !auth || !auth.isAuthenticated()) {
-        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0 });
+        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
         return;
       }
 
@@ -228,12 +248,12 @@ export function useLibrarySync(): UseLibrarySyncResult {
         logLibrary('[%s] raw collections from catalog: %o', providerId,
           collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
 
-        const { playlists, albums } = splitCollections(collections);
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
         logLibrary('[%s] after splitCollections — playlists: %o', providerId,
           playlists.map(p => ({ name: p.name, tracks: p.tracks })));
         logLibrary('[%s] after splitCollections — albums: %o', providerId,
           albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
         writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
@@ -312,8 +332,8 @@ export function useLibrarySync(): UseLibrarySyncResult {
           catalog.listCollections(undefined, { forceRefresh: true }),
           catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
         ]);
-        const { playlists, albums } = splitCollections(collections);
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
         writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
@@ -367,6 +387,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     albums,
     likedSongsCount,
     likedSongsPerProvider,
+    allMusicCount,
     isInitialLoadComplete: syncState.isInitialLoadComplete,
     isSyncing: syncState.isSyncing,
     isLikedSongsSyncing,

--- a/src/utils/__tests__/playlistFilters.test.ts
+++ b/src/utils/__tests__/playlistFilters.test.ts
@@ -133,16 +133,7 @@ describe('filterAndSortPlaylists', () => {
       expect(result[2].name).toBe('Chill Vibes'); // 2024-06-15
     });
 
-    it('keeps anchor playlists before sorted remainder (All Music id "", liked-songs)', () => {
-      const allMusic: PlaylistInfo = {
-        id: '',
-        name: 'All Music',
-        description: null,
-        images: [],
-        tracks: { total: 100 },
-        owner: null,
-        added_at: '2020-01-01T10:00:00Z',
-      };
+    it('keeps Liked Songs anchored before sorted remainder (All Music has its own anchored card now)', () => {
       const likedInList: PlaylistInfo = {
         id: 'liked-songs',
         name: 'Liked Songs',
@@ -152,10 +143,9 @@ describe('filterAndSortPlaylists', () => {
         owner: null,
         added_at: '2021-01-01T10:00:00Z',
       };
-      const mixed = [mockPlaylists[2], allMusic, mockPlaylists[0], likedInList];
+      const mixed = [mockPlaylists[2], mockPlaylists[0], likedInList];
       const result = filterAndSortPlaylists(mixed, '', 'name-asc');
       expect(result.map(p => p.name)).toEqual([
-        'All Music',
         'Liked Songs',
         'Chill Vibes',
         'Road Trip',
@@ -364,21 +354,10 @@ describe('filterAndSortAlbums', () => {
       expect(result[1].name).toBe('Let It Be');
     });
 
-    it('keeps anchor album (id "") before sorted remainder', () => {
-      const allMusic: AlbumInfo = {
-        id: '',
-        name: 'All Music',
-        artists: 'Various',
-        images: [],
-        release_date: '',
-        total_tracks: 999,
-        uri: '',
-        added_at: '2010-01-01T10:00:00Z',
-      };
-      const mixed = [mockAlbums[2], allMusic, mockAlbums[0]];
+    it('sorts albums without anchor exceptions (All Music no longer lives in the album list)', () => {
+      const mixed = [mockAlbums[2], mockAlbums[0]];
       const result = filterAndSortAlbums(mixed, '', 'name-asc');
       expect(result.map(a => a.name)).toEqual([
-        'All Music',
         'Abbey Road',
         'Random Access Memories',
       ]);


### PR DESCRIPTION
## Summary
- Adds `AllMusicCard.tsx` with a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph (modeled on `LikedSongsCard`)
- Subtitle reads `"{N} tracks • Shuffled"` in both grid and list layouts
- Splits the Dropbox "All Music" aggregate out of the album grid via `useLibrarySync` and renders it at the top anchor slot of the playlist grid alongside Liked Songs
- Adds `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` and retires the `id === ''` entries from `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS`
- Suppresses Liked Songs sub-options and the delete option in the playlist popover when the row is the All Music aggregate

## Test plan
- [x] `AllMusicCard` renders the title, `"{N} tracks • Shuffled"` subtitle, and shuffle-glyph art in both grid and list layouts
- [x] All Music is not rendered in `AlbumGrid`
- [x] All Music is rendered in `PlaylistGrid` at the top anchor slot, before Liked Songs
- [x] All Music is hidden when Dropbox is not in `enabledProviderIds` or is excluded by the provider filter chip
- [x] Pin/unpin via `ALL_MUSIC_PIN_ID` persists across remounts through the pinned-items store
- [x] `npm run test:run` — 1051/1051 pass
- [x] `npx tsc -b --noEmit` clean

Closes #1091