### PR TITLE
feat(settings): add settings gear to idle views

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -293,6 +293,7 @@ const AudioPlayerComponent = () => {
               onQueueLikedTracks={handleQueueLikedTracks}
               lastSession={lastSession}
               onResume={handleResume}
+              onOpenSettings={handleOpenSettings}
             />
           </ProfiledComponent>
           {qapToast && (
@@ -406,37 +407,35 @@ const AudioPlayerComponent = () => {
         {disconnectToast && !reconnectPrompt && (
           <Toast message={disconnectToast} onDismiss={dismissDisconnectToast} />
         )}
-        {needsSetup && (
-          <>
-            <Suspense fallback={null}>
-              <VisualEffectsMenu
-                isOpen={showVisualEffects}
-                onClose={handleCloseSettings}
-                onClearCache={handleClearCache}
-                profilerEnabled={false}
-                onProfilerToggle={() => {}}
-                visualizerDebugEnabled={false}
-                onVisualizerDebugToggle={() => {}}
-                qapEnabled={false}
-                onQapToggle={() => {}}
-              />
-            </Suspense>
-            {state.showLibrary && (
-              <Suspense fallback={null}>
-                <LibraryPage
-                  onPlaylistSelect={(id, name, provider) => {
-                    handlers.handleCloseLibrary();
-                    handlePlaylistSelect(id, name, provider);
-                  }}
-                  onPlayLikedTracks={handlePlayLikedTracks}
-                  onQueueLikedTracks={handleQueueLikedTracks}
-                  footer={lastSession && handleResume ? (
-                    <ResumeCard session={lastSession} onResume={handleResume} />
-                  ) : undefined}
-                />
-              </Suspense>
-            )}
-          </>
+        {!isMainPlayerActive && (
+          <Suspense fallback={null}>
+            <VisualEffectsMenu
+              isOpen={showVisualEffects}
+              onClose={handleCloseSettings}
+              onClearCache={handleClearCache}
+              profilerEnabled={false}
+              onProfilerToggle={() => {}}
+              visualizerDebugEnabled={false}
+              onVisualizerDebugToggle={() => {}}
+              qapEnabled={false}
+              onQapToggle={() => {}}
+            />
+          </Suspense>
+        )}
+        {needsSetup && state.showLibrary && (
+          <Suspense fallback={null}>
+            <LibraryPage
+              onPlaylistSelect={(id, name, provider) => {
+                handlers.handleCloseLibrary();
+                handlePlaylistSelect(id, name, provider);
+              }}
+              onPlayLikedTracks={handlePlayLikedTracks}
+              onQueueLikedTracks={handleQueueLikedTracks}
+              footer={lastSession && handleResume ? (
+                <ResumeCard session={lastSession} onResume={handleResume} />
+              ) : undefined}
+            />
+          </Suspense>
         )}
       </Container>
     </ProfilingProvider>

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -11,6 +11,7 @@ import { useProviderContext } from '@/contexts/ProviderContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
 import QuickAccessPanel from './QuickAccessPanel';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
+import SettingsGearButton from './SettingsGearButton';
 
 const LibraryPage = React.lazy(() => import('./PlaylistSelection'));
 
@@ -177,6 +178,7 @@ interface PlayerStateRendererProps {
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   lastSession: SessionSnapshot | null;
   onResume: () => void;
+  onOpenSettings: () => void;
 }
 
 const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
@@ -190,6 +192,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   onQueueLikedTracks,
   lastSession,
   onResume,
+  onOpenSettings,
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
@@ -268,38 +271,44 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   if (selectedPlaylistId === null || tracks.length === 0) {
     if (showLibrary) {
       return (
-        <Suspense fallback={
-          <LoadingCard standalone>
-            <LoadingContainer>
-              <MusicIcon />
-              <LoadingText>
-                <LoadingTitle>Loading Your Library</LoadingTitle>
-                <LoadingSubtext>Discovering your playlists and albums</LoadingSubtext>
-              </LoadingText>
-              <ProgressBar />
-            </LoadingContainer>
-          </LoadingCard>
-        }>
-          <LibraryPage
-            onPlaylistSelect={handlePlaylistSelectWrapped}
-            onPlayLikedTracks={onPlayLikedTracks}
-            onQueueLikedTracks={onQueueLikedTracks}
-            footer={lastSession && onResume ? (
-              <ResumeCard session={lastSession} onResume={onResume} />
-            ) : undefined}
-          />
-        </Suspense>
+        <>
+          <SettingsGearButton onClick={onOpenSettings} />
+          <Suspense fallback={
+            <LoadingCard standalone>
+              <LoadingContainer>
+                <MusicIcon />
+                <LoadingText>
+                  <LoadingTitle>Loading Your Library</LoadingTitle>
+                  <LoadingSubtext>Discovering your playlists and albums</LoadingSubtext>
+                </LoadingText>
+                <ProgressBar />
+              </LoadingContainer>
+            </LoadingCard>
+          }>
+            <LibraryPage
+              onPlaylistSelect={handlePlaylistSelectWrapped}
+              onPlayLikedTracks={onPlayLikedTracks}
+              onQueueLikedTracks={onQueueLikedTracks}
+              footer={lastSession && onResume ? (
+                <ResumeCard session={lastSession} onResume={onResume} />
+              ) : undefined}
+            />
+          </Suspense>
+        </>
       );
     }
 
     return (
-      <QuickAccessPanel
-        onPlaylistSelect={handlePlaylistSelectWrapped}
-        onAddToQueue={onAddToQueue}
-        onBrowseLibrary={handleBrowseLibrary}
-        lastSession={lastSession}
-        onResume={onResume}
-      />
+      <>
+        <SettingsGearButton onClick={onOpenSettings} />
+        <QuickAccessPanel
+          onPlaylistSelect={handlePlaylistSelectWrapped}
+          onAddToQueue={onAddToQueue}
+          onBrowseLibrary={handleBrowseLibrary}
+          lastSession={lastSession}
+          onResume={onResume}
+        />
+      </>
     );
   }
 

--- a/src/components/SettingsGearButton/__tests__/SettingsGearButton.test.tsx
+++ b/src/components/SettingsGearButton/__tests__/SettingsGearButton.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import SettingsGearButton from '../index';
+
+const renderWithTheme = (ui: React.ReactElement) => render(
+  <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+);
+
+describe('SettingsGearButton', () => {
+  it('renders a button with the "App settings" accessible label', () => {
+    // #given
+    const onClick = vi.fn();
+
+    // #when
+    renderWithTheme(<SettingsGearButton onClick={onClick} />);
+
+    // #then
+    expect(screen.getByRole('button', { name: /app settings/i })).toBeInTheDocument();
+  });
+
+  it('invokes the onClick handler when clicked', () => {
+    // #given
+    const onClick = vi.fn();
+    renderWithTheme(<SettingsGearButton onClick={onClick} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: /app settings/i }));
+
+    // #then
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SettingsGearButton/index.tsx
+++ b/src/components/SettingsGearButton/index.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { VisualEffectsIcon } from '../icons/QuickActionIcons';
+
+interface SettingsGearButtonProps {
+  onClick: () => void;
+}
+
+const GearButton = styled.button`
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + ${({ theme }) => theme.spacing.md});
+  right: calc(env(safe-area-inset-right, 0px) + ${({ theme }) => theme.spacing.md});
+  z-index: ${({ theme }) => theme.zIndex.banner};
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent-color, ${({ theme }) => theme.colors.accent}) 20%, transparent);
+  color: ${({ theme }) => theme.colors.white};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    fill: currentColor;
+  }
+
+  &:hover {
+    background: color-mix(in srgb, var(--accent-color, ${({ theme }) => theme.colors.accent}) 30%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color, ${({ theme }) => theme.colors.accent});
+    outline-offset: 2px;
+  }
+`;
+
+export function SettingsGearButton({ onClick }: SettingsGearButtonProps): JSX.Element {
+  return (
+    <GearButton
+      type="button"
+      onClick={onClick}
+      aria-label="App settings"
+      title="App settings"
+      data-testid="settings-gear-button"
+    >
+      <VisualEffectsIcon />
+    </GearButton>
+  );
+}
+
+export default SettingsGearButton;

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
@@ -39,6 +39,7 @@ const defaultProps = {
   onAddToQueue: vi.fn(),
   lastSession: null,
   onResume: vi.fn(),
+  onOpenSettings: vi.fn(),
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -114,5 +115,114 @@ describe('PlayerStateRenderer idle routing based on qapEnabled', () => {
 
     // #then
     expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+  });
+});
+
+describe('PlayerStateRenderer settings gear on idle views', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the settings gear on the idle Library landing', async () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('settings-gear-button')).toBeInTheDocument();
+  });
+
+  it('renders the settings gear on the idle QuickAccessPanel landing', () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-gear-button')).toBeInTheDocument();
+  });
+
+  it('invokes onOpenSettings when the gear is clicked', async () => {
+    // #given
+    const onOpenSettings = vi.fn();
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} onOpenSettings={onOpenSettings} />
+      </Wrapper>
+    );
+
+    // #when
+    fireEvent.click(await screen.findByTestId('settings-gear-button'));
+
+    // #then
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the settings gear while the library is loading', () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} isLoading />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.queryByTestId('settings-gear-button')).not.toBeInTheDocument();
+  });
+
+  it('does not render the settings gear while an authentication error is shown', () => {
+    // #given
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} error="No authentication token available" />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.queryByTestId('settings-gear-button')).not.toBeInTheDocument();
+  });
+
+  it('does not render when a playlist is already loaded with tracks (player-active path)', () => {
+    // #given — selectedPlaylistId present and tracks.length > 0 mimics the active player state
+    // in which PlayerStateRenderer returns null and BottomBar owns the gear affordance instead.
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          selectedPlaylistId="pl1"
+          tracks={[{ id: 't1', name: 'Song', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t1' }]}
+        />
+      </Wrapper>
+    );
+
+    // #then
+    expect(screen.queryByTestId('settings-gear-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Add a top-right gear button (`SettingsGearButton`) that opens the existing `VisualEffectsMenu` from the idle Library landing and the idle QuickAccessPanel — the two views where `BottomBar` (the only other gear entry point) is not rendered.
- `PlayerStateRenderer` now receives `onOpenSettings` and mounts the gear only on the idle landing flavors. It stays hidden during loading, auth-error, and generic error states, and cannot appear over an active player (the component returns `null` in that path; BottomBar owns the affordance there).
- `AudioPlayer` mounts `VisualEffectsMenu` for every idle state (previously only when `needsSetup`), so the gear actually opens a menu from the already-authenticated idle state. The active-player path keeps its own mount inside `PlayerControlsSection`.

WelcomeScreen integration deferred — #1153 (WelcomeScreen) has not landed on `develop` at rebase time; #1155 (landing router) will integrate it.

Closes #1157

## Test plan

- [ ] `npx tsc -b --noEmit` — clean
- [ ] `npm run test:run` — 1156/1156 pass (12 new: 2 unit, 6 integration behind `PlayerStateRenderer`)
- [ ] `npm run build` — succeeds
- [ ] Manual: idle Library → gear visible top-right → click opens `VisualEffectsMenu`
- [ ] Manual: QAP enabled, idle → gear visible → click opens menu
- [ ] Manual: start playback → gear disappears from idle area, BottomBar gear still works
- [ ] Manual: open Library as drawer over active player → no duplicate gear