### PR TITLE
feat(qap): add Resume hero above pins

### DIFF
--- a/src/components/QuickAccessPanel/ResumeHero.tsx
+++ b/src/components/QuickAccessPanel/ResumeHero.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import {
+  ResumeHeroSection,
+  ResumeHeroArt,
+  ResumeHeroText,
+  ResumeHeroEyebrow,
+  ResumeHeroTitle,
+  ResumeHeroSubtitle,
+  ResumeHeroButton,
+} from './styled';
+
+interface ResumeHeroProps {
+  session: SessionSnapshot;
+  onResume: () => void;
+}
+
+const ResumeHero: React.FC<ResumeHeroProps> = ({ session, onResume }) => {
+  const title = session.trackTitle ?? session.collectionName;
+  const subtitleParts = [session.trackArtist, session.collectionName].filter(Boolean);
+  const subtitle = subtitleParts.join(' • ') || session.collectionName;
+
+  return (
+    <ResumeHeroSection aria-labelledby="qap-resume-hero-title">
+      <ResumeHeroArt>
+        {session.trackImage ? (
+          <img src={session.trackImage} alt="" loading="lazy" />
+        ) : (
+          <span aria-hidden="true">♪</span>
+        )}
+      </ResumeHeroArt>
+      <ResumeHeroText>
+        <ResumeHeroEyebrow>Pick up where you left off</ResumeHeroEyebrow>
+        <ResumeHeroTitle id="qap-resume-hero-title">{title}</ResumeHeroTitle>
+        <ResumeHeroSubtitle>{subtitle}</ResumeHeroSubtitle>
+      </ResumeHeroText>
+      <ResumeHeroButton
+        type="button"
+        onClick={onResume}
+        aria-label={`Resume ${title}`}
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+        Resume
+      </ResumeHeroButton>
+    </ResumeHeroSection>
+  );
+};
+
+export default ResumeHero;

--- a/src/components/QuickAccessPanel/__tests__/QuickAccessPanel.test.tsx
+++ b/src/components/QuickAccessPanel/__tests__/QuickAccessPanel.test.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import QuickAccessPanel from '../index';
 import type { ProviderId } from '@/types/domain';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 vi.mock('@/hooks/useLibrarySync', () => ({
   useLibrarySync: vi.fn(),
@@ -94,7 +95,12 @@ function setupUnifiedLiked(isUnifiedLikedActive: boolean, totalCount: number) {
   } as ReturnType<typeof useUnifiedLikedTracks>);
 }
 
-function renderPanel() {
+interface RenderPanelOptions {
+  lastSession?: SessionSnapshot | null;
+  onResume?: () => void;
+}
+
+function renderPanel(options: RenderPanelOptions = {}) {
   mockUsePinnedItemsContext.mockReturnValue({
     pinnedPlaylistIds: [],
     pinnedAlbumIds: [],
@@ -112,11 +118,22 @@ function renderPanel() {
         onPlaylistSelect={vi.fn()}
         onAddToQueue={vi.fn()}
         onBrowseLibrary={vi.fn()}
-        lastSession={null}
-        onResume={vi.fn()}
+        lastSession={options.lastSession ?? null}
+        onResume={options.onResume ?? vi.fn()}
       />
     </ThemeProvider>
   );
+}
+
+function makeSession(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
+  return {
+    collectionId: 'col-1',
+    collectionName: 'My Playlist',
+    trackIndex: 3,
+    trackTitle: 'Track Title',
+    trackArtist: 'Artist Name',
+    ...overrides,
+  };
 }
 
 function getLikedCount(): number {
@@ -238,5 +255,72 @@ describe('QuickAccessPanel effectiveLikedCount', () => {
       // #then
       expect(getLikedCount()).toBe(150);
     });
+  });
+});
+
+describe('QuickAccessPanel Resume hero', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupProviderContext(['spotify']);
+    setupLibrarySync([{ provider: 'spotify', count: 10 }]);
+    setupUnifiedLiked(false, 0);
+  });
+
+  it('renders the hero when a valid lastSession is provided', () => {
+    // #given
+    const session = makeSession({ trackTitle: 'Hero Track', collectionName: 'Hero Mix' });
+
+    // #when
+    renderPanel({ lastSession: session });
+
+    // #then
+    expect(screen.getByText('Pick up where you left off')).toBeInTheDocument();
+    expect(screen.getByText('Hero Track')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Resume Hero Track/ })).toBeInTheDocument();
+  });
+
+  it('does not render the hero when lastSession is null', () => {
+    // #when
+    renderPanel({ lastSession: null });
+
+    // #then
+    expect(screen.queryByText('Pick up where you left off')).not.toBeInTheDocument();
+  });
+
+  it('does not render the hero when lastSession has an empty collectionId (stale/invalid)', () => {
+    // #given
+    const session = makeSession({ collectionId: '' });
+
+    // #when
+    renderPanel({ lastSession: session });
+
+    // #then
+    expect(screen.queryByText('Pick up where you left off')).not.toBeInTheDocument();
+  });
+
+  it('invokes onResume when the hero button is clicked', () => {
+    // #given
+    const onResume = vi.fn();
+    const session = makeSession({ trackTitle: 'Click Me' });
+
+    // #when
+    renderPanel({ lastSession: session, onResume });
+    fireEvent.click(screen.getByRole('button', { name: /Resume Click Me/ }));
+
+    // #then
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses the footer ResumeCard when the hero is visible', () => {
+    // #given
+    const session = makeSession({ trackTitle: 'Only Hero' });
+
+    // #when
+    renderPanel({ lastSession: session });
+
+    // #then — only one resume affordance, the hero button (matched by name)
+    const resumeAffordances = screen.getAllByRole('button', { name: /Resume/ });
+    expect(resumeAffordances).toHaveLength(1);
+    expect(resumeAffordances[0]).toHaveAccessibleName('Resume Only Hero');
   });
 });

