### PR TITLE
docs: document AllMusicCard placement and shuffle-by-default semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,11 @@ Dropbox root/
     ├── cover.jpg     # also: album.jpg, folder.jpg, front.jpg
     └── 01 - Track.mp3
 ```
-Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection is always prepended.
+Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended.
+
+**Dropbox "All Music" card**: `useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. `AllMusicCard` (`src/components/PlaylistSelection/AllMusicCard.tsx`) renders the row in the **playlist grid** at the top anchor slot, alongside `LikedSongsCard`. The card uses a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph in both grid and list layouts; subtitle is `"{N} tracks • Shuffled"`. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
+
+**All Music shuffle-by-default**: Loading or appending the All Music aggregate always shuffles, independently of the global `shuffleEnabled` toggle. Detection uses `isAllMusicRef(collectionRef)` from `src/constants/playlist.ts`. `useCollectionLoader.applyTracks` accepts a `forceShuffle` option that ORs with `shuffleEnabled`; `loadCollection` passes `{ forceShuffle: isAllMusicRef(ref) }`. `useQueueManagement.handleAddToQueue` shuffles the fetched tracks with `shuffleArray()` before deduping and appending. The user's `shuffleEnabled` preference is not mutated — it remains whatever they set globally.
 
 **Dropbox Liked Songs**: Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet
 - **Playlists & Albums** — Browse, search, sort, filter, and pin your **library** collections (not the same as the playback queue)
+- **All Music shuffle** — Dropbox users get an "All Music" card pinned to the top of the playlist grid that always plays your entire library shuffled
 - **Unified Liked Songs** — Merge liked tracks from connected providers into one queue; "Play Liked" and "Queue Liked" filter any collection to just your favorites
 - **Track Radio** — Generate a one-shot radio playlist from the current track (Last.fm-powered matching)
 - **Visual Effects** — Dynamic glow, configurable album art filters, accent color backgrounds

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -157,7 +157,7 @@ On mobile, `useLibraryRoot` sets `ignoreProviderFilters = isMobile` (line 125). 
 - Non-empty array = show only items from selected providers
 - Toggle semantics: clicking a provider in the filter adds/removes it; removing the last provider resets to "all"
 
-**Sort anchors:** Certain special collections (`LIKED_SONGS_ID`, Dropbox "All Music" with id `''`) are exempt from sort reordering -- they always stay in catalog order. Defined in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`.
+**Sort anchors:** `LIKED_SONGS_ID` is exempt from sort reordering — it always stays in catalog order. Defined in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`. The Dropbox "All Music" aggregate (id `''`) used to live here too, but it was retired when All Music moved out of the sortable lists into its own dedicated `AllMusicCard`. `LIBRARY_ALBUM_SORT_ANCHOR_IDS` is now empty.
 
 ## Pinned Items
 
@@ -207,6 +207,52 @@ Refresh triggers:
 
 When unified liked is active and user clicks "Liked Songs" without specifying a provider, `useCollectionLoader.loadUnifiedLiked` fetches from all providers, merges, sorts, and loads into the queue.
 
+## All Music Card
+
+**File:** `src/components/PlaylistSelection/AllMusicCard.tsx`
+
+Dropbox exposes a synthetic "All Music" collection (kind `'folder'`, id `''`) that aggregates every audio file in the user's library. The card representation lives in the **playlist grid** rather than the album grid.
+
+### Source of truth
+
+`useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` on the hook result, separate from `playlists` and `albums`. It is then threaded through `useLibraryRoot` into `LibraryDataContextValue.allMusicCount`. Because All Music never enters the `albums` array, `AlbumGrid` cannot render it.
+
+### Placement
+
+`PlaylistGrid` renders `AllMusicCard` at the top anchor slot, alongside `LikedSongsCard`:
+
+- When `ALL_MUSIC_PIN_ID` is pinned, the card renders **above** the `Pinned` section label.
+- When unpinned, the card renders **above** the unpinned playlist list (still anchored to the top).
+- The card is hidden when Dropbox is not in `enabledProviderIds` or is excluded by the provider filter chip.
+- During the initial load, the card renders with a spinner subtitle until `allMusicCount` resolves.
+
+### Visual design
+
+- **Art:** Dropbox-tinted gradient (`getLikedSongsGradient('dropbox')`) with a prominent crossed-arrows shuffle SVG glyph (no emoji). The same component renders in both grid (64px glyph) and list (28px glyph) layouts.
+- **Title:** `"All Music"`.
+- **Subtitle:** `"{N} tracks • Shuffled"` — communicates the shuffle-by-default semantics.
+
+### Pin identifier
+
+Pin state uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (defined in `src/constants/playlist.ts`), distinct from the underlying collection id `''`. Using a stable pin identifier means the pin survives changes to how the catalog represents All Music. Pin/unpin flows through `PinnedItemsContext.togglePinPlaylist` like any other playlist pin and persists to IndexedDB.
+
+### Popover actions
+
+Clicking the card opens the standard playlist popover via `useItemActions`. The "Liked Songs" sub-options and the "Delete" option are suppressed for All Music (`isAllMusicPlaylist(playlist)` check) because the synthetic collection has no underlying playlist to like or delete.
+
+## Shuffle-by-default semantics
+
+The All Music aggregate always plays shuffled, independently of the global `shuffleEnabled` toggle. This is enforced at two entry points:
+
+| Entry point | Behavior |
+|------------|----------|
+| `useCollectionLoader.loadCollection(ref)` | Calls `applyTracks(list, { forceShuffle: isAllMusicRef(ref) })`. `applyTracks` ORs `forceShuffle` with `shuffleEnabled`, so All Music always shuffles regardless of the user's global preference. |
+| `useQueueManagement.handleAddToQueue(id, ...)` | When `isAllMusicRef(collectionRef)` is true, the fetched tracks are passed through `shuffleArray()` before deduping and appending to the queue. |
+
+The detection helper `isAllMusicRef(ref)` (from `src/constants/playlist.ts`) returns true when `ref.provider === 'dropbox' && ref.kind === 'folder' && ref.id === ''`.
+
+**The user's `shuffleEnabled` preference is never mutated.** Forcing shuffle for All Music is purely additive — it does not flip the global toggle, so loading All Music and then loading a different collection returns to the user's chosen shuffle state.
+
 ## ResumeCard
 
 `LibraryPage` accepts a `footer` prop. `AudioPlayer.tsx` passes a `ResumeCard` as the footer when `lastSession` and `handleResume` are available, allowing users to resume a previous playback session regardless of QAP state.
