### PR TITLE
cleanup(constants): remove unused ERROR_RESET_DELAY_MS export

### DIFF
--- a/src/constants/statusTiming.ts
+++ b/src/constants/statusTiming.ts
@@ -1,3 +1,2 @@
 export const STATUS_RESET_DELAY_MS = 1500;
-export const ERROR_RESET_DELAY_MS = 2000;
 export const TOAST_DISPLAY_DURATION_MS = 4000;


### PR DESCRIPTION
## Summary
- Dropped `ERROR_RESET_DELAY_MS = 2000` from `src/constants/statusTiming.ts`; the constant was defined in #1137 but never imported, because the success and error reset paths collapsed into a single `STATUS_RESET_DELAY_MS` via `FEEDBACK_DISPLAY_MS` / `useAsyncAction`
- No call site change — deletion is isolated to the constants file

## Test plan
- `grep -rn ERROR_RESET_DELAY_MS src/` returns zero results
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- `npm run lint` passes

Closes #1146