### PR TITLE
refactor(styled): replace magic numbers with named constants

### DIFF
--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
 import { ZEN_BAR_DURATION } from '@/constants/zenAnimation';
+import { TOUCH_TARGET_MIN_PX } from '@/constants/a11y';
 
 export const BOTTOM_BAR_HEIGHT = 60;
+
+const ZEN_GRIP_PILL_WIDTH = '36px';
+const ZEN_GRIP_PILL_HEIGHT = '4px';
+const ZEN_GRIP_PILL_BOTTOM_OFFSET = '10px';
 
 export const BottomBarContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== '$hidden',
@@ -34,12 +39,12 @@ export const BottomBarInner = styled.div`
 export const ZenGripPill = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== '$visible',
 })<{ $visible: boolean }>`
-  width: 36px;
-  height: 4px;
+  width: ${ZEN_GRIP_PILL_WIDTH};
+  height: ${ZEN_GRIP_PILL_HEIGHT};
   background: rgba(255, 255, 255, 0.35);
   border-radius: 2px;
   position: absolute;
-  bottom: 10px;
+  bottom: ${ZEN_GRIP_PILL_BOTTOM_OFFSET};
   left: 50%;
   transform: translateX(-50%);
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
@@ -53,7 +58,7 @@ export const ZenTriggerZone = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  height: 48px;
+  height: ${TOUCH_TARGET_MIN_PX}px;
   z-index: ${({ theme }) => Number(theme.zIndex.mobileMenu) - 1};
   background: transparent;
 `;

--- a/src/components/controls/VolumeControl/styled.ts
+++ b/src/components/controls/VolumeControl/styled.ts
@@ -1,13 +1,21 @@
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 
+const POPOVER_PADDING_Y = '12px';
+const SLIDER_TRACK_WIDTH = '4px';
+const SLIDER_TRACK_HEIGHT = '120px';
+const SLIDER_THUMB_SIZE = '14px';
+const VOLUME_LABEL_FONT_SIZE = '10px';
+const VOLUME_LABEL_MIN_WIDTH = '22px';
+const MUTE_BUTTON_ICON_SIZE = '16px';
+
 export const PopoverContainer = styled.div`
   position: fixed;
   z-index: ${({ theme }) => theme.zIndex.popover};
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 12px ${({ theme }) => theme.spacing.sm};
+  padding: ${POPOVER_PADDING_Y} ${({ theme }) => theme.spacing.sm};
   gap: ${({ theme }) => theme.spacing.sm};
   background: ${({ theme }) => theme.colors.popover.background};
   border: 1px solid ${({ theme }) => theme.colors.popover.border};
@@ -19,8 +27,8 @@ export const PopoverContainer = styled.div`
 
 export const SliderTrack = styled.div<{ $fillPercent: number }>`
   position: relative;
-  width: 4px;
-  height: 120px;
+  width: ${SLIDER_TRACK_WIDTH};
+  height: ${SLIDER_TRACK_HEIGHT};
   background: ${({ theme }) => theme.colors.control.backgroundHover};
   border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
@@ -44,8 +52,8 @@ export const SliderThumb = styled.div<{ $percent: number }>`
   left: 50%;
   bottom: ${({ $percent }) => $percent}%;
   transform: translate(-50%, 50%);
-  width: 14px;
-  height: 14px;
+  width: ${SLIDER_THUMB_SIZE};
+  height: ${SLIDER_THUMB_SIZE};
   background: var(--accent-color);
   border-radius: 50%;
   pointer-events: none;
@@ -71,17 +79,17 @@ export const MuteButton = styled.button<{ $isMuted: boolean }>`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: ${MUTE_BUTTON_ICON_SIZE};
+    height: ${MUTE_BUTTON_ICON_SIZE};
     fill: currentColor;
   }
 `;
 
 export const VolumeLabel = styled.span`
-  font-size: 10px;
+  font-size: ${VOLUME_LABEL_FONT_SIZE};
   font-family: monospace;
   color: ${theme.colors.gray[400]};
   user-select: none;
-  min-width: 22px;
+  min-width: ${VOLUME_LABEL_MIN_WIDTH};
   text-align: center;
 `;

--- a/src/constants/a11y.ts
+++ b/src/constants/a11y.ts
@@ -1,0 +1,5 @@
+/**
+ * Minimum touch target size in pixels per WCAG 2.5.5 (Level AAA) and Apple HIG.
+ * Use for any interactive surface that must be reliably tappable on touch devices.
+ */
+export const TOUCH_TARGET_MIN_PX = 48;


### PR DESCRIPTION
## Summary
- Extract pixel literals in `VolumeControl/styled.ts` (popover padding, slider track/thumb dimensions, label font/min-width, mute icon size) to module-local constants
- Extract `ZenGripPill` width/height/bottom-offset literals in `BottomBar/styled.ts` to module-local constants
- Add `src/constants/a11y.ts` exporting `TOUCH_TARGET_MIN_PX = 48` (WCAG 2.5.5 / HIG); use it for `ZenTriggerZone` height so the touch-target rationale is self-documenting

Stacked on #1131.

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (1080 tests)
- [x] `npm run build` succeeds
- [ ] Manual: volume popover and zen-mode bottom bar render and behave identically

Closes #827