### PR TITLE
refactor(bottombar): add explicit z-index tokens for zen trigger layers

### DIFF
--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -59,13 +59,13 @@ export const ZenTriggerZone = styled.div`
   left: 0;
   right: 0;
   height: ${TOUCH_TARGET_MIN_PX}px;
-  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 1};
+  z-index: ${({ theme }) => theme.zIndex.zenTrigger};
   background: transparent;
 `;
 
 export const ZenBackdrop = styled.div`
   position: fixed;
   inset: 0;
-  z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 2};
+  z-index: ${({ theme }) => theme.zIndex.zenBackdrop};
   background: transparent;
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -197,6 +197,8 @@ export const theme = {
     sticky: '1100',
     banner: '1200',
     overlay: '1300',
+    zenBackdrop: '1348',
+    zenTrigger: '1349',
     mobileMenu: '1350',
     modal: '1400',
     popover: '1500',


### PR DESCRIPTION
## Summary
- Added \`zenTrigger\` (1349) and \`zenBackdrop\` (1348) tokens to \`theme.zIndex\`, sandwiched just below \`mobileMenu\` (1350).
- Replaced \`Number(theme.zIndex.mobileMenu) - 1/-2\` arithmetic in \`BottomBar/styled.ts\` with direct theme-provider reads on \`ZenTriggerZone\` and \`ZenBackdrop\`.
- No other files referenced this arithmetic pattern; stacking order relative to \`BottomBarContainer\` is preserved.

## Test plan
- [x] \`npx tsc -b --noEmit\` passes
- [x] \`npm run test:run\` passes (1080 tests)
- [x] \`npm run build\` succeeds
- [ ] Visual: zen mode trigger + backdrop still layer correctly relative to bottom bar

Closes #826