### PR TITLE
refactor: extract UI status reset timing constants

### DIFF
--- a/src/components/DevBug/FeedbackPanel.tsx
+++ b/src/components/DevBug/FeedbackPanel.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { Category, SelectedElement, ConsoleEntry } from '@/types/devbug';
 
+import { TOAST_DISPLAY_DURATION_MS } from '@/constants/statusTiming';
+
 const PANEL_STYLES = `
   :host {
     all: initial;
@@ -586,7 +588,7 @@ export function FeedbackPanel(props: FeedbackPanelProps) {
           message: 'GitHub token not configured. Set VITE_DEVBUG_GITHUB_TOKEN.',
           type: 'error',
         });
-        setTimeout(() => setToast(null), 4000);
+        setTimeout(() => setToast(null), TOAST_DISPLAY_DURATION_MS);
         return;
       }
 

--- a/src/components/VisualEffectsMenu/ProviderDataSection.tsx
+++ b/src/components/VisualEffectsMenu/ProviderDataSection.tsx
@@ -2,7 +2,8 @@ import React, { memo, useState, useCallback } from 'react';
 
 import type { CatalogProvider } from '@/types/providers';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
-import { useAsyncAction, FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 
 import {
   ControlGroup,
@@ -78,7 +79,7 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
     }
     if (fileInputRef.current) fileInputRef.current.value = '';
     setImportStatus('done');
-    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, FEEDBACK_DISPLAY_MS);
+    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, STATUS_RESET_DELAY_MS);
   }, [catalog]);
 
   const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';

--- a/src/components/VisualEffectsMenu/index.tsx
+++ b/src/components/VisualEffectsMenu/index.tsx
@@ -26,7 +26,7 @@ import {
   CacheCancelButton,
 } from './styled';
 
-import { FEEDBACK_DISPLAY_MS } from '@/hooks/useAsyncAction';
+import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 
 import { MusicSourcesSection, NativeQueueSyncSection } from './SourcesSections';
 import { ProviderDataSection } from './ProviderDataSection';
@@ -112,7 +112,7 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
     setClearLikes(false);
     setClearPins(false);
     setClearAccentColors(false);
-    setTimeout(() => setClearState('idle'), FEEDBACK_DISPLAY_MS);
+    setTimeout(() => setClearState('idle'), STATUS_RESET_DELAY_MS);
   }, [onClearCache, clearLikes, clearPins, clearAccentColors]);
 
   return createPortal(

--- a/src/constants/statusTiming.ts
+++ b/src/constants/statusTiming.ts
@@ -1,0 +1,3 @@
+export const STATUS_RESET_DELAY_MS = 1500;
+export const ERROR_RESET_DELAY_MS = 2000;
+export const TOAST_DISPLAY_DURATION_MS = 4000;

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback, useRef } from 'react';
 
-export const FEEDBACK_DISPLAY_MS = 1500;
+import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
+
+export const FEEDBACK_DISPLAY_MS = STATUS_RESET_DELAY_MS;
 
 type AsyncStatus = 'idle' | 'working' | 'done';
 


### PR DESCRIPTION
## Summary
- Added shared constants for UI status reset delays (success reset, error reset, toast auto-dismiss) previously hardcoded as 1500/2000/4000ms in 5+ call sites
- Replaced inline timeouts in `ProviderDataSection`, `VisualEffectsMenu/index`, and `FeedbackPanel` with named constant imports
- Intent is explicit; future tuning is a one-line change

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- Behavior unchanged — values identical to originals

Closes #852