### PR TITLE
refactor(library): dedupe sort select and extract max-width constant

### DIFF
--- a/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
+++ b/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
@@ -156,6 +156,29 @@ const ClearIconSvg = () => (
   </svg>
 );
 
+interface SortSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  labels: Record<string, string>;
+  ariaLabel: string;
+}
+
+function renderSortSelect({ value, onChange, labels, ariaLabel }: SortSelectProps): JSX.Element {
+  return (
+    <SortSelect
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+    >
+      {Object.entries(labels).map(([optValue, label]) => (
+        <option key={optValue} value={optValue}>
+          {label}
+        </option>
+      ))}
+    </SortSelect>
+  );
+}
+
 export function MobileLibraryBottomBar(): JSX.Element {
   const {
     viewMode,
@@ -191,30 +214,20 @@ export function MobileLibraryBottomBar(): JSX.Element {
         )}
       </SearchInputWrapper>
 
-      {viewMode === 'playlists' ? (
-        <SortSelect
-          value={playlistSort}
-          onChange={(e) => setPlaylistSort(e.target.value as PlaylistSortOption)}
-          aria-label="Sort playlists"
-        >
-          {Object.entries(PLAYLIST_SORT_LABELS).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </SortSelect>
-      ) : (
-        <SortSelect
-          value={albumSort}
-          onChange={(e) => setAlbumSort(e.target.value as AlbumSortOption)}
-          aria-label="Sort albums"
-        >
-          {Object.entries(ALBUM_SORT_LABELS).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </SortSelect>
+      {renderSortSelect(
+        viewMode === 'playlists'
+          ? {
+              value: playlistSort,
+              onChange: (v) => setPlaylistSort(v as PlaylistSortOption),
+              labels: PLAYLIST_SORT_LABELS,
+              ariaLabel: 'Sort playlists',
+            }
+          : {
+              value: albumSort,
+              onChange: (v) => setAlbumSort(v as AlbumSortOption),
+              labels: ALBUM_SORT_LABELS,
+              ariaLabel: 'Sort albums',
+            },
       )}
     </BarContainer>
   );

--- a/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
+++ b/src/components/PlaylistSelection/MobileLibraryBottomBar.tsx
@@ -11,6 +11,7 @@ import type {
 import { useLibraryBrowsingContext } from './LibraryContext';
 
 const MIN_TAP_TARGET = '44px';
+const SORT_SELECT_MAX_WIDTH = '9rem';
 
 const BarContainer = styled.div`
   display: flex;
@@ -123,7 +124,7 @@ const SortSelect = styled.select`
   cursor: pointer;
   transition: all ${theme.transitions.fast};
   appearance: none;
-  max-width: 9rem;
+  max-width: ${SORT_SELECT_MAX_WIDTH};
 
   &:hover {
     background: ${theme.colors.control.backgroundHover};


### PR DESCRIPTION
## Summary
- Extracted `SORT_SELECT_MAX_WIDTH = '9rem'` constant alongside the existing `MIN_TAP_TARGET` to document layout intent (#983)
- Replaced two near-identical `<SortSelect>` JSX blocks (playlist + album sort) with a single helper driven by `viewMode`, eliminating ~24 lines of duplication (#982)
- Visual output and behavior unchanged

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- `npm run lint` passes (no new errors introduced)
- Visually verify (reviewer): open the mobile library overlay, toggle playlist ↔ album view, confirm the sort dropdown renders correctly in both modes with the same width and styling as before

Closes #982
Closes #983