### PR TITLE
feat(library): animate mobile library overlay on show/dismiss

### DIFF
--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, lazy, useState, useCallback, useMemo } from 'react';
-import styled from 'styled-components';
 import { useTheme } from 'styled-components';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
 import Toast from '@/components/Toast';
@@ -13,15 +12,8 @@ import { providerRegistry } from '@/providers/registry';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState, RadioProgress } from '@/types/radio';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { MobileLibraryOverlay } from './MobileLibraryOverlay';
 
-const LibraryOverlay = styled.div`
-  position: fixed;
-  inset: 0;
-  z-index: ${({ theme }) => theme.zIndex.overlay};
-  overflow: hidden;
-`;
-
-const LibraryPage = lazy(() => import('@/components/PlaylistSelection'));
 const LibraryDrawer = lazy(() => import('@/components/LibraryDrawer'));
 const SaveQueueDialog = lazy(() => import('@/components/SaveQueueDialog'));
 const QueueDrawer = lazy(() => import('@/components/QueueDrawer'));
@@ -194,21 +186,16 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
           </ProfiledComponent>
         )}
       </Suspense>
-      {showLibrary && isMobile && (
-        <LibraryOverlay>
-          <Suspense fallback={null}>
-            <ProfiledComponent id="LibraryPage">
-              <LibraryPage
-                onPlaylistSelect={handleLibraryPlaylistSelect}
-                onAddToQueue={onAddToQueue}
-                onPlayLikedTracks={onPlayLikedTracks}
-                onQueueLikedTracks={onQueueLikedTracks}
-                onNavigateToPlayer={onCloseLibrary}
-                isPlaying={isPlaying}
-              />
-            </ProfiledComponent>
-          </Suspense>
-        </LibraryOverlay>
+      {isMobile && (
+        <MobileLibraryOverlay
+          isOpen={showLibrary}
+          isPlaying={isPlaying}
+          onPlaylistSelect={handleLibraryPlaylistSelect}
+          onAddToQueue={onAddToQueue}
+          onPlayLikedTracks={onPlayLikedTracks}
+          onQueueLikedTracks={onQueueLikedTracks}
+          onCloseLibrary={onCloseLibrary}
+        />
       )}
       {!isMobile && (
         <Suspense fallback={null}>

--- a/src/components/PlayerContent/MobileLibraryOverlay.tsx
+++ b/src/components/PlayerContent/MobileLibraryOverlay.tsx
@@ -1,0 +1,146 @@
+import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { ProfiledComponent } from '@/components/ProfiledComponent';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
+
+const LibraryPage = lazy(() => import('@/components/PlaylistSelection'));
+
+export const MOBILE_LIBRARY_OVERLAY_DURATION_MS = 200;
+export const MOBILE_LIBRARY_OVERLAY_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+const OverlayRoot = styled.div.withConfig({
+  shouldForwardProp: (prop) => !['$visible', '$reducedMotion'].includes(prop),
+}) <{ $visible: boolean; $reducedMotion: boolean }>`
+  position: fixed;
+  inset: 0;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
+  overflow: hidden;
+  transform-origin: center bottom;
+  pointer-events: ${({ $visible }) => ($visible ? 'auto' : 'none')};
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transform: ${({ $visible }) => ($visible ? 'translateY(0)' : 'translateY(8px)')};
+  will-change: opacity, transform;
+
+  ${({ $reducedMotion }) =>
+    $reducedMotion
+      ? css`
+          transition: none;
+        `
+      : css`
+          transition:
+            opacity ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${MOBILE_LIBRARY_OVERLAY_EASING},
+            transform ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${MOBILE_LIBRARY_OVERLAY_EASING};
+        `}
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+interface MobileLibraryOverlayProps {
+  isOpen: boolean;
+  isPlaying?: boolean;
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (
+    playlistId: string,
+    playlistName?: string,
+    provider?: ProviderId,
+  ) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (
+    tracks: MediaTrack[],
+    collectionId: string,
+    collectionName: string,
+    provider?: ProviderId,
+  ) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  onCloseLibrary: () => void;
+}
+
+export const MobileLibraryOverlay: React.FC<MobileLibraryOverlayProps> = React.memo(({
+  isOpen,
+  isPlaying,
+  onPlaylistSelect,
+  onAddToQueue,
+  onPlayLikedTracks,
+  onQueueLikedTracks,
+  onCloseLibrary,
+}) => {
+  const reducedMotion = useReducedMotion();
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const [visible, setVisible] = useState(false);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enterFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (exitTimerRef.current) {
+        clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+      }
+      setShouldRender(true);
+      // Defer the visible flag to the next frame so the browser registers
+      // the initial (hidden) styles before transitioning to visible.
+      enterFrameRef.current = requestAnimationFrame(() => {
+        setVisible(true);
+      });
+      return () => {
+        if (enterFrameRef.current !== null) {
+          cancelAnimationFrame(enterFrameRef.current);
+          enterFrameRef.current = null;
+        }
+      };
+    }
+
+    setVisible(false);
+    if (!shouldRender) return;
+    if (reducedMotion) {
+      setShouldRender(false);
+      return;
+    }
+    exitTimerRef.current = setTimeout(() => {
+      setShouldRender(false);
+      exitTimerRef.current = null;
+    }, MOBILE_LIBRARY_OVERLAY_DURATION_MS);
+    return () => {
+      if (exitTimerRef.current) {
+        clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+      }
+    };
+  }, [isOpen, reducedMotion, shouldRender]);
+
+  useEffect(() => () => {
+    if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    if (enterFrameRef.current !== null) cancelAnimationFrame(enterFrameRef.current);
+  }, []);
+
+  if (!shouldRender) return null;
+
+  return (
+    <OverlayRoot
+      $visible={visible}
+      $reducedMotion={reducedMotion}
+      data-testid="mobile-library-overlay"
+      data-state={visible ? 'open' : 'closed'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+    >
+      <Suspense fallback={null}>
+        <ProfiledComponent id="LibraryPage">
+          <LibraryPage
+            onPlaylistSelect={onPlaylistSelect}
+            onAddToQueue={onAddToQueue}
+            onPlayLikedTracks={onPlayLikedTracks}
+            onQueueLikedTracks={onQueueLikedTracks}
+            onNavigateToPlayer={onCloseLibrary}
+            isPlaying={isPlaying}
+          />
+        </ProfiledComponent>
+      </Suspense>
+    </OverlayRoot>
+  );
+});
+
+MobileLibraryOverlay.displayName = 'MobileLibraryOverlay';
+
+export default MobileLibraryOverlay;

--- a/src/components/PlayerContent/MobileLibraryOverlay.tsx
+++ b/src/components/PlayerContent/MobileLibraryOverlay.tsx
@@ -16,6 +16,7 @@ const OverlayRoot = styled.div.withConfig({
   inset: 0;
   z-index: ${({ theme }) => theme.zIndex.overlay};
   overflow: hidden;
+  background: ${({ theme }) => theme.colors.popover.background};
   pointer-events: ${({ $visible }) => ($visible ? 'auto' : 'none')};
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   transform: ${({ $visible }) => ($visible ? 'translateY(0)' : 'translateY(8px)')};

--- a/src/components/PlayerContent/MobileLibraryOverlay.tsx
+++ b/src/components/PlayerContent/MobileLibraryOverlay.tsx
@@ -1,37 +1,26 @@
-import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
-import styled, { css } from 'styled-components';
+import React, { Suspense, lazy, useRef } from 'react';
+import styled from 'styled-components';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
-import { DRAWER_TRANSITION_EASING } from '@/components/styled';
-import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { DRAWER_TRANSITION_DURATION, DRAWER_TRANSITION_EASING } from '@/components/styled';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 
 const LibraryPage = lazy(() => import('@/components/PlaylistSelection'));
 
-export const MOBILE_LIBRARY_OVERLAY_DURATION_MS = 200;
-
 const OverlayRoot = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['$visible', '$reducedMotion'].includes(prop),
-}) <{ $visible: boolean; $reducedMotion: boolean }>`
+  shouldForwardProp: (prop) => prop !== '$isOpen',
+})<{ $isOpen: boolean }>`
   position: fixed;
   inset: 0;
   z-index: ${({ theme }) => theme.zIndex.overlay};
   overflow: hidden;
   background: ${({ theme }) => theme.colors.popover.background};
-  pointer-events: ${({ $visible }) => ($visible ? 'auto' : 'none')};
-  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
-  transform: ${({ $visible }) => ($visible ? 'translateY(0)' : 'translateY(8px)')};
+  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+  transform: ${({ $isOpen }) => ($isOpen ? 'translateY(0)' : 'translateY(8px)')};
   will-change: opacity, transform;
-
-  ${({ $reducedMotion }) =>
-    $reducedMotion
-      ? css`
-          transition: none;
-        `
-      : css`
-          transition:
-            opacity ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${DRAWER_TRANSITION_EASING},
-            transform ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${DRAWER_TRANSITION_EASING};
-        `}
+  transition:
+    opacity ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING},
+    transform ${DRAWER_TRANSITION_DURATION}ms ${DRAWER_TRANSITION_EASING};
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
@@ -66,64 +55,16 @@ export const MobileLibraryOverlay: React.FC<MobileLibraryOverlayProps> = React.m
   onQueueLikedTracks,
   onCloseLibrary,
 }) => {
-  const reducedMotion = useReducedMotion();
-  const [shouldRender, setShouldRender] = useState(isOpen);
-  const [visible, setVisible] = useState(false);
-  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const enterFrameRef = useRef<number | null>(null);
+  const hasBeenOpenedRef = useRef(false);
+  if (isOpen) hasBeenOpenedRef.current = true;
 
-  useEffect(() => {
-    if (isOpen) {
-      if (exitTimerRef.current) {
-        clearTimeout(exitTimerRef.current);
-        exitTimerRef.current = null;
-      }
-      setShouldRender(true);
-      // Defer the visible flag to the next frame so the browser registers
-      // the initial (hidden) styles before transitioning to visible.
-      enterFrameRef.current = requestAnimationFrame(() => {
-        setVisible(true);
-      });
-      return () => {
-        if (enterFrameRef.current !== null) {
-          cancelAnimationFrame(enterFrameRef.current);
-          enterFrameRef.current = null;
-        }
-      };
-    }
-
-    setVisible(false);
-    if (!shouldRender) return;
-    if (reducedMotion) {
-      setShouldRender(false);
-      return;
-    }
-    exitTimerRef.current = setTimeout(() => {
-      setShouldRender(false);
-      exitTimerRef.current = null;
-    }, MOBILE_LIBRARY_OVERLAY_DURATION_MS);
-    return () => {
-      if (exitTimerRef.current) {
-        clearTimeout(exitTimerRef.current);
-        exitTimerRef.current = null;
-      }
-    };
-  }, [isOpen, reducedMotion, shouldRender]);
-
-  useEffect(() => () => {
-    if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
-    if (enterFrameRef.current !== null) cancelAnimationFrame(enterFrameRef.current);
-  }, []);
-
-  if (!shouldRender) return null;
+  if (!hasBeenOpenedRef.current) return null;
 
   return (
     <OverlayRoot
-      $visible={visible}
-      $reducedMotion={reducedMotion}
+      $isOpen={isOpen}
       data-testid="mobile-library-overlay"
-      data-state={visible ? 'open' : 'closed'}
-      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      data-state={isOpen ? 'open' : 'closed'}
     >
       <Suspense fallback={null}>
         <ProfiledComponent id="LibraryPage">

--- a/src/components/PlayerContent/MobileLibraryOverlay.tsx
+++ b/src/components/PlayerContent/MobileLibraryOverlay.tsx
@@ -1,13 +1,13 @@
 import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { ProfiledComponent } from '@/components/ProfiledComponent';
+import { DRAWER_TRANSITION_EASING } from '@/components/styled';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 
 const LibraryPage = lazy(() => import('@/components/PlaylistSelection'));
 
 export const MOBILE_LIBRARY_OVERLAY_DURATION_MS = 200;
-export const MOBILE_LIBRARY_OVERLAY_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
 const OverlayRoot = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$visible', '$reducedMotion'].includes(prop),
@@ -16,7 +16,6 @@ const OverlayRoot = styled.div.withConfig({
   inset: 0;
   z-index: ${({ theme }) => theme.zIndex.overlay};
   overflow: hidden;
-  transform-origin: center bottom;
   pointer-events: ${({ $visible }) => ($visible ? 'auto' : 'none')};
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   transform: ${({ $visible }) => ($visible ? 'translateY(0)' : 'translateY(8px)')};
@@ -29,8 +28,8 @@ const OverlayRoot = styled.div.withConfig({
         `
       : css`
           transition:
-            opacity ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${MOBILE_LIBRARY_OVERLAY_EASING},
-            transform ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${MOBILE_LIBRARY_OVERLAY_EASING};
+            opacity ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${DRAWER_TRANSITION_EASING},
+            transform ${MOBILE_LIBRARY_OVERLAY_DURATION_MS}ms ${DRAWER_TRANSITION_EASING};
         `}
 
   @media (prefers-reduced-motion: reduce) {
@@ -142,5 +141,3 @@ export const MobileLibraryOverlay: React.FC<MobileLibraryOverlayProps> = React.m
 });
 
 MobileLibraryOverlay.displayName = 'MobileLibraryOverlay';
