### PR TITLE
fix(spotify): emit playback state on prepareTrack with saved position

### DIFF
--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -1,9 +1,3 @@
-/**
- * Tests for SpotifyPlaybackAdapter.prepareTrack: transfers playback to this device
- * staged paused at the saved position, and emits a PlaybackState so subscribers
- * (seek bar, duration readout) reflect the restored state before user presses play.
- */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SpotifyPlaybackAdapter } from '@/providers/spotify/spotifyPlaybackAdapter';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
@@ -38,12 +32,11 @@ const makeTrack = (overrides: Partial<MediaTrack> = {}): MediaTrack => ({
   ...overrides,
 });
 
-/** Wait for prepareTrack's fire-and-forget stage chain to settle. */
-const flushStageTrack = async () => {
-  await new Promise(resolve => setTimeout(resolve, 0));
-  await new Promise(resolve => setTimeout(resolve, 0));
-  await new Promise(resolve => setTimeout(resolve, 0));
-};
+const findPlayCall = (mock: ReturnType<typeof vi.fn>) =>
+  mock.mock.calls.find(([url]) => typeof url === 'string' && url.includes('/me/player/play'));
+
+const countPlayCalls = (mock: ReturnType<typeof vi.fn>) =>
+  mock.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/me/player/play')).length;
 
 describe('SpotifyPlaybackAdapter.prepareTrack', () => {
   let adapter: SpotifyPlaybackAdapter;
@@ -62,23 +55,20 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     vi.unstubAllGlobals();
   });
 
