### PR TITLE
fix(visualizers): apply grid wave displacement on both axes

### DIFF
--- a/src/components/VisualizerDebugPanel/index.tsx
+++ b/src/components/VisualizerDebugPanel/index.tsx
@@ -87,6 +87,8 @@ export function VisualizerDebugPanel() {
   const [loadStatus, setLoadStatus] = useState<'idle' | 'ok' | 'err'>('idle');
   const [particleOpen, setParticleOpen] = useState(true);
   const [trailOpen, setTrailOpen] = useState(true);
+  const [waveOpen, setWaveOpen] = useState(true);
+  const [gridOpen, setGridOpen] = useState(true);
 
   const handleDownload = useCallback(() => {
     if (!ctx) return;
@@ -106,9 +108,11 @@ export function VisualizerDebugPanel() {
 
   if (!ctx?.isDebugMode) return null;
 
-  const { config, setParticleOverride, setTrailOverride, reset, copyExportToClipboard } = ctx;
+  const { config, setParticleOverride, setTrailOverride, setWaveOverride, setGridOverride, reset, copyExportToClipboard } = ctx;
   const p = config.particle;
   const t = config.trail;
+  const wv = config.wave;
+  const gv = config.grid;
 
   return (
     <Panel>
@@ -159,6 +163,53 @@ export function VisualizerDebugPanel() {
             <ParamNumber label="countPixelDivisor" value={t.countPixelDivisor} min={2000} max={10000} step={500} onChange={(v) => setTrailOverride('countPixelDivisor', v)} />
             <ParamNumber label="countPixelDivisorMobile" value={t.countPixelDivisorMobile} min={4000} max={15000} step={500} onChange={(v) => setTrailOverride('countPixelDivisorMobile', v)} />
             <ParamNumber label="driftDecay" value={t.driftDecay} min={0.99} max={1} step={0.0001} onChange={(v) => setTrailOverride('driftDecay', v)} />
+          </>
+        )}
+      </Section>
+
+      <Section>
+        <SectionHeader type="button" onClick={() => setWaveOpen((o) => !o)}>
+          Wave {waveOpen ? '▼' : '▶'}
+        </SectionHeader>
+        {waveOpen && (
+          <>
+            <ParamNumber label="waveCount" value={wv.waveCount} min={1} max={20} step={1} onChange={(v) => setWaveOverride('waveCount', v)} />
+            <ParamSlider label="phaseSpeedMin" value={wv.phaseSpeedMin} min={0.001} max={0.05} step={0.001} onChange={(v) => setWaveOverride('phaseSpeedMin', v)} />
+            <ParamSlider label="phaseSpeedSpread" value={wv.phaseSpeedSpread} min={0} max={0.05} step={0.001} onChange={(v) => setWaveOverride('phaseSpeedSpread', v)} />
+            <ParamSlider label="amplitudeBase" value={wv.amplitudeBase} min={0} max={0.15} step={0.005} onChange={(v) => setWaveOverride('amplitudeBase', v)} />
+            <ParamSlider label="amplitudeLayerScale" value={wv.amplitudeLayerScale} min={0} max={0.2} step={0.005} onChange={(v) => setWaveOverride('amplitudeLayerScale', v)} />
+            <ParamSlider label="frequencyMin" value={wv.frequencyMin} min={0.001} max={0.02} step={0.0005} onChange={(v) => setWaveOverride('frequencyMin', v)} />
+            <ParamSlider label="frequencySpread" value={wv.frequencySpread} min={0} max={0.01} step={0.0005} onChange={(v) => setWaveOverride('frequencySpread', v)} />
+            <ParamSlider label="yBaseStart" value={wv.yBaseStart} min={0} max={1} step={0.05} onChange={(v) => setWaveOverride('yBaseStart', v)} />
+            <ParamSlider label="yBaseLayerScale" value={wv.yBaseLayerScale} min={0} max={1} step={0.05} onChange={(v) => setWaveOverride('yBaseLayerScale', v)} />
+            <ParamSlider label="opacityBase" value={wv.opacityBase} min={0} max={0.5} step={0.01} onChange={(v) => setWaveOverride('opacityBase', v)} />
+            <ParamSlider label="opacityLayerScale" value={wv.opacityLayerScale} min={0} max={0.5} step={0.01} onChange={(v) => setWaveOverride('opacityLayerScale', v)} />
+            <ParamSlider label="pausedSpeedMult" value={wv.pausedSpeedMult} min={0} max={1} step={0.05} onChange={(v) => setWaveOverride('pausedSpeedMult', v)} />
+          </>
+        )}
+      </Section>
+
+      <Section>
+        <SectionHeader type="button" onClick={() => setGridOpen((o) => !o)}>
+          Grid Wave {gridOpen ? '▼' : '▶'}
+        </SectionHeader>
+        {gridOpen && (
+          <>
+            <ParamNumber label="spacing" value={gv.spacing} min={10} max={80} step={1} onChange={(v) => setGridOverride('spacing', v)} />
+            <ParamNumber label="spacingMobile" value={gv.spacingMobile} min={8} max={50} step={1} onChange={(v) => setGridOverride('spacingMobile', v)} />
+            <ParamNumber label="waveCount" value={gv.waveCount} min={1} max={10} step={1} onChange={(v) => setGridOverride('waveCount', v)} />
+            <ParamSlider label="waveSpeedBase" value={gv.waveSpeedBase} min={0.001} max={0.03} step={0.001} onChange={(v) => setGridOverride('waveSpeedBase', v)} />
+            <ParamSlider label="waveSpeedSpread" value={gv.waveSpeedSpread} min={0} max={0.02} step={0.001} onChange={(v) => setGridOverride('waveSpeedSpread', v)} />
+            <ParamSlider label="amplitudeBase" value={gv.amplitudeBase} min={0.01} max={0.4} step={0.01} onChange={(v) => setGridOverride('amplitudeBase', v)} />
+            <ParamSlider label="frequencyBase" value={gv.frequencyBase} min={0.001} max={0.02} step={0.0005} onChange={(v) => setGridOverride('frequencyBase', v)} />
+            <ParamSlider label="frequencySpread" value={gv.frequencySpread} min={0} max={0.01} step={0.0005} onChange={(v) => setGridOverride('frequencySpread', v)} />
+            <ParamSlider label="perspectiveStrength" value={gv.perspectiveStrength} min={0} max={0.5} step={0.01} onChange={(v) => setGridOverride('perspectiveStrength', v)} />
+            <ParamSlider label="edgeIntensity" value={gv.edgeIntensity} min={0} max={1} step={0.05} onChange={(v) => setGridOverride('edgeIntensity', v)} />
+            <ParamSlider label="baseRadius" value={gv.baseRadius} min={0.5} max={8} step={0.1} onChange={(v) => setGridOverride('baseRadius', v)} />
+            <ParamSlider label="radiusWaveScale" value={gv.radiusWaveScale} min={0} max={4} step={0.1} onChange={(v) => setGridOverride('radiusWaveScale', v)} />
+            <ParamSlider label="opacityBase" value={gv.opacityBase} min={0} max={1} step={0.05} onChange={(v) => setGridOverride('opacityBase', v)} />
+            <ParamSlider label="opacityWaveScale" value={gv.opacityWaveScale} min={0} max={1} step={0.05} onChange={(v) => setGridOverride('opacityWaveScale', v)} />
+            <ParamSlider label="pausedSpeedMult" value={gv.pausedSpeedMult} min={0} max={1} step={0.05} onChange={(v) => setGridOverride('pausedSpeedMult', v)} />
           </>
         )}
       </Section>

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -136,15 +136,18 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
       const centerX = width / 2;
 
       state.particles.forEach(particle => {
-        let displacement = 0;
+        let dispX = 0, dispY = 0;
         state.waves.forEach(wave => {
-          const proj = particle.baseX * wave.angleX * wave.frequency + particle.baseY * wave.angleY * wave.frequency;
-          displacement += Math.sin(proj + wave.phase);
+          const proj = particle.baseX * wave.angleX * wave.frequency
+                     + particle.baseY * wave.angleY * wave.frequency;
+          const d = Math.sin(proj + wave.phase);
+          dispX += d * wave.angleX;
+          dispY += d * wave.angleY;
         });
-        displacement /= g.waveCount;
+        dispX /= g.waveCount;
+        dispY /= g.waveCount;
 
-        const normalizedDisp = (displacement + 1) / 2;
-        const yOffset = displacement * amplitude;
+        const normalizedDisp = (Math.hypot(dispX, dispY) + 1) / 2;
 
         const edgeFactor = Math.abs(particle.baseX - centerX) / Math.max(1, centerX);
         const depthFactor = particle.gridY / Math.max(1, rows - 1);
@@ -156,8 +159,8 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
           (g.opacityBase + normalizedDisp * g.opacityWaveScale) * perspectiveScale * intensityScale
         ));
 
-        const x = particle.baseX;
-        const y = particle.baseY + yOffset;
+        const x = particle.baseX + dispX * amplitude;
+        const y = particle.baseY + dispY * amplitude;
 
         if (x < -radius || x > width + radius || y < -radius || y > height + radius) return;
 

--- a/src/contexts/VisualizerDebugContext.tsx
+++ b/src/contexts/VisualizerDebugContext.tsx
@@ -54,6 +54,8 @@ interface VisualizerDebugContextValue {
   setOverrides: (next: VisualizerDebugOverrides | null | ((prev: VisualizerDebugOverrides | null) => VisualizerDebugOverrides | null)) => void;
   setParticleOverride: <K extends keyof VisualizerDebugConfig['particle']>(key: K, value: VisualizerDebugConfig['particle'][K]) => void;
   setTrailOverride: <K extends keyof VisualizerDebugConfig['trail']>(key: K, value: VisualizerDebugConfig['trail'][K]) => void;
+  setWaveOverride: <K extends keyof VisualizerDebugConfig['wave']>(key: K, value: VisualizerDebugConfig['wave'][K]) => void;
+  setGridOverride: <K extends keyof VisualizerDebugConfig['grid']>(key: K, value: VisualizerDebugConfig['grid'][K]) => void;
   reset: () => void;
   exportAsJson: () => string;
   copyExportToClipboard: () => Promise<void>;
@@ -92,6 +94,20 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
     setOverrides(prev => ({
       ...prev,
       trail: { ...prev?.trail, [key]: value },
+    }));
+  }, [setOverrides]);
+
+  const setWaveOverride = useCallback(<K extends keyof VisualizerDebugConfig['wave']>(key: K, value: VisualizerDebugConfig['wave'][K]) => {
+    setOverrides(prev => ({
+      ...prev,
+      wave: { ...prev?.wave, [key]: value },
+    }));
+  }, [setOverrides]);
+
+  const setGridOverride = useCallback(<K extends keyof VisualizerDebugConfig['grid']>(key: K, value: VisualizerDebugConfig['grid'][K]) => {
+    setOverrides(prev => ({
+      ...prev,
+      grid: { ...prev?.grid, [key]: value },
     }));
   }, [setOverrides]);
 
@@ -141,6 +157,8 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       setOverrides,
       setParticleOverride,
       setTrailOverride,
+      setWaveOverride,
+      setGridOverride,
       reset,
       exportAsJson,
       copyExportToClipboard,
@@ -154,6 +172,8 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       setOverrides,
       setParticleOverride,
       setTrailOverride,
+      setWaveOverride,
+      setGridOverride,
       reset,
       exportAsJson,
       copyExportToClipboard,


### PR DESCRIPTION
## Summary
- Grid visualizer now applies wave displacement on both X and Y axes using each wave's direction vector, instead of collapsing into Y-only motion
- Projection math is unchanged; only the displacement vector accumulation is updated to carry dispX and dispY separately

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- Manually verify in the app: enable the Grid visualizer (`V` key cycles styles or via settings) and confirm motion is 2D (organic surface distortion) rather than vertical bobbing

Closes #868

Closes #830