### PR TITLE
refactor(bottombar): consume actions from hooks instead of drilling props

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -5,6 +5,10 @@ import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useVolume } from '@/hooks/useVolume';
+import { useTrackListContext, useCurrentTrackContext } from '@/contexts/TrackContext';
+import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
+import { useBottomBarActions } from '@/contexts/BottomBarActionsContext';
 import {
   VisualEffectsIcon,
   BackToLibraryIcon,
@@ -16,45 +20,25 @@ import {
 } from '../icons/QuickActionIcons';
 
 const AUTOHIDE_DELAY = 1000;
-const noop = () => {};
 
-interface BottomBarProps {
-  zenModeEnabled?: boolean;
-  hidden?: boolean;
-  isMuted: boolean;
-  volume: number;
-  onMuteToggle?: () => void;
-  onVolumeChange?: (volume: number) => void;
-  onShowVisualEffects: () => void;
-  onBackToLibrary?: () => void;
-  onShowQueue: () => void;
-  onZenModeToggle?: () => void;
-  shuffleEnabled?: boolean;
-  onShuffleToggle?: () => void;
-  onStartRadio?: () => void;
-  radioGenerating?: boolean;
-  onOpenQuickAccessPanel?: () => void;
-}
-
-const BottomBar = React.memo(function BottomBar({
-  zenModeEnabled,
-  hidden,
-  isMuted,
-  volume,
-  onMuteToggle,
-  onVolumeChange,
-  onShowVisualEffects,
-  onBackToLibrary,
-  onShowQueue,
-  onZenModeToggle,
-  shuffleEnabled,
-  onShuffleToggle,
-  onStartRadio,
-  radioGenerating,
-  onOpenQuickAccessPanel,
-}: BottomBarProps) {
+const BottomBar = React.memo(function BottomBar() {
   const { isMobile, isTablet, isTouchDevice } = usePlayerSizingContext();
   const [qapEnabled] = useQapEnabled();
+  const { currentTrack } = useCurrentTrackContext();
+  const { isMuted, volume, handleMuteToggle, setVolumeLevel } = useVolume(currentTrack?.provider);
+  const { shuffleEnabled, handleShuffleToggle } = useTrackListContext();
+  const { zenModeEnabled } = useVisualEffectsContext();
+  const {
+    hidden,
+    showSettings,
+    showQueue,
+    openLibrary,
+    toggleZenMode,
+    startRadio,
+    openQuickAccessPanel,
+    radioGenerating,
+  } = useBottomBarActions();
+
   const [barVisible, setBarVisible] = useState(!zenModeEnabled);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const isHoveringRef = useRef(false);
@@ -124,7 +108,7 @@ const BottomBar = React.memo(function BottomBar({
 
   if (hidden) return null;
 
-  const isHidden = !barVisible && !!zenModeEnabled;
+  const isHidden = !barVisible && zenModeEnabled;
 
   return createPortal(
     <>
@@ -148,32 +132,30 @@ const BottomBar = React.memo(function BottomBar({
           <VolumeControl
             isMuted={isMuted}
             volume={volume}
-            onClick={onMuteToggle ?? noop}
-            onVolumeChange={onVolumeChange ?? noop}
+            onClick={handleMuteToggle}
+            onVolumeChange={setVolumeLevel}
             isMobile={isMobile}
             isTablet={isTablet}
           />
 
-          {onShuffleToggle && (
-            <ControlButton
-              $isMobile={isMobile}
-              $isTablet={isTablet}
-              isActive={shuffleEnabled}
-              onClick={onShuffleToggle}
-              title={`Shuffle ${shuffleEnabled ? 'ON' : 'OFF'}`}
-              aria-label="Shuffle"
-              aria-pressed={shuffleEnabled}
-            >
-              <ShuffleIcon />
-            </ControlButton>
-          )}
+          <ControlButton
+            $isMobile={isMobile}
+            $isTablet={isTablet}
+            isActive={shuffleEnabled}
+            onClick={handleShuffleToggle}
+            title={`Shuffle ${shuffleEnabled ? 'ON' : 'OFF'}`}
+            aria-label="Shuffle"
+            aria-pressed={shuffleEnabled}
+          >
+            <ShuffleIcon />
+          </ControlButton>
 
-          {onStartRadio && (
+          {startRadio && (
             <ControlButton
               $isMobile={isMobile}
               $isTablet={isTablet}
               $compact
-              onClick={onStartRadio}
+              onClick={startRadio}
               title={radioGenerating ? 'Generating radio playlist...' : 'Generate radio playlist from current track'}
               disabled={radioGenerating}
               aria-label="Generate radio playlist from current track"
@@ -182,12 +164,12 @@ const BottomBar = React.memo(function BottomBar({
             </ControlButton>
           )}
 
-          {qapEnabled && onOpenQuickAccessPanel && (
+          {qapEnabled && openQuickAccessPanel && (
             <ControlButton
               $isMobile={isMobile}
               $isTablet={isTablet}
               $compact
-              onClick={onOpenQuickAccessPanel}
+              onClick={openQuickAccessPanel}
               title="Quick Access Panel"
               aria-label="Quick Access Panel"
             >
@@ -199,51 +181,47 @@ const BottomBar = React.memo(function BottomBar({
             $isMobile={isMobile}
             $isTablet={isTablet}
             $compact
-            onClick={onShowVisualEffects}
+            onClick={showSettings}
             title="App settings"
             aria-label="App settings"
           >
             <VisualEffectsIcon />
           </ControlButton>
 
-          {onBackToLibrary && (
-            <ControlButton
-              $isMobile={isMobile}
-              $isTablet={isTablet}
-              $compact
-              onClick={onBackToLibrary}
-              title="Back to Library"
-              aria-label="Back to Library"
-            >
-              <BackToLibraryIcon />
-            </ControlButton>
-          )}
+          <ControlButton
+            $isMobile={isMobile}
+            $isTablet={isTablet}
+            $compact
+            onClick={openLibrary}
+            title="Back to Library"
+            aria-label="Back to Library"
+          >
+            <BackToLibraryIcon />
+          </ControlButton>
 
           <ControlButton
             $isMobile={isMobile}
             $isTablet={isTablet}
             $compact
-            onClick={onShowQueue}
+            onClick={showQueue}
             title="Show Queue"
             aria-label="Show Queue"
           >
             <QueueIcon />
           </ControlButton>
 
-          {onZenModeToggle && (
-            <ControlButton
-              $isMobile={isMobile}
-              $isTablet={isTablet}
-              $compact
-              isActive={zenModeEnabled}
-              onClick={onZenModeToggle}
-              title={`Zen Mode ${zenModeEnabled ? 'ON' : 'OFF'}`}
-              aria-label="Zen Mode"
-              aria-pressed={zenModeEnabled}
-            >
-              <ZenModeIcon />
-            </ControlButton>
-          )}
+          <ControlButton
+            $isMobile={isMobile}
+            $isTablet={isTablet}
+            $compact
+            isActive={zenModeEnabled}
+            onClick={toggleZenMode}
+            title={`Zen Mode ${zenModeEnabled ? 'ON' : 'OFF'}`}
+            aria-label="Zen Mode"
+            aria-pressed={zenModeEnabled}
+          >
+            <ZenModeIcon />
+          </ControlButton>
         </BottomBarInner>
       </BottomBarContainer>
     </>,

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState, useCallback, useRef } from 'react';
+import React, { Suspense, lazy, useState, useCallback, useMemo, useRef } from 'react';
 import { useTheme } from 'styled-components';
 import { CardContent } from '@/components/styled';
 import SpotifyPlayerControls from '@/components/SpotifyPlayerControls';
@@ -13,6 +13,7 @@ import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useVolume } from '@/hooks/useVolume';
 import { useTrackListContext } from '@/contexts/TrackContext';
+import { BottomBarActionsProvider, type BottomBarActionsValue } from '@/contexts/BottomBarActionsContext';
 import { clearCacheWithOptions } from '@/services/cache/libraryCache';
 import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
@@ -127,11 +128,11 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   isLikePending,
   onLikeToggle,
 }) => {
-  const { tracks, shuffleEnabled, handleShuffleToggle } = useTrackListContext();
+  const { tracks, handleShuffleToggle } = useTrackListContext();
   const { isMobile } = usePlayerSizingContext();
   const { accentColor } = useColorContext();
   const { effectiveGlow, restoreGlowSettings } = useVisualEffectsState();
-  const { handleMuteToggle, isMuted, volume, setVolumeLevel } = useVolume(currentTrackProvider);
+  const { handleMuteToggle, volume, setVolumeLevel } = useVolume(currentTrackProvider);
 
   const {
     visualEffectsEnabled,
@@ -274,6 +275,28 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
     setVolumeLevel(Math.max(0, (volume ?? 50) - 5));
   }, [volume, setVolumeLevel]);
 
+  const bottomBarActions = useMemo<BottomBarActionsValue>(() => ({
+    hidden: showLibrary && isMobile,
+    showSettings: handleShowVisualEffects,
+    showQueue: onShowQueue,
+    openLibrary: onOpenLibrary,
+    toggleZenMode: onZenModeToggle,
+    startRadio: isRadioAvailable ? onStartRadio : undefined,
+    openQuickAccessPanel: onOpenQuickAccessPanel,
+    radioGenerating: radioState?.isGenerating,
+  }), [
+    showLibrary,
+    isMobile,
+    handleShowVisualEffects,
+    onShowQueue,
+    onOpenLibrary,
+    onZenModeToggle,
+    isRadioAvailable,
+    onStartRadio,
+    onOpenQuickAccessPanel,
+    radioState?.isGenerating,
+  ]);
+
   useKeyboardShortcuts({
     onPlayPause: handlePlayPause,
     onNext: onNext,
@@ -340,23 +363,9 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
         </ZenControlsInner>
       </ZenControlsWrapper>
       <ProfiledComponent id="BottomBar">
-        <BottomBar
-          zenModeEnabled={zenModeEnabled}
-          hidden={showLibrary && isMobile}
-          isMuted={isMuted}
-          volume={volume}
-          onMuteToggle={handleMuteToggle}
-          onVolumeChange={setVolumeLevel}
-          onShowVisualEffects={handleShowVisualEffects}
-          onBackToLibrary={onOpenLibrary}
-          onShowQueue={onShowQueue}
-          onZenModeToggle={onZenModeToggle}
-          shuffleEnabled={shuffleEnabled}
-          onShuffleToggle={handleShuffleToggle}
-          onStartRadio={isRadioAvailable ? onStartRadio : undefined}
-          radioGenerating={radioState?.isGenerating}
-          onOpenQuickAccessPanel={onOpenQuickAccessPanel}
-        />
+        <BottomBarActionsProvider value={bottomBarActions}>
+          <BottomBar />
+        </BottomBarActionsProvider>
       </ProfiledComponent>
       {settingsHasBeenOpenedRef.current && (
         <Suspense fallback={<VisualEffectsLoadingFallback />}>

--- a/src/components/__tests__/BottomBar.test.tsx
+++ b/src/components/__tests__/BottomBar.test.tsx
@@ -6,6 +6,11 @@ import { theme } from '@/styles/theme';
 import BottomBar from '../BottomBar';
 import { TestWrapper } from '@/test/testWrappers';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import {
+  BottomBarActionsProvider,
+  type BottomBarActionsValue,
+} from '@/contexts/BottomBarActionsContext';
+import { useVisualEffectsContext } from '@/contexts/VisualEffectsContext';
 
 vi.mock('@/services/spotifyPlayer', () => ({
   spotifyPlayer: {
@@ -54,85 +59,151 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
   usePlayerSizingContext: vi.fn(() => mockSizingContext),
 }));
 
-const defaultProps = {
-  zenModeEnabled: false,
-  isMuted: false,
-  volume: 50,
-  onMuteToggle: vi.fn(),
-  onVolumeChange: vi.fn(),
-  onShowVisualEffects: vi.fn(),
-  onBackToLibrary: vi.fn(),
-  onShowQueue: vi.fn(),
-  onZenModeToggle: vi.fn(),
-  shuffleEnabled: false,
-  onShuffleToggle: vi.fn(),
-};
+function makeActions(overrides?: Partial<BottomBarActionsValue>): BottomBarActionsValue {
+  return {
+    hidden: false,
+    showSettings: vi.fn(),
+    showQueue: vi.fn(),
+    openLibrary: vi.fn(),
+    toggleZenMode: vi.fn(),
+    startRadio: vi.fn(),
+    openQuickAccessPanel: vi.fn(),
+    radioGenerating: false,
+    ...overrides,
+  };
+}
 
-function renderBottomBar(overrides?: Partial<typeof defaultProps>) {
-  const props = { ...defaultProps, ...overrides };
-  Object.keys(props).forEach((key) => {
-    const val = props[key as keyof typeof props];
-    if (typeof val === 'function') {
-      (val as ReturnType<typeof vi.fn>).mockClear();
-    }
-  });
+function ZenModeSetter({ enabled }: { enabled: boolean }) {
+  const { setZenModeEnabled } = useVisualEffectsContext();
+  React.useEffect(() => {
+    setZenModeEnabled(enabled);
+  }, [enabled, setZenModeEnabled]);
+  return null;
+}
+
+interface RenderOptions {
+  actions?: BottomBarActionsValue;
+  zenModeEnabled?: boolean;
+}
+
+function primeZenMode(enabled: boolean) {
+  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) =>
+    key === 'vorbis-player-zen-mode-enabled' ? JSON.stringify(enabled) : null
+  );
+}
+
+function renderBottomBar(options?: RenderOptions) {
+  const actions = options?.actions ?? makeActions();
+  const zen = options?.zenModeEnabled ?? false;
+  primeZenMode(zen);
   const result = render(
     <ThemeProvider theme={theme}>
       <TestWrapper>
-        <BottomBar {...props} />
+        <ZenModeSetter enabled={zen} />
+        <BottomBarActionsProvider value={actions}>
+          <BottomBar />
+        </BottomBarActionsProvider>
       </TestWrapper>
     </ThemeProvider>
   );
-  return { ...result, props };
+  return { ...result, actions };
+}
+
+function rerenderBottomBar(
+  rerender: ReturnType<typeof render>['rerender'],
+  options: RenderOptions,
+) {
+  const actions = options.actions ?? makeActions();
+  const zen = options.zenModeEnabled ?? false;
+  rerender(
+    <ThemeProvider theme={theme}>
+      <TestWrapper>
+        <ZenModeSetter enabled={zen} />
+        <BottomBarActionsProvider value={actions}>
+          <BottomBar />
+        </BottomBarActionsProvider>
+      </TestWrapper>
+    </ThemeProvider>
+  );
 }
 
 describe('BottomBar', () => {
   it('renders into document.body via portal', () => {
+    // #given / #when
     renderBottomBar();
+
+    // #then
     const bar = document.body.querySelector('[title="App settings"]');
     expect(bar).toBeTruthy();
   });
 
-  it('clicking the back-to-library button calls onBackToLibrary', () => {
-    const { props } = renderBottomBar();
-    const backButton = screen.getByTitle('Back to Library');
-    fireEvent.click(backButton);
-    expect(props.onBackToLibrary).toHaveBeenCalledOnce();
+  it('clicking the back-to-library button calls openLibrary', () => {
+    // #given
+    const { actions } = renderBottomBar();
+
+    // #when
+    fireEvent.click(screen.getByTitle('Back to Library'));
+
+    // #then
+    expect(actions.openLibrary).toHaveBeenCalledOnce();
   });
 
-  it('zen mode button is visible when onZenModeToggle is provided', () => {
-    renderBottomBar({ onZenModeToggle: vi.fn() });
+  it('zen mode button is always rendered', () => {
+    // #given / #when
+    renderBottomBar();
+
+    // #then
     expect(screen.getByTitle(/zen mode/i)).toBeTruthy();
   });
 
-  it('zen mode button is absent when onZenModeToggle is not provided', () => {
-    renderBottomBar({ onZenModeToggle: undefined });
-    expect(screen.queryByTitle(/zen mode/i)).toBeNull();
+  it('shuffle button reflects shuffle state from track context', () => {
+    // #given — TestWrapper's TrackProvider defaults shuffleEnabled to false
+    renderBottomBar();
+
+    // #then
+    const shuffleButton = screen.getByTitle(/shuffle/i);
+    expect(shuffleButton.getAttribute('aria-pressed')).toBe('false');
   });
 
-  it('shuffle button shows active state when shuffle is enabled', () => {
-    renderBottomBar({ shuffleEnabled: true });
-    const shuffleButton = screen.getByTitle('Shuffle ON');
-    expect(shuffleButton).toBeTruthy();
-    expect(shuffleButton.getAttribute('aria-pressed')).toBe('true');
-  });
+  it('visual effects button calls showSettings when clicked', () => {
+    // #given
+    const { actions } = renderBottomBar();
 
-  it('visual effects button calls onShowVisualEffects when clicked', () => {
-    const { props } = renderBottomBar();
+    // #when
     fireEvent.click(screen.getByTitle('App settings'));
-    expect(props.onShowVisualEffects).toHaveBeenCalledOnce();
+
+    // #then
+    expect(actions.showSettings).toHaveBeenCalledOnce();
   });
 
-  it('queue button calls onShowQueue when clicked', () => {
-    const { props } = renderBottomBar();
+  it('queue button calls showQueue when clicked', () => {
+    // #given
+    const { actions } = renderBottomBar();
+
+    // #when
     fireEvent.click(screen.getByTitle('Show Queue'));
-    expect(props.onShowQueue).toHaveBeenCalledOnce();
+
+    // #then
+    expect(actions.showQueue).toHaveBeenCalledOnce();
   });
 
-  it('zen mode button calls onZenModeToggle when clicked', () => {
-    const { props } = renderBottomBar();
+  it('zen mode button calls toggleZenMode when clicked', () => {
+    // #given
+    const { actions } = renderBottomBar();
+
+    // #when
     fireEvent.click(screen.getByTitle(/zen mode/i));
-    expect(props.onZenModeToggle).toHaveBeenCalledOnce();
+
+    // #then
+    expect(actions.toggleZenMode).toHaveBeenCalledOnce();
+  });
+
+  it('radio button is hidden when startRadio is not provided', () => {
+    // #given / #when
+    renderBottomBar({ actions: makeActions({ startRadio: undefined }) });
+
+    // #then
+    expect(screen.queryByTitle(/generate radio/i)).toBeNull();
   });
 
   it('bar remains visible in normal mode — no hide timer is started', () => {
@@ -150,22 +221,12 @@ describe('BottomBar', () => {
     vi.useRealTimers();
   });
 
-  it('portal renders fewer elements in normal mode than in zen mode', () => {
-    // #given — count baseline children before any render
-    const baselineCount = document.body.childElementCount;
+  it('returns null when hidden flag is true', () => {
+    // #given / #when
+    renderBottomBar({ actions: makeActions({ hidden: true }) });
 
-    // #when — render in zen mode
-    const { unmount: unmountZen } = renderBottomBar({ zenModeEnabled: true });
-    const zenCount = document.body.childElementCount - baselineCount;
-    unmountZen();
-
-    // render in normal mode
-    const baselineCount2 = document.body.childElementCount;
-    renderBottomBar({ zenModeEnabled: false });
-    const normalCount = document.body.childElementCount - baselineCount2;
-
-    // #then — zen mode adds one extra element (ZenTriggerZone)
-    expect(zenCount).toBe(normalCount + 1);
+    // #then
+    expect(screen.queryByTitle('App settings')).toBeNull();
   });
 });
 
@@ -189,7 +250,7 @@ describe('BottomBar — zen mode show/hide state machine', () => {
       vi.advanceTimersByTime(AUTOHIDE_DELAY);
     });
 
-    // #then — trigger zone is present (zen mode on) and backdrop is absent (bar hidden)
+    // #then — backdrop is absent (bar hidden)
     const portalChildren = Array.from(document.body.children);
     const backdrop = portalChildren.find(
       (el) => el.tagName === 'DIV' && el.getAttribute('style')?.includes('inset')
@@ -199,24 +260,11 @@ describe('BottomBar — zen mode show/hide state machine', () => {
 
   it('trigger zone is rendered only when zen mode is enabled', () => {
     // #given
-    const { rerender } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
-
+    const { rerender } = renderBottomBar({ zenModeEnabled: false });
     const countWithoutZen = document.body.childElementCount;
 
     // #when
-    rerender(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    rerenderBottomBar(rerender, { zenModeEnabled: true });
 
     // #then — one extra portal child (ZenTriggerZone) is added
     expect(document.body.childElementCount).toBe(countWithoutZen + 1);
@@ -224,13 +272,7 @@ describe('BottomBar — zen mode show/hide state machine', () => {
 
   it('bar re-appears when zen mode is disabled after being enabled', () => {
     // #given — start in zen mode and let the bar auto-hide
-    const { rerender } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    const { rerender } = renderBottomBar({ zenModeEnabled: true });
 
     act(() => {
       vi.advanceTimersByTime(AUTOHIDE_DELAY);
@@ -239,13 +281,7 @@ describe('BottomBar — zen mode show/hide state machine', () => {
     const countWhileZen = document.body.childElementCount;
 
     // #when — zen mode is turned off
-    rerender(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    rerenderBottomBar(rerender, { zenModeEnabled: false });
 
     // #then — trigger zone is gone, portal has fewer children again
     expect(document.body.childElementCount).toBe(countWhileZen - 1);
@@ -256,22 +292,10 @@ describe('BottomBar — zen mode show/hide state machine', () => {
 
   it('bar hides after autohide delay following zen mode enable', () => {
     // #given — zen disabled initially (bar visible); transitioning to zen on starts the timer
-    const { rerender } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    const { rerender } = renderBottomBar({ zenModeEnabled: false });
 
     // #when — toggle zen mode on
-    rerender(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    rerenderBottomBar(rerender, { zenModeEnabled: true });
 
     const countBeforeTimeout = document.body.childElementCount;
 
@@ -287,21 +311,9 @@ describe('BottomBar — zen mode show/hide state machine', () => {
 
   it('mouseenter on the bar container cancels the hide timer', () => {
     // #given — zen mode on, bar is visible, hide timer is running
-    const { rerender } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    const { rerender } = renderBottomBar({ zenModeEnabled: false });
 
-    rerender(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    rerenderBottomBar(rerender, { zenModeEnabled: true });
 
     // BottomBarContainer is always the last direct child of document.body (portal renders it last)
     const barContainer = document.body.lastElementChild as HTMLElement;
@@ -319,28 +331,15 @@ describe('BottomBar — zen mode show/hide state machine', () => {
 
   it('mouseleave on the bar container restarts the hide timer', () => {
     // #given — zen mode on, mouse entered (timer cancelled)
-    const { rerender } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: false }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    const { rerender } = renderBottomBar({ zenModeEnabled: false });
 
-    rerender(
-      <ThemeProvider theme={theme}>
-        <TestWrapper>
-          <BottomBar {...{ ...defaultProps, zenModeEnabled: true }} />
-        </TestWrapper>
-      </ThemeProvider>
-    );
+    rerenderBottomBar(rerender, { zenModeEnabled: true });
 
     const barContainer = document.body.lastElementChild as HTMLElement;
 
     act(() => { fireEvent.mouseEnter(barContainer); });
     act(() => { vi.advanceTimersByTime(AUTOHIDE_DELAY * 2); });
 
-    // bar is still visible after hovering
     const countBeforeLeave = document.body.childElementCount;
 
     // #when — mouse leaves the bar

--- a/src/components/__tests__/LibraryNavigation.test.tsx
+++ b/src/components/__tests__/LibraryNavigation.test.tsx
@@ -66,24 +66,36 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
 // -------------------------------------------------------------------------- //
 
 import BottomBar from '../BottomBar';
+import {
+  BottomBarActionsProvider,
+  type BottomBarActionsValue,
+} from '@/contexts/BottomBarActionsContext';
 
-function renderBottomBar(overrides: Partial<React.ComponentProps<typeof BottomBar>> = {}) {
-  const defaults: React.ComponentProps<typeof BottomBar> = {
-    isMuted: false,
-    volume: 50,
-    onShowVisualEffects: vi.fn(),
-    onShowQueue: vi.fn(),
-    onBackToLibrary: vi.fn(),
+function makeActions(overrides?: Partial<BottomBarActionsValue>): BottomBarActionsValue {
+  return {
+    hidden: false,
+    showSettings: vi.fn(),
+    showQueue: vi.fn(),
+    openLibrary: vi.fn(),
+    toggleZenMode: vi.fn(),
+    startRadio: vi.fn(),
+    openQuickAccessPanel: vi.fn(),
+    radioGenerating: false,
+    ...overrides,
   };
-  const props = { ...defaults, ...overrides };
+}
+
+function renderBottomBar(actions: BottomBarActionsValue = makeActions()) {
   render(
     <ThemeProvider theme={theme}>
       <TestWrapper>
-        <BottomBar {...props} />
+        <BottomBarActionsProvider value={actions}>
+          <BottomBar />
+        </BottomBarActionsProvider>
       </TestWrapper>
     </ThemeProvider>
   );
-  return props;
+  return actions;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,25 +103,24 @@ function renderBottomBar(overrides: Partial<React.ComponentProps<typeof BottomBa
 // ---------------------------------------------------------------------------
 
 describe('Library open/close via BottomBar', () => {
-  it('BottomBar onBackToLibrary callback is called when the "Back to Library" button is clicked', () => {
+  it('BottomBar openLibrary action is called when the "Back to Library" button is clicked', () => {
     // #given
-    const onBackToLibrary = vi.fn();
-
-    renderBottomBar({ onBackToLibrary });
+    const openLibrary = vi.fn();
+    renderBottomBar(makeActions({ openLibrary }));
 
     // #when
     fireEvent.click(screen.getByTitle('Back to Library'));
 
     // #then
-    expect(onBackToLibrary).toHaveBeenCalledOnce();
+    expect(openLibrary).toHaveBeenCalledOnce();
   });
 
-  it('does not render "Back to Library" button when onBackToLibrary is not provided', () => {
+  it('renders the "Back to Library" button as a permanent control', () => {
     // #given / #when
-    renderBottomBar({ onBackToLibrary: undefined });
+    renderBottomBar();
 
-    // #then
-    expect(screen.queryByTitle('Back to Library')).toBeNull();
+    // #then — context always supplies an openLibrary action, so the button is unconditional
+    expect(screen.queryByTitle('Back to Library')).not.toBeNull();
   });
 });
 

--- a/src/contexts/BottomBarActionsContext.tsx
+++ b/src/contexts/BottomBarActionsContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext } from 'react';
+
+export interface BottomBarActionsValue {
+  hidden: boolean;
+  showSettings: () => void;
+  showQueue: () => void;
+  openLibrary: () => void;
+  toggleZenMode: () => void;
+  startRadio?: () => void;
+  openQuickAccessPanel?: () => void;
+  radioGenerating?: boolean;
+}
+
+const BottomBarActionsContext = createContext<BottomBarActionsValue | null>(null);
+
+interface BottomBarActionsProviderProps {
+  value: BottomBarActionsValue;
+  children: React.ReactNode;
+}
+
+export function BottomBarActionsProvider({ value, children }: BottomBarActionsProviderProps) {
+  return (
+    <BottomBarActionsContext.Provider value={value}>
+      {children}
+    </BottomBarActionsContext.Provider>
+  );
+}
+
+export function useBottomBarActions(): BottomBarActionsValue {
+  const ctx = useContext(BottomBarActionsContext);
+  if (!ctx) {
+    throw new Error('useBottomBarActions must be used within BottomBarActionsProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- BottomBar now reads volume/mute (`useVolume`), shuffle (`useTrackListContext`), zen mode (`useVisualEffectsContext`), and current track (`useCurrentTrackContext`) directly, dropping all 14 props.
- New minimal `BottomBarActionsContext` carries the composed/external action callbacks (`showSettings`, `showQueue`, `openLibrary`, `toggleZenMode`, `startRadio`, `openQuickAccessPanel`) plus the derived `hidden` flag and `radioGenerating` signal.
- `PlayerControlsSection` wraps the lone `<BottomBar />` render in `<BottomBarActionsProvider>` with a memoized value built from the same handlers it already coordinates; tests updated to match.

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (1080/1080)
- [x] `npm run build` succeeds
- [ ] Manual: BottomBar controls still function (play/pause, next/prev, library, queue, shuffle, zen toggle, volume, mute)

Closes #820