--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -9,7 +9,7 @@ import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import { Chip, ChipRow } from '@/components/styled/FilterChips';
 import ProviderIcon from '@/components/ProviderIcon';
-import ResumeCard from './ResumeCard';
+import ResumeHero from './ResumeHero';
 import PinRing from './PinRing';
 import {
   PanelRoot,
@@ -87,9 +87,14 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
   };
 
   const showProviderChips = connectedProviderIds.length > 1;
+  const hasValidSession = Boolean(lastSession && lastSession.collectionId);
 
   return (
     <PanelRoot>
+      {hasValidSession && lastSession && (
+        <ResumeHero session={lastSession} onResume={onResume} />
+      )}
+
       <PinRing
         pinnedPlaylists={pinnedPlaylists}
         pinnedAlbums={pinnedAlbums}
@@ -128,10 +133,6 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
           Browse Library →
         </BrowseButton>
       </BrowseSection>
-
-      {lastSession && lastSession.collectionId && (
-        <ResumeCard session={lastSession} onResume={onResume} />
-      )}
     </PanelRoot>
   );
 };

--- a/src/components/QuickAccessPanel/styled.ts
+++ b/src/components/QuickAccessPanel/styled.ts
@@ -23,6 +23,108 @@ export const PanelRoot = styled.div`
   animation: ${fadeIn} 0.25s ease-out;
 `;
 
+export const ResumeHeroSection = styled.section`
+  position: relative;
+  flex-shrink: 0;
+  margin: ${theme.spacing.md} ${theme.spacing.md} 0;
+  padding: ${theme.spacing.md};
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.md};
+  border-radius: ${theme.borderRadius['2xl']};
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background:
+    linear-gradient(135deg, rgba(100, 108, 255, 0.22) 0%, rgba(144, 82, 82, 0.18) 100%),
+    rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: ${theme.shadows.drop};
+  overflow: hidden;
+`;
+
+export const ResumeHeroArt = styled.div`
+  width: 88px;
+  height: 88px;
+  border-radius: ${theme.borderRadius.xl};
+  overflow: hidden;
+  flex-shrink: 0;
+  background: ${theme.colors.control.background};
+  box-shadow: ${theme.shadows.albumArtDepth};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const ResumeHeroText = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export const ResumeHeroEyebrow = styled.span`
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.semibold};
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+`;
+
+export const ResumeHeroTitle = styled.span`
+  font-size: ${theme.fontSize.xl};
+  font-weight: ${theme.fontWeight.bold};
+  color: ${theme.colors.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ResumeHeroSubtitle = styled.span`
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.muted.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ResumeHeroButton = styled.button`
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: ${theme.spacing.xs};
+  padding: ${theme.spacing.sm} ${theme.spacing.lg};
+  border-radius: ${theme.borderRadius.full};
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.94);
+  color: #111;
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.semibold};
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background ${theme.transitions.fast}, transform ${theme.transitions.fast};
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    background: #ffffff;
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+`;
+
 export const ResumeCardRoot = styled.button`
   display: flex;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

- Adds a prominent `ResumeHero` at the top of `QuickAccessPanel` (above `PinRing`) whenever a valid `lastSession` is provided.
- Hero is visually dominant: larger album art (88px), bold track title, eyebrow + collection/artist subtitle, pill Resume CTA with play glyph. Reuses the panel's glass aesthetic with a tinted primary/secondary gradient.
- Clicking the Resume button invokes the existing `onResume` handler — no duplication of resume logic.
- Suppresses the footer `ResumeCard` inside QAP to avoid duplicate affordances. External usages (`PlayerStateRenderer`, `LibraryDrawer`, `AudioPlayer`) are untouched.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1153 tests pass (11 in QAP suite, +5 new)
- [x] `npm run build` clean
- [ ] Visual: verify hero renders above PinRing when `lastSession` exists; footer ResumeCard is gone
- [ ] Visual: hero is missing when no session
- [ ] Click Resume button triggers autoplay from saved position

Closes #1156