### PR TITLE
chore: tidy codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ dist-ssr
 public/audio/
 .claude/settings.local.json
 .claude/HANDOFF.md
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Electron build outputs
 dist-electron/


### PR DESCRIPTION
## Summary

Codebase hygiene sweep after the desktop landing rework release (#1166).

- Add `.claude/scheduled_tasks.lock` to `.gitignore` — runtime per-session lockfile that should never be committed.
- Add `.claude/worktrees/` to `.gitignore` — manual-fallback worktree root used by `/swarmkit:squad` when the Agent Teams backend ignores `isolation: "worktree"` (smallorbit-plugins#362).

Companion local cleanup (already applied locally, no commit needed):
- Removed merged local branch `rc/2026-04-19.8`.
- Removed empty `.claude/worktrees/` directory.
- Removed stale `.claude/scheduled_tasks.lock` file.

## Test plan

- [x] `npm run test:run` — 1199/1199 passing
- [x] No source code changes; only `.gitignore`