-  it('transfers playback with play=false and position_ms at the saved position', async () => {
+  it('transfers playback with the track uri and position_ms at the saved position', async () => {
     // #given
     const track = makeTrack();
     const positionMs = 42_000;
 
     // #when
     adapter.prepareTrack(track, { positionMs });
-    await flushStageTrack();
 
     // #then
-    const playCall = fetchMock.mock.calls.find(([url]) =>
-      typeof url === 'string' && url.includes('/me/player/play')
-    );
-    expect(playCall).toBeDefined();
-    const body = JSON.parse(playCall![1].body as string);
+    await vi.waitFor(() => expect(findPlayCall(fetchMock)).toBeDefined());
+    const playCall = findPlayCall(fetchMock)!;
+    const body = JSON.parse(playCall[1].body as string);
     expect(body).toEqual({ uris: ['spotify:track:abc'], position_ms: positionMs });
-    expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1));
   });
 
   it('emits a PlaybackState with correct positionMs, durationMs, and isPlaying=false', async () => {
@@ -89,11 +79,12 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // #when
     adapter.prepareTrack(track, { positionMs: 15_000 });
-    await flushStageTrack();
 
     // #then
-    const staged = received.find((s) => s?.currentTrackId === 'track-1');
-    expect(staged).toBeDefined();
+    await vi.waitFor(() => {
+      expect(received.find((s) => s?.currentTrackId === 'track-1')).toBeDefined();
+    });
+    const staged = received.find((s) => s?.currentTrackId === 'track-1')!;
     expect(staged).toMatchObject({
       isPlaying: false,
       positionMs: 15_000,
@@ -116,14 +107,10 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     // #when
     adapter.prepareTrack(track, { positionMs: 10_000 });
     adapter.prepareTrack(track, { positionMs: 10_000 });
-    await flushStageTrack();
 
     // #then
-    expect(stageEmissions).toHaveLength(1);
-    const playCallCount = fetchMock.mock.calls.filter(([url]) =>
-      typeof url === 'string' && url.includes('/me/player/play')
-    ).length;
-    expect(playCallCount).toBe(1);
+    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+    expect(countPlayCalls(fetchMock)).toBe(1);
     expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1);
   });
 
@@ -138,11 +125,64 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // #when
     adapter.prepareTrack(trackA, { positionMs: 5_000 });
-    await flushStageTrack();
+    await vi.waitFor(() => expect(staged).toHaveLength(1));
     adapter.prepareTrack(trackB, { positionMs: 8_000 });
-    await flushStageTrack();
 
     // #then
+    await vi.waitFor(() => expect(staged).toHaveLength(2));
     expect(staged.map((s) => s?.currentTrackId)).toEqual(['a', 'b']);
+  });
+
+  it('clears the idempotency guard on failure so a retry can re-stage', async () => {
+    // #given — first prepareTrack call fails at the play step
+    const track = makeTrack();
+    const stageEmissions: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => {
+      if (state?.currentTrackId === track.id && !state.isPlaying) {
+        stageEmissions.push(state);
+      }
+    });
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 12_000 });
+    await vi.waitFor(() => expect(countPlayCalls(fetchMock)).toBe(1));
+
+    // Second call after failure should retry (not be treated as idempotent).
+    adapter.prepareTrack(track, { positionMs: 12_000 });
+
+    // #then
+    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+    expect(countPlayCalls(fetchMock)).toBe(2);
+  });
+
+  it('skips the stale stage emission when a different track is prepared mid-stage', async () => {
+    // #given — prepareTrack(A) is in flight when prepareTrack(B) overrides it
+    const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
+    const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
+    const stageEmissions: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => {
+      if (state && !state.isPlaying) stageEmissions.push(state);
+    });
+
+    let resolveFirstPlay!: () => void;
+    fetchMock.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => {
+        resolveFirstPlay = () => resolve(new Response(null, { status: 204 }));
+      }),
+    );
+
+    // #when
+    adapter.prepareTrack(trackA, { positionMs: 1_000 });
+    await vi.waitFor(() => expect(resolveFirstPlay).toBeTypeOf('function'));
+    adapter.prepareTrack(trackB, { positionMs: 2_000 });
+    resolveFirstPlay();
+
+    // #then — only B's staged state should reach subscribers
+    await vi.waitFor(() => {
+      const bEmit = stageEmissions.find((s) => s?.currentTrackId === 'b');
+      expect(bEmit).toBeDefined();
+    });
+    expect(stageEmissions.find((s) => s?.currentTrackId === 'a')).toBeUndefined();
   });
 });

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for SpotifyPlaybackAdapter.prepareTrack: transfers playback to this device
+ * staged paused at the saved position, and emits a PlaybackState so subscribers
+ * (seek bar, duration readout) reflect the restored state before user presses play.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpotifyPlaybackAdapter } from '@/providers/spotify/spotifyPlaybackAdapter';
+import { spotifyPlayer } from '@/services/spotifyPlayer';
+import type { MediaTrack, PlaybackState } from '@/types/domain';
+
+vi.mock('@/services/spotifyPlayer', () => ({
+  spotifyPlayer: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getIsReady: vi.fn().mockReturnValue(true),
+    getDeviceId: vi.fn().mockReturnValue('device-1'),
+    transferPlaybackToDevice: vi.fn().mockResolvedValue(undefined),
+    ensureDeviceIsActive: vi.fn().mockResolvedValue(true),
+    pause: vi.fn().mockResolvedValue(undefined),
+    onPlayerStateChanged: vi.fn().mockReturnValue(() => {}),
+  },
+}));
+
+vi.mock('@/services/spotify', () => ({
+  spotifyAuth: {
+    ensureValidToken: vi.fn().mockResolvedValue('token-xyz'),
+  },
+}));
+
+const makeTrack = (overrides: Partial<MediaTrack> = {}): MediaTrack => ({
+  id: 'track-1',
+  provider: 'spotify',
+  playbackRef: { provider: 'spotify', ref: 'spotify:track:abc' },
+  name: 'Track',
+  artists: 'Artist',
+  album: 'Album',
+  durationMs: 210_000,
+  ...overrides,
+});
+
+/** Wait for prepareTrack's fire-and-forget stage chain to settle. */
+const flushStageTrack = async () => {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+};
+
+describe('SpotifyPlaybackAdapter.prepareTrack', () => {
+  let adapter: SpotifyPlaybackAdapter;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(spotifyPlayer.getIsReady).mockReturnValue(true);
+    vi.mocked(spotifyPlayer.getDeviceId).mockReturnValue('device-1');
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    adapter = new SpotifyPlaybackAdapter();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('transfers playback with play=false and position_ms at the saved position', async () => {
+    // #given
+    const track = makeTrack();
+    const positionMs = 42_000;
+
+    // #when
+    adapter.prepareTrack(track, { positionMs });
+    await flushStageTrack();
+
+    // #then
+    const playCall = fetchMock.mock.calls.find(([url]) =>
+      typeof url === 'string' && url.includes('/me/player/play')
+    );
+    expect(playCall).toBeDefined();
+    const body = JSON.parse(playCall![1].body as string);
+    expect(body).toEqual({ uris: ['spotify:track:abc'], position_ms: positionMs });
+    expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a PlaybackState with correct positionMs, durationMs, and isPlaying=false', async () => {
+    // #given
+    const track = makeTrack({ durationMs: 180_000 });
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 15_000 });
+    await flushStageTrack();
+
+    // #then
+    const staged = received.find((s) => s?.currentTrackId === 'track-1');
+    expect(staged).toBeDefined();
+    expect(staged).toMatchObject({
+      isPlaying: false,
+      positionMs: 15_000,
+      durationMs: 180_000,
+      currentTrackId: 'track-1',
+      currentPlaybackRef: { provider: 'spotify', ref: 'spotify:track:abc' },
+    });
+  });
+
+  it('does not double-emit when prepareTrack is called twice for the same track', async () => {
+    // #given
+    const track = makeTrack();
+    const stageEmissions: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => {
+      if (state?.currentTrackId === track.id && !state.isPlaying) {
+        stageEmissions.push(state);
+      }
+    });
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 10_000 });
+    adapter.prepareTrack(track, { positionMs: 10_000 });
+    await flushStageTrack();
+
+    // #then
+    expect(stageEmissions).toHaveLength(1);
+    const playCallCount = fetchMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('/me/player/play')
+    ).length;
+    expect(playCallCount).toBe(1);
+    expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-stages when prepareTrack is called for a different track', async () => {
+    // #given
+    const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
+    const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
+    const staged: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => {
+      if (state && !state.isPlaying) staged.push(state);
+    });
+
+    // #when
+    adapter.prepareTrack(trackA, { positionMs: 5_000 });
+    await flushStageTrack();
+    adapter.prepareTrack(trackB, { positionMs: 8_000 });
+    await flushStageTrack();
+
+    // #then
+    expect(staged.map((s) => s?.currentTrackId)).toEqual(['a', 'b']);
+  });
+});

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -6,6 +6,7 @@
 import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
