### PR TITLE
release: 2026-04-18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,11 @@ Dropbox root/
     ├── cover.jpg     # also: album.jpg, folder.jpg, front.jpg
     └── 01 - Track.mp3
 ```
-Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection is always prepended.
+Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended.
+
+**Dropbox "All Music" card**: `useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. `AllMusicCard` (`src/components/PlaylistSelection/AllMusicCard.tsx`) renders the row in the **playlist grid** at the top anchor slot, alongside `LikedSongsCard`. The card uses a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph in both grid and list layouts; subtitle is `"{N} tracks • Shuffled"`. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
+
+**All Music shuffle-by-default**: Loading or appending the All Music aggregate always shuffles, independently of the global `shuffleEnabled` toggle. Detection uses `isAllMusicRef(collectionRef)` from `src/constants/playlist.ts`. `useCollectionLoader.applyTracks` accepts a `forceShuffle` option that ORs with `shuffleEnabled`; `loadCollection` passes `{ forceShuffle: isAllMusicRef(ref) }`. `useQueueManagement.handleAddToQueue` shuffles the fetched tracks with `shuffleArray()` before deduping and appending. The user's `shuffleEnabled` preference is not mutated — it remains whatever they set globally.
 
 **Dropbox Liked Songs**: Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,17 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 
 **Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`). Both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection`.
 
+**Provider toggle (Music Sources section in settings)**:
+- Each provider row has a single on/off toggle — there is no separate Reconnect button.
+- `enabledProviderIds` — localStorage-persisted set of providers the user has opted into.
+- `connectedProviderIds` — derived set: `enabledProviderIds` ∩ authenticated providers. Used by cross-provider features (Unified Liked Songs, radio resolver).
+- Toggle-OFF: opens `ProviderDisconnectDialog` showing the provider name and count of queued tracks that will be removed. Confirming calls `logout()`, removes the provider from `enabledProviderIds`, and cleans up queue/playback state. The last enabled provider's toggle is disabled to prevent a zero-provider state.
+- Toggle-ON when already authenticated: silently adds to `enabledProviderIds`.
+- Toggle-ON when not authenticated: calls `beginLogin({ popup: true })` immediately. The provider is added to `enabledProviderIds` only after the OAuth popup reports success via `AUTH_COMPLETE_EVENT`.
+- OAuth cancel/failure: toggle reverts; a toast shows `"Couldn't connect to {provider}. Try again."`.
+- Mid-session unrecoverable 401: `logout()` is called automatically; a toast shows `"{Provider} disconnected — session expired."`.
+- Implementation: `src/components/VisualEffectsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
+
 **Unified playback across providers**:
 - Queue items are represented as provider-agnostic `MediaTrack` records and can mix Spotify + Dropbox tracks in one queue.
 - Provider model:
@@ -131,12 +142,12 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
   - `useProviderPlayback` resolves provider per index (`track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback).
   - `usePlayerLogic` owns control actions and playback-state synchronization using `getDrivingProviderId()`.
   - `useAutoAdvance` advances based on events from the current driving provider.
