### PR TITLE
refactor(theme): centralize z-index values that bypass the theme scale

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { flexCenter, srOnly } from '@/styles/utils';
+import { theme } from '@/styles/theme';
 import PlayerStateRenderer from './PlayerStateRenderer';
 import PlayerContent from './PlayerContent';
 import BackgroundVisualizer from './BackgroundVisualizer';
@@ -37,7 +38,7 @@ const Container = styled.div`
 const QuickAccessOverlay = styled.div`
   position: fixed;
   inset: 0;
-  z-index: 1200;
+  z-index: ${({ theme }) => theme.zIndex.banner};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -336,7 +337,7 @@ const AudioPlayerComponent = () => {
             left: 0,
             width: 44,
             height: 44,
-            zIndex: 999990,
+            zIndex: theme.zIndex.debugOverlayAbove,
           }}
         />
         <ProfiledComponent id="AccentColorBackground">

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { theme } from '@/styles/theme';
 
 interface LogEntry {
   time: string;
@@ -94,7 +95,7 @@ export default function DebugOverlay({ active }: { active: boolean }) {
       <div
         onClick={() => setVisible(v => !v)}
         style={{
-          position: 'fixed', bottom: 8, left: 8, zIndex: 999999,
+          position: 'fixed', bottom: 8, left: 8, zIndex: theme.zIndex.debugTopmost,
           background: errorCount > 0 ? 'rgba(220,40,40,0.9)' : 'rgba(50,50,50,0.85)',
           color: '#0f0', borderRadius: '50%', width: 32, height: 32,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -109,14 +110,14 @@ export default function DebugOverlay({ active }: { active: boolean }) {
 
       {visible && (
         <div style={{
-          position: 'fixed', inset: 0, zIndex: 999998,
+          position: 'fixed', inset: 0, zIndex: theme.zIndex.debugModal,
           background: 'rgba(0,0,0,0.94)', color: '#ccc',
           fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
           fontSize: 10, overflow: 'auto',
           padding: '44px 8px 8px', WebkitOverflowScrolling: 'touch',
         }}>
           <div style={{
-            position: 'fixed', top: 0, left: 0, right: 0, zIndex: 999999,
+            position: 'fixed', top: 0, left: 0, right: 0, zIndex: theme.zIndex.debugTopmost,
             display: 'flex', gap: 8, padding: '8px',
             background: 'rgba(20,20,20,0.95)', backdropFilter: 'blur(12px)',
             borderBottom: '1px solid #333',

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const ZEN_CLICK_ZONE_Z = 5;
+
 interface ZenClickZoneOverlayProps {
   isPlaying: boolean;
   visible: boolean;
@@ -13,7 +15,7 @@ const Overlay = styled.div`
   position: absolute;
   inset: 0;
   pointer-events: none;
-  z-index: 5;
+  z-index: ${ZEN_CLICK_ZONE_Z};
   border-radius: ${({ theme }) => theme.borderRadius['3xl']};
   overflow: hidden;
   display: flex;

--- a/src/components/PlayerContent/ZenLikeOverlay.tsx
+++ b/src/components/PlayerContent/ZenLikeOverlay.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const ZEN_LIKE_BUTTON_Z = 6;
+
 interface ZenLikeOverlayProps {
   isLiked: boolean;
   isVisible: boolean;
@@ -15,7 +17,7 @@ const LikeButton = styled.button.withConfig({
   position: absolute;
   bottom: 12px;
   right: 12px;
-  z-index: 6;
+  z-index: ${ZEN_LIKE_BUTTON_Z};
   pointer-events: auto;
   background: rgba(0, 0, 0, 0.45);
   border-radius: ${({ theme }) => theme.borderRadius.full};

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -21,6 +21,12 @@ import {
   ZEN_ART_MARGIN_V_MOBILE,
 } from '@/constants/zenAnimation';
 
+const LOADING_CARD_BACKGROUND_Z = 0;
+const PLAYER_CONTAINER_Z = 1;
+const LOADING_CARD_OVERLAY_Z = 1;
+const CONTENT_WRAPPER_Z = 2;
+const ALBUM_ART_Z = 3;
+
 export const ContentWrapper = styled.div.withConfig({
   shouldForwardProp: (prop) => !['width', 'padding', 'useFluidSizing', 'transitionDuration', 'transitionEasing', '$zenMode'].includes(prop),
 }) <{
@@ -39,7 +45,7 @@ export const ContentWrapper = styled.div.withConfig({
   padding-bottom: ${props => props.padding}px;
   box-sizing: border-box;
   position: relative;
-  z-index: 2;
+  z-index: ${CONTENT_WRAPPER_Z};
   overflow: visible;
 
   transition: width ${props => props.$zenMode ? `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms` : `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`},
@@ -56,7 +62,7 @@ export const ContentWrapper = styled.div.withConfig({
 
 export const PlayerContainer = styled.div`
   position: relative;
-  z-index: 1;
+  z-index: ${PLAYER_CONTAINER_Z};
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -167,7 +173,7 @@ export const ZenTrackArtist = styled.div`
 export const ClickableAlbumArtContainer = styled.div<{ $swipeEnabled?: boolean; $bothGestures?: boolean }>`
   position: relative;
   cursor: pointer;
-  z-index: 3;
+  z-index: ${ALBUM_ART_Z};
   perspective: 1200px;
   filter: drop-shadow(${({ theme }) => theme.shadows.drop});
   ${({ $swipeEnabled, $bothGestures }) => $swipeEnabled && `
@@ -220,7 +226,7 @@ export const LoadingCard = styled.div.withConfig({
       background-position: center;
       background-repeat: no-repeat;
       border-radius: ${theme.borderRadius.xl};
-      z-index: 0;
+      z-index: ${LOADING_CARD_BACKGROUND_Z};
     }
     &::before {
       position: absolute;
@@ -229,7 +235,7 @@ export const LoadingCard = styled.div.withConfig({
       backdrop-filter: blur(40px) saturate(180%);
       -webkit-backdrop-filter: blur(40px) saturate(180%);
       border-radius: ${theme.borderRadius.xl};
-      z-index: 1;
+      z-index: ${LOADING_CARD_OVERLAY_Z};
     }
   ` : `
     background: linear-gradient(

--- a/src/components/ProfilingOverlay.tsx
+++ b/src/components/ProfilingOverlay.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useProfilingContext, type ProfilingSnapshot } from '@/contexts/ProfilingContext';
+import { theme } from '@/styles/theme';
 
 const btnStyle: React.CSSProperties = {
   color: '#ddd', background: 'rgba(80,80,80,0.8)', border: '1px solid #555',
@@ -57,7 +58,7 @@ export function ProfilingOverlay(): React.ReactElement | null {
 
   return (
     <div style={{
-      position: 'fixed', top: 8, left: 8, zIndex: 999980,
+      position: 'fixed', top: 8, left: 8, zIndex: theme.zIndex.debugOverlay,
       background: 'rgba(0,0,0,0.85)', color: '#fff', borderRadius: 8,
       padding: 8, fontSize: 11, fontFamily: 'monospace',
       maxWidth: 360, maxHeight: '80vh', overflow: 'auto', userSelect: 'none',

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -25,6 +25,8 @@ import {
   SwipeRemoveBackdrop,
 } from './QueueTrackList.styled';
 
+const DRAG_ACTIVE_Z = 10;
+
 const GripIcon = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
     <circle cx="5" cy="3" r="1.5" />
@@ -185,7 +187,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragging ? 10 : undefined,
+    zIndex: isDragging ? DRAG_ACTIVE_Z : undefined,
     position: 'relative' as const,
   };
 

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -10,6 +10,8 @@ import TimelineControls from './controls/TimelineControls';
 import ProviderIcon from './ProviderIcon';
 import type { ProviderId } from '@/types/domain';
 
+const PROVIDER_BADGE_Z = 12;
+
 
 interface SpotifyPlayerControlsProps {
   currentTrack: MediaTrack | null;
@@ -77,7 +79,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   return (
     <PlayerControlsContainer $isMobile={isMobile} $isTablet={isTablet} $compact={!isDesktop}>
       {showProviderBadge && trackProvider && (
-        <div style={{ position: 'absolute', top: 6, right: 6, zIndex: 12 }}>
+        <div style={{ position: 'absolute', top: 6, right: 6, zIndex: PROVIDER_BADGE_Z }}>
           <ProviderIcon provider={trackProvider} size={22} />
         </div>
       )}

--- a/src/components/controls/styled.ts
+++ b/src/components/controls/styled.ts
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 import { theme } from '../../styles/theme';
 
+const TRACK_INFO_ROW_Z = 10;
+const TRACK_INFO_TEXT_Z = 11;
+
 // --- Main Container ---
 export const PlayerControlsContainer = styled.div<{ $isMobile: boolean; $isTablet: boolean; $compact?: boolean }>`
   position: relative;
@@ -55,7 +58,7 @@ export const TrackInfoOnlyRow = styled.div<{ $compact?: boolean }>`
   margin-bottom: 0;
   margin-top: 0;
   position: relative;
-  z-index: 10;
+  z-index: ${TRACK_INFO_ROW_Z};
   text-shadow: ${({ theme }) => theme.shadows.textSm};
 
   @media (max-width: ${theme.breakpoints.lg}) {
@@ -83,7 +86,7 @@ export const PlayerTrackName = styled.div<{ $isMobile: boolean; $isTablet: boole
   white-space: nowrap;
   width: 100%;
   position: relative;
-  z-index: 11;
+  z-index: ${TRACK_INFO_TEXT_Z};
   text-shadow: ${({ theme }) => theme.shadows.textMd};
 
   /* Reset button-specific styles when rendered as a button (as="button") */
@@ -115,7 +118,7 @@ export const PlayerTrackAlbum = styled.div`
   white-space: nowrap;
   width: 100%;
   position: relative;
-  z-index: 11;
+  z-index: ${TRACK_INFO_TEXT_Z};
   text-shadow: ${({ theme }) => theme.shadows.textControl};
 `;
 
@@ -144,7 +147,7 @@ export const PlayerTrackArtist = styled.div`
   white-space: nowrap;
   width: 100%;
   position: relative;
-  z-index: 11;
+  z-index: ${TRACK_INFO_TEXT_Z};
   text-shadow: ${({ theme }) => theme.shadows.textControl};
 `;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -206,7 +206,12 @@ export const theme = {
     toast: '1700',
     tooltip: '1800',
     uiOverlay: '2000',
-    eyedropper: '10000'
+    eyedropper: '10000',
+    debug: '999000',
+    debugOverlay: '999980',
+    debugOverlayAbove: '999990',
+    debugModal: '999998',
+    debugTopmost: '999999'
   },
   
   // Player-specific sizing constraints


### PR DESCRIPTION
## Summary
- Added debug-tier z-index tokens to `theme.zIndex` (debug/debugOverlay/debugOverlayAbove/debugModal/debugTopmost) so the 999xxx shadow scale has a documented home
- Migrated raw z-index literals in `AudioPlayer`, `DebugOverlay`, `ProfilingOverlay` to theme tokens
- Replaced component-local raw numbers (0-12 range) with named `const` at the top of each styled file, matching the pattern used by `MIN_TAP_TARGET` elsewhere

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- `npm run lint` passes
- Stacking order unchanged — all substitutions preserve original numeric values

Closes #849