@@ -248,6 +294,7 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 | `src/components/PlaylistSelection/PlaylistGrid.tsx` | Playlist card grid |
 | `src/components/PlaylistSelection/AlbumGrid.tsx` | Album card grid |
 | `src/components/PlaylistSelection/LikedSongsCard.tsx` | Liked songs entry card |
+| `src/components/PlaylistSelection/AllMusicCard.tsx` | Dropbox "All Music" entry card with shuffle branding |
 | `src/components/LibraryDrawer/FilterSidebar.tsx` | Collection type toggle and provider checkboxes (desktop only) |
 | `src/components/AudioPlayer.tsx` | Renders `LibraryPage` lazily when `showLibrary` is true |
 | `src/components/PlayerStateRenderer.tsx` | Idle view routing (QAP vs library) |
@@ -260,7 +307,7 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 | `src/hooks/useRecentlyPlayedCollections.ts` | Recently played collection history (localStorage) |
 | `src/hooks/usePlayerLogic.ts` | `showLibrary`, `handleOpenLibrary`, `handleCloseLibrary` |
 | `src/utils/playlistFilters.ts` | Filter/sort/pin-split utilities |
-| `src/constants/playlist.ts` | LIKED_SONGS_ID, sort anchor IDs, ID encoding |
+| `src/constants/playlist.ts` | LIKED_SONGS_ID, ALL_MUSIC_PIN_ID, isAllMusicRef, isAllMusicPlaylist, sort anchor IDs, ID encoding |
 | `src/components/PlayerContent/DrawerOrchestrator.tsx` | Drawer switching and toast management |
 
 ## Cross-Cutting Concerns

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -417,7 +417,7 @@ Dropbox root/
 - Parent folder = artist name
 - Track ID = lowercase file path
 - Album ID = lowercase folder path
-- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list
+- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list. It is rendered by `AllMusicCard` in the playlist grid (not the album grid) and always plays shuffled. See [Library — All Music Card](./library.md#all-music-card) for placement, pin behavior (`ALL_MUSIC_PIN_ID = 'dropbox-all-music'`), and shuffle-by-default semantics.
 
 ### Token Refresh
 


### PR DESCRIPTION
## Summary
Documents the AllMusicCard introduced in #1091 and the shuffle-by-default behavior introduced in #1090.

- **README.md** — adds an "All Music shuffle" bullet under Playlists & Albums.
- **CLAUDE.md** — extends the Dropbox provider section with paragraphs covering AllMusicCard placement, the `splitCollections` / `allMusicCount` source of truth, `ALL_MUSIC_PIN_ID`, the retired `id === ''` sort anchors, and the `isAllMusicRef`-driven forced shuffle in `applyTracks` and `handleAddToQueue` (with the explicit note that the global `shuffleEnabled` toggle is never mutated).
- **docs/features/library.md** — rewrites the sort-anchors paragraph (`LIBRARY_ALBUM_SORT_ANCHOR_IDS` is now empty), adds "All Music Card" and "Shuffle-by-default semantics" subsections, lists `AllMusicCard.tsx` in the key files table, and updates the `src/constants/playlist.ts` entry.
- **docs/features/providers.md** — cross-links the Dropbox folder structure bullet to the new library docs.

Depends on #1111 and #1112. Once both merge, this PR captures the resulting feature accurately.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] No code changes — docs-only PR
- [x] Cross-links between `library.md` and `providers.md` resolve
- [x] All file paths and identifier names match the code shipped in #1111 / #1112

Closes #1092