-- Unified liked songs can merge liked tracks from all connected providers and sort by `addedAt`.
+- Unified liked songs can merge liked tracks from all connected providers (`connectedProviderIds`) and sort by `addedAt`.
 
 **Radio generation**:
 - Radio is a one-shot action (not a sticky toggle) that builds a playlist from the current track.
 - `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
-- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated.
+- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated and Spotify is in `connectedProviderIds`.
 - Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
 - **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 
 ## Features
 
-- **Multi-Provider Support** — Stream from Spotify or your personal Dropbox music library
+- **Multi-Provider Support** — Stream from Spotify or your personal Dropbox music library; enable/disable providers via a single toggle in settings (requires re-auth when not yet connected; disabling removes that provider's tracks from the queue)
 - **Unified Cross-Provider Playback** — Keep playback controls consistent across mixed Spotify + Dropbox queues
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet
 - **Playlists & Albums** — Browse, search, sort, filter, and pin your **library** collections (not the same as the playback queue)
+- **All Music shuffle** — Dropbox users get an "All Music" card pinned to the top of the playlist grid that always plays your entire library shuffled
 - **Unified Liked Songs** — Merge liked tracks from connected providers into one queue; "Play Liked" and "Queue Liked" filter any collection to just your favorites
 - **Track Radio** — Generate a one-shot radio playlist from the current track (Last.fm-powered matching)
 - **Visual Effects** — Dynamic glow, configurable album art filters, accent color backgrounds

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -157,7 +157,7 @@ On mobile, `useLibraryRoot` sets `ignoreProviderFilters = isMobile` (line 125). 
 - Non-empty array = show only items from selected providers
 - Toggle semantics: clicking a provider in the filter adds/removes it; removing the last provider resets to "all"
 
-**Sort anchors:** Certain special collections (`LIKED_SONGS_ID`, Dropbox "All Music" with id `''`) are exempt from sort reordering -- they always stay in catalog order. Defined in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`.
+**Sort anchors:** `LIKED_SONGS_ID` is exempt from sort reordering — it always stays in catalog order. Defined in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`. The Dropbox "All Music" aggregate (id `''`) used to live here too, but it was retired when All Music moved out of the sortable lists into its own dedicated `AllMusicCard`. `LIBRARY_ALBUM_SORT_ANCHOR_IDS` is now empty.
 
 ## Pinned Items
 
@@ -207,6 +207,52 @@ Refresh triggers:
 
 When unified liked is active and user clicks "Liked Songs" without specifying a provider, `useCollectionLoader.loadUnifiedLiked` fetches from all providers, merges, sorts, and loads into the queue.
 
+## All Music Card
+
+**File:** `src/components/PlaylistSelection/AllMusicCard.tsx`
+
+Dropbox exposes a synthetic "All Music" collection (kind `'folder'`, id `''`) that aggregates every audio file in the user's library. The card representation lives in the **playlist grid** rather than the album grid.
+
+### Source of truth
+
+`useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` on the hook result, separate from `playlists` and `albums`. It is then threaded through `useLibraryRoot` into `LibraryDataContextValue.allMusicCount`. Because All Music never enters the `albums` array, `AlbumGrid` cannot render it.
+
+### Placement
+
+`PlaylistGrid` renders `AllMusicCard` at the top anchor slot, alongside `LikedSongsCard`:
+
+- When `ALL_MUSIC_PIN_ID` is pinned, the card renders **above** the `Pinned` section label.
+- When unpinned, the card renders **above** the unpinned playlist list (still anchored to the top).
+- The card is hidden when Dropbox is not in `enabledProviderIds` or is excluded by the provider filter chip.
+- During the initial load, the card renders with a spinner subtitle until `allMusicCount` resolves.
+
+### Visual design
+
+- **Art:** Dropbox-tinted gradient (`getLikedSongsGradient('dropbox')`) with a prominent crossed-arrows shuffle SVG glyph (no emoji). The same component renders in both grid (64px glyph) and list (28px glyph) layouts.
+- **Title:** `"All Music"`.
+- **Subtitle:** `"{N} tracks • Shuffled"` — communicates the shuffle-by-default semantics.
+
+### Pin identifier
+
+Pin state uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (defined in `src/constants/playlist.ts`), distinct from the underlying collection id `''`. Using a stable pin identifier means the pin survives changes to how the catalog represents All Music. Pin/unpin flows through `PinnedItemsContext.togglePinPlaylist` like any other playlist pin and persists to IndexedDB.
+
+### Popover actions
+
+Clicking the card opens the standard playlist popover via `useItemActions`. The "Liked Songs" sub-options and the "Delete" option are suppressed for All Music (`isAllMusicPlaylist(playlist)` check) because the synthetic collection has no underlying playlist to like or delete.
+
+## Shuffle-by-default semantics
+
+The All Music aggregate always plays shuffled, independently of the global `shuffleEnabled` toggle. This is enforced at two entry points:
+
+| Entry point | Behavior |
+|------------|----------|
+| `useCollectionLoader.loadCollection(ref)` | Calls `applyTracks(list, { forceShuffle: isAllMusicRef(ref) })`. `applyTracks` ORs `forceShuffle` with `shuffleEnabled`, so All Music always shuffles regardless of the user's global preference. |
+| `useQueueManagement.handleAddToQueue(id, ...)` | When `isAllMusicRef(collectionRef)` is true, the fetched tracks are passed through `shuffleArray()` before deduping and appending to the queue. |
+
+The detection helper `isAllMusicRef(ref)` (from `src/constants/playlist.ts`) returns true when `ref.provider === 'dropbox' && ref.kind === 'folder' && ref.id === ''`.
+
+**The user's `shuffleEnabled` preference is never mutated.** Forcing shuffle for All Music is purely additive — it does not flip the global toggle, so loading All Music and then loading a different collection returns to the user's chosen shuffle state.
+
 ## ResumeCard
 
 `LibraryPage` accepts a `footer` prop. `AudioPlayer.tsx` passes a `ResumeCard` as the footer when `lastSession` and `handleResume` are available, allowing users to resume a previous playback session regardless of QAP state.
@@ -248,6 +294,7 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 | `src/components/PlaylistSelection/PlaylistGrid.tsx` | Playlist card grid |
 | `src/components/PlaylistSelection/AlbumGrid.tsx` | Album card grid |
 | `src/components/PlaylistSelection/LikedSongsCard.tsx` | Liked songs entry card |
+| `src/components/PlaylistSelection/AllMusicCard.tsx` | Dropbox "All Music" entry card with shuffle branding |
 | `src/components/LibraryDrawer/FilterSidebar.tsx` | Collection type toggle and provider checkboxes (desktop only) |
 | `src/components/AudioPlayer.tsx` | Renders `LibraryPage` lazily when `showLibrary` is true |
 | `src/components/PlayerStateRenderer.tsx` | Idle view routing (QAP vs library) |
@@ -260,7 +307,7 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 | `src/hooks/useRecentlyPlayedCollections.ts` | Recently played collection history (localStorage) |
 | `src/hooks/usePlayerLogic.ts` | `showLibrary`, `handleOpenLibrary`, `handleCloseLibrary` |
 | `src/utils/playlistFilters.ts` | Filter/sort/pin-split utilities |
-| `src/constants/playlist.ts` | LIKED_SONGS_ID, sort anchor IDs, ID encoding |
+| `src/constants/playlist.ts` | LIKED_SONGS_ID, ALL_MUSIC_PIN_ID, isAllMusicRef, isAllMusicPlaylist, sort anchor IDs, ID encoding |
 | `src/components/PlayerContent/DrawerOrchestrator.tsx` | Drawer switching and toast management |
 
 ## Cross-Cutting Concerns

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -417,7 +417,7 @@ Dropbox root/
 - Parent folder = artist name
 - Track ID = lowercase file path
 - Album ID = lowercase folder path
-- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list
+- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list. It is rendered by `AllMusicCard` in the playlist grid (not the album grid) and always plays shuffled. See [Library — All Music Card](./library.md#all-music-card) for placement, pin behavior (`ALL_MUSIC_PIN_ID = 'dropbox-all-music'`), and shuffle-by-default semantics.
 
 ### Token Refresh
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -192,7 +192,7 @@ const AudioPlayerComponent = () => {
     onReorderQueue: handlers.handleReorderQueue,
   }), [handlers, handleAlbumPlay, handlePlaylistSelect, handleOpenQuickAccessPanel]);
 
-  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt } = useProviderContext();
+  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();
   // Setup is needed when no provider has been chosen yet and none are connected,
   // or when the active provider isn't authenticated and no other enabled provider is either.
   // connectedProviderIds is the subset of enabledProviderIds with valid auth.
@@ -398,6 +398,9 @@ const AudioPlayerComponent = () => {
             onDismiss={dismissReconnectPrompt}
             persistent
           />
+        )}
+        {disconnectToast && !reconnectPrompt && (
+          <Toast message={disconnectToast} onDismiss={dismissDisconnectToast} />
         )}
         {needsSetup && (
           <>

--- a/src/components/PlaylistSelection/AllMusicCard.tsx
+++ b/src/components/PlaylistSelection/AllMusicCard.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+import {
+  GridCardArtWrapper,
+  GridCardTextArea,
+  GridCardTitle,
+  GridCardSubtitle,
+  PlaylistImageWrapper,
+  PlaylistInfoDiv,
+  PlaylistName,
+  PlaylistDetails,
+  PinButton,
+  PinnableListItem,
+  GridCardPinOverlay,
+  PinnableGridCard,
+  TabSpinner,
+} from './styled';
+import { allMusicAsPlaylistInfo, getLikedSongsGradient } from './playlistUtils';
+import { PinIcon } from './utils';
+import { useLibraryPins, useLibraryActions } from './LibraryContext';
+
+const ALL_MUSIC_TITLE = 'All Music';
+
+interface AllMusicCardProps {
+  layout: 'grid' | 'list';
+  count: number;
+}
+
+const ShuffleArt: React.FC<{ gradient: string; layout: 'grid' | 'list' }> = ({ gradient, layout }) => {
+  const glyphSize = layout === 'list' ? 28 : 64;
+  return (
+    <div
+      data-testid="all-music-art"
+      style={{
+        background: gradient,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        borderRadius: layout === 'list' ? '0.5rem' : undefined,
+        color: 'white',
+      }}
+    >
+      <svg
+        data-testid="all-music-shuffle-glyph"
+        width={glyphSize}
+        height={glyphSize}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M16 3h5v5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M4 20 21 3"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M21 16v5h-5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15 15l6 6"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M4 4l5 5"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
+};
+
+const AllMusicCard: React.FC<AllMusicCardProps> = React.memo(function AllMusicCard({ layout, count }) {
+  const { isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
+  const { onPlaylistContextMenu } = useLibraryActions();
+
+  const allMusicPinned = isPlaylistPinned(ALL_MUSIC_PIN_ID);
+  const gradient = getLikedSongsGradient('dropbox');
+
+  const subtitleText = count > 0 ? `${count} tracks • Shuffled` : null;
+  const subtitle = subtitleText ?? <TabSpinner />;
+
+  const openPopover = (e: React.MouseEvent) =>
+    onPlaylistContextMenu(allMusicAsPlaylistInfo(), e);
+
+  if (layout === 'grid') {
+    return (
+      <PinnableGridCard
+        key="all-music"
+        onClick={openPopover}
+        onContextMenu={openPopover}
+      >
+        <GridCardArtWrapper style={{ position: 'relative' }}>
+          <ShuffleArt gradient={gradient} layout="grid" />
+          <GridCardPinOverlay
+            $isPinned={allMusicPinned}
+            onClick={(e) => onPinPlaylistClick(ALL_MUSIC_PIN_ID, e)}
+          >
+            <PinIcon filled={allMusicPinned} />
+          </GridCardPinOverlay>
+        </GridCardArtWrapper>
+        <GridCardTextArea>
+          <GridCardTitle>{ALL_MUSIC_TITLE}</GridCardTitle>
+          <GridCardSubtitle>{subtitle}</GridCardSubtitle>
+        </GridCardTextArea>
+      </PinnableGridCard>
+    );
+  }
+
+  return (
+    <PinnableListItem key="all-music" onClick={openPopover} onContextMenu={openPopover}>
+      <PlaylistImageWrapper>
+        <ShuffleArt gradient={gradient} layout="list" />
+      </PlaylistImageWrapper>
+      <PlaylistInfoDiv>
+        <PlaylistName>{ALL_MUSIC_TITLE}</PlaylistName>
+        <PlaylistDetails>{subtitle}</PlaylistDetails>
+      </PlaylistInfoDiv>
+      <PinButton
+        $isPinned={allMusicPinned}
+        $disabled={!canPinMorePlaylists && !allMusicPinned}
+        onClick={(e) => onPinPlaylistClick(ALL_MUSIC_PIN_ID, e)}
+        title={allMusicPinned ? 'Unpin' : (canPinMorePlaylists ? 'Pin to top' : 'Pin limit reached (12)')}
+        aria-label={allMusicPinned ? 'Unpin All Music' : 'Pin All Music to top'}
+      >
+        <PinIcon filled={allMusicPinned} />
+      </PinButton>
+    </PinnableListItem>
+  );
+});
+
+export { AllMusicCard };

--- a/src/components/PlaylistSelection/LibraryContext.tsx
+++ b/src/components/PlaylistSelection/LibraryContext.tsx
@@ -71,6 +71,8 @@ export interface LibraryDataContextValue {
   isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
+  /** Track count for the Dropbox "All Music" aggregate row. 0 when Dropbox is disabled. */
+  allMusicCount: number;
   activeDescriptor: ProviderDescriptor | null;
 }
 

--- a/src/components/PlaylistSelection/PlaylistGrid.tsx
+++ b/src/components/PlaylistSelection/PlaylistGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { PlaylistInfo } from '../../services/spotify';
-import { LIKED_SONGS_ID } from '@/constants/playlist';
+import { ALL_MUSIC_PIN_ID, LIKED_SONGS_ID } from '@/constants/playlist';
 import ProviderIcon from '../ProviderIcon';
 import { PlaylistTypeIcon } from '../icons/QuickActionIcons';
 import {
@@ -26,14 +26,16 @@ import {
 import { PinIcon, PlaylistImage, GridCardImageComponent } from './utils';
 import { useLibraryBrowsingContext, useLibraryPins, useLibraryActions, useLibraryData } from './LibraryContext';
 import { LikedSongsCard } from './LikedSongsCard';
+import { AllMusicCard } from './AllMusicCard';
 
 export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const { hasActiveFilters, searchQuery, providerFilters } = useLibraryBrowsingContext();
   const { pinnedPlaylists, unpinnedPlaylists, isPlaylistPinned, canPinMorePlaylists, onPinPlaylistClick } = useLibraryPins();
   const { onPlaylistContextMenu } = useLibraryActions();
-  const { inDrawer, likedSongsPerProvider, likedSongsCount, isUnifiedLikedActive, unifiedLikedCount, isInitialLoadComplete, showProviderBadges } = useLibraryData();
+  const { inDrawer, likedSongsPerProvider, likedSongsCount, isUnifiedLikedActive, unifiedLikedCount, isInitialLoadComplete, showProviderBadges, allMusicCount, enabledProviderIds } = useLibraryData();
 
   const likedSongsPinned = isPlaylistPinned(LIKED_SONGS_ID);
+  const allMusicPinned = isPlaylistPinned(ALL_MUSIC_PIN_ID);
 
   const filteredLikedSongsPerProvider = providerFilters.length > 0
     ? likedSongsPerProvider.filter(e => providerFilters.includes(e.provider))
@@ -53,6 +55,11 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
       ))
     : <LikedSongsCard layout={layout} count={effectiveLikedCount} />
   );
+
+  const dropboxEnabled = enabledProviderIds.includes('dropbox');
+  const passesProviderFilter = providerFilters.length === 0 || providerFilters.includes('dropbox');
+  const showAllMusic = dropboxEnabled && passesProviderFilter && (allMusicCount > 0 || !isInitialLoadComplete);
+  const allMusicItem = showAllMusic && <AllMusicCard layout={layout} count={allMusicCount} />;
 
   const renderPlaylistGrid = (playlist: PlaylistInfo) => {
     const pinned = isPlaylistPinned(playlist.id);
@@ -123,7 +130,9 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   };
 
   const renderFn = inDrawer ? renderPlaylistGrid : renderPlaylistList;
-  const hasPinnedSection = pinnedPlaylists.length > 0 || (likedSongsPinned && showLikedSongs && !hasActiveFilters);
+  const hasPinnedSection = pinnedPlaylists.length > 0
+    || (likedSongsPinned && showLikedSongs && !hasActiveFilters)
+    || (allMusicPinned && showAllMusic && !hasActiveFilters);
 
   const filteredPlaylistsCount = pinnedPlaylists.length + unpinnedPlaylists.length;
   const emptyState = filteredPlaylistsCount === 0 && likedSongsCount === 0 && isInitialLoadComplete && (
@@ -137,9 +146,11 @@ export const PlaylistGrid: React.FC = React.memo(function PlaylistGrid() {
   const Grid = inDrawer ? MobileGrid : PlaylistGridDiv;
   return (
     <Grid $inDrawer={inDrawer ? undefined : false}>
+      {!hasActiveFilters && allMusicPinned && allMusicItem}
       {!hasActiveFilters && likedSongsPinned && likedSongsItem}
       {pinnedPlaylists.map(renderFn)}
       {hasPinnedSection && <PinnedSectionLabel key="__pin-sep">Pinned</PinnedSectionLabel>}
+      {(hasActiveFilters || !allMusicPinned) && allMusicItem}
       {(hasActiveFilters || !likedSongsPinned) && likedSongsItem}
       {unpinnedPlaylists.map(renderFn)}
       {emptyState}

--- a/src/components/PlaylistSelection/__tests__/AllMusicCard.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/AllMusicCard.test.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { AllMusicCard } from '../AllMusicCard';
+import {
+  LibraryActionsProvider,
+  LibraryDataProvider,
+  LibraryPinProvider,
+  type LibraryActionsContextValue,
+  type LibraryDataContextValue,
+  type LibraryPinContextValue,
+} from '../LibraryContext';
+import { ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+import { PinnedItemsProvider, usePinnedItemsContext } from '@/contexts/PinnedItemsContext';
+import { setPins, UNIFIED_PROVIDER } from '@/services/settings/pinnedItemsStorage';
+
+interface HarnessOverrides {
+  isPinned?: boolean;
+  canPinMore?: boolean;
+  onPlaylistContextMenu?: LibraryActionsContextValue['onPlaylistContextMenu'];
+  onPinPlaylistClick?: LibraryPinContextValue['onPinPlaylistClick'];
+}
+
+function renderWithContext(
+  layout: 'grid' | 'list',
+  count: number,
+  overrides: HarnessOverrides = {},
+): { onPlaylistContextMenu: ReturnType<typeof vi.fn>; onPinPlaylistClick: ReturnType<typeof vi.fn> } {
+  const onPlaylistContextMenu = vi.fn();
+  const onPinPlaylistClick = vi.fn();
+
+  const data: LibraryDataContextValue = {
+    inDrawer: layout === 'grid',
+    albums: [],
+    isInitialLoadComplete: true,
+    showProviderBadges: false,
+    enabledProviderIds: ['dropbox'],
+    likedSongsPerProvider: [],
+    likedSongsCount: 0,
+    isLikedSongsSyncing: false,
+    isUnifiedLikedActive: false,
+    unifiedLikedCount: 0,
+    allMusicCount: count,
+    activeDescriptor: null,
+  };
+
+  const pin: LibraryPinContextValue = {
+    pinnedPlaylists: [],
+    unpinnedPlaylists: [],
+    pinnedAlbums: [],
+    unpinnedAlbums: [],
+    isPlaylistPinned: (id: string) => (overrides.isPinned ?? false) && id === ALL_MUSIC_PIN_ID,
+    canPinMorePlaylists: overrides.canPinMore ?? true,
+    isAlbumPinned: () => false,
+    canPinMoreAlbums: true,
+    onPinPlaylistClick: overrides.onPinPlaylistClick ?? onPinPlaylistClick,
+    onPinAlbumClick: vi.fn(),
+  };
+
+  const actions: LibraryActionsContextValue = {
+    onPlaylistClick: vi.fn(),
+    onPlaylistContextMenu: overrides.onPlaylistContextMenu ?? onPlaylistContextMenu,
+    onLikedSongsClick: vi.fn(),
+    onAlbumClick: vi.fn(),
+    onAlbumContextMenu: vi.fn(),
+    onArtistClick: vi.fn(),
+  };
+
+  render(
+    <ThemeProvider theme={theme}>
+      <LibraryDataProvider value={data}>
+        <LibraryPinProvider value={pin}>
+          <LibraryActionsProvider value={actions}>
+            <AllMusicCard layout={layout} count={count} />
+          </LibraryActionsProvider>
+        </LibraryPinProvider>
+      </LibraryDataProvider>
+    </ThemeProvider>,
+  );
+
+  return { onPlaylistContextMenu, onPinPlaylistClick };
+}
+
+describe('AllMusicCard', () => {
+  describe('grid layout', () => {
+    it('renders the title, "{N} tracks • Shuffled" subtitle, and shuffle glyph', () => {
+      // #when
+      renderWithContext('grid', 248);
+
+      // #then
+      expect(screen.getByText('All Music')).toBeInTheDocument();
+      expect(screen.getByText('248 tracks • Shuffled')).toBeInTheDocument();
+      expect(screen.getByTestId('all-music-shuffle-glyph')).toBeInTheDocument();
+    });
+
+    it('renders the branded art container with a linear-gradient background', () => {
+      // #when
+      renderWithContext('grid', 5);
+
+      // #then
+      const art = screen.getByTestId('all-music-art');
+      const style = art.getAttribute('style') ?? '';
+      expect(style.toLowerCase()).toContain('linear-gradient');
+    });
+
+    it('opens the playlist popover when the card is clicked', () => {
+      // #when
+      const { onPlaylistContextMenu } = renderWithContext('grid', 10);
+      fireEvent.click(screen.getByText('All Music'));
+
+      // #then
+      expect(onPlaylistContextMenu).toHaveBeenCalledTimes(1);
+      const playlistArg = onPlaylistContextMenu.mock.calls[0][0];
+      expect(playlistArg).toMatchObject({ id: '', name: 'All Music', provider: 'dropbox' });
+    });
+  });
+
+  describe('list layout', () => {
+    it('renders the title, "{N} tracks • Shuffled" subtitle, and shuffle glyph', () => {
+      // #when
+      renderWithContext('list', 12);
+
+      // #then
+      expect(screen.getByText('All Music')).toBeInTheDocument();
+      expect(screen.getByText('12 tracks • Shuffled')).toBeInTheDocument();
+      expect(screen.getByTestId('all-music-shuffle-glyph')).toBeInTheDocument();
+    });
+
+    it('exposes a pin button labelled for All Music', () => {
+      // #when
+      renderWithContext('list', 12, { isPinned: false });
+
+      // #then
+      expect(screen.getByRole('button', { name: /pin all music to top/i })).toBeInTheDocument();
+    });
+
+    it('switches the pin button label to "Unpin All Music" when pinned', () => {
+      // #when
+      renderWithContext('list', 12, { isPinned: true });
+
+      // #then
+      expect(screen.getByRole('button', { name: /unpin all music/i })).toBeInTheDocument();
+    });
+
+    it('invokes onPinPlaylistClick with ALL_MUSIC_PIN_ID when the pin button is clicked', () => {
+      // #when
+      const { onPinPlaylistClick } = renderWithContext('list', 12);
+      fireEvent.click(screen.getByRole('button', { name: /pin all music to top/i }));
+
+      // #then
+      expect(onPinPlaylistClick).toHaveBeenCalledTimes(1);
+      expect(onPinPlaylistClick.mock.calls[0][0]).toBe(ALL_MUSIC_PIN_ID);
+    });
+  });
+});
+
+function PinHarness({ onState }: { onState: (state: { ids: string[]; togglePin: (id: string) => void }) => void }) {
+  const { pinnedPlaylistIds, togglePinPlaylist } = usePinnedItemsContext();
+  React.useEffect(() => {
+    onState({ ids: pinnedPlaylistIds, togglePin: togglePinPlaylist });
+  }, [pinnedPlaylistIds, togglePinPlaylist, onState]);
+  return null;
+}
+
+describe('AllMusicCard pin persistence', () => {
+  beforeEach(async () => {
+    await setPins(UNIFIED_PROVIDER, 'playlists', []);
+    await setPins(UNIFIED_PROVIDER, 'albums', []);
+  });
+
+  it('persists ALL_MUSIC_PIN_ID across remounts via the pinned-items store', async () => {
+    // #given — simulate a previous session pinning All Music
+    await setPins(UNIFIED_PROVIDER, 'playlists', [ALL_MUSIC_PIN_ID]);
+
+    // #when — fresh provider mount reads the persisted state
+    const states: Array<{ ids: string[]; togglePin: (id: string) => void }> = [];
+    render(
+      <PinnedItemsProvider>
+        <PinHarness onState={(s) => states.push(s)} />
+      </PinnedItemsProvider>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).toContain(ALL_MUSIC_PIN_ID);
+    });
+  });
+
+  it('toggling unpin removes ALL_MUSIC_PIN_ID from persisted state', async () => {
+    // #given
+    await setPins(UNIFIED_PROVIDER, 'playlists', [ALL_MUSIC_PIN_ID]);
+    const states: Array<{ ids: string[]; togglePin: (id: string) => void }> = [];
+    render(
+      <PinnedItemsProvider>
+        <PinHarness onState={(s) => states.push(s)} />
+      </PinnedItemsProvider>,
+    );
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).toContain(ALL_MUSIC_PIN_ID);
+    });
+
+    // #when
+    await act(async () => {
+      states.at(-1)?.togglePin(ALL_MUSIC_PIN_ID);
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(states.at(-1)?.ids).not.toContain(ALL_MUSIC_PIN_ID);
+    });
+  });
+});

--- a/src/components/PlaylistSelection/__tests__/AllMusicPlacement.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/AllMusicPlacement.test.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})) as unknown as typeof IntersectionObserver;
+
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { PlaylistGrid } from '../PlaylistGrid';
+import { AlbumGrid } from '../AlbumGrid';
+import {
+  LibraryActionsProvider,
+  LibraryBrowsingProvider,
+  LibraryDataProvider,
+  LibraryPinProvider,
+  type LibraryActionsContextValue,
+  type LibraryBrowsingContextValue,
+  type LibraryDataContextValue,
+  type LibraryPinContextValue,
+} from '../LibraryContext';
+import type { AlbumInfo } from '../../../services/spotify';
+
+const baseBrowsing: LibraryBrowsingContextValue = {
+  viewMode: 'playlists',
+  setViewMode: () => undefined,
+  searchQuery: '',
+  setSearchQuery: () => undefined,
+  playlistSort: 'recently-added',
+  setPlaylistSort: () => undefined,
+  albumSort: 'recently-added',
+  setAlbumSort: () => undefined,
+  artistFilter: '',
+  setArtistFilter: () => undefined,
+  providerFilters: [],
+  setProviderFilters: () => undefined,
+  handleProviderToggle: () => undefined,
+  availableGenres: [],
+  selectedGenres: [],
+  setSelectedGenres: () => undefined,
+  handleGenreToggle: () => undefined,
+  recentlyPlayed: [],
+  onRecentlyPlayedSelect: () => undefined,
+  hasActiveFilters: false,
+  handleClearFilters: () => undefined,
+};
+
+const baseActions: LibraryActionsContextValue = {
+  onPlaylistClick: vi.fn(),
+  onPlaylistContextMenu: vi.fn(),
+  onLikedSongsClick: vi.fn(),
+  onAlbumClick: vi.fn(),
+  onAlbumContextMenu: vi.fn(),
+  onArtistClick: vi.fn(),
+};
+
+const basePin: LibraryPinContextValue = {
+  pinnedPlaylists: [],
+  unpinnedPlaylists: [],
+  pinnedAlbums: [],
+  unpinnedAlbums: [],
+  isPlaylistPinned: () => false,
+  canPinMorePlaylists: true,
+  isAlbumPinned: () => false,
+  canPinMoreAlbums: true,
+  onPinPlaylistClick: vi.fn(),
+  onPinAlbumClick: vi.fn(),
+};
+
+const baseData: LibraryDataContextValue = {
+  inDrawer: false,
+  albums: [],
+  isInitialLoadComplete: true,
+  showProviderBadges: false,
+  enabledProviderIds: ['dropbox'],
+  likedSongsPerProvider: [],
+  likedSongsCount: 0,
+  isLikedSongsSyncing: false,
+  isUnifiedLikedActive: false,
+  unifiedLikedCount: 0,
+  allMusicCount: 250,
+  activeDescriptor: null,
+};
+
+function renderGrid(
+  Component: React.ComponentType,
+  data: Partial<LibraryDataContextValue> = {},
+  pin: Partial<LibraryPinContextValue> = {},
+  browsing: Partial<LibraryBrowsingContextValue> = {},
+) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <LibraryDataProvider value={{ ...baseData, ...data }}>
+        <LibraryBrowsingProvider value={{ ...baseBrowsing, ...browsing }}>
+          <LibraryPinProvider value={{ ...basePin, ...pin }}>
+            <LibraryActionsProvider value={baseActions}>
+              <Component />
+            </LibraryActionsProvider>
+          </LibraryPinProvider>
+        </LibraryBrowsingProvider>
+      </LibraryDataProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('PlaylistGrid placement of AllMusicCard', () => {
+  it('renders AllMusicCard inside the playlist grid when Dropbox is enabled', () => {
+    // #when
+    renderGrid(PlaylistGrid);
+
+    // #then
+    expect(screen.getByText('All Music')).toBeInTheDocument();
+    expect(screen.getByText('250 tracks • Shuffled')).toBeInTheDocument();
+  });
+
+  it('places AllMusicCard before any other entry (top anchor slot, before Liked Songs and pinned playlists)', () => {
+    // #when
+    renderGrid(PlaylistGrid, {
+      likedSongsCount: 7,
+      likedSongsPerProvider: [{ provider: 'dropbox', count: 7 }],
+    });
+
+    // #then — All Music heading appears before Liked Songs in document order
+    const allMusic = screen.getByText('All Music');
+    const liked = screen.getByText('Liked Songs');
+    expect(allMusic.compareDocumentPosition(liked) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('hides AllMusicCard when Dropbox is not in enabledProviderIds', () => {
+    // #when
+    renderGrid(PlaylistGrid, { enabledProviderIds: ['spotify'] });
+
+    // #then
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+
+  it('hides AllMusicCard when Dropbox is excluded by provider filter chip', () => {
+    // #when
+    renderGrid(PlaylistGrid, undefined, undefined, { providerFilters: ['spotify'] });
+
+    // #then
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+});
+
+describe('AlbumGrid does not render All Music', () => {
+  const dropboxAlbum: AlbumInfo = {
+    id: '/Artist/Abbey Road',
+    name: 'Abbey Road',
+    artists: 'The Beatles',
+    images: [],
+    release_date: '1969',
+    total_tracks: 17,
+    uri: '',
+    provider: 'dropbox',
+  };
+
+  it('renders only real albums even though All Music is fed via context data', () => {
+    // #when
+    renderGrid(
+      AlbumGrid,
+      { albums: [dropboxAlbum] },
+      { unpinnedAlbums: [dropboxAlbum] },
+    );
+
+    // #then
+    expect(screen.getByText('Abbey Road')).toBeInTheDocument();
+    expect(screen.queryByText('All Music')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-state message when no real albums are present', () => {
+    // #when
+    const { container } = renderGrid(AlbumGrid);
+
+    // #then
+    expect(within(container).queryByText('All Music')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PlaylistSelection/playlistUtils.ts
+++ b/src/components/PlaylistSelection/playlistUtils.ts
@@ -31,3 +31,16 @@ export function likedSongsAsPlaylistInfo(provider?: ProviderId): PlaylistInfo {
     provider,
   };
 }
+
+/** Minimal playlist row for the Dropbox "All Music" aggregate — used to open the playlist popover. */
+export function allMusicAsPlaylistInfo(): PlaylistInfo {
+  return {
+    id: '',
+    name: 'All Music',
+    description: null,
+    images: [],
+    tracks: null,
+    owner: null,
+    provider: 'dropbox',
+  };
+}

--- a/src/components/PlaylistSelection/useItemActions.tsx
+++ b/src/components/PlaylistSelection/useItemActions.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import type { AlbumInfo, PlaylistInfo } from '../../services/spotify';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
-import { LIKED_SONGS_ID, isAlbumId, toAlbumPlaylistId } from '@/constants/playlist';
+import { LIKED_SONGS_ID, isAlbumId, isAllMusicPlaylist, toAlbumPlaylistId } from '@/constants/playlist';
 import TrackInfoPopover from '../controls/TrackInfoPopover';
 import Toast from '../Toast';
 import { useItemPopover } from './useItemPopover';
@@ -79,17 +79,22 @@ export function useItemActions({
       onQueue: onAddToQueue ? () => onAddToQueue(playlist.id, playlist.name, playlist.provider) : undefined,
     });
 
-    options.push(...buildLikedOptions({
-      collectionId: playlist.id,
-      collectionName: playlist.name,
-      collectionProvider: playlist.provider,
-      descriptor,
-      likedLoading,
-      onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
-      onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
-    }));
+    const isAllMusic = isAllMusicPlaylist(playlist);
 
-    const canDelete = descriptor?.capabilities.hasDeleteCollection &&
+    if (!isAllMusic) {
+      options.push(...buildLikedOptions({
+        collectionId: playlist.id,
+        collectionName: playlist.name,
+        collectionProvider: playlist.provider,
+        descriptor,
+        likedLoading,
+        onPlayLiked: onPlayLikedTracks ? handlePlayLiked : undefined,
+        onQueueLiked: onQueueLikedTracks ? handleQueueLiked : undefined,
+      }));
+    }
+
+    const canDelete = !isAllMusic &&
+      descriptor?.capabilities.hasDeleteCollection &&
       descriptor.catalog.deleteCollection &&
       playlist.id !== LIKED_SONGS_ID &&
       !isAlbumId(playlist.id);

--- a/src/components/PlaylistSelection/useLibraryContextValues.ts
+++ b/src/components/PlaylistSelection/useLibraryContextValues.ts
@@ -52,6 +52,7 @@ interface UseLibraryContextValuesParams {
   isLikedSongsSyncing: boolean;
   isUnifiedLikedActive: boolean;
   unifiedLikedCount: number;
+  allMusicCount: number;
   activeDescriptor: ProviderDescriptor | null;
 }
 
@@ -96,6 +97,7 @@ export function useLibraryContextValues({
   isLikedSongsSyncing,
   isUnifiedLikedActive,
   unifiedLikedCount,
+  allMusicCount,
   activeDescriptor,
 }: UseLibraryContextValuesParams): LibraryContextValuesResult {
   const browsingValue: LibraryBrowsingContextValue = useMemo(
@@ -200,6 +202,7 @@ export function useLibraryContextValues({
       isLikedSongsSyncing,
       isUnifiedLikedActive,
       unifiedLikedCount,
+      allMusicCount,
       activeDescriptor,
     }),
     [
@@ -214,6 +217,7 @@ export function useLibraryContextValues({
       isLikedSongsSyncing,
       isUnifiedLikedActive,
       unifiedLikedCount,
+      allMusicCount,
       activeDescriptor,
     ]
   );

--- a/src/components/PlaylistSelection/useLibraryRoot.ts
+++ b/src/components/PlaylistSelection/useLibraryRoot.ts
@@ -53,6 +53,7 @@ export function useLibraryRoot({
     albums,
     likedSongsCount,
     likedSongsPerProvider,
+    allMusicCount,
     isInitialLoadComplete,
     isLikedSongsSyncing,
     removeCollection,
@@ -209,6 +210,7 @@ export function useLibraryRoot({
     isLikedSongsSyncing,
     isUnifiedLikedActive,
     unifiedLikedCount,
+    allMusicCount,
     activeDescriptor: activeDescriptor ?? null,
   });
 

--- a/src/components/ProviderDisconnectDialog.tsx
+++ b/src/components/ProviderDisconnectDialog.tsx
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import {
+  DialogOverlay,
+  DialogBox,
+  DialogTitle,
+  DialogButtonRow,
+  DialogButton,
+} from './styled/Dialog';
+
+const DialogMessage = styled.p`
+  margin: 0;
+  color: ${theme.colors.gray[300]};
+  font-size: ${theme.fontSize.sm};
+  line-height: 1.5;
+`;
+
+const WarningText = styled.p`
+  margin: 0;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: ${theme.borderRadius.md};
+  color: rgba(252, 165, 165, 0.9);
+  font-size: ${theme.fontSize.xs};
+  line-height: 1.4;
+`;
+
+interface ProviderDisconnectDialogProps {
+  providerName: string;
+  affectedQueueCount?: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ProviderDisconnectDialog({
+  providerName,
+  affectedQueueCount,
+  onConfirm,
+  onCancel,
+}: ProviderDisconnectDialogProps) {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  return createPortal(
+    <DialogOverlay onClick={onCancel} onKeyDown={handleKeyDown}>
+      <DialogBox
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="provider-disconnect-title"
+        onClick={e => e.stopPropagation()}
+      >
+        <DialogTitle id="provider-disconnect-title">Disconnect {providerName}</DialogTitle>
+        <DialogMessage>
+          Are you sure you want to disconnect <strong>{providerName}</strong>?
+        </DialogMessage>
+        {affectedQueueCount != null && affectedQueueCount > 0 && (
+          <WarningText>
+            Disconnecting will stop playback and remove {affectedQueueCount} queued{' '}
+            {affectedQueueCount === 1 ? 'track' : 'tracks'}.
+          </WarningText>
+        )}
+        <DialogButtonRow>
+          <DialogButton onClick={onCancel}>Cancel</DialogButton>
+          <DialogButton $destructive onClick={onConfirm} autoFocus>
+            Disconnect
+          </DialogButton>
+        </DialogButtonRow>
+      </DialogBox>
+    </DialogOverlay>,
+    document.body,
+  );
+}

--- a/src/components/VisualEffectsMenu/SourcesSections.tsx
+++ b/src/components/VisualEffectsMenu/SourcesSections.tsx
@@ -1,8 +1,13 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { useProviderContext } from '@/contexts/ProviderContext';
+import { useTrackListContext, useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { AUTH_COMPLETE_EVENT } from '@/constants/events';
+import type { ProviderId } from '@/types/domain';
+import Toast from '@/components/Toast';
+import ProviderDisconnectDialog from '@/components/ProviderDisconnectDialog';
 
 import {
   FilterSection,
@@ -13,39 +18,179 @@ import {
   ProviderRow,
   ProviderName,
   ProviderStatusBadge,
-  ProviderConnectAction,
 } from './styled';
 import Switch from '@/components/controls/Switch';
 
 export const MusicSourcesSection = memo(() => {
   const { registry, enabledProviderIds, toggleProvider } = useProviderContext();
+  const { tracks, setTracks, setOriginalTracks } = useTrackListContext();
+  const { currentTrackIndex, setCurrentTrackIndex } = useCurrentTrackContext();
   const providers = useMemo(() => registry.getAll(), [registry]);
 
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [disconnectDialogProviderId, setDisconnectDialogProviderId] = useState<ProviderId | null>(null);
+  const pendingPopup = useRef<{ providerId: ProviderId; popup: Window } | null>(null);
+  const popupPollInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearPendingPopup = useCallback(() => {
+    if (popupPollInterval.current !== null) {
+      clearInterval(popupPollInterval.current);
+      popupPollInterval.current = null;
+    }
+    pendingPopup.current = null;
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type !== AUTH_COMPLETE_EVENT) return;
+
+      const pending = pendingPopup.current;
+      if (!pending) return;
+      if (event.data?.provider !== pending.providerId) return;
+
+      clearPendingPopup();
+      toggleProvider(pending.providerId);
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [toggleProvider, clearPendingPopup]);
+
+  const handleToggleOn = useCallback(
+    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
+      if (descriptor.auth.isAuthenticated()) {
+        toggleProvider(descriptor.id);
+        return;
+      }
+
+      const providerId = descriptor.id;
+      const providerName = descriptor.name;
+
+      // Intercept window.open to capture the popup reference when beginLogin opens it
+      const originalOpen = window.open.bind(window);
+      window.open = (...args: Parameters<typeof window.open>) => {
+        window.open = originalOpen;
+        const win = originalOpen(...args);
+        if (!win) {
+          setToastMessage(`Couldn't connect to ${providerName}. Try again.`);
+          return win;
+        }
+
+        pendingPopup.current = { providerId, popup: win };
+        popupPollInterval.current = setInterval(() => {
+          if (!pendingPopup.current) return;
+          if (pendingPopup.current.popup.closed) {
+            const pending = pendingPopup.current;
+            clearPendingPopup();
+            const desc = registry.get(pending.providerId);
+            if (!desc?.auth.isAuthenticated()) {
+              const name = registry.get(pending.providerId)?.name ?? pending.providerId;
+              setToastMessage(`Couldn't connect to ${name}. Try again.`);
+            } else {
+              toggleProvider(pending.providerId);
+            }
+          }
+        }, 500);
+
+        return win;
+      };
+
+      descriptor.auth.beginLogin({ popup: true }).catch(() => {
+        window.open = originalOpen;
+        clearPendingPopup();
+        setToastMessage(`Couldn't connect to ${providerName}. Try again.`);
+      });
+    },
+    [registry, toggleProvider, clearPendingPopup],
+  );
+
+  useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
+
+  const handleConfirmDisconnect = useCallback(() => {
+    const id = disconnectDialogProviderId;
+    if (!id) return;
+
+    setDisconnectDialogProviderId(null);
+
+    const descriptor = registry.get(id);
+    descriptor?.playback.pause().catch(() => {});
+
+    const providerTracks = tracks.filter(t => t.provider === id);
+    const providerTrackIds = new Set(providerTracks.map(t => t.id));
+    const remainingTracks = tracks.filter(t => t.provider !== id);
+
+    if (remainingTracks.length === 0) {
+      setTracks([]);
+      setOriginalTracks([]);
+      setCurrentTrackIndex(0);
+    } else {
+      const playingTrack = tracks[currentTrackIndex];
+      const removedBeforeCurrent = tracks
+        .slice(0, currentTrackIndex)
+        .filter(t => providerTrackIds.has(t.id)).length;
+      const newIndex = Math.max(
+        0,
+        Math.min(currentTrackIndex - removedBeforeCurrent, remainingTracks.length - 1),
+      );
+      setTracks(remainingTracks);
+      setOriginalTracks(prev => prev.filter(t => t.provider !== id));
+      if (playingTrack && providerTrackIds.has(playingTrack.id)) {
+        setCurrentTrackIndex(0);
+      } else {
+        setCurrentTrackIndex(newIndex);
+      }
+    }
+
+    descriptor?.auth.logout();
+    toggleProvider(id);
+  }, [
+    disconnectDialogProviderId,
+    registry,
+    tracks,
+    currentTrackIndex,
+    setTracks,
+    setOriginalTracks,
+    setCurrentTrackIndex,
+    toggleProvider,
+  ]);
+
   if (providers.length < 2) return null;
