### PR TITLE
refactor(visualizers): extract shared particle count calculation utility

### DIFF
--- a/src/components/visualizers/ParticleVisualizer.tsx
+++ b/src/components/visualizers/ParticleVisualizer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
+import { calculateParticleCount } from '../../utils/particleCount';
 
 interface ParticleVisualizerProps {
   intensity: number;
@@ -42,13 +43,7 @@ export const ParticleVisualizer: React.FC<ParticleVisualizerProps> = ({
   const p = config.particle;
 
   const getParticleCount = useCallback((width: number, height: number, intensityValue: number): number => {
-    const pixelCount = width * height;
-    const isMobile = width < 768;
-    const scale = Math.max(0.1, intensityValue / 60);
-    if (isMobile) {
-      return Math.round(Math.min(p.countBaseMobile, Math.floor(pixelCount / p.countPixelDivisorMobile)) * scale);
-    }
-    return Math.round(Math.min(p.countBaseDesktop, Math.floor(pixelCount / p.countPixelDivisor)) * scale);
+    return calculateParticleCount(width, height, intensityValue, p);
   }, [p]);
 
   const initializeParticles = useCallback((

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useEffect } from 'react';
 import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
+import { calculateParticleCount } from '../../utils/particleCount';
 
 interface AlbumArtBounds {
   left: number;
@@ -74,13 +75,7 @@ export const TrailVisualizer: React.FC<TrailVisualizerProps> = ({
   });
 
   const getParticleCount = useCallback((width: number, height: number, intensityValue: number): number => {
-    const pixelCount = width * height;
-    const isMobile = width < 768;
-    const scale = Math.max(0.1, intensityValue / 60);
-    if (isMobile) {
-      return Math.round(Math.min(t.countBaseMobile, Math.floor(pixelCount / t.countPixelDivisorMobile)) * scale);
-    }
-    return Math.round(Math.min(t.countBaseDesktop, Math.floor(pixelCount / t.countPixelDivisor)) * scale);
+    return calculateParticleCount(width, height, intensityValue, t);
   }, [t]);
 
   const initializeParticles = useCallback((

--- a/src/utils/particleCount.ts
+++ b/src/utils/particleCount.ts
@@ -1,0 +1,21 @@
+interface ParticleCountConfig {
+  countBaseMobile: number;
+  countPixelDivisorMobile: number;
+  countBaseDesktop: number;
+  countPixelDivisor: number;
+}
+
+export function calculateParticleCount(
+  width: number,
+  height: number,
+  intensityValue: number,
+  config: ParticleCountConfig
+): number {
+  const pixelCount = width * height;
+  const isMobile = width < 768;
+  const scale = Math.max(0.1, intensityValue / 60);
+  if (isMobile) {
+    return Math.round(Math.min(config.countBaseMobile, Math.floor(pixelCount / config.countPixelDivisorMobile)) * scale);
+  }
+  return Math.round(Math.min(config.countBaseDesktop, Math.floor(pixelCount / config.countPixelDivisor)) * scale);
+}


### PR DESCRIPTION
## Summary
- Extracted the viewport-based particle-count calculation duplicated between `ParticleVisualizer` and `TrailVisualizer` into a shared utility (`src/utils/particleCount.ts`)
- Both visualizers now derive density from the same source, eliminating drift risk and making future tuning a one-file change

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes (1080 tests, 85 files)
- `npm run lint` passes (no new errors introduced — pre-existing errors unchanged)
- Manually verify particle density unchanged — compute the function output for representative viewport sizes and confirm it matches the previous inline logic's outputs

Closes #829