### PR TITLE
feat(welcome): add WelcomeScreen and useWelcomeSeen hook

### DIFF
--- a/src/components/WelcomeScreen/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/WelcomeScreen/__tests__/WelcomeScreen.test.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import WelcomeScreen from '../index';
+import { WELCOME_SEEN_STORAGE_KEY } from '@/hooks/useWelcomeSeen';
+import type { ProviderId } from '@/types/domain';
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(),
+}));
+
+vi.mock('@/components/ProviderIcon', () => ({
+  default: ({ provider }: { provider: string }) => (
+    <span data-testid={`provider-icon-${provider}`} />
+  ),
+}));
+
+import { useProviderContext } from '@/contexts/ProviderContext';
+
+const mockUseProviderContext = vi.mocked(useProviderContext);
+
+interface SetupOptions {
+  enabled?: ProviderId[];
+  connected?: ProviderId[];
+}
+
+function setupProviderContext({ enabled = [], connected = [] }: SetupOptions) {
+  mockUseProviderContext.mockReturnValue({
+    enabledProviderIds: enabled,
+    connectedProviderIds: connected,
+    getDescriptor: (id: ProviderId) => ({
+      id,
+      name: id === 'spotify' ? 'Spotify' : 'Dropbox',
+    }),
+  } as unknown as ReturnType<typeof useProviderContext>);
+}
+
+function renderWelcome(
+  props: Partial<React.ComponentProps<typeof WelcomeScreen>> = {},
+) {
+  const onConnectProvider = props.onConnectProvider ?? vi.fn();
+  const onBrowseLibrary = props.onBrowseLibrary ?? vi.fn();
+  const onDismiss = props.onDismiss;
+
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <WelcomeScreen
+        onConnectProvider={onConnectProvider}
+        onBrowseLibrary={onBrowseLibrary}
+        onDismiss={onDismiss}
+      />
+    </ThemeProvider>,
+  );
+
+  return { ...utils, onConnectProvider, onBrowseLibrary, onDismiss };
+}
+
+describe('WelcomeScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('renders the hero greeting', () => {
+    // #given
+    setupProviderContext({ enabled: ['spotify'], connected: [] });
+
+    // #when
+    renderWelcome();
+
+    // #then
+    expect(screen.getByText('Welcome to Vorbis Player')).toBeInTheDocument();
+  });
+
+  describe('primary CTA', () => {
+    it('shows "Connect a provider" when no providers are connected', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify', 'dropbox'], connected: [] });
+
+      // #when
+      renderWelcome();
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Connect a provider' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Browse your library' })).not.toBeInTheDocument();
+    });
+
+    it('shows "Browse your library" when at least one provider is connected', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify', 'dropbox'], connected: ['spotify'] });
+
+      // #when
+      renderWelcome();
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Browse your library' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Connect a provider' })).not.toBeInTheDocument();
+    });
+
+    it('invokes onConnectProvider when clicked in the disconnected state', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify'], connected: [] });
+      const { onConnectProvider, onBrowseLibrary } = renderWelcome();
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: 'Connect a provider' }));
+
+      // #then
+      expect(onConnectProvider).toHaveBeenCalledTimes(1);
+      expect(onBrowseLibrary).not.toHaveBeenCalled();
+    });
+
+    it('invokes onBrowseLibrary when clicked in the connected state', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify'], connected: ['spotify'] });
+      const { onConnectProvider, onBrowseLibrary } = renderWelcome();
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: 'Browse your library' }));
+
+      // #then
+      expect(onBrowseLibrary).toHaveBeenCalledTimes(1);
+      expect(onConnectProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('provider status block', () => {
+    it('lists each enabled provider with its connection state', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify', 'dropbox'], connected: ['spotify'] });
+
+      // #when
+      renderWelcome();
+
+      // #then
+      expect(screen.getByText('Spotify')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox')).toBeInTheDocument();
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+      expect(screen.getByText('Not connected')).toBeInTheDocument();
+    });
+
+    it('renders the empty hint when no providers are enabled', () => {
+      // #given
+      setupProviderContext({ enabled: [], connected: [] });
+
+      // #when
+      renderWelcome();
+
+      // #then
+      expect(
+        screen.getByText(/No providers enabled yet/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('dismiss-for-good control', () => {
+    it('persists welcomeSeen=true via localStorage when clicked', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify'], connected: ['spotify'] });
+      renderWelcome();
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: /don't show this again/i }));
+
+      // #then
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        WELCOME_SEEN_STORAGE_KEY,
+        'true',
+      );
+    });
+
+    it('invokes onDismiss callback when provided', () => {
+      // #given
+      setupProviderContext({ enabled: ['spotify'], connected: ['spotify'] });
+      const onDismiss = vi.fn();
+      renderWelcome({ onDismiss });
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: /don't show this again/i }));
+
+      // #then
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/WelcomeScreen/index.tsx
+++ b/src/components/WelcomeScreen/index.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useMemo } from 'react';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
+import ProviderIcon from '@/components/ProviderIcon';
+import type { ProviderId } from '@/types/domain';
+import {
+  WelcomeRoot,
+  WelcomeContent,
+  HeroTitle,
+  HeroSubtitle,
+  ProviderStatusBlock,
+  ProviderStatusHeading,
+  ProviderStatusList,
+  ProviderStatusItem,
+  ProviderStatusLabel,
+  ProviderStatusPill,
+  ProviderStatusEmpty,
+  CtaRow,
+  PrimaryCta,
+  DismissButton,
+} from './styled';
+
+interface WelcomeScreenProps {
+  onConnectProvider: () => void;
+  onBrowseLibrary: () => void;
+  onDismiss?: () => void;
+}
+
+const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
+  onConnectProvider,
+  onBrowseLibrary,
+  onDismiss,
+}) => {
+  const { enabledProviderIds, connectedProviderIds, getDescriptor } = useProviderContext();
+  const [, setWelcomeSeen] = useWelcomeSeen();
+
+  const hasConnectedProvider = connectedProviderIds.length > 0;
+
+  const providerRows = useMemo(
+    () =>
+      enabledProviderIds
+        .map((id: ProviderId) => {
+          const descriptor = getDescriptor(id);
+          if (!descriptor) return null;
+          return {
+            id,
+            name: descriptor.name,
+            connected: connectedProviderIds.includes(id),
+          };
+        })
+        .filter((row): row is { id: ProviderId; name: string; connected: boolean } => row !== null),
+    [enabledProviderIds, connectedProviderIds, getDescriptor],
+  );
+
+  const handlePrimaryCta = useCallback(() => {
+    if (hasConnectedProvider) {
+      onBrowseLibrary();
+    } else {
+      onConnectProvider();
+    }
+  }, [hasConnectedProvider, onBrowseLibrary, onConnectProvider]);
+
+  const handleDismiss = useCallback(() => {
+    setWelcomeSeen(true);
+    onDismiss?.();
+  }, [setWelcomeSeen, onDismiss]);
+
+  const primaryCtaLabel = hasConnectedProvider ? 'Browse your library' : 'Connect a provider';
+  const subtitle = hasConnectedProvider
+    ? 'Jump into your music whenever you are ready.'
+    : 'Connect a music source to start listening.';
+
+  return (
+    <WelcomeRoot role="region" aria-label="Welcome to Vorbis Player">
+      <WelcomeContent>
+        <div>
+          <HeroTitle>Welcome to Vorbis Player</HeroTitle>
+          <HeroSubtitle>{subtitle}</HeroSubtitle>
+        </div>
+
+        <ProviderStatusBlock>
+          <ProviderStatusHeading>Music sources</ProviderStatusHeading>
+          {providerRows.length === 0 ? (
+            <ProviderStatusEmpty>
+              No providers enabled yet. Connect one to get started.
+            </ProviderStatusEmpty>
+          ) : (
+            <ProviderStatusList>
+              {providerRows.map((row) => (
+                <ProviderStatusItem key={row.id}>
+                  <ProviderIcon provider={row.id} size={18} />
+                  <ProviderStatusLabel>{row.name}</ProviderStatusLabel>
+                  <ProviderStatusPill $connected={row.connected}>
+                    {row.connected ? 'Connected' : 'Not connected'}
+                  </ProviderStatusPill>
+                </ProviderStatusItem>
+              ))}
+            </ProviderStatusList>
+          )}
+        </ProviderStatusBlock>
+
+        <CtaRow>
+          <PrimaryCta type="button" onClick={handlePrimaryCta}>
+            {primaryCtaLabel}
+          </PrimaryCta>
+          <DismissButton type="button" onClick={handleDismiss}>
+            Don&apos;t show this again
+          </DismissButton>
+        </CtaRow>
+      </WelcomeContent>
+    </WelcomeRoot>
+  );
+};
+
+export default WelcomeScreen;
+export { WelcomeScreen };

--- a/src/components/WelcomeScreen/styled.ts
+++ b/src/components/WelcomeScreen/styled.ts
@@ -1,0 +1,187 @@
+import styled, { keyframes } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+const fadeInUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const WelcomeRoot = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 1.25rem;
+  border: 1px solid ${theme.colors.border};
+  box-shadow: ${theme.shadows.albumArt};
+  background: ${theme.colors.muted.background};
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  padding: ${theme.spacing['2xl']} ${theme.spacing.xl};
+  animation: ${fadeInUp} 0.35s ease-out;
+  container-type: inline-size;
+`;
+
+export const WelcomeContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: ${theme.spacing.lg};
+  max-width: 480px;
+  width: 100%;
+  margin: 0 auto;
+  flex: 1;
+`;
+
+export const HeroTitle = styled.h1`
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize['3xl']};
+  font-weight: ${theme.fontWeight.bold};
+  margin: 0;
+  letter-spacing: -0.02em;
+  text-shadow: ${theme.shadows.textMd};
+
+  @container (min-width: 600px) {
+    font-size: ${theme.fontSize['4xl']};
+  }
+`;
+
+export const HeroSubtitle = styled.p`
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.base};
+  margin: 0;
+  line-height: 1.5;
+`;
+
+export const ProviderStatusBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.sm};
+  width: 100%;
+  padding: ${theme.spacing.md} ${theme.spacing.lg};
+  border: 1px solid ${theme.colors.borderSubtle};
+  border-radius: ${theme.borderRadius.xl};
+  background: rgba(255, 255, 255, 0.04);
+`;
+
+export const ProviderStatusHeading = styled.div`
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.semibold};
+  color: ${theme.colors.muted.foreground};
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`;
+
+export const ProviderStatusList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xs};
+`;
+
+export const ProviderStatusItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.foreground};
+`;
+
+export const ProviderStatusLabel = styled.span`
+  flex: 1;
+  text-align: left;
+`;
+
+export const ProviderStatusPill = styled.span<{ $connected: boolean }>`
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.medium};
+  padding: 2px ${theme.spacing.sm};
+  border-radius: ${theme.borderRadius.full};
+  color: ${({ $connected }) => ($connected ? theme.colors.success : theme.colors.muted.foreground)};
+  background: ${({ $connected }) =>
+    $connected ? 'rgba(16, 185, 129, 0.12)' : 'rgba(255, 255, 255, 0.06)'};
+  border: 1px solid
+    ${({ $connected }) =>
+      $connected ? 'rgba(16, 185, 129, 0.35)' : theme.colors.borderSubtle};
+`;
+
+export const ProviderStatusEmpty = styled.div`
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.muted.foreground};
+  line-height: 1.4;
+  text-align: left;
+`;
+
+export const CtaRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: ${theme.spacing.sm};
+  width: 100%;
+`;
+
+export const PrimaryCta = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${theme.spacing.sm};
+  width: 100%;
+  padding: ${theme.spacing.md} ${theme.spacing.xl};
+  border-radius: ${theme.borderRadius.full};
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: ${theme.colors.accent};
+  color: ${theme.colors.foregroundDark};
+  font-size: ${theme.fontSize.base};
+  font-weight: ${theme.fontWeight.semibold};
+  cursor: pointer;
+  transition: transform ${theme.transitions.fast}, background ${theme.transitions.fast};
+
+  &:hover {
+    background: ${theme.colors.accentHover};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const DismissButton = styled.button`
+  align-self: center;
+  background: transparent;
+  border: none;
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.medium};
+  padding: ${theme.spacing.xs} ${theme.spacing.md};
+  cursor: pointer;
+  border-radius: ${theme.borderRadius.full};
+  transition: color ${theme.transitions.fast}, background ${theme.transitions.fast};
+
+  &:hover {
+    color: ${theme.colors.foreground};
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+`;

--- a/src/hooks/__tests__/useWelcomeSeen.test.ts
+++ b/src/hooks/__tests__/useWelcomeSeen.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWelcomeSeen, WELCOME_SEEN_STORAGE_KEY } from '../useWelcomeSeen';
+
+describe('useWelcomeSeen', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('defaults to false when localStorage is empty', () => {
+    // #when
+    const { result } = renderHook(() => useWelcomeSeen());
+
+    // #then
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('can be set to true', () => {
+    // #given
+    const { result } = renderHook(() => useWelcomeSeen());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('persists to localStorage under the vorbis-player-welcome-seen key', () => {
+    // #given
+    const { result } = renderHook(() => useWelcomeSeen());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      WELCOME_SEEN_STORAGE_KEY,
+      'true',
+    );
+  });
+
+  it('reads initial value from localStorage when already seen', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === WELCOME_SEEN_STORAGE_KEY) return 'true';
+      return null;
+    });
+
+    // #when
+    const { result } = renderHook(() => useWelcomeSeen());
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('exposes the correct storage key constant', () => {
+    // #then
+    expect(WELCOME_SEEN_STORAGE_KEY).toBe('vorbis-player-welcome-seen');
+  });
+});

--- a/src/hooks/useWelcomeSeen.ts
+++ b/src/hooks/useWelcomeSeen.ts
@@ -1,0 +1,7 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export const WELCOME_SEEN_STORAGE_KEY = 'vorbis-player-welcome-seen';
+
+export const useWelcomeSeen = (): [boolean, (value: boolean) => void] => {
+  return useLocalStorage<boolean>(WELCOME_SEEN_STORAGE_KEY, false);
+};


### PR DESCRIPTION
## Summary

- Adds `useWelcomeSeen` hook (wraps `useLocalStorage<boolean>('vorbis-player-welcome-seen', false)`) so the dismiss-for-good flag persists across sessions.
- Adds `WelcomeScreen` in `src/components/WelcomeScreen/` — hero greeting, per-provider status summary, context-aware primary CTA (*Connect a provider* when `connectedProviderIds.length === 0`, *Browse your library* otherwise), and a *Don't show this again* control that persists via the hook.
- Component is intentionally **not** wired into `PlayerStateRenderer`; integration is #1155's scope. Callbacks (`onConnectProvider`, `onBrowseLibrary`, `onDismiss`) keep the component decoupled and testable.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1162/1162 passing (14 new tests across hook + component)
- [x] `npm run build` — success
- [ ] Visual/interaction verification deferred to #1155 (first wire-up into the landing router)

Closes #1153