### PR TITLE
feat(player): hydrate player without autoplay

### DIFF
--- a/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
@@ -1,0 +1,311 @@
+/**
+ * Tests for usePlayerLogic.handleHydrate — restores session state without autoplay.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { usePlayerLogic } from '../usePlayerLogic';
+import { TrackProvider } from '@/contexts/TrackContext';
+import { VisualEffectsProvider } from '@/contexts/visualEffects';
+import { ColorProvider } from '@/contexts/ColorContext';
+import { ProviderProvider } from '@/contexts/ProviderContext';
+import { makeMediaTrack } from '@/test/fixtures';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+
+const playTrackSpy = vi.fn();
+const mockPrepareTrack = vi.fn();
+
+vi.mock('@/hooks/usePlaylistManager', () => ({
+  usePlaylistManager: vi.fn(() => ({ handlePlaylistSelect: vi.fn() })),
+}));
+
+vi.mock('@/hooks/useProviderPlayback', () => ({
+  useProviderPlayback: vi.fn(() => ({
+    playTrack: playTrackSpy,
+    currentPlaybackProviderRef: { current: null },
+  })),
+}));
+
+vi.mock('@/hooks/useAutoAdvance', () => ({
+  useAutoAdvance: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAccentColor', () => ({
+  useAccentColor: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(() => ({ isUnifiedLikedActive: false })),
+}));
+
+vi.mock('@/hooks/useRadio', () => ({
+  useRadio: vi.fn(() => ({
+    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    startRadio: vi.fn(),
+    stopRadio: vi.fn(),
+    isRadioAvailable: true,
+  })),
+}));
+
+const mockDescriptor = {
+  id: 'spotify' as const,
+  catalog: { listTracks: vi.fn().mockResolvedValue([]) },
+  playback: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    playTrack: vi.fn(),
+    getState: vi.fn().mockResolvedValue(null),
+    subscribe: vi.fn(() => vi.fn()),
+    prepareTrack: mockPrepareTrack,
+  },
+  capabilities: { hasSaveTrack: true, hasExternalLink: true, hasLikedCollection: true },
+};
+
+vi.mock('@/contexts/ProviderContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/contexts/ProviderContext')>();
+  return {
+    ...actual,
+    useProviderContext: vi.fn(() => ({
+      activeDescriptor: mockDescriptor,
+      setActiveProviderId: vi.fn(),
+      getDescriptor: vi.fn((id: string) => (id === 'spotify' ? mockDescriptor : undefined)),
+      connectedProviderIds: ['spotify'],
+      chosenProviderId: 'spotify',
+      activeProviderId: 'spotify',
+      setProviderSwitchInterceptor: vi.fn(),
+      registry: {},
+      needsProviderSelection: false,
+      enabledProviderIds: ['spotify'],
+      toggleProvider: vi.fn(),
+      isProviderEnabled: vi.fn(() => true),
+      hasMultipleProviders: false,
+      fallthroughNotification: null,
+      dismissFallthroughNotification: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('@/services/spotify', () => ({
+  spotifyAuth: {
+    handleRedirect: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated: vi.fn().mockReturnValue(false),
+    getAccessToken: vi.fn().mockReturnValue('test-token'),
+    ensureValidToken: vi.fn().mockResolvedValue('test-token'),
+    redirectToAuth: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/spotifyPlayer', () => ({
+  spotifyPlayer: {
+    onPlayerStateChanged: vi.fn(() => vi.fn()),
+    getCurrentState: vi.fn().mockResolvedValue(null),
+    resume: vi.fn(),
+    pause: vi.fn(),
+    setVolume: vi.fn().mockResolvedValue(undefined),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    playTrack: vi.fn().mockResolvedValue(undefined),
+    getDeviceId: vi.fn().mockReturnValue(null),
+    getIsReady: vi.fn().mockReturnValue(false),
+  },
+}));
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn(() => mockDescriptor),
+    getAll: vi.fn(() => []),
+    register: vi.fn(),
+  },
+}));
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => (
+  <ProviderProvider>
+    <TrackProvider>
+      <VisualEffectsProvider>
+        <ColorProvider>
+          {children}
+        </ColorProvider>
+      </VisualEffectsProvider>
+    </TrackProvider>
+  </ProviderProvider>
+);
+
+function makeSession(overrides?: Partial<SessionSnapshot>): SessionSnapshot {
+  const trackA = makeMediaTrack({ id: 'track-a', name: 'Song A', artists: 'Artist A' });
+  const trackB = makeMediaTrack({ id: 'track-b', name: 'Song B', artists: 'Artist B' });
+  return {
+    collectionId: 'playlist-xyz',
+    collectionName: 'My Playlist',
+    collectionProvider: 'spotify',
+    trackIndex: 1,
+    trackId: 'track-b',
+    queueTracks: [trackA, trackB],
+    playbackPosition: 42_000,
+    ...overrides,
+  };
+}
+
+describe('usePlayerLogic — handleHydrate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    playTrackSpy.mockClear();
+    mockPrepareTrack.mockClear();
+  });
+
+  it('restores queue state and paused position without calling playTrack', async () => {
+    // #given
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(result.current.state.tracks).toHaveLength(2);
+    expect(result.current.state.tracks[0].id).toBe('track-a');
+    expect(result.current.state.tracks[1].id).toBe('track-b');
+    expect(result.current.state.selectedPlaylistId).toBe('playlist-xyz');
+    expect(result.current.state.isPlaying).toBe(false);
+    expect(result.current.state.playbackPosition).toBe(42_000);
+    expect(playTrackSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls prepareTrack with the resolved track and saved positionMs', async () => {
+    // #given
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
+    const [passedTrack, passedOptions] = mockPrepareTrack.mock.calls[0];
+    expect(passedTrack.id).toBe('track-b');
+    expect(passedOptions).toEqual({ positionMs: 42_000 });
+  });
+
+  it('omits positionMs option when saved position is missing or zero', async () => {
+    // #given
+    const session = makeSession({ playbackPosition: 0 });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(result.current.state.playbackPosition).toBe(0);
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
+    const passedOptions = mockPrepareTrack.mock.calls[0][1];
+    expect(passedOptions).toBeUndefined();
+  });
+
+  it('resolves target index by trackId when it exists in the queue', async () => {
+    // #given — trackIndex points at 0, but trackId matches track at position 1
+    const session = makeSession({ trackIndex: 0, trackId: 'track-b' });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(mockPrepareTrack.mock.calls[0][0].id).toBe('track-b');
+  });
+
+  it('triggers playTrack with saved positionMs on the next handlePlay', async () => {
+    // #given
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+    playTrackSpy.mockClear();
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handlePlay();
+    });
+
+    // #then
+    expect(playTrackSpy).toHaveBeenCalledTimes(1);
+    const [index, skipOnError, options] = playTrackSpy.mock.calls[0];
+    expect(index).toBe(1);
+    expect(skipOnError).toBe(false);
+    expect(options).toEqual({ positionMs: 42_000 });
+  });
+
+  it('does not re-trigger playTrack on a second handlePlay after hydrate', async () => {
+    // #given
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+      await result.current.handlers.handlePlay();
+    });
+    playTrackSpy.mockClear();
+
+    // #when — a second press should fall through to the normal resume path
+    await act(async () => {
+      await result.current.handlers.handlePlay();
+    });
+
+    // #then
+    expect(playTrackSpy).not.toHaveBeenCalled();
+    expect(mockDescriptor.playback.resume).toHaveBeenCalled();
+  });
+
+  it('no-ops when session has no queueTracks', async () => {
+    // #given
+    const session = makeSession({ queueTracks: [] });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(result.current.state.tracks).toHaveLength(0);
+    expect(result.current.state.selectedPlaylistId).toBeNull();
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
+    expect(playTrackSpy).not.toHaveBeenCalled();
+  });
+
+  it('discards a pending hydrate when handleNext runs first', async () => {
+    // #given
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+    playTrackSpy.mockClear();
+
+    // #when — user skips to next, consuming playback routing without the hydrate options
+    await act(async () => {
+      result.current.handlers.handleNext();
+    });
+    const nextCall = playTrackSpy.mock.calls.at(-1);
+    playTrackSpy.mockClear();
+    await act(async () => {
+      await result.current.handlers.handlePlay();
+    });
+
+    // #then — handleNext took over; subsequent handlePlay uses resume, not a hydrated start
+    expect(nextCall?.[0]).toBe(0); // wrapped around from index 1 -> 0 in a 2-track queue
+    expect(playTrackSpy).not.toHaveBeenCalled();
+    expect(mockDescriptor.playback.resume).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -10,6 +10,7 @@ import { useAccentColor } from '@/hooks/useAccentColor';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { useRadio } from '@/hooks/useRadio';
 import type { ProviderId } from '@/types/domain';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
 import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
@@ -77,6 +78,10 @@ export function usePlayerLogic() {
   const currentTrackIndexRef = useRef(currentTrackIndex);
   currentTrackIndexRef.current = currentTrackIndex;
   const expectedTrackIdRef = useRef<string | null>(null);
+  // Holds the target index + position when handleHydrate restores a session without autoplay.
+  // The next handlePlay consumes this to start playback at the saved offset; other control paths
+  // (next/previous/new collection) clear it so a stale hydrate can't hijack a fresh user action.
+  const hydratedPendingPlayRef = useRef<{ index: number; positionMs?: number } | null>(null);
 
   // Playback state from provider events (local — not shared via context)
   const [isPlaying, setIsPlaying] = useState(false);
@@ -95,8 +100,20 @@ export function usePlayerLogic() {
     mediaTracksRef,
     onAuthExpired: (providerId: ProviderId) => setAuthExpired(providerId),
   });
-  const { playTrack } = providerPlayback;
+  const providerPlayTrack = providerPlayback.playTrack;
   const drivingProviderRef = providerPlayback.currentPlaybackProviderRef;
+
+  // Any call into playTrack represents a concrete playback action, which supersedes
+  // a pending hydrate. Wrap the underlying playTrack so downstream consumers don't
+  // each have to clear the pending-hydrate ref individually.
+  const playTrack = useCallback(async (
+    index: number,
+    skipOnError = false,
+    options?: { positionMs?: number },
+  ) => {
+    hydratedPendingPlayRef.current = null;
+    return providerPlayTrack(index, skipOnError, options);
+  }, [providerPlayTrack]);
 
   /** Resolve provider currently driving playback; falls back to active provider when unknown. */
   const getDrivingProviderId = useCallback((): ProviderId | null => (
@@ -214,6 +231,21 @@ export function usePlayerLogic() {
   }, [tracks.length, playTrack, setCurrentTrackIndex]);
 
   const handlePlay = useCallback(async () => {
+    const pending = hydratedPendingPlayRef.current;
+    if (pending) {
+      hydratedPendingPlayRef.current = null;
+      logQueue(
+        'handlePlay — hydrated start index=%d, positionMs=%s',
+        pending.index,
+        pending.positionMs ?? 'NONE',
+      );
+      await playTrack(
+        pending.index,
+        false,
+        pending.positionMs ? { positionMs: pending.positionMs } : undefined,
+      );
+      return;
+    }
     const drivingId = getDrivingProviderId();
     logQueue(
       'handlePlay — drivingProvider=%s, index=%d, track=%s',
@@ -228,7 +260,57 @@ export function usePlayerLogic() {
     } catch {
       // Autoplay policy or network errors are handled by the playback adapter
     }
-  }, [getDrivingProviderId, getDrivingProviderDescriptor]);
+  }, [playTrack, getDrivingProviderId, getDrivingProviderDescriptor]);
+
+  const handleHydrate = useCallback(async (session: SessionSnapshot): Promise<void> => {
+    if (!session.queueTracks?.length) return;
+    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPositionMs } = session;
+
+    const targetIdx = trackId
+      ? queueTracks.findIndex(t => t.id === trackId)
+      : Math.min(trackIndex, queueTracks.length - 1);
+    const resolvedIdx = targetIdx >= 0 ? targetIdx : Math.min(trackIndex, queueTracks.length - 1);
+
+    setTracks(queueTracks);
+    setOriginalTracks(queueTracks);
+    setSelectedPlaylistId(collectionId);
+    setCurrentTrackIndex(resolvedIdx);
+    mediaTracksRef.current = queueTracks;
+    expectedTrackIdRef.current = queueTracks[resolvedIdx]?.id ?? null;
+
+    const positionMs = savedPositionMs && savedPositionMs > 0 ? savedPositionMs : undefined;
+    setPlaybackPosition(positionMs ?? 0);
+    setIsPlaying(false);
+
+    const targetTrack = queueTracks[resolvedIdx];
+    const providerId = targetTrack?.provider ?? activeDescriptor?.id;
+    if (providerId && targetTrack) {
+      drivingProviderRef.current = providerId;
+      const descriptor = providerRegistry.get(providerId);
+      descriptor?.playback.prepareTrack?.(
+        targetTrack,
+        positionMs ? { positionMs } : undefined,
+      );
+    }
+
+    hydratedPendingPlayRef.current = { index: resolvedIdx, positionMs };
+
+    logQueue(
+      'handleHydrate — index=%d, track=%s, positionMs=%s, provider=%s',
+      resolvedIdx,
+      trkSummary(targetTrack),
+      positionMs ?? 'NONE',
+      providerId ?? 'NONE',
+    );
+  }, [
+    setTracks,
+    setOriginalTracks,
+    setSelectedPlaylistId,
+    setCurrentTrackIndex,
+    mediaTracksRef,
+    activeDescriptor,
+    drivingProviderRef,
+  ]);
 
   const handlePause = useCallback(() => {
     const drivingId = getDrivingProviderId();
@@ -303,6 +385,7 @@ export function usePlayerLogic() {
       handleStartRadio,
       handleRemoveFromQueue,
       handleReorderQueue,
+      handleHydrate,
     }),
     [
       loadCollection,
@@ -320,6 +403,7 @@ export function usePlayerLogic() {
       handleStartRadio,
       handleRemoveFromQueue,
       handleReorderQueue,
+      handleHydrate,
     ]
   );
 

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -195,7 +195,9 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     });
   }
 
