### PR TITLE
fix(pins): exclude special cards from MAX_PINS cap

### DIFF
--- a/src/contexts/PinnedItemsContext.tsx
+++ b/src/contexts/PinnedItemsContext.tsx
@@ -1,6 +1,14 @@
 import React, { createContext, useContext, useCallback, useMemo, useState, useEffect } from 'react';
 import { getPins, setPins, migratePinsFromLocalStorage, MAX_PINS, UNIFIED_PROVIDER, PINS_CHANGED_EVENT } from '@/services/settings/pinnedItemsStorage';
 import { getPreferencesSync } from '@/providers/dropbox/dropboxPreferencesSync';
+import { LIKED_SONGS_ID, ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+
+/** IDs that are always rendered in the grid and should not count against MAX_PINS. */
+const SPECIAL_PIN_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID, ALL_MUSIC_PIN_ID]);
+
+function countUserPins(ids: string[]): number {
+  return ids.filter(id => !SPECIAL_PIN_IDS.has(id)).length;
+}
 
 interface PinnedItemsContextValue {
   pinnedPlaylistIds: string[];
@@ -62,7 +70,7 @@ export function PinnedItemsProvider({ children }: { children: React.ReactNode })
 
   const togglePinPlaylist = useCallback((id: string) => {
     setPinnedPlaylistIds(prev => {
-      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : prev.length + pinnedAlbumIds.length >= MAX_PINS ? prev : [...prev, id];
+      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : countUserPins(prev) + countUserPins(pinnedAlbumIds) >= MAX_PINS && !SPECIAL_PIN_IDS.has(id) ? prev : [...prev, id];
       setPins(UNIFIED_PROVIDER, 'playlists', next).catch(err => console.warn('[PinnedItemsContext] pin write failed:', err));
       getPreferencesSync()?.schedulePush();
       return next;
@@ -71,16 +79,16 @@ export function PinnedItemsProvider({ children }: { children: React.ReactNode })
 
   const togglePinAlbum = useCallback((id: string) => {
     setPinnedAlbumIds(prev => {
-      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : pinnedPlaylistIds.length + prev.length >= MAX_PINS ? prev : [...prev, id];
+      const next = prev.includes(id) ? prev.filter(pid => pid !== id) : countUserPins(pinnedPlaylistIds) + countUserPins(prev) >= MAX_PINS && !SPECIAL_PIN_IDS.has(id) ? prev : [...prev, id];
       setPins(UNIFIED_PROVIDER, 'albums', next).catch(err => console.warn('[PinnedItemsContext] pin write failed:', err));
       getPreferencesSync()?.schedulePush();
       return next;
     });
   }, [pinnedPlaylistIds]);
 
-  const totalPinned = pinnedPlaylistIds.length + pinnedAlbumIds.length;
-  const canPinMorePlaylists = totalPinned < MAX_PINS;
-  const canPinMoreAlbums = totalPinned < MAX_PINS;
+  const totalUserPinned = countUserPins(pinnedPlaylistIds) + countUserPins(pinnedAlbumIds);
+  const canPinMorePlaylists = totalUserPinned < MAX_PINS;
+  const canPinMoreAlbums = totalUserPinned < MAX_PINS;
 
   const value = useMemo<PinnedItemsContextValue>(() => ({
     pinnedPlaylistIds,

--- a/src/contexts/__tests__/PinnedItemsContext.test.tsx
+++ b/src/contexts/__tests__/PinnedItemsContext.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { PinnedItemsProvider, usePinnedItemsContext } from '@/contexts/PinnedItemsContext';
+import { LIKED_SONGS_ID, ALL_MUSIC_PIN_ID } from '@/constants/playlist';
+import { MAX_PINS } from '@/services/settings/pinnedItemsStorage';
+
+vi.mock('@/services/settings/pinnedItemsStorage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/settings/pinnedItemsStorage')>();
+  const store: Record<string, string[]> = {};
+  return {
+    ...actual,
+    getPins: vi.fn(async (_provider: string, type: string) => store[type] ?? []),
+    setPins: vi.fn(async (_provider: string, type: string, ids: string[]) => { store[type] = ids; }),
+    migratePinsFromLocalStorage: vi.fn(async () => {}),
+  };
+});
+
+vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
+  getPreferencesSync: vi.fn(() => null),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <PinnedItemsProvider>{children}</PinnedItemsProvider>;
+}
+
+describe('PinnedItemsContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('MAX_PINS cap with special cards', () => {
+    it('pinning LIKED_SONGS_ID does not reduce remaining capacity for regular collections', async () => {
+      // #given
+      const { result } = renderHook(() => usePinnedItemsContext(), { wrapper });
+
+      // #when — pin the special Liked Songs card
+      act(() => {
+        result.current.togglePinPlaylist(LIKED_SONGS_ID);
+      });
+
+      // #then — 12 regular collections can still be pinned
+      expect(result.current.canPinMorePlaylists).toBe(true);
+    });
+
+    it('pinning ALL_MUSIC_PIN_ID does not reduce remaining capacity for regular collections', async () => {
+      // #given
+      const { result } = renderHook(() => usePinnedItemsContext(), { wrapper });
+
+      // #when — pin the special All Music card
+      act(() => {
+        result.current.togglePinPlaylist(ALL_MUSIC_PIN_ID);
+      });
+
+      // #then — 12 regular collections can still be pinned
+      expect(result.current.canPinMorePlaylists).toBe(true);
+    });
+
+    it(`allows ${MAX_PINS} regular playlists even when LIKED_SONGS_ID and ALL_MUSIC_PIN_ID are pinned`, async () => {
+      // #given
+      const { result } = renderHook(() => usePinnedItemsContext(), { wrapper });
+
+      // pin both special cards
+      act(() => {
+        result.current.togglePinPlaylist(LIKED_SONGS_ID);
+        result.current.togglePinPlaylist(ALL_MUSIC_PIN_ID);
+      });
+
+      // #when — pin MAX_PINS regular collections
+      for (let i = 0; i < MAX_PINS; i++) {
+        act(() => {
+          result.current.togglePinPlaylist(`regular-playlist-${i}`);
+        });
+      }
+
+      // #then — all MAX_PINS regular playlists are pinned (special cards don't count against the cap)
+      const regularPins = result.current.pinnedPlaylistIds.filter(
+        id => id !== LIKED_SONGS_ID && id !== ALL_MUSIC_PIN_ID
+      );
+      expect(regularPins).toHaveLength(MAX_PINS);
+      expect(result.current.canPinMorePlaylists).toBe(false);
+    });
+
+    it('reports canPinMorePlaylists=false only when MAX_PINS regular collections are pinned', async () => {
+      // #given
+      const { result } = renderHook(() => usePinnedItemsContext(), { wrapper });
+
+      // pin LIKED_SONGS_ID (special — should not count)
+      act(() => {
+        result.current.togglePinPlaylist(LIKED_SONGS_ID);
+      });
+
+      // pin MAX_PINS - 1 regular playlists
+      for (let i = 0; i < MAX_PINS - 1; i++) {
+        act(() => {
+          result.current.togglePinPlaylist(`p-${i}`);
+        });
+      }
+
+      // #when — still one slot remaining
+      // #then
+      expect(result.current.canPinMorePlaylists).toBe(true);
+
+      // #when — fill the last slot
+      act(() => {
+        result.current.togglePinPlaylist(`p-${MAX_PINS - 1}`);
+      });
+
+      // #then — now at capacity
+      expect(result.current.canPinMorePlaylists).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `SPECIAL_PIN_IDS` set (`LIKED_SONGS_ID`, `ALL_MUSIC_PIN_ID`) and `countUserPins()` helper in `PinnedItemsContext.tsx` that filters special IDs before comparing against `MAX_PINS`
- Toggle guards in `togglePinPlaylist` / `togglePinAlbum` and the `canPinMore*` flags now use `countUserPins()` so special cards never consume regular user slots
- Special cards themselves bypass the cap check (`!SPECIAL_PIN_IDS.has(id)`) so they can always be toggled
- Added 4 unit tests in `src/contexts/__tests__/PinnedItemsContext.test.tsx` covering the new behavior

## Test plan
- TypeScript: `npx tsc -b --noEmit` — clean
- Unit: `npm run test:run` — 1082 tests pass
- Manual: pin Liked Songs + All Music, confirm 12 regular collections can still be pinned

Closes #1114