+
+  const disconnectDescriptor = disconnectDialogProviderId
+    ? registry.get(disconnectDialogProviderId)
+    : null;
+  const affectedQueueCount = disconnectDialogProviderId
+    ? tracks.filter(t => t.provider === disconnectDialogProviderId).length
+    : 0;
 
   return (
     <FilterSection>
       <SectionTitle>Music Sources</SectionTitle>
+      {toastMessage && (
+        <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
+      )}
       <FilterGrid>
         {providers.map((descriptor) => {
           const isEnabled = enabledProviderIds.includes(descriptor.id);
           const isConnected = descriptor.auth.isAuthenticated();
           const isLastEnabled = enabledProviderIds.length <= 1 && isEnabled;
-          const status = !isEnabled ? 'disabled' : isConnected ? 'connected' : 'expired';
+          const status = isEnabled && isConnected ? 'connected' : 'disabled';
           return (
             <ProviderRow key={descriptor.id}>
               <ProviderName>{descriptor.name}</ProviderName>
               <ProviderStatusBadge $status={status}>
-                {status === 'connected' ? 'Connected' : status === 'expired' ? 'Expired' : ''}
+                {status === 'connected' ? 'Connected' : ''}
               </ProviderStatusBadge>
-              {isEnabled && !isConnected && (
-                <ProviderConnectAction onClick={() => descriptor.auth.beginLogin({ popup: true })}>
-                  Reconnect
-                </ProviderConnectAction>
-              )}
               <Switch
                 on={isEnabled}
-                onToggle={() => toggleProvider(descriptor.id)}
+                onToggle={() => {
+                  if (!isEnabled) {
+                    handleToggleOn(descriptor);
+                  } else {
+                    setDisconnectDialogProviderId(descriptor.id);
+                  }
+                }}
                 ariaLabel={`${isEnabled ? 'Disable' : 'Enable'} ${descriptor.name}`}
                 disabled={isLastEnabled}
                 variant="neutral"
@@ -54,6 +199,14 @@ export const MusicSourcesSection = memo(() => {
           );
         })}
       </FilterGrid>
+      {disconnectDescriptor && (
+        <ProviderDisconnectDialog
+          providerName={disconnectDescriptor.name}
+          affectedQueueCount={affectedQueueCount}
+          onConfirm={handleConfirmDisconnect}
+          onCancel={() => setDisconnectDialogProviderId(null)}
+        />
+      )}
     </FilterSection>
   );
 });