-  prepareTrack(track: MediaTrack): void {
+  prepareTrack(track: MediaTrack, _options?: { positionMs?: number }): void {
+    // Prefetch the temporary link so playTrack doesn't pay the fetch cost when invoked.
+    // positionMs is applied during playTrack, not here — HTML5 Audio can't seek without a src.
     this.catalog.prefetchTemporaryLink(track.playbackRef.ref);
   }
 

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -242,8 +242,10 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     return spotifyPlayer.lastPlayTrackTime;
   }
 
-  prepareTrack(_track: MediaTrack): void {
+  prepareTrack(_track: MediaTrack, _options?: { positionMs?: number }): void {
     // Pre-warm the auth token so no refresh delay hits the next transition.
+    // The Spotify Web Playback SDK has no preload-without-play mode, so positionMs
+    // is accepted for interface parity but applied when playTrack is later invoked.
     spotifyAuth.ensureValidToken().catch(() => {});
   }
 

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -79,8 +79,8 @@ export interface PlaybackProvider {
   getState(): Promise<PlaybackState | null>;
   /** Subscribe to state changes (returns unsubscribe). */
   subscribe(listener: (state: PlaybackState | null) => void): () => void;
-  /** Optional: pre-warm resources for an upcoming track (e.g. fetch temporary links). */
-  prepareTrack?(track: MediaTrack): void;
+  /** Optional: pre-warm resources for an upcoming track (e.g. fetch temporary links). Supplying positionMs lets the adapter prepare to resume at that offset. */
+  prepareTrack?(track: MediaTrack, options?: { positionMs?: number }): void;
   /** Optional: re-fetch album art for the currently playing track. */
   refreshCurrentTrackArt?(): void;
   /** Optional: epoch ms of the last playTrack call (used by auto-advance cooldown). */


### PR DESCRIPTION
## Summary

- Adds `handleHydrate(session)` to `usePlayerLogic` (`src/hooks/usePlayerLogic.ts`) that restores the last session's queue, selected collection, current index, and saved playback position — then pre-warms the target track via `prepareTrack` without starting playback. The seek bar reflects `lastSession.playbackPosition` before the user interacts.
- Extends `PlaybackProvider.prepareTrack` to accept optional `{ positionMs }`; Spotify and Dropbox adapters accept the new option (applied on the subsequent `playTrack` call, since neither SDK preloads at a specific offset).
- Wires a pending-hydrate ref so the next `handlePlay` dispatches `playTrack(index, { positionMs })`, while `handleNext` / `handlePrevious` / any fresh `playTrack` clear the ref so a stale hydrate can't hijack later user actions.
- `handleResume` in `AudioPlayer.tsx` is untouched — the ResumeCard / hero path still autoplays.
- Exposes `handleHydrate` via the `usePlayerLogic` handlers object for #1155 (landing router) to call.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1156/1156 pass (new `usePlayerLogic.hydrate.test.tsx` covers 8 scenarios: restore + paused state, `prepareTrack` positionMs, missing/zero position, trackId resolution, subsequent `handlePlay` starts at saved position, second `handlePlay` falls through to resume, no-op on empty queue, handleNext discards pending hydrate)
- [x] `npm run build` clean
- [ ] Manual: returning user with QAP off — queue + scrub position restored, playback paused; first play starts at saved offset.

Closes #1154