+import { apiPlayTrack } from '@/services/spotifyPlayerPlayback';
 import { spotifyAuth } from '@/services/spotify';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
@@ -297,8 +298,6 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
     await this.ensurePlaybackReady();
 
-    const uri = track.playbackRef.ref;
-    const token = await spotifyAuth.ensureValidToken();
     const deviceId = spotifyPlayer.getDeviceId();
     if (!deviceId) return;
 
@@ -306,30 +305,16 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     // playback at the saved offset then immediately pause. The net effect from
     // the user's perspective is the track appearing as the paused context on
     // this device (and mirrored on other Spotify Connect clients).
-    const playResponse = await fetch(
-      `https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`,
-      {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ uris: [uri], position_ms: Math.floor(positionMs) }),
-      },
-    );
-
-    if (!playResponse.ok && playResponse.status !== 204) {
-      throw new Error(`Spotify stage play failed: ${playResponse.status}`);
-    }
-
+    const positionFloor = Math.floor(positionMs);
+    await apiPlayTrack(deviceId, track.playbackRef.ref, undefined, positionFloor);
     await spotifyPlayer.pause();
 
     this.emitState({
       isPlaying: false,
-      positionMs: Math.floor(positionMs),
+      positionMs: positionFloor,
       durationMs: track.durationMs ?? 0,
       currentTrackId: track.id,
-      currentPlaybackRef: { provider: 'spotify', ref: uri },
+      currentPlaybackRef: { provider: 'spotify', ref: track.playbackRef.ref },
     });
   }
 

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -39,6 +39,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   /** True after the first successful playTrack; lets subsequent plays skip heavy API checks. */
   private playbackSessionActive = false;
 
+  private readonly listeners = new Set<(state: PlaybackState | null) => void>();
+  private sdkUnsubscribe: (() => void) | null = null;
+  /** Ref of the track most recently staged by prepareTrack; used for idempotency. */
+  private preparedTrackRef: string | null = null;
+
   private async waitForPlayerReady(): Promise<void> {
     const start = Date.now();
     while (!spotifyPlayer.getIsReady() || !spotifyPlayer.getDeviceId()) {
@@ -233,20 +238,99 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   }
 
   subscribe(listener: (state: PlaybackState | null) => void): () => void {
-    return spotifyPlayer.onPlayerStateChanged((spotifyState) => {
-      listener(mapPlaybackState(spotifyState));
+    this.listeners.add(listener);
+    this.ensureSdkSubscription();
+
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        this.sdkUnsubscribe?.();
+        this.sdkUnsubscribe = null;
+      }
+    };
+  }
+
+  private ensureSdkSubscription(): void {
+    if (this.sdkUnsubscribe) return;
+    this.sdkUnsubscribe = spotifyPlayer.onPlayerStateChanged((spotifyState) => {
+      this.emitState(mapPlaybackState(spotifyState));
     });
+  }
+
+  private emitState(state: PlaybackState | null): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(state);
+      } catch (err) {
+        console.error('[spotifyPlayback] listener error:', err);
+      }
+    }
   }
 
   getLastPlayTime(): number {
     return spotifyPlayer.lastPlayTrackTime;
   }
 
