### PR TITLE
feat(landing): wire router with stale-session cutoff

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -294,6 +294,7 @@ const AudioPlayerComponent = () => {
               lastSession={lastSession}
               onResume={handleResume}
               onOpenSettings={handleOpenSettings}
+              onHydrate={handlers.handleHydrate}
             />
           </ProfiledComponent>
           {qapToast && (

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -1,7 +1,7 @@
-import React, { Suspense, useCallback, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
-import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { isSessionStale, type SessionSnapshot } from '@/services/sessionPersistence';
 import { Card, CardHeader, CardContent } from '../components/styled';
 import { Button } from '../components/styled';
 import { Alert, AlertDescription } from '../components/styled';
@@ -9,9 +9,11 @@ import { flexColumn, cardBase } from '../styles/utils';
 import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
 import QuickAccessPanel from './QuickAccessPanel';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 import SettingsGearButton from './SettingsGearButton';
+import WelcomeScreen from './WelcomeScreen';
 
 const LibraryPage = React.lazy(() => import('./PlaylistSelection'));
 
@@ -179,6 +181,20 @@ interface PlayerStateRendererProps {
   lastSession: SessionSnapshot | null;
   onResume: () => void;
   onOpenSettings: () => void;
+  onHydrate: (session: SessionSnapshot) => Promise<void>;
+}
+
+type IdleRoute = 'welcome' | 'qap' | 'hydrate' | 'library';
+
+function resolveIdleRoute(
+  welcomeSeen: boolean,
+  qapEnabled: boolean,
+  hasValidSession: boolean,
+): IdleRoute {
+  if (!welcomeSeen) return 'welcome';
+  if (qapEnabled) return 'qap';
+  if (hasValidSession) return 'hydrate';
+  return 'library';
 }
 
 const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
@@ -193,27 +209,43 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   lastSession,
   onResume,
   onOpenSettings,
+  onHydrate,
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
   const [qapEnabled] = useQapEnabled();
-  const [showLibrary, setShowLibrary] = useState(!qapEnabled);
+  const [welcomeSeen] = useWelcomeSeen();
+  const hasValidSession = !isSessionStale(lastSession);
+  const route = resolveIdleRoute(welcomeSeen, qapEnabled, hasValidSession);
+  // "Browse Library" is a one-way door: once engaged, the idle view stays on
+  // Library even if routing inputs would otherwise pick QAP.
+  const [libraryOverride, setLibraryOverride] = useState(false);
+
+  const hydrateFiredRef = useRef(false);
+  useEffect(() => {
+    if (hydrateFiredRef.current) return;
+    if (route !== 'hydrate') return;
+    if (!lastSession) return;
+    hydrateFiredRef.current = true;
+    void onHydrate(lastSession);
+  }, [route, lastSession, onHydrate]);
 
   const handleConnectClick = useCallback(() => {
     activeDescriptor?.auth.beginLogin();
   }, [activeDescriptor]);
 
   const handleBrowseLibrary = useCallback(() => {
-    setShowLibrary(true);
+    setLibraryOverride(true);
   }, []);
 
   const handlePlaylistSelectWrapped = useCallback(
     (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => {
-      setShowLibrary(false);
+      setLibraryOverride(false);
       onPlaylistSelect(id, name, provider);
     },
     [onPlaylistSelect],
   );
+
 
   if (isLoading) {
     return (
@@ -269,47 +301,78 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   }
 
   if (selectedPlaylistId === null || tracks.length === 0) {
-    if (showLibrary) {
+    const libraryView = (
+      <>
+        <SettingsGearButton onClick={onOpenSettings} />
+        <Suspense fallback={
+          <LoadingCard standalone>
+            <LoadingContainer>
+              <MusicIcon />
+              <LoadingText>
+                <LoadingTitle>Loading Your Library</LoadingTitle>
+                <LoadingSubtext>Discovering your playlists and albums</LoadingSubtext>
+              </LoadingText>
+              <ProgressBar />
+            </LoadingContainer>
+          </LoadingCard>
+        }>
+          <LibraryPage
+            onPlaylistSelect={handlePlaylistSelectWrapped}
+            onPlayLikedTracks={onPlayLikedTracks}
+            onQueueLikedTracks={onQueueLikedTracks}
+            footer={lastSession && onResume ? (
+              <ResumeCard session={lastSession} onResume={onResume} />
+            ) : undefined}
+          />
+        </Suspense>
+      </>
+    );
+
+    if (libraryOverride) return libraryView;
+
+    if (route === 'welcome') {
       return (
         <>
           <SettingsGearButton onClick={onOpenSettings} />
-          <Suspense fallback={
-            <LoadingCard standalone>
-              <LoadingContainer>
-                <MusicIcon />
-                <LoadingText>
-                  <LoadingTitle>Loading Your Library</LoadingTitle>
-                  <LoadingSubtext>Discovering your playlists and albums</LoadingSubtext>
-                </LoadingText>
-                <ProgressBar />
-              </LoadingContainer>
-            </LoadingCard>
-          }>
-            <LibraryPage
-              onPlaylistSelect={handlePlaylistSelectWrapped}
-              onPlayLikedTracks={onPlayLikedTracks}
-              onQueueLikedTracks={onQueueLikedTracks}
-              footer={lastSession && onResume ? (
-                <ResumeCard session={lastSession} onResume={onResume} />
-              ) : undefined}
-            />
-          </Suspense>
+          <WelcomeScreen
+            onConnectProvider={handleConnectClick}
+            onBrowseLibrary={handleBrowseLibrary}
+          />
         </>
       );
     }
 
-    return (
-      <>
-        <SettingsGearButton onClick={onOpenSettings} />
-        <QuickAccessPanel
-          onPlaylistSelect={handlePlaylistSelectWrapped}
-          onAddToQueue={onAddToQueue}
-          onBrowseLibrary={handleBrowseLibrary}
-          lastSession={lastSession}
-          onResume={onResume}
-        />
-      </>
-    );
+    if (route === 'hydrate') {
+      return (
+        <LoadingCard standalone>
+          <LoadingContainer>
+            <MusicIcon />
+            <LoadingText>
+              <LoadingTitle>Restoring Your Session</LoadingTitle>
+              <LoadingSubtext>Loading your last queue</LoadingSubtext>
+            </LoadingText>
+            <ProgressBar />
+          </LoadingContainer>
+        </LoadingCard>
+      );
+    }
+
+    if (route === 'qap') {
+      return (
+        <>
+          <SettingsGearButton onClick={onOpenSettings} />
+          <QuickAccessPanel
+            onPlaylistSelect={handlePlaylistSelectWrapped}
+            onAddToQueue={onAddToQueue}
+            onBrowseLibrary={handleBrowseLibrary}
+            lastSession={hasValidSession ? lastSession : null}
+            onResume={onResume}
+          />
+        </>
+      );
+    }
+
+    return libraryView;
   }
 
   return null;

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -320,6 +320,7 @@ describe('PlayerStateRenderer idle routing', () => {
 describe('PlayerStateRenderer settings gear on idle views', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
   });
 
   it('renders the settings gear on the idle Library landing', async () => {

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import PlayerStateRenderer from '../PlayerStateRenderer';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
+import { STALE_SESSION_MS, type SessionSnapshot } from '@/services/sessionPersistence';
 
 vi.mock('@/hooks/useQapEnabled', () => ({
   useQapEnabled: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWelcomeSeen', () => ({
+  useWelcomeSeen: vi.fn(),
 }));
 
 vi.mock('@/contexts/ProviderContext', () => ({
@@ -16,7 +22,11 @@ vi.mock('@/contexts/ProviderContext', () => ({
       id: 'spotify',
       name: 'Spotify',
       capabilities: { hasSaveTrack: true, hasExternalLink: true },
+      auth: { beginLogin: vi.fn() },
     },
+    enabledProviderIds: [],
+    connectedProviderIds: [],
+    getDescriptor: () => undefined,
   })),
 }));
 
@@ -28,7 +38,32 @@ vi.mock('../QuickAccessPanel', () => ({
   default: () => <div data-testid="quick-access-panel">QuickAccessPanel</div>,
 }));
 
+vi.mock('../WelcomeScreen', () => ({
+  default: ({ onBrowseLibrary }: { onBrowseLibrary: () => void }) => (
+    <div data-testid="welcome-screen">
+      <button type="button" onClick={onBrowseLibrary}>browse</button>
+    </div>
+  ),
+}));
+
 const mockUseQapEnabled = vi.mocked(useQapEnabled);
+const mockUseWelcomeSeen = vi.mocked(useWelcomeSeen);
+
+const freshSession: SessionSnapshot = {
+  collectionId: 'col-1',
+  collectionName: 'Test',
+  trackIndex: 0,
+  savedAt: Date.now(),
+  queueTracks: [],
+};
+
+const staleSession: SessionSnapshot = {
+  collectionId: 'col-1',
+  collectionName: 'Test',
+  trackIndex: 0,
+  savedAt: Date.now() - STALE_SESSION_MS - 1000,
+  queueTracks: [],
+};
 
 const defaultProps = {
   isLoading: false,
@@ -40,82 +75,246 @@ const defaultProps = {
   lastSession: null,
   onResume: vi.fn(),
   onOpenSettings: vi.fn(),
+  onHydrate: vi.fn(async () => {}),
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>
 );
 
-describe('PlayerStateRenderer idle routing based on qapEnabled', () => {
+describe('PlayerStateRenderer idle routing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
   });
 
-  it('renders PlaylistSelection when qapEnabled is false (default)', async () => {
+  it('renders WelcomeScreen when welcomeSeen is false (supersedes session + qap)', () => {
+    // #given — brand-new user even if they somehow had a valid session + qap on
+    mockUseWelcomeSeen.mockReturnValue([false, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={freshSession} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByTestId('welcome-screen')).toBeInTheDocument();
+    expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+  });
+
+  it('renders QuickAccessPanel when welcomeSeen + qapEnabled + valid session', () => {
     // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={freshSession} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('welcome-screen')).not.toBeInTheDocument();
+  });
+
+  it('renders QuickAccessPanel when welcomeSeen + qapEnabled + no session', () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={null} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
+  });
+
+  it('renders QuickAccessPanel when welcomeSeen + qapEnabled + stale session', () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={staleSession} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
+  });
+
+  it('calls onHydrate once on mount when welcomeSeen + !qapEnabled + valid session', async () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrate = vi.fn(async () => {});
+
+    // #when
+    const { rerender } = render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          onHydrate={onHydrate}
+          lastSession={freshSession}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(onHydrate).toHaveBeenCalledTimes(1);
+    });
+    expect(onHydrate).toHaveBeenCalledWith(freshSession);
+
+    // #when — re-render shouldn't fire hydrate again
+    rerender(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          onHydrate={onHydrate}
+          lastSession={freshSession}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(onHydrate).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a restoring placeholder (not the library) in the hydrate branch', () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
 
     // #when
     render(
       <Wrapper>
-        <PlayerStateRenderer {...defaultProps} />
-      </Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={freshSession} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByText(/Restoring Your Session/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
+  });
+
+  it('renders LibraryPage when welcomeSeen + !qapEnabled + no session', async () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={null} />
+      </Wrapper>,
     );
 
     // #then
     await waitFor(() => {
       expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
   });
 
-  it('does not render QuickAccessPanel when qapEnabled is false (default)', async () => {
+  it('renders LibraryPage when welcomeSeen + !qapEnabled + stale session', async () => {
     // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
 
     // #when
     render(
       <Wrapper>
-        <PlayerStateRenderer {...defaultProps} />
-      </Wrapper>
+        <PlayerStateRenderer {...defaultProps} lastSession={staleSession} />
+      </Wrapper>,
     );
 
     // #then
     await waitFor(() => {
-      expect(screen.queryByTestId('quick-access-panel')).not.toBeInTheDocument();
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
     });
   });
 
-  it('renders QuickAccessPanel when qapEnabled is true', () => {
+  it('does not call onHydrate for a stale session', async () => {
     // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrate = vi.fn(async () => {});
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          onHydrate={onHydrate}
+          lastSession={staleSession}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
+    expect(onHydrate).not.toHaveBeenCalled();
+  });
+
+  it('welcomeSeen=false supersedes a valid session and QAP setting', () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([false, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrate = vi.fn(async () => {});
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          onHydrate={onHydrate}
+          lastSession={freshSession}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByTestId('welcome-screen')).toBeInTheDocument();
+    expect(onHydrate).not.toHaveBeenCalled();
+  });
+
+  it('switches to LibraryPage when Browse Library is clicked from WelcomeScreen', async () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([false, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
 
     // #when
     render(
       <Wrapper>
         <PlayerStateRenderer {...defaultProps} />
-      </Wrapper>
+      </Wrapper>,
     );
+    act(() => {
+      screen.getByText('browse').click();
+    });
 
     // #then
-    expect(screen.getByTestId('quick-access-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
   });
 
-  it('does not render PlaylistSelection when qapEnabled is true', () => {
-    // #given
-    mockUseQapEnabled.mockReturnValue([true, vi.fn()]);
-
-    // #when
-    render(
-      <Wrapper>
-        <PlayerStateRenderer {...defaultProps} />
-      </Wrapper>
-    );
-
-    // #then
-    expect(screen.queryByTestId('playlist-selection')).not.toBeInTheDocument();
-  });
 });
 
 describe('PlayerStateRenderer settings gear on idle views', () => {

--- a/src/services/__tests__/sessionPersistence.test.ts
+++ b/src/services/__tests__/sessionPersistence.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { saveSession, loadSession, clearSession } from '../sessionPersistence';
+import {
+  saveSession,
+  loadSession,
+  clearSession,
+  isSessionStale,
+  STALE_SESSION_MS,
+} from '../sessionPersistence';
 import type { SessionSnapshot } from '../sessionPersistence';
 
 const localStorageMock = (() => {
@@ -126,6 +132,79 @@ describe('sessionPersistence', () => {
 
       // #then
       expect(loaded?.playbackPosition).toBe(500);
+    });
+  });
+
+  describe('isSessionStale', () => {
+    const now = 1_700_000_000_000;
+
+    it('returns true for null session', () => {
+      // #when / #then
+      expect(isSessionStale(null, now)).toBe(true);
+    });
+
+    it('returns true for undefined session', () => {
+      // #when / #then
+      expect(isSessionStale(undefined, now)).toBe(true);
+    });
+
+    it('returns true when savedAt is missing', () => {
+      // #given
+      const session: SessionSnapshot = { ...baseSnapshot };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(true);
+    });
+
+    it('returns true when savedAt is undefined explicitly', () => {
+      // #given
+      const session: SessionSnapshot = { ...baseSnapshot, savedAt: undefined };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(true);
+    });
+
+    it('returns false when savedAt is exactly at the 30-day cutoff', () => {
+      // #given — "older than 30 days" is strict, so exactly 30 days is still fresh
+      const session: SessionSnapshot = { ...baseSnapshot, savedAt: now - STALE_SESSION_MS };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(false);
+    });
+
+    it('returns true when savedAt is 1ms past the 30-day cutoff', () => {
+      // #given
+      const session: SessionSnapshot = { ...baseSnapshot, savedAt: now - STALE_SESSION_MS - 1 };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(true);
+    });
+
+    it('returns false for a session saved just now', () => {
+      // #given
+      const session: SessionSnapshot = { ...baseSnapshot, savedAt: now };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(false);
+    });
+
+    it('returns false for a session saved 1 day ago', () => {
+      // #given
+      const session: SessionSnapshot = {
+        ...baseSnapshot,
+        savedAt: now - 24 * 60 * 60 * 1000,
+      };
+
+      // #when / #then
+      expect(isSessionStale(session, now)).toBe(false);
+    });
+
+    it('uses Date.now() when now is not provided', () => {
+      // #given — savedAt 1 second ago relative to real clock
+      const session: SessionSnapshot = { ...baseSnapshot, savedAt: Date.now() - 1000 };
+
+      // #when / #then
+      expect(isSessionStale(session)).toBe(false);
     });
   });
 

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -2,6 +2,9 @@ import type { MediaTrack, ProviderId } from '@/types/domain';
 
 const SESSION_KEY = 'vorbis-player-last-session';
 
+/** Sessions older than this are treated as absent for landing routing. */
+export const STALE_SESSION_MS = 30 * 24 * 60 * 60 * 1000;
+
 export interface SessionSnapshot {
   collectionId: string;
   collectionName: string;
@@ -56,6 +59,20 @@ export function loadSession(): SessionSnapshot | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns true when the session is absent, missing a savedAt timestamp, or
+ * older than STALE_SESSION_MS. Callers use this to decide whether to surface
+ * resume affordances on the landing view.
+ */
+export function isSessionStale(
+  session: SessionSnapshot | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!session) return true;
+  if (typeof session.savedAt !== 'number') return true;
+  return now - session.savedAt > STALE_SESSION_MS;
 }
 
 export function clearSession(): void {


### PR DESCRIPTION
## Summary

Replaces the binary `showLibrary` in `PlayerStateRenderer` with a routing function keyed on `{ welcomeSeen, lastSession, qapEnabled }`:

- `welcomeSeen === false` → `<WelcomeScreen />` (supersedes all other inputs)
- valid `lastSession` + `qapEnabled` → `<QuickAccessPanel />` with Resume hero
- valid `lastSession` + `!qapEnabled` → calls `handleHydrate` once on mount, shows a "Restoring Your Session" placeholder until the parent flips to `PlayerContent`
- no/stale session + `qapEnabled` → `<QuickAccessPanel />`
- no/stale session + `!qapEnabled` → `<LibraryPage />`

Adds `isSessionStale(session, now)` + `STALE_SESSION_MS = 30d` to `src/services/sessionPersistence.ts` so the router and future callers share the same freshness definition. Absent sessions and sessions missing `savedAt` are treated as stale.

"Browse Library" remains a one-way door via a local `libraryOverride`.

Closes #1155.

## Dependencies

This branch stacks on #1153, #1154, and #1156. PR depends on #1160, #1161, #1162 being merged first — the base diff will show only 1155's changes once those land; before then it shows the stack.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1191/1191 green, including:
  - All five routing branches in `PlayerStateRenderer.test.tsx`
  - `welcomeSeen === false` supersedes a valid session
  - `onHydrate` called exactly once on mount for QAP-off returning-user branch; not called for stale sessions
  - Browse-Library override locks route to library
  - `isSessionStale` edge cases: null/undefined session, missing savedAt, exact 30-day boundary, 1ms past boundary
- [x] `npm run build` clean