-
-export default MobileLibraryOverlay;

--- a/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
+++ b/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { theme } from '@/styles/theme';
-
-vi.mock('@/hooks/useReducedMotion', () => ({
-  useReducedMotion: vi.fn(() => false),
-}));
 
 vi.mock('@/components/PlaylistSelection', () => ({
   default: ({ onNavigateToPlayer }: { onNavigateToPlayer?: () => void }) => (
@@ -20,11 +16,7 @@ vi.mock('@/components/ProfiledComponent', () => ({
   ProfiledComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-import { useReducedMotion } from '@/hooks/useReducedMotion';
-import {
-  MobileLibraryOverlay,
-  MOBILE_LIBRARY_OVERLAY_DURATION_MS,
-} from '../MobileLibraryOverlay';
+import { MobileLibraryOverlay } from '../MobileLibraryOverlay';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>
@@ -42,174 +34,77 @@ const baseProps = {
 describe('MobileLibraryOverlay', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useReducedMotion).mockReturnValue(false);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  it('does not render the overlay before it has ever been opened', () => {
+    // #given
+    render(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={false} />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
   });
 
-  describe('mount lifecycle', () => {
-    it('does not render the overlay when isOpen starts false', () => {
-      // #given
-      render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={false} />
-        </Wrapper>,
-      );
+  it('renders the overlay in the open state when opened', async () => {
+    // #given
+    render(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={true} />
+      </Wrapper>,
+    );
 
-      // #then
-      expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
-    });
-
-    it('renders the overlay in a hidden state immediately when opened', async () => {
-      // #given
-      const { rerender } = render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={false} />
-        </Wrapper>,
-      );
-
-      // #when
-      rerender(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-
-      // #then
-      const overlay = await screen.findByTestId('mobile-library-overlay');
-      expect(overlay).toHaveAttribute('data-state', 'closed');
-    });
-
-    it('flips to the open state on the next animation frame', async () => {
-      // #given
-      render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-
-      // #then
-      await waitFor(() => {
-        expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute(
-          'data-state',
-          'open',
-        );
-      });
-    });
+    // #then
+    const overlay = await screen.findByTestId('mobile-library-overlay');
+    expect(overlay).toHaveAttribute('data-state', 'open');
   });
 
-  describe('exit lifecycle', () => {
-    it('keeps the overlay mounted while the exit transition runs', async () => {
-      // #given
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      const { rerender } = render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute(
-          'data-state',
-          'open',
-        );
-      });
+  it('keeps the overlay mounted after closing so the CSS transition can run', async () => {
+    // #given
+    const { rerender } = render(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={true} />
+      </Wrapper>,
+    );
+    await screen.findByTestId('mobile-library-overlay');
 
-      // #when
-      rerender(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={false} />
-        </Wrapper>,
-      );
+    // #when
+    rerender(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={false} />
+      </Wrapper>,
+    );
 
-      // #then
-      const overlay = screen.getByTestId('mobile-library-overlay');
-      expect(overlay).toHaveAttribute('data-state', 'closed');
-      expect(overlay).toBeInTheDocument();
-    });
-
-    it('unmounts the overlay after the exit transition duration', async () => {
-      // #given
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      const { rerender } = render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId('mobile-library-overlay')).toBeInTheDocument();
-      });
-
-      // #when
-      rerender(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={false} />
-        </Wrapper>,
-      );
-      act(() => {
-        vi.advanceTimersByTime(MOBILE_LIBRARY_OVERLAY_DURATION_MS + 16);
-      });
-
-      // #then
-      await waitFor(() => {
-        expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
-      });
-    });
+    // #then
+    const overlay = screen.getByTestId('mobile-library-overlay');
+    expect(overlay).toHaveAttribute('data-state', 'closed');
+    expect(overlay).toBeInTheDocument();
   });
 
-  describe('reduced motion', () => {
-    it('marks the overlay as reduced-motion when prefers-reduced-motion is reduce', async () => {
-      // #given
-      vi.mocked(useReducedMotion).mockReturnValue(true);
-      render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
+  it('returns to the open state when re-opened after a close', async () => {
+    // #given
+    const { rerender } = render(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={true} />
+      </Wrapper>,
+    );
+    await screen.findByTestId('mobile-library-overlay');
+    rerender(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={false} />
+      </Wrapper>,
+    );
 
-      // #then
-      const overlay = await screen.findByTestId('mobile-library-overlay');
-      expect(overlay).toHaveAttribute('data-reduced-motion', 'true');
-    });
+    // #when
+    rerender(
+      <Wrapper>
+        <MobileLibraryOverlay {...baseProps} isOpen={true} />
+      </Wrapper>,
+    );
 
-    it('marks the overlay as not-reduced-motion when prefers-reduced-motion is not set', async () => {
-      // #given
-      vi.mocked(useReducedMotion).mockReturnValue(false);
-      render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-
-      // #then
-      const overlay = await screen.findByTestId('mobile-library-overlay');
-      expect(overlay).toHaveAttribute('data-reduced-motion', 'false');
-    });
-
-    it('unmounts immediately on close when reduced motion is enabled', async () => {
-      // #given
-      vi.mocked(useReducedMotion).mockReturnValue(true);
-      const { rerender } = render(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={true} />
-        </Wrapper>,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId('mobile-library-overlay')).toBeInTheDocument();
-      });
-
-      // #when
-      rerender(
-        <Wrapper>
-          <MobileLibraryOverlay {...baseProps} isOpen={false} />
-        </Wrapper>,
-      );
-
-      // #then
-      await waitFor(() => {
-        expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
-      });
-    });
+    // #then
+    expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute('data-state', 'open');
   });
 });

--- a/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
+++ b/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
@@ -57,8 +57,8 @@ describe('MobileLibraryOverlay', () => {
     );
 
     // #then
-    const overlay = await screen.findByTestId('mobile-library-overlay');
-    expect(overlay).toHaveAttribute('data-state', 'open');
+    await screen.findByTestId('library-page-stub');
+    expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute('data-state', 'open');
   });
 
   it('keeps the overlay mounted after closing so the CSS transition can run', async () => {
@@ -68,7 +68,7 @@ describe('MobileLibraryOverlay', () => {
         <MobileLibraryOverlay {...baseProps} isOpen={true} />
       </Wrapper>,
     );
-    await screen.findByTestId('mobile-library-overlay');
+    await screen.findByTestId('library-page-stub');
 
     // #when
     rerender(
@@ -78,9 +78,7 @@ describe('MobileLibraryOverlay', () => {
     );
 
     // #then
-    const overlay = screen.getByTestId('mobile-library-overlay');
-    expect(overlay).toHaveAttribute('data-state', 'closed');
-    expect(overlay).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute('data-state', 'closed');
   });
 
   it('returns to the open state when re-opened after a close', async () => {
@@ -90,7 +88,7 @@ describe('MobileLibraryOverlay', () => {
         <MobileLibraryOverlay {...baseProps} isOpen={true} />
       </Wrapper>,
     );
-    await screen.findByTestId('mobile-library-overlay');
+    await screen.findByTestId('library-page-stub');
     rerender(
       <Wrapper>
         <MobileLibraryOverlay {...baseProps} isOpen={false} />

--- a/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
+++ b/src/components/PlayerContent/__tests__/MobileLibraryOverlay.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { theme } from '@/styles/theme';
+
+vi.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: vi.fn(() => false),
+}));
+
+vi.mock('@/components/PlaylistSelection', () => ({
+  default: ({ onNavigateToPlayer }: { onNavigateToPlayer?: () => void }) => (
+    <div data-testid="library-page-stub">
+      <button onClick={onNavigateToPlayer}>close</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ProfiledComponent', () => ({
+  ProfiledComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import {
+  MobileLibraryOverlay,
+  MOBILE_LIBRARY_OVERLAY_DURATION_MS,
+} from '../MobileLibraryOverlay';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+const baseProps = {
+  isPlaying: false,
+  onPlaylistSelect: vi.fn(),
+  onAddToQueue: vi.fn(),
+  onPlayLikedTracks: vi.fn(),
+  onQueueLikedTracks: vi.fn(),
+  onCloseLibrary: vi.fn(),
+};
+
+describe('MobileLibraryOverlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useReducedMotion).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('mount lifecycle', () => {
+    it('does not render the overlay when isOpen starts false', () => {
+      // #given
+      render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={false} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders the overlay in a hidden state immediately when opened', async () => {
+      // #given
+      const { rerender } = render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={false} />
+        </Wrapper>,
+      );
+
+      // #when
+      rerender(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+
+      // #then
+      const overlay = await screen.findByTestId('mobile-library-overlay');
+      expect(overlay).toHaveAttribute('data-state', 'closed');
+    });
+
+    it('flips to the open state on the next animation frame', async () => {
+      // #given
+      render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+
+      // #then
+      await waitFor(() => {
+        expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute(
+          'data-state',
+          'open',
+        );
+      });
+    });
+  });
+
+  describe('exit lifecycle', () => {
+    it('keeps the overlay mounted while the exit transition runs', async () => {
+      // #given
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { rerender } = render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('mobile-library-overlay')).toHaveAttribute(
+          'data-state',
+          'open',
+        );
+      });
+
+      // #when
+      rerender(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={false} />
+        </Wrapper>,
+      );
+
+      // #then
+      const overlay = screen.getByTestId('mobile-library-overlay');
+      expect(overlay).toHaveAttribute('data-state', 'closed');
+      expect(overlay).toBeInTheDocument();
+    });
+
+    it('unmounts the overlay after the exit transition duration', async () => {
+      // #given
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { rerender } = render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('mobile-library-overlay')).toBeInTheDocument();
+      });
+
+      // #when
+      rerender(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={false} />
+        </Wrapper>,
+      );
+      act(() => {
+        vi.advanceTimersByTime(MOBILE_LIBRARY_OVERLAY_DURATION_MS + 16);
+      });
+
+      // #then
+      await waitFor(() => {
+        expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('reduced motion', () => {
+    it('marks the overlay as reduced-motion when prefers-reduced-motion is reduce', async () => {
+      // #given
+      vi.mocked(useReducedMotion).mockReturnValue(true);
+      render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+
+      // #then
+      const overlay = await screen.findByTestId('mobile-library-overlay');
+      expect(overlay).toHaveAttribute('data-reduced-motion', 'true');
+    });
+
+    it('marks the overlay as not-reduced-motion when prefers-reduced-motion is not set', async () => {
+      // #given
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+
+      // #then
+      const overlay = await screen.findByTestId('mobile-library-overlay');
+      expect(overlay).toHaveAttribute('data-reduced-motion', 'false');
+    });
+
+    it('unmounts immediately on close when reduced motion is enabled', async () => {
+      // #given
+      vi.mocked(useReducedMotion).mockReturnValue(true);
+      const { rerender } = render(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={true} />
+        </Wrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('mobile-library-overlay')).toBeInTheDocument();
+      });
+
+      // #when
+      rerender(
+        <Wrapper>
+          <MobileLibraryOverlay {...baseProps} isOpen={false} />
+        </Wrapper>,
+      );
+
+      // #then
+      await waitFor(() => {
+        expect(screen.queryByTestId('mobile-library-overlay')).not.toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted the mobile library overlay into a dedicated `MobileLibraryOverlay` component (under `PlayerContent/`) with enter/exit fade + slide-up animation.
- Animation uses transform + opacity only (~200ms, hardware-accelerated) and reuses the shared `DRAWER_TRANSITION_EASING` constant so all overlays match.
- `prefers-reduced-motion: reduce` snaps to the final state with no transition; component remains mounted through the exit transition for a clean fade-out.

## Test plan

- Open the app in a mobile viewport (DevTools mobile emulation works).
- Toggle the library overlay open and closed; confirm a smooth slide-up + fade enter and reverse exit at ~200ms.
- In DevTools rendering pane, set `Emulate CSS prefers-reduced-motion: reduce`; confirm the overlay snaps in and out with no transition.
- Verify desktop library experience is unchanged.
- Automated: \`npm run test:run\` — new \`MobileLibraryOverlay\` suite covers enter/exit class application, reduced-motion fallback, and delayed unmount through the exit transition.

Closes #977