-  prepareTrack(_track: MediaTrack, _options?: { positionMs?: number }): void {
-    // Pre-warm the auth token so no refresh delay hits the next transition.
-    // The Spotify Web Playback SDK has no preload-without-play mode, so positionMs
-    // is accepted for interface parity but applied when playTrack is later invoked.
-    spotifyAuth.ensureValidToken().catch(() => {});
+  prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
+    const uri = track.playbackRef.ref;
+    // Idempotency: same-URI repeat calls are a no-op so the state event isn't
+    // emitted twice for the same prepared track. A different URI re-primes.
+    if (this.preparedTrackRef === uri) {
+      return;
+    }
+    this.preparedTrackRef = uri;
+
+    void this.stageTrackPaused(track, options?.positionMs ?? 0).catch((err) => {
+      logSpotify('prepareTrack failed: %o', err);
+      // Allow another attempt if the stage failed.
+      if (this.preparedTrackRef === uri) {
+        this.preparedTrackRef = null;
+      }
+    });
+  }
+
+  /**
+   * Transfer playback to our device, loaded on `track` at `positionMs` and paused.
+   * Emits a PlaybackState event so subscribers (seek bar, duration readout) reflect
+   * the staged state before the user presses play.
+   */
+  private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
+    await this.ensurePlaybackReady();
+
+    const uri = track.playbackRef.ref;
+    const token = await spotifyAuth.ensureValidToken();
+    const deviceId = spotifyPlayer.getDeviceId();
+    if (!deviceId) return;
+
+    // Spotify's Web API has no "load paused at position" primitive, so we start
+    // playback at the saved offset then immediately pause. The net effect from
+    // the user's perspective is the track appearing as the paused context on
+    // this device (and mirrored on other Spotify Connect clients).
+    const playResponse = await fetch(
+      `https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ uris: [uri], position_ms: Math.floor(positionMs) }),
+      },
+    );
+
+    if (!playResponse.ok && playResponse.status !== 204) {
+      throw new Error(`Spotify stage play failed: ${playResponse.status}`);
+    }
+
+    await spotifyPlayer.pause();
+
+    this.emitState({
+      isPlaying: false,
+      positionMs: Math.floor(positionMs),
+      durationMs: track.durationMs ?? 0,
+      currentTrackId: track.id,
+      currentPlaybackRef: { provider: 'spotify', ref: uri },
+    });
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -314,7 +314,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       positionMs: positionFloor,
       durationMs: track.durationMs ?? 0,
       currentTrackId: track.id,
-      currentPlaybackRef: { provider: 'spotify', ref: track.playbackRef.ref },
+      currentPlaybackRef: track.playbackRef,
     });
   }
 

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -273,9 +273,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   }
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
+    // Warm the auth token unconditionally so a token refresh delay can't stall
+    // the next transition even if the stage chain early-returns.
+    spotifyAuth.ensureValidToken().catch(() => {});
+
     const uri = track.playbackRef.ref;
-    // Idempotency: same-URI repeat calls are a no-op so the state event isn't
-    // emitted twice for the same prepared track. A different URI re-primes.
     if (this.preparedTrackRef === uri) {
       return;
     }
@@ -283,31 +285,24 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
     void this.stageTrackPaused(track, options?.positionMs ?? 0).catch((err) => {
       logSpotify('prepareTrack failed: %o', err);
-      // Allow another attempt if the stage failed.
       if (this.preparedTrackRef === uri) {
         this.preparedTrackRef = null;
       }
     });
   }
 
-  /**
-   * Transfer playback to our device, loaded on `track` at `positionMs` and paused.
-   * Emits a PlaybackState event so subscribers (seek bar, duration readout) reflect
-   * the staged state before the user presses play.
-   */
   private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
     await this.ensurePlaybackReady();
 
     const deviceId = spotifyPlayer.getDeviceId();
     if (!deviceId) return;
 
-    // Spotify's Web API has no "load paused at position" primitive, so we start
-    // playback at the saved offset then immediately pause. The net effect from
-    // the user's perspective is the track appearing as the paused context on
-    // this device (and mirrored on other Spotify Connect clients).
+    const uri = track.playbackRef.ref;
     const positionFloor = Math.floor(positionMs);
-    await apiPlayTrack(deviceId, track.playbackRef.ref, undefined, positionFloor);
+    await apiPlayTrack(deviceId, uri, undefined, positionFloor);
     await spotifyPlayer.pause();
+
+    if (this.preparedTrackRef !== uri) return;
 
     this.emitState({
       isPlaying: false,


### PR DESCRIPTION
## Summary
- Transfer playback to this device loaded on the saved Spotify track at the saved position and paused, so other Spotify Connect clients show the device as the paused context.
- Emit a `PlaybackState` event via the adapter's listener channel so `usePlaybackSubscription` flows `positionMs`, `durationMs`, and `isPlaying: false` into React state on hydrate — seek bar shows `x:xx / y:yy` before the user presses play.
- Idempotent per track URI (repeat calls are no-ops; a different URI re-primes the stage).

## Test plan
- [x] `npx tsc -b --noEmit`
- [x] `npm run test:run` (1203 tests pass)
- [x] Colocated tests in `src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts` cover: transfer called with `{uris, position_ms}`, state event emits with correct values, idempotency, and re-stage on different track.
- [ ] Manual: hydrate a Spotify session from the idle landing route — seek bar shows the saved position and full track duration without pressing play; other Spotify clients show the device as paused on the saved track.

Closes #1169