### PR TITLE
test(library): regression test for artist-click through search flow

### DIFF
--- a/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
+++ b/src/components/PlaylistSelection/__tests__/useLibraryRoot.test.tsx
@@ -400,6 +400,70 @@ describe('useLibraryRoot behavioral coverage', () => {
   });
 });
 
+describe('useLibraryRoot artist-click → search-clear flow', () => {
+  const fakeMouseEvent = { stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+  function setupArtistClickFixture() {
+    setLibrarySync(
+      [],
+      [
+        makeAlbumInfo({ id: 'a-1', name: 'Kind of Blue', artists: 'Miles Davis' }),
+        makeAlbumInfo({ id: 'a-2', name: 'Bitches Brew', artists: 'Miles Davis' }),
+        makeAlbumInfo({ id: 'a-3', name: 'Nevermind', artists: 'Nirvana' }),
+      ],
+    );
+    return renderLibraryRoot();
+  }
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockIsMobile.current = false;
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('clicking an artist populates searchQuery with the artist name', () => {
+    const { result } = setupArtistClickFixture();
+
+    // #when
+    act(() => {
+      result.current.actionsValue.onArtistClick('Miles Davis', fakeMouseEvent);
+    });
+
+    // #then
+    expect(result.current.browsingValue.searchQuery).toBe('Miles Davis');
+  });
+
+  it('album list filters to only the clicked artist after artist click', () => {
+    const { result } = setupArtistClickFixture();
+
+    // #when
+    act(() => {
+      result.current.actionsValue.onArtistClick('Miles Davis', fakeMouseEvent);
+    });
+
+    // #then
+    expect(albumNames(result).sort()).toEqual(['Bitches Brew', 'Kind of Blue']);
+  });
+
+  it('clearing searchQuery restores the unfiltered album list', () => {
+    const { result } = setupArtistClickFixture();
+
+    // #given — artist filter applied
+    act(() => {
+      result.current.actionsValue.onArtistClick('Miles Davis', fakeMouseEvent);
+    });
+
+    // #when
+    act(() => {
+      result.current.browsingValue.setSearchQuery('');
+    });
+
+    // #then
+    expect(albumNames(result).sort()).toEqual(['Bitches Brew', 'Kind of Blue', 'Nevermind']);
+  });
+});
+
 describe('useLibraryRoot grid behavior', () => {
   beforeEach(() => {
     window.localStorage.clear();


### PR DESCRIPTION
## Summary
- Regression test locking in the #1073 wire-through: clicking an artist populates `searchQuery`, the album list filters to only that artist's albums, and clearing `searchQuery` restores the full unfiltered list.
- Scope note: asserting `artistFilter` removal from context is deferred to the final merge (chain #1074 through #1076 removes the field; this PR stacks on #1073 only, where the field still exists).

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — all 24 tests pass (21 pre-existing + 3 new) on top of #1073

Closes #1077