### PR TITLE
fix(dropbox): emit playback state on prepareTrack with saved position

### DIFF
--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -243,11 +243,8 @@ describe('DropboxPlaybackAdapter', () => {
   });
 
   describe('prepareTrack', () => {
-    const flush = async (): Promise<void> => {
-      for (let i = 0; i < 5; i += 1) {
-        await Promise.resolve();
-      }
-    };
+    const findHydrateCall = (listener: ReturnType<typeof vi.fn>, trackId: string) =>
+      listener.mock.calls.find(([state]) => state?.currentTrackId === trackId);
 
     it('emits paused state with positionMs and durationMs after metadata loads', async () => {
       // #given
@@ -258,20 +255,17 @@ describe('DropboxPlaybackAdapter', () => {
 
       // #when
       adapter.prepareTrack(track, { positionMs: 45_000 });
-      await flush();
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
 
       mockAudio.duration = 200;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 45;
       (mockAudio as any).__triggerEvent('loadedmetadata');
-      await flush();
 
       // #then
-      expect(mockAudio.src).toBe('https://example.com/stream.mp3');
+      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-hydrate')).toBeDefined());
+      const state = findHydrateCall(listener, 'track-hydrate')![0] as PlaybackState;
       expect(mockAudio.currentTime).toBe(45);
-      const hydrateCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-hydrate');
-      expect(hydrateCall).toBeDefined();
-      const state = hydrateCall![0] as PlaybackState;
       expect(state.isPlaying).toBe(false);
       expect(state.positionMs).toBe(45_000);
       expect(state.durationMs).toBe(200_000);
@@ -287,18 +281,16 @@ describe('DropboxPlaybackAdapter', () => {
 
       // #when
       adapter.prepareTrack(track, { positionMs: 10_000 });
-      await flush();
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
 
       mockAudio.duration = Infinity;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 10;
       (mockAudio as any).__triggerEvent('loadedmetadata');
-      await flush();
 
       // #then
-      const hydrateCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-live');
-      expect(hydrateCall).toBeDefined();
-      const state = hydrateCall![0] as PlaybackState;
+      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-live')).toBeDefined());
+      const state = findHydrateCall(listener, 'track-live')![0] as PlaybackState;
       expect(state.isPlaying).toBe(false);
       expect(state.positionMs).toBe(10_000);
       expect(state.durationMs).toBe(0);
@@ -321,11 +313,12 @@ describe('DropboxPlaybackAdapter', () => {
 
       // #when
       adapter.prepareTrack(upcoming);
-      await flush();
 
       // #then
+      await vi.waitFor(() =>
+        expect(mockCatalog.prefetchTemporaryLink).toHaveBeenCalledWith(upcoming.playbackRef.ref),
+      );
       expect(mockAudio.src).toBe('https://example.com/current.mp3');
-      expect(mockCatalog.prefetchTemporaryLink).toHaveBeenCalledWith(upcoming.playbackRef.ref);
     });
 
     it('cancels a pending prepareTrack when a new src is set by playTrack', async () => {
@@ -345,24 +338,44 @@ describe('DropboxPlaybackAdapter', () => {
       await adapter.initialize();
       adapter.subscribe(listener);
 
-      // #when
+      // #when — trackA's src is set and prepareTrack is awaiting loadedmetadata;
+      // playTrack(B) supersedes before the event fires.
       adapter.prepareTrack(trackA, { positionMs: 30_000 });
-      await flush();
-      // trackA's getTemporaryLink has resolved; src is set. Now kick off playTrack for trackB
-      // before the loadedmetadata event for trackA fires.
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/a.mp3'));
       await adapter.playTrack(trackB);
-
       listener.mockClear();
 
       // Now the stale loadedmetadata for the prior src fires.
       mockAudio.duration = 220;
       mockAudio.readyState = 1;
       (mockAudio as any).__triggerEvent('loadedmetadata');
-      await flush();
+      await Promise.resolve();
 
       // #then
-      const staleCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-a');
-      expect(staleCall).toBeUndefined();
+      expect(findHydrateCall(listener, 'track-a')).toBeUndefined();
+    });
+
+    it('emits no stale state when getTemporaryLink rejects', async () => {
+      // #given — hydrate is best-effort; a failed fetch must not leak state to subscribers
+      const track = makeMediaTrack({
+        id: 'track-fail',
+        playbackRef: { provider: 'dropbox', ref: '/Music/fail.mp3' },
+      });
+      const listener = vi.fn();
+      vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(new Error('network down'));
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when
+      adapter.prepareTrack(track, { positionMs: 20_000 });
+
+      // #then — wait for the rejected fetch to settle, then assert nothing leaked
+      await vi.waitFor(() =>
+        expect(mockCatalog.getTemporaryLink).toHaveBeenCalledWith(track.playbackRef.ref),
+      );
+      await Promise.resolve();
+      expect(mockAudio.src).toBe('');
+      expect(findHydrateCall(listener, 'track-fail')).toBeUndefined();
     });
   });
 });

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -350,8 +350,7 @@ describe('DropboxPlaybackAdapter', () => {
       await flush();
       // trackA's getTemporaryLink has resolved; src is set. Now kick off playTrack for trackB
       // before the loadedmetadata event for trackA fires.
-      const playPromise = adapter.playTrack(trackB);
-      await playPromise;
+      await adapter.playTrack(trackB);
 
       listener.mockClear();
 
@@ -362,7 +361,6 @@ describe('DropboxPlaybackAdapter', () => {
       await flush();
 
       // #then
-      // The stale prepareTrack should not emit with trackA as currentTrackId.
       const staleCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-a');
       expect(staleCall).toBeUndefined();
     });

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -29,11 +29,13 @@ const mockAudio = {
   volume: 1,
   src: '',
   preload: '',
+  readyState: 0,
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
 };
 
 vi.stubGlobal('Audio', vi.fn(() => mockAudio) as any);
+vi.stubGlobal('HTMLMediaElement', { HAVE_METADATA: 1 } as any);
 
 // Mock ID3 parser
 vi.mock('@/utils/id3Parser', () => ({
@@ -76,6 +78,12 @@ describe('DropboxPlaybackAdapter', () => {
     mockAudio.duration = NaN;
     mockAudio.volume = 1;
     mockAudio.src = '';
+    mockAudio.readyState = 0;
+    mockAudio.removeEventListener.mockImplementation((event: string, listener: (e: any) => void) => {
+      if (eventListeners[event]) {
+        eventListeners[event] = eventListeners[event].filter((l) => l !== listener);
+      }
+    });
 
     adapter = new DropboxPlaybackAdapter(mockCatalog as DropboxCatalogAdapter);
   });
@@ -232,5 +240,131 @@ describe('DropboxPlaybackAdapter', () => {
     expect(state!.positionMs).toBe(30000);
     expect(state!.durationMs).toBe(210000);
     expect(state!.currentPlaybackRef).toEqual(track.playbackRef);
+  });
+
+  describe('prepareTrack', () => {
+    const flush = async (): Promise<void> => {
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve();
+      }
+    };
+
+    it('emits paused state with positionMs and durationMs after metadata loads', async () => {
+      // #given
+      const track = makeMediaTrack({ id: 'track-hydrate', durationMs: 300000 });
+      const listener = vi.fn();
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when
+      adapter.prepareTrack(track, { positionMs: 45_000 });
+      await flush();
+
+      mockAudio.duration = 200;
+      mockAudio.readyState = 1;
+      mockAudio.currentTime = 45;
+      (mockAudio as any).__triggerEvent('loadedmetadata');
+      await flush();
+
+      // #then
+      expect(mockAudio.src).toBe('https://example.com/stream.mp3');
+      expect(mockAudio.currentTime).toBe(45);
+      const hydrateCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-hydrate');
+      expect(hydrateCall).toBeDefined();
+      const state = hydrateCall![0] as PlaybackState;
+      expect(state.isPlaying).toBe(false);
+      expect(state.positionMs).toBe(45_000);
+      expect(state.durationMs).toBe(200_000);
+      expect(state.trackMetadata?.durationMs).toBe(200_000);
+    });
+
+    it('omits durationMs metadata when audio.duration is Infinity', async () => {
+      // #given
+      const track = makeMediaTrack({ id: 'track-live', durationMs: 180_000 });
+      const listener = vi.fn();
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+      await flush();
+
+      mockAudio.duration = Infinity;
+      mockAudio.readyState = 1;
+      mockAudio.currentTime = 10;
+      (mockAudio as any).__triggerEvent('loadedmetadata');
+      await flush();
+
+      // #then
+      const hydrateCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-live');
+      expect(hydrateCall).toBeDefined();
+      const state = hydrateCall![0] as PlaybackState;
+      expect(state.isPlaying).toBe(false);
+      expect(state.positionMs).toBe(10_000);
+      expect(state.durationMs).toBe(0);
+      expect(state.trackMetadata?.durationMs).toBeUndefined();
+    });
+
+    it('does not clobber audio.src when a track is already loaded (next-track prewarm)', async () => {
+      // #given
+      const current = makeMediaTrack({
+        id: 'current',
+        playbackRef: { provider: 'dropbox', ref: '/Music/current.mp3' },
+      });
+      const upcoming = makeMediaTrack({
+        id: 'upcoming',
+        playbackRef: { provider: 'dropbox', ref: '/Music/upcoming.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!).mockResolvedValueOnce('https://example.com/current.mp3');
+      await adapter.initialize();
+      await adapter.playTrack(current);
+
+      // #when
+      adapter.prepareTrack(upcoming);
+      await flush();
+
+      // #then
+      expect(mockAudio.src).toBe('https://example.com/current.mp3');
+      expect(mockCatalog.prefetchTemporaryLink).toHaveBeenCalledWith(upcoming.playbackRef.ref);
+    });
+
+    it('cancels a pending prepareTrack when a new src is set by playTrack', async () => {
+      // #given
+      const trackA = makeMediaTrack({
+        id: 'track-a',
+        playbackRef: { provider: 'dropbox', ref: '/Music/A/01.mp3' },
+      });
+      const trackB = makeMediaTrack({
+        id: 'track-b',
+        playbackRef: { provider: 'dropbox', ref: '/Music/B/01.mp3' },
+      });
+      const listener = vi.fn();
+      vi.mocked(mockCatalog.getTemporaryLink!)
+        .mockResolvedValueOnce('https://example.com/a.mp3')
+        .mockResolvedValueOnce('https://example.com/b.mp3');
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when
+      adapter.prepareTrack(trackA, { positionMs: 30_000 });
+      await flush();
+      // trackA's getTemporaryLink has resolved; src is set. Now kick off playTrack for trackB
+      // before the loadedmetadata event for trackA fires.
+      const playPromise = adapter.playTrack(trackB);
+      await playPromise;
+
+      listener.mockClear();
+
+      // Now the stale loadedmetadata for the prior src fires.
+      mockAudio.duration = 220;
+      mockAudio.readyState = 1;
+      (mockAudio as any).__triggerEvent('loadedmetadata');
+      await flush();
+
+      // #then
+      // The stale prepareTrack should not emit with trackA as currentTrackId.
+      const staleCall = listener.mock.calls.find(([state]) => state?.currentTrackId === 'track-a');
+      expect(staleCall).toBeUndefined();
+    });
   });
 });

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -23,6 +23,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private pendingMetadataUpdate: PlaybackState['trackMetadata'] | null = null;
   private pendingDurationMs: number | null = null;
   private pendingError: PlaybackState['playbackError'] | null = null;
+  private prepareGeneration = 0;
 
   private catalog: DropboxCatalogAdapter;
   private lastPlayTime = 0;
@@ -42,7 +43,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.audio.addEventListener('timeupdate', () => this.notifyListeners());
     this.audio.addEventListener('loadedmetadata', () => {
       const dur = this.audio!.duration;
-      if (!isNaN(dur) && dur > 0 && this.currentTrack) {
+      if (Number.isFinite(dur) && dur > 0 && this.currentTrack) {
         const durationMs = Math.floor(dur * 1000);
         this.pendingDurationMs = durationMs;
         putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
@@ -66,6 +67,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
   async playTrack(track: MediaTrack, options?: { positionMs?: number }): Promise<void> {
     this.ensureAudio();
+    // Invalidate any pending prepareTrack so it can't emit stale state for the old src.
+    this.prepareGeneration += 1;
 
     const dropboxPath = track.playbackRef.ref;
 
@@ -195,10 +198,55 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     });
   }
 
-  prepareTrack(track: MediaTrack, _options?: { positionMs?: number }): void {
-    // Prefetch the temporary link so playTrack doesn't pay the fetch cost when invoked.
-    // positionMs is applied during playTrack, not here — HTML5 Audio can't seek without a src.
+  prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     this.catalog.prefetchTemporaryLink(track.playbackRef.ref);
+    this.primeAudioForHydrate(track, options?.positionMs).catch(() => {
+      // Hydration is best-effort; playTrack will retry when invoked.
+    });
+  }
+
+  private async primeAudioForHydrate(track: MediaTrack, positionMs?: number): Promise<void> {
+    this.ensureAudio();
+    const audio = this.audio!;
+    // Only prime audio when nothing is loaded — during next-track pre-warm
+    // the current src is mid-playback and must not be replaced.
+    if (audio.src && this.currentTrack) return;
+
+    const generation = ++this.prepareGeneration;
+
+    const streamUrl = await this.catalog.getTemporaryLink(track.playbackRef.ref);
+    if (generation !== this.prepareGeneration) return;
+
+    this.currentTrack = track;
+    this.hydrateAlbumArtFromCache(track);
+    audio.src = streamUrl;
+
+    if (audio.readyState < HTMLMediaElement.HAVE_METADATA) {
+      await new Promise<void>((resolve) => {
+        const onLoaded = () => {
+          audio.removeEventListener('loadedmetadata', onLoaded);
+          audio.removeEventListener('error', onLoaded);
+          resolve();
+        };
+        audio.addEventListener('loadedmetadata', onLoaded);
+        audio.addEventListener('error', onLoaded);
+      });
+    }
+    if (generation !== this.prepareGeneration) return;
+
+    if (positionMs && positionMs > 0) {
+      audio.currentTime = positionMs / 1000;
+    }
+
+    const rawDuration = audio.duration;
+    const durationMs = Number.isFinite(rawDuration) && rawDuration > 0
+      ? Math.floor(rawDuration * 1000)
+      : undefined;
+
+    if (durationMs !== undefined) {
+      this.pendingDurationMs = durationMs;
+    }
+    this.notifyListeners();
   }
 
   refreshCurrentTrackArt(): void {
@@ -292,10 +340,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private getStateSync(): PlaybackState | null {
     if (!this.audio || !this.currentTrack) return null;
 
+    const rawDuration = this.audio.duration;
     const state: PlaybackState = {
       isPlaying: !this.audio.paused && !this.audio.ended,
       positionMs: Math.floor(this.audio.currentTime * 1000),
-      durationMs: isNaN(this.audio.duration) ? 0 : Math.floor(this.audio.duration * 1000),
+      durationMs: Number.isFinite(rawDuration) ? Math.floor(rawDuration * 1000) : 0,
       currentTrackId: this.currentTrack.id,
       currentPlaybackRef: this.currentTrack.playbackRef,
     };

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -238,14 +238,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       audio.currentTime = positionMs / 1000;
     }
 
-    const rawDuration = audio.duration;
-    const durationMs = Number.isFinite(rawDuration) && rawDuration > 0
-      ? Math.floor(rawDuration * 1000)
-      : undefined;
-
-    if (durationMs !== undefined) {
-      this.pendingDurationMs = durationMs;
-    }
+    // The 'loadedmetadata' listener in ensureAudio has already populated
+    // pendingDurationMs; this notify re-emits with the seeked positionMs.
     this.notifyListeners();
   }
 

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -217,29 +217,44 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     const streamUrl = await this.catalog.getTemporaryLink(track.playbackRef.ref);
     if (generation !== this.prepareGeneration) return;
 
-    this.currentTrack = track;
-    this.hydrateAlbumArtFromCache(track);
     audio.src = streamUrl;
 
     if (audio.readyState < HTMLMediaElement.HAVE_METADATA) {
       await new Promise<void>((resolve) => {
-        const onLoaded = () => {
-          audio.removeEventListener('loadedmetadata', onLoaded);
-          audio.removeEventListener('error', onLoaded);
+        // Resolve on either signal so the prime unblocks even when the
+        // resource fails to load. The generation re-check below drops stale
+        // primes, and the error fallback emits durationMs: 0 via getStateSync.
+        const onSettle = () => {
+          audio.removeEventListener('loadedmetadata', onSettle);
+          audio.removeEventListener('error', onSettle);
           resolve();
         };
-        audio.addEventListener('loadedmetadata', onLoaded);
-        audio.addEventListener('error', onLoaded);
+        audio.addEventListener('loadedmetadata', onSettle);
+        audio.addEventListener('error', onSettle);
       });
     }
     if (generation !== this.prepareGeneration) return;
+
+    // Commit track state only after metadata has settled and this prime
+    // hasn't been superseded, so getStateSync can't observe a mixed state
+    // where currentTrack points at a not-yet-loaded src.
+    this.currentTrack = track;
+    this.hydrateAlbumArtFromCache(track);
 
     if (positionMs && positionMs > 0) {
       audio.currentTime = positionMs / 1000;
     }
 
-    // The 'loadedmetadata' listener in ensureAudio has already populated
-    // pendingDurationMs; this notify re-emits with the seeked positionMs.
+    // The ensureAudio loadedmetadata listener short-circuits when it fires
+    // before currentTrack is set (see the guard there), so populate the
+    // persisted-duration side effects ourselves now that currentTrack is live.
+    const dur = audio.duration;
+    if (Number.isFinite(dur) && dur > 0) {
+      const durationMs = Math.floor(dur * 1000);
+      this.pendingDurationMs = durationMs;
+      putDurationMs(track.id, durationMs).catch(() => {});
+    }
+
     this.notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- `dropboxPlaybackAdapter.prepareTrack` now primes the HTMLAudioElement with the track's stream URL on hydrate, waits for `loadedmetadata`, seeks to the saved position, and emits a paused `PlaybackState` so the seek bar shows position + duration before the user taps play.
- Guards priming so next-track pre-warm keeps the currently-playing track intact; uses a generation counter so a subsequent `playTrack`/`prepareTrack` cancels any pending priming without emitting stale state.
- Treats infinite-duration streams as unknown duration (emits `trackMetadata.durationMs: undefined`), letting the UI fall back to the catalog duration; tightens the existing `loadedmetadata` and `getStateSync` guards to reject `Infinity` alongside `NaN`.

## Test plan
- [x] `npx tsc -b --noEmit` is clean.
- [x] `npm run test:run` — 1207 tests pass, including three new colocated cases under `src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts` covering the paused state emission, infinite-duration fallback, src-change cancellation, and the new next-track-prewarm no-clobber guard.
- [ ] Manual: resume a Dropbox track mid-playback, reload the app, confirm the seek bar shows the saved position and the track's full duration before pressing play.

Closes #1170