### PR TITLE
fix(controls): restore track name font and add hover underline

### DIFF
--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -95,6 +95,12 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
     font-family: inherit;
     text-align: inherit;
     cursor: pointer;
+    transition: opacity ${({ theme }) => theme.transitions.fast} ease;
+
+    &:hover {
+      opacity: 0.8;
+      text-decoration: underline;
+    }
   }
 `;
 

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -92,7 +92,7 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
     border: none;
     padding: 0;
     margin: 0;
-    font: inherit;
+    font-family: inherit;
     text-align: inherit;
     cursor: pointer;
   }


### PR DESCRIPTION
## Summary
- Replace `font: inherit` with `font-family: inherit` in the `PlayerTrackName` button variant so the semibold weight, `2xl` size, and line-height set on the styled.div are preserved. The shorthand was introduced in #1063 and regressed the track-name styling whenever Last.fm made the name clickable.
- Add a hover affordance (`opacity 0.8` + `text-decoration: underline` via `transitions.fast`) to the button variant, matching `AlbumLink` and `ArtistLink`, so all three interactive pieces of track info signal clickability the same way.

## Test plan
- [x] \`npx tsc -b --noEmit\` — clean
- [ ] Manual: with Last.fm configured, confirm the track name renders at the same weight/size as before #1063
- [ ] Manual: hover over track name, artist name, and album name — all three show the same underline + opacity fade