--- a/src/components/VisualEffectsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/VisualEffectsMenu/__tests__/SourcesSections.test.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeProviderDescriptor, makeMediaTrack } from '@/test/fixtures';
+import type { ProviderDescriptor } from '@/types/providers';
+
+// ── Context mocks ──────────────────────────────────────────────────────────
+
+const mockToggleProvider = vi.fn();
+const mockSetTracks = vi.fn();
+const mockSetOriginalTracks = vi.fn();
+const mockSetCurrentTrackIndex = vi.fn();
+
+const mockRegistry = {
+  getAll: vi.fn<[], ProviderDescriptor[]>(() => []),
+  get: vi.fn<[string], ProviderDescriptor | undefined>(() => undefined),
+  has: vi.fn(() => true),
+};
+
+let mockEnabledProviderIds: string[] = ['spotify', 'dropbox'];
+let mockTracks: ReturnType<typeof makeMediaTrack>[] = [];
+let mockCurrentTrackIndex = 0;
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    registry: mockRegistry,
+    enabledProviderIds: mockEnabledProviderIds,
+    toggleProvider: mockToggleProvider,
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: vi.fn(() => ({
+    tracks: mockTracks,
+    setTracks: mockSetTracks,
+    setOriginalTracks: mockSetOriginalTracks,
+  })),
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrackIndex: mockCurrentTrackIndex,
+    setCurrentTrackIndex: mockSetCurrentTrackIndex,
+  })),
+}));
+
+vi.mock('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: vi.fn((key: string, defaultValue: unknown) => [defaultValue, vi.fn()]),
+}));
+
+// Import after mocks are set up
+import { MusicSourcesSection } from '../SourcesSections';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+function makeSpotifyDescriptor(authOverrides?: Partial<ProviderDescriptor['auth']>): ProviderDescriptor {
+  return makeProviderDescriptor({
+    id: 'spotify',
+    name: 'Spotify',
+    auth: {
+      ...makeProviderDescriptor().auth,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      ...authOverrides,
+    },
+  });
+}
+
+function makeDropboxDescriptor(authOverrides?: Partial<ProviderDescriptor['auth']>): ProviderDescriptor {
+  return makeProviderDescriptor({
+    id: 'dropbox' as 'spotify',
+    name: 'Dropbox',
+    auth: {
+      ...makeProviderDescriptor().auth,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      ...authOverrides,
+    },
+  });
+}
+
+describe('MusicSourcesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnabledProviderIds = ['spotify', 'dropbox'];
+    mockTracks = [];
+    mockCurrentTrackIndex = 0;
+    mockRegistry.getAll.mockReturnValue([]);
+    mockRegistry.get.mockReturnValue(undefined);
+  });
+
+  describe('toggle-off: disconnect dialog flow', () => {
+    it('opens ProviderDisconnectDialog when an enabled provider toggle is turned off', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      const spotifyToggle = screen.getByLabelText('Disable Spotify');
+      fireEvent.click(spotifyToggle);
+
+      // #then
+      expect(screen.getByText('Disconnect Spotify')).toBeInTheDocument();
+    });
+
+    it('calls descriptor.auth.logout() and toggleProvider when dialog is confirmed', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+      expect(screen.getByText('Disconnect Spotify')).toBeInTheDocument();
+
+      // #when
+      fireEvent.click(screen.getByText('Disconnect'));
+
+      // #then
+      expect(spotifyDesc.auth.logout).toHaveBeenCalledOnce();
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
+    });
+
+    it('closes the dialog and leaves state unchanged when Cancel is clicked', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockReturnValue(spotifyDesc);
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
+      expect(spotifyDesc.auth.logout).not.toHaveBeenCalled();
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('shows affected-track count in disconnect dialog when provider has queued tracks', () => {
+      // #given
+      const spotifyTrack1 = makeMediaTrack({ id: 'track-1', provider: 'spotify' });
+      const spotifyTrack2 = makeMediaTrack({ id: 'track-2', provider: 'spotify' });
+      const dropboxTrack = makeMediaTrack({ id: 'track-3', provider: 'dropbox' as 'spotify' });
+      mockTracks = [spotifyTrack1, spotifyTrack2, dropboxTrack];
+
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then
+      expect(screen.getByText(/remove 2 queued tracks/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('toggle-on: silent enable when authenticated', () => {
+    it('calls toggleProvider directly without opening a popup when provider is already authenticated', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(true) });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
+      expect(spotifyDesc.auth.beginLogin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggle-on: unauthenticated provider login', () => {
+    it('calls descriptor.auth.beginLogin when provider is not authenticated', async () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // Stub window.open to simulate a popup that never closes
+      const mockPopup = { closed: false } as Window;
+      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then
+      await waitFor(() => {
+        expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
+      });
+    });
+  });
+
+  describe('toggle-on: OAuth cancellation/failure', () => {
+    it('shows error toast when beginLogin promise rejects', async () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockRejectedValue(new Error('popup blocked'));
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // window.open returns null to simulate blocked popup, triggering the error path
+      vi.spyOn(window, 'open').mockReturnValue(null);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+
+      // #then — toast appears with the correct copy
+      await waitFor(() => {
+        expect(screen.getByText(/Couldn't connect to Spotify/i)).toBeInTheDocument();
+      });
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('shows error toast and does not enable the provider when the popup is dismissed (closed without completing OAuth)', async () => {
+      // #given — provider not yet authenticated, beginLogin opens a popup that closes immediately
+      const isAuthenticated = vi.fn().mockReturnValue(false);
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // The popup window is immediately closed (user dismissed the OAuth popup)
+      const mockPopup = { closed: true } as Window;
+      // Use Object.defineProperty to bypass any lingering spy on window.open
+      const mockPopupObj = { closed: true };
+      const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
+      Object.defineProperty(window, 'open', {
+        value: () => mockPopupObj,
+        writable: true,
+        configurable: true,
+      });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockImplementation(async () => {
+        window.open('https://accounts.spotify.com/authorize', '_blank');
+      });
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
+      await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
+
+      // #then — poll detects closed popup within 500ms and shows the error toast
+      await waitFor(
+        () => {
+          expect(screen.getByText(/Couldn't connect to Spotify/i)).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+      expect(mockToggleProvider).not.toHaveBeenCalled();
+
+      // Restore original window.open property descriptor
+      if (originalDescriptor) {
+        Object.defineProperty(window, 'open', originalDescriptor);
+      }
+    });
+  });
+
+  describe('last-enabled guard', () => {
+    it('disables the toggle for the sole remaining enabled provider', () => {
+      // #given — only one provider is enabled
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.getByLabelText('Disable Spotify')).toBeDisabled();
+    });
+
+    it('does not disable the toggle when multiple providers are enabled', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.getByLabelText('Disable Spotify')).not.toBeDisabled();
+    });
+  });
+
+  describe('Reconnect button', () => {
+    it('has no Reconnect button in the rendered DOM', () => {
+      // #given
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.queryByRole('button', { name: /reconnect/i })).not.toBeInTheDocument();
+      expect(screen.queryByText(/reconnect/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/VisualEffectsMenu/styled.ts
+++ b/src/components/VisualEffectsMenu/styled.ts
@@ -224,35 +224,14 @@ export const ProviderName = styled.span`
   flex-shrink: 0;
 `;
 
-export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'expired' | 'disabled' }>`
+export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' }>`
   font-size: 0.6875rem;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   color: ${({ $status, theme }) =>
-    $status === 'connected'
-      ? theme.colors.success
-      : $status === 'expired'
-        ? '#f0a030'
-        : theme.colors.muted.foreground};
+    $status === 'connected' ? theme.colors.success : theme.colors.muted.foreground};
   flex: 1;
 `;
 
-export const ProviderConnectAction = styled.button`
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(--accent-color);
-  font-size: 0.6875rem;
-  font-weight: ${({ theme }) => theme.fontWeight.semibold};
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: opacity ${({ theme }) => theme.transitions.fast};
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;
 
 export const CacheOptionsList = styled.ul`
   list-style: none;

--- a/src/components/__tests__/ProviderDisconnectDialog.test.tsx
+++ b/src/components/__tests__/ProviderDisconnectDialog.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import ProviderDisconnectDialog from '../ProviderDisconnectDialog';
+
+function renderDialog(overrides?: {
+  providerName?: string;
+  affectedQueueCount?: number;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) {
+  const props = {
+    providerName: 'Spotify',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <ProviderDisconnectDialog {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('ProviderDisconnectDialog', () => {
+  describe('content rendering', () => {
+    it('renders the provider name in title and body', () => {
+      // #given / #when
+      renderDialog({ providerName: 'Dropbox' });
+
+      // #then
+      expect(screen.getByText('Disconnect Dropbox')).toBeInTheDocument();
+      expect(screen.getByText(/disconnect.*Dropbox/i)).toBeInTheDocument();
+    });
+
+    it('renders the affected-queue count line when count is positive', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 5 });
+
+      // #then
+      expect(screen.getByText(/remove 5 queued tracks/i)).toBeInTheDocument();
+    });
+
+    it('uses singular "track" when affected count is 1', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 1 });
+
+      // #then
+      expect(screen.getByText(/remove 1 queued track\./i)).toBeInTheDocument();
+    });
+
+    it('hides the count line when affectedQueueCount is 0', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: 0 });
+
+      // #then
+      expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+    });
+
+    it('hides the count line when affectedQueueCount is undefined', () => {
+      // #given / #when
+      renderDialog({ affectedQueueCount: undefined });
+
+      // #then
+      expect(screen.queryByText(/queued/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('button interactions', () => {
+    it('calls onCancel when Cancel is clicked', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('calls onConfirm when Disconnect is clicked', () => {
+      // #given
+      const onConfirm = vi.fn();
+      renderDialog({ onConfirm });
+
+      // #when
+      fireEvent.click(screen.getByText('Disconnect'));
+
+      // #then
+      expect(onConfirm).toHaveBeenCalledOnce();
+    });
+
+    it('calls onCancel when the overlay backdrop is clicked', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+      // Dialog is portalled to document.body — query the overlay from there
+      const overlay = document.body.querySelector('[style]') ?? document.body.firstElementChild as HTMLElement;
+      // The overlay is the fixed-position div wrapping the dialog box
+      const dialogBox = screen.getByRole('dialog');
+      const overlayEl = dialogBox.parentElement as HTMLElement;
+
+      // #when
+      fireEvent.click(overlayEl);
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('calls onCancel when Escape is pressed on the overlay', () => {
+      // #given
+      const onCancel = vi.fn();
+      renderDialog({ onCancel });
+      const dialogBox = screen.getByRole('dialog');
+      const overlayEl = dialogBox.parentElement as HTMLElement;
+
+      // #when
+      fireEvent.keyDown(overlayEl, { key: 'Escape' });
+
+      // #then
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('destructive button styling', () => {
+    it('Disconnect button has $destructive prop applied', () => {
+      // #given / #when
+      renderDialog();
+      const disconnectButton = screen.getByText('Disconnect');
+
+      // #then — $destructive renders red background via styled-components
+      expect(disconnectButton).toHaveStyle({ background: 'rgba(239, 68, 68, 0.85)' });
+    });
+  });
+});

--- a/src/components/__tests__/VisualEffectsMenu.test.tsx
+++ b/src/components/__tests__/VisualEffectsMenu.test.tsx
@@ -31,6 +31,18 @@ vi.mock('@/contexts/ProviderContext', () => ({
   })),
 }));
 
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: vi.fn(() => ({
+    tracks: [],
+    setTracks: vi.fn(),
+    setOriginalTracks: vi.fn(),
+  })),
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+  })),
+}));
+
 vi.mock('@/contexts/ProfilingContext', () => ({
   useProfilingContext: vi.fn(() => ({
     enabled: false,

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -12,7 +12,11 @@ export const LIKED_SONGS_NAME = 'Liked Songs';
 /** Special playlist ID representing the radio queue */
 export const RADIO_PLAYLIST_ID = 'radio';
 
-/** Pin-list identifier for the Dropbox "All Music" aggregate collection. */
+/**
+ * Pin identifier for the Dropbox "All Music" aggregate row.
+ * Distinct from the underlying collection id (`''`) so the pin survives
+ * even if the catalog representation of All Music changes.
+ */
 export const ALL_MUSIC_PIN_ID = 'dropbox-all-music';
 
 /** Returns true when the ref points at the Dropbox "All Music" aggregate (folder with empty id). */
@@ -20,11 +24,16 @@ export function isAllMusicRef(ref: CollectionRef): boolean {
   return ref.provider === 'dropbox' && ref.kind === 'folder' && 'id' in ref && ref.id === '';
 }
 
-/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row, Dropbox "All Music" uses id ''). */
-export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, '']);
+/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row). */
+export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID]);
 
-/** Album IDs that stay in catalog order and are not reordered by library sort (Dropbox aggregate uses id ''). */
-export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set(['']);
+/** Album IDs that stay in catalog order and are not reordered by library sort. */
+export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set();
+
+/** Returns true when the playlist info represents the Dropbox "All Music" aggregate row. */
+export function isAllMusicPlaylist(playlist: { id: string; provider?: string }): boolean {
+  return playlist.id === '' && playlist.provider === 'dropbox';
+}
 
 /** Check whether a playlist selection ID represents an album */
 export function isAlbumId(playlistId: string): boolean {

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -1,3 +1,5 @@
+import type { CollectionRef } from '@/types/domain';
+
 /** Prefix used when encoding an album ID as a playlist selection ID */
 export const ALBUM_ID_PREFIX = 'album:';
 
@@ -9,6 +11,14 @@ export const LIKED_SONGS_NAME = 'Liked Songs';
 
 /** Special playlist ID representing the radio queue */
 export const RADIO_PLAYLIST_ID = 'radio';
+
+/** Pin-list identifier for the Dropbox "All Music" aggregate collection. */
+export const ALL_MUSIC_PIN_ID = 'dropbox-all-music';
+
+/** Returns true when the ref points at the Dropbox "All Music" aggregate (folder with empty id). */
+export function isAllMusicRef(ref: CollectionRef): boolean {
+  return ref.provider === 'dropbox' && ref.kind === 'folder' && 'id' in ref && ref.id === '';
+}
 
 /** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row, Dropbox "All Music" uses id ''). */
 export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, '']);

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -60,6 +60,11 @@ interface ProviderContextValue {
   acceptReconnectPrompt: () => void;
   /** Dismiss the reconnect prompt without reconnecting. */
   dismissReconnectPrompt: () => void;
+
+  /** Auto-dismiss toast shown immediately when a provider is disconnected due to an unrecoverable 401. */
+  disconnectToast: string | null;
+  /** Dismiss the disconnect toast. */
+  dismissDisconnectToast: () => void;
 }
 
 const ProviderContext =
@@ -162,6 +167,10 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   // ── Session-expired reconnect prompt ─────────────────────────────────
   const [reconnectPrompt, setReconnectPrompt] = useState<{ providerId: ProviderId; message: string } | null>(null);
 
+  // ── Disconnect toast (auto-dismiss) ──────────────────────────────────
+  const [disconnectToast, setDisconnectToast] = useState<string | null>(null);
+  const dismissDisconnectToast = useCallback(() => setDisconnectToast(null), []);
+
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
       const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
@@ -176,6 +185,7 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
           message: `Your ${name} session has expired. Tap to reconnect.`,
         };
       });
+      setDisconnectToast(`${name} disconnected — session expired.`);
       setAuthRevision(prev => prev + 1);
     };
 
@@ -301,10 +311,12 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       reconnectPrompt,
       acceptReconnectPrompt,
       dismissReconnectPrompt,
+      disconnectToast,
+      dismissDisconnectToast,
     }),
     // authRevision triggers re-evaluation when a popup completes OAuth
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, authRevision],
+    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast, authRevision],
   );
 
   return (

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -601,6 +601,90 @@ describe('useCollectionLoader', () => {
     );
   });
 
+  it('forces shuffle when loading Dropbox All Music even when global shuffleEnabled is false', async () => {
+    // #given — All Music is addressed as dropbox folder with empty id; provide an ordered list we can detect re-ordering on
+    const tracks = Array.from({ length: 20 }, (_, i) => makeMediaTrack(String(i + 1)));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(tracks) };
+    const dropboxDescriptor = {
+      id: 'dropbox' as const,
+      catalog: mockCatalog,
+      playback: { pause: vi.fn() },
+    };
+    mockGetDescriptor.mockReturnValue(dropboxDescriptor);
+    mockActiveDescriptor = { id: 'dropbox', playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — loadCollection with empty id (All Music ref)
+    await act(async () => {
+      await result.current.loadCollection('', 'dropbox');
+    });
+
+    // #then — originalTracks preserves order; tracks is a permutation that is not guaranteed to equal input order
+    expect(mockSetOriginalTracks).toHaveBeenCalledWith(tracks);
+    const emittedTracks = mockSetTracks.mock.calls[0][0] as MediaTrack[];
+    expect(emittedTracks).toHaveLength(tracks.length);
+    expect(emittedTracks.map(t => t.id).sort((a, b) => Number(a) - Number(b))).toEqual(tracks.map(t => t.id));
+    // With 20 items a Fisher-Yates shuffle reordering equalling the original is vanishingly unlikely
+    const identical = emittedTracks.every((t, i) => t.id === tracks[i].id);
+    expect(identical).toBe(false);
+  });
+
+  it('does not force-shuffle non-All-Music Dropbox folder collections when shuffleEnabled is false', async () => {
+    // #given — regression guard: a normal dropbox folder (non-empty id) must keep catalog order
+    const tracks = Array.from({ length: 20 }, (_, i) => makeMediaTrack(String(i + 1)));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(tracks) };
+    const dropboxDescriptor = {
+      id: 'dropbox' as const,
+      catalog: mockCatalog,
+      playback: { pause: vi.fn() },
+    };
+    mockGetDescriptor.mockReturnValue(dropboxDescriptor);
+    mockActiveDescriptor = { id: 'dropbox', playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — a specific album/folder path, not All Music
+    await act(async () => {
+      await result.current.loadCollection('/Music/Artist/Album', 'dropbox');
+    });
+
+    // #then — tracks should be in input (catalog) order
+    expect(mockSetTracks).toHaveBeenCalledWith(tracks);
+  });
+
   it('does not call record when the unified liked load returns no tracks', async () => {
     // #given
     mockGetDescriptor.mockReturnValue({

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -150,6 +150,77 @@ describe('useQueueManagement', () => {
     expect(response).toEqual({ added: 3, collectionName: 'My Playlist' });
   });
 
+  it('handleAddToQueue shuffles Dropbox All Music tracks before appending', async () => {
+    // #given — existing queue + All Music ref ('' id, dropbox folder) returning a large ordered list
+    mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+    const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+    const incoming = Array.from({ length: 20 }, (_, i) => makeMediaTrack(`n${i + 1}`));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(incoming) };
+    const dropboxDescriptor = { id: 'dropbox' as const, catalog: mockCatalog, playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: dropboxDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when — empty playlist id resolves to All Music (dropbox/folder/'')
+    await act(async () => {
+      await result.current.handleAddToQueue('');
+    });
+
+    // #then — setTracks updater yields a shuffled permutation of the incoming tracks appended to the existing queue
+    expect(mockSetTracks).toHaveBeenCalledWith(expect.any(Function));
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: MediaTrack[]) => MediaTrack[];
+    const appended = tracksUpdater([makeMediaTrack('a'), makeMediaTrack('b')]);
+    expect(appended).toHaveLength(22);
+    expect(appended[0].id).toBe('a');
+    expect(appended[1].id).toBe('b');
+    const appendedIds = appended.slice(2).map(t => t.id);
+    expect(appendedIds.slice().sort()).toEqual(incoming.map(t => t.id).slice().sort());
+    const orderPreserved = appendedIds.every((id, i) => id === incoming[i].id);
+    expect(orderPreserved).toBe(false);
+  });
+
+  it('handleAddToQueue preserves catalog order when appending a non-All-Music Dropbox folder', async () => {
+    // #given — regression guard for shuffle-by-default semantics
+    mediaTracksRef.current = [makeMediaTrack('a')];
+    const tracks = [makeTrack({ id: 'a' })];
+    const incoming = Array.from({ length: 20 }, (_, i) => makeMediaTrack(`n${i + 1}`));
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(incoming) };
+    const dropboxDescriptor = { id: 'dropbox' as const, catalog: mockCatalog, playback: { pause: vi.fn() } };
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: dropboxDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when — non-empty folder id (not All Music)
+    await act(async () => {
+      await result.current.handleAddToQueue('/Music/Artist/Album');
+    });
+
+    // #then — appended portion preserves incoming order
+    const tracksUpdater = mockSetTracks.mock.calls[0][0] as (prev: MediaTrack[]) => MediaTrack[];
+    const appended = tracksUpdater([makeMediaTrack('a')]);
+    expect(appended.slice(1).map(t => t.id)).toEqual(incoming.map(t => t.id));
+  });
+
   it('handleAddToQueue appends tracks to an existing queue without resetting currentTrackIndex', async () => {
     // #given
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/__tests__/useUnifiedLikedTracks.test.ts
+++ b/src/hooks/__tests__/useUnifiedLikedTracks.test.ts
@@ -223,6 +223,33 @@ describe('useUnifiedLikedTracks', () => {
     });
   });
 
+  it('excludes enabled-but-disconnected providers from the merged result', async () => {
+    // #given - spotify is connected, dropbox is enabled but not in connectedProviderIds
+    const spotifyTracks = [makeTrack('s1', 'spotify', 2000)];
+    const dropboxTracks = [makeTrack('d1', 'dropbox', 1000)];
+    mockConnectedProviderIds.push('spotify'); // only spotify is connected
+    const spotifyDesc = makeDescriptor('spotify', spotifyTracks);
+    const dropboxDesc = makeDescriptor('dropbox', dropboxTracks);
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return spotifyDesc;
+      if (id === 'dropbox') return dropboxDesc;
+      return undefined;
+    });
+    mockRegistryGet.mockImplementation((id: string) => {
+      if (id === 'spotify') return spotifyDesc;
+      if (id === 'dropbox') return dropboxDesc;
+      return undefined;
+    });
+
+    // #when - render hook with only one connected provider
+    const { result } = renderHook(() => useUnifiedLikedTracks());
+
+    // #then - unified mode inactive, no dropbox tracks fetched
+    expect(result.current.isUnifiedLikedActive).toBe(false);
+    expect(result.current.unifiedTracks).toEqual([]);
+    expect(vi.mocked(dropboxDesc.catalog.listTracks)).not.toHaveBeenCalled();
+  });
+
   it('serves cached data immediately on subsequent hook mounts', async () => {
     // #given - set up providers
     const spotifyTracks = [makeTrack('s1', 'spotify', 2000)];

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import { LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvePlaylistRef } from '@/constants/playlist';
+import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
@@ -66,9 +66,10 @@ export function useCollectionLoader({
     return clearWithError(err instanceof Error ? err.message : fallbackMessage);
   }, [clearWithError]);
 
-  const applyTracks = useCallback((tracks: MediaTrack[]) => {
+  const applyTracks = useCallback((tracks: MediaTrack[], options?: { forceShuffle?: boolean }) => {
     setOriginalTracks(tracks);
-    if (shuffleEnabled) {
+    const shouldShuffle = shuffleEnabled || options?.forceShuffle === true;
+    if (shouldShuffle) {
       const indices = shuffleArray(tracks.map((_, i) => i));
       const shuffled = indices.map(i => tracks[i]);
       mediaTracksRef.current = shuffled;
@@ -171,7 +172,7 @@ export function useCollectionLoader({
 
       if (list.length === 0) return clearWithError('No tracks found in this collection.');
 
-      applyTracks(list);
+      applyTracks(list, { forceShuffle: isAllMusicRef(collectionRef) });
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
       await playTrack(0);

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -24,6 +24,8 @@ interface UseLibrarySyncResult {
   likedSongsCount: number;
   /** Liked counts broken down by provider (for multi-provider liked songs cards). */
   likedSongsPerProvider: PerProviderLikedCount[];
+  /** Total track count for the Dropbox "All Music" aggregate row, or 0 when Dropbox is not enabled. */
+  allMusicCount: number;
   isInitialLoadComplete: boolean;
   isSyncing: boolean;
   /** True while liked counts from the synchronous cache seed are being verified by async sources. */
@@ -83,19 +85,33 @@ function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
   };
 }
 
-function splitCollections(collections: MediaCollection[]): { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[] } {
+/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
+function isAllMusicCollection(c: MediaCollection): boolean {
+  return c.provider === 'dropbox' && c.id === '';
+}
+
+function splitCollections(collections: MediaCollection[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  allMusicCount: number;
+} {
   const playlists: CachedPlaylistInfo[] = [];
   const albums: AlbumInfo[] = [];
   let playlistOrdinal = 0;
   let albumOrdinal = 0;
+  let allMusicCount = 0;
   for (const c of collections) {
+    if (isAllMusicCollection(c)) {
+      allMusicCount = c.trackCount ?? 0;
+      continue;
+    }
     if (c.kind === 'album') {
       albums.push(collectionToAlbumInfo(c, albumOrdinal++));
     } else {
       playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
     }
   }
-  return { playlists, albums };
+  return { playlists, albums, allMusicCount };
 }
 
 export function useLibrarySync(): UseLibrarySyncResult {
@@ -105,6 +121,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const [albums, setAlbums] = useState<AlbumInfo[]>([]);
   const [likedSongsCount, setLikedSongsCount] = useState(() => initialSnapshot.total);
   const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>(() => initialSnapshot.perProvider);
+  const [allMusicCount, setAllMusicCount] = useState(0);
   const [syncState, setSyncState] = useState<SyncState>({
     isInitialLoadComplete: false,
     isSyncing: false,
@@ -119,7 +136,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,
   });
-  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>>(new Map());
+  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
 
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
   const catalogProviderIds = enabledProviderIds.filter(id => id !== engineProviderId);
@@ -128,6 +145,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     const allPlaylists: CachedPlaylistInfo[] = [];
     const allAlbums: AlbumInfo[] = [];
     let totalLikedCount = 0;
+    let totalAllMusicCount = 0;
     const perProvider: PerProviderLikedCount[] = [];
 
     if (isEngineProviderEnabled && engineProviderId) {
@@ -144,6 +162,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
         allPlaylists.push(...data.playlists);
         allAlbums.push(...data.albums);
         totalLikedCount += data.likedCount;
+        totalAllMusicCount += data.allMusicCount;
         if (data.likedCount > 0) {
           perProvider.push({ provider: providerId, count: data.likedCount });
         }
@@ -154,6 +173,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     setAlbums(allAlbums);
     setLikedSongsCount(totalLikedCount);
     setLikedSongsPerProvider(perProvider);
+    setAllMusicCount(totalAllMusicCount);
   }, [isEngineProviderEnabled, engineProviderId, enabledProviderIds]);
 
   useEffect(() => {
@@ -212,7 +232,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       const catalog = descriptor?.catalog;
       const auth = descriptor?.auth;
       if (!catalog || !auth || !auth.isAuthenticated()) {
-        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0 });
+        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
         return;
       }
 
@@ -228,12 +248,12 @@ export function useLibrarySync(): UseLibrarySyncResult {
         logLibrary('[%s] raw collections from catalog: %o', providerId,
           collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
 
-        const { playlists, albums } = splitCollections(collections);
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
         logLibrary('[%s] after splitCollections — playlists: %o', providerId,
           playlists.map(p => ({ name: p.name, tracks: p.tracks })));
         logLibrary('[%s] after splitCollections — albums: %o', providerId,
           albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
         writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
@@ -312,8 +332,8 @@ export function useLibrarySync(): UseLibrarySyncResult {
           catalog.listCollections(undefined, { forceRefresh: true }),
           catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
         ]);
-        const { playlists, albums } = splitCollections(collections);
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount });
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
         writeLikedCountSnapshot(providerId, likedCount);
         mergeAndSetData();
         setSyncState(prev => ({
@@ -367,6 +387,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
     albums,
     likedSongsCount,
     likedSongsPerProvider,
+    allMusicCount,
     isInitialLoadComplete: syncState.isInitialLoadComplete,
     isSyncing: syncState.isSyncing,
     isLikedSongsSyncing,

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -2,8 +2,9 @@ import { useCallback, useRef } from 'react';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
-import { resolvePlaylistRef } from '@/constants/playlist';
+import { isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { logQueue } from '@/lib/debugLog';
+import { shuffleArray } from '@/utils/shuffleArray';
 import {
   appendMediaTracks,
   moveItemInArray,
@@ -78,7 +79,8 @@ export function useQueueManagement({
         const catalog = targetDescriptor.catalog;
         const { id: collectionId, kind: collectionKind } = resolvePlaylistRef(playlistId, targetProviderId);
         const collectionRef = { provider: targetProviderId, kind: collectionKind, id: collectionId } as const;
-        const newMediaTracks = await catalog.listTracks(collectionRef);
+        const fetchedTracks = await catalog.listTracks(collectionRef);
+        const newMediaTracks = isAllMusicRef(collectionRef) ? shuffleArray(fetchedTracks) : fetchedTracks;
 
         const existingIds = new Set(tracksRef.current.map((t) => t.id));
         const uniqueNewTracks = newMediaTracks.filter((t) => !existingIds.has(t.id));

--- a/src/services/__tests__/radioPipeline.test.ts
+++ b/src/services/__tests__/radioPipeline.test.ts
@@ -228,6 +228,53 @@ describe('runRadioPipeline', () => {
       expect(result!.queue.some((t) => t.id === 'resolved-1')).toBe(true);
     });
 
+    it('skips unauthenticated search providers silently', async () => {
+      // #given
+      const seedTrack = makeMediaTrack({ id: 'seed-1', name: 'Creep', artists: 'Radiohead' });
+      const catalogTrack = makeMediaTrack({ id: 'rec-1', name: 'Karma Police', artists: 'Radiohead' });
+      const resolvedTrack = makeMediaTrack({ id: 'resolved-1', name: 'Missing Song', artists: 'Missing Artist' });
+      const catalogProvider = makeCatalogProvider([catalogTrack]);
+
+      const unauthenticatedProvider = makeProviderDescriptor({
+        capabilities: { hasSaveTrack: false, hasExternalLink: false, hasLikedCollection: false, hasTrackSearch: true },
+        auth: {
+          providerId: 'spotify',
+          isAuthenticated: vi.fn().mockReturnValue(false),
+          getAccessToken: vi.fn(),
+          beginLogin: vi.fn(),
+          handleCallback: vi.fn(),
+          logout: vi.fn(),
+        },
+        catalog: {
+          providerId: 'spotify',
+          listCollections: vi.fn().mockResolvedValue([]),
+          listTracks: vi.fn().mockResolvedValue([]),
+          searchTrack: vi.fn().mockResolvedValue(resolvedTrack),
+        },
+      });
+
+      const generateQueue = vi.fn().mockResolvedValue(
+        makeRadioResult({
+          queue: [catalogTrack],
+          unmatchedSuggestions: [{ name: 'Missing Song', artist: 'Missing Artist', matchScore: 0.5 }],
+        }),
+      );
+
+      // #when
+      const result = await runRadioPipeline({
+        seedTrack,
+        catalogProvider,
+        searchProviders: [unauthenticatedProvider],
+        onProgress,
+        generateQueue,
+      });
+
+      // #then - disconnected provider is not used for resolution
+      expect(result).not.toBeNull();
+      expect(result!.queue.some((t) => t.id === 'resolved-1')).toBe(false);
+      expect(vi.mocked(unauthenticatedProvider.catalog.searchTrack)).not.toHaveBeenCalled();
+    });
+
     it('does not add resolved tracks that duplicate existing queue entries by artists||name', async () => {
       // #given
       const seedTrack = makeMediaTrack({ id: 'seed-1', name: 'Creep', artists: 'Radiohead' });

--- a/src/utils/__tests__/playlistFilters.test.ts
+++ b/src/utils/__tests__/playlistFilters.test.ts
@@ -133,16 +133,7 @@ describe('filterAndSortPlaylists', () => {
       expect(result[2].name).toBe('Chill Vibes'); // 2024-06-15
     });
 
-    it('keeps anchor playlists before sorted remainder (All Music id "", liked-songs)', () => {
-      const allMusic: PlaylistInfo = {
-        id: '',
-        name: 'All Music',
-        description: null,
-        images: [],
-        tracks: { total: 100 },
-        owner: null,
-        added_at: '2020-01-01T10:00:00Z',
-      };
+    it('keeps Liked Songs anchored before sorted remainder (All Music has its own anchored card now)', () => {
       const likedInList: PlaylistInfo = {
         id: 'liked-songs',
         name: 'Liked Songs',
@@ -152,10 +143,9 @@ describe('filterAndSortPlaylists', () => {
         owner: null,
         added_at: '2021-01-01T10:00:00Z',
       };
-      const mixed = [mockPlaylists[2], allMusic, mockPlaylists[0], likedInList];
+      const mixed = [mockPlaylists[2], mockPlaylists[0], likedInList];
       const result = filterAndSortPlaylists(mixed, '', 'name-asc');
       expect(result.map(p => p.name)).toEqual([
-        'All Music',
         'Liked Songs',
         'Chill Vibes',
         'Road Trip',
@@ -364,21 +354,10 @@ describe('filterAndSortAlbums', () => {
       expect(result[1].name).toBe('Let It Be');
     });
 
-    it('keeps anchor album (id "") before sorted remainder', () => {
-      const allMusic: AlbumInfo = {
-        id: '',
-        name: 'All Music',
-        artists: 'Various',
-        images: [],
-        release_date: '',
-        total_tracks: 999,
-        uri: '',
-        added_at: '2010-01-01T10:00:00Z',
-      };
-      const mixed = [mockAlbums[2], allMusic, mockAlbums[0]];
+    it('sorts albums without anchor exceptions (All Music no longer lives in the album list)', () => {
+      const mixed = [mockAlbums[2], mockAlbums[0]];
       const result = filterAndSortAlbums(mixed, '', 'name-asc');
       expect(result.map(a => a.name)).toEqual([
-        'All Music',
         'Abbey Road',
         'Random Access Memories',
       ]);


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-18.7`

### Changes
- test(provider): add coverage for disconnected provider exclusion (#1106)
- feat(auth): auto-disconnect provider and show toast on unrecoverable 401 (#1105)
- feat(provider-settings): add ProviderDisconnectDialog (#1104)
- docs: document AllMusicCard placement and shuffle-by-default semantics (#1113)
- feat(library): add AllMusicCard with shuffle branding to playlist grid (#1112)
- feat(library): force shuffle for All Music on load and append (#1111)

Closes #1090
Closes #1091
Closes #1092
Closes #1093
Closes #1095
Closes #1096
Closes #1097
Closes #1098
Closes #1099
Closes #1100
Closes #1101
Closes #1102