### PR TITLE
feat(player): surface resuming toast when hydrate fires

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -135,21 +135,21 @@ const AudioPlayerComponent = () => {
   const [qapToast, setQapToast] = useState<{ message: string; actionLabel?: string; onAction?: () => void } | null>(null);
   const handleQapToastDismiss = useCallback(() => setQapToast(null), []);
 
-  const [resumeToast, setResumeToast] = useState<{ message: string } | null>(null);
-  const dismissResumeToast = useCallback(() => setResumeToast(null), []);
+  const [resumeToastMessage, setResumeToastMessage] = useState<string | null>(null);
+  const dismissResumeToast = useCallback(() => setResumeToastMessage(null), []);
   const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack) => {
-    setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
+    setResumeToastMessage(`Resuming '${track.name}' — press play to continue.`);
   }, []);
   const withResumeDismiss = useCallback(
     <T extends (...args: never[]) => unknown>(fn: T): T => ((...args) => {
-      setResumeToast(null);
+      setResumeToastMessage(null);
       return fn(...args);
     }) as T,
     [],
   );
   useEffect(() => {
-    if (resumeToast && showQueue) setResumeToast(null);
-  }, [resumeToast, showQueue]);
+    if (showQueue) setResumeToastMessage(null);
+  }, [showQueue]);
   const handleAddToQueueFromPanel = useCallback(
     async (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => {
       const result = await handlers.handleAddToQueue(id, name, provider);
@@ -421,8 +421,8 @@ const AudioPlayerComponent = () => {
         {qapToast && (
           <Toast message={qapToast.message} actionLabel={qapToast.actionLabel} onAction={qapToast.onAction} onDismiss={handleQapToastDismiss} />
         )}
-        {resumeToast && (
-          <Toast message={resumeToast.message} onDismiss={dismissResumeToast} />
+        {resumeToastMessage && (
+          <Toast message={resumeToastMessage} onDismiss={dismissResumeToast} />
         )}
         {fallthroughNotification && (
           <Toast message={fallthroughNotification} onDismiss={dismissFallthroughNotification} />

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -140,18 +140,13 @@ const AudioPlayerComponent = () => {
   const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack) => {
     setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
   }, []);
-  const handlePlayWithResumeDismiss = useCallback(() => {
-    setResumeToast(null);
-    handlers.handlePlay();
-  }, [handlers]);
-  const handlePauseWithResumeDismiss = useCallback(() => {
-    setResumeToast(null);
-    handlers.handlePause();
-  }, [handlers]);
-  const handleOpenLibraryWithResumeDismiss = useCallback(() => {
-    setResumeToast(null);
-    handlers.handleOpenLibrary();
-  }, [handlers]);
+  const withResumeDismiss = useCallback(
+    <T extends (...args: never[]) => unknown>(fn: T): T => ((...args) => {
+      setResumeToast(null);
+      return fn(...args);
+    }) as T,
+    [],
+  );
   useEffect(() => {
     if (resumeToast && showQueue) setResumeToast(null);
   }, [resumeToast, showQueue]);
@@ -197,32 +192,35 @@ const AudioPlayerComponent = () => {
     [handlers, setShowQueue],
   );
 
-  const playbackHandlers = useMemo(() => ({
-    onPlay: handlePlayWithResumeDismiss,
-    onPause: handlePauseWithResumeDismiss,
-    onNext: handlers.handleNext,
-    onPrevious: handlers.handlePrevious,
-    onTrackSelect: handlers.playTrack,
-    onOpenLibrary: handleOpenLibraryWithResumeDismiss,
-    onCloseLibrary: handlers.handleCloseLibrary,
-    onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
-    onPlaylistSelect: handlePlaylistSelect,
-    onAddToQueue: handlers.handleAddToQueue,
-    onPlayLikedTracks: handlePlayLikedTracks,
-    onQueueLikedTracks: handleQueueLikedTracks,
-    onAlbumPlay: handleAlbumPlay,
-    onBackToLibrary: handleOpenLibraryWithResumeDismiss,
-    onStartRadio: handlers.handleStartRadio,
-    onRemoveFromQueue: handlers.handleRemoveFromQueue,
-    onReorderQueue: handlers.handleReorderQueue,
-  }), [
+  const playbackHandlers = useMemo(() => {
+    const onOpenLibrary = withResumeDismiss(handlers.handleOpenLibrary);
+    return {
+      onPlay: withResumeDismiss(handlers.handlePlay),
+      onPause: withResumeDismiss(handlers.handlePause),
+      onNext: handlers.handleNext,
+      onPrevious: handlers.handlePrevious,
+      onTrackSelect: handlers.playTrack,
+      onOpenLibrary,
+      onCloseLibrary: handlers.handleCloseLibrary,
+      onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
+      onPlaylistSelect: handlePlaylistSelect,
+      onAddToQueue: handlers.handleAddToQueue,
+      onPlayLikedTracks: handlePlayLikedTracks,
+      onQueueLikedTracks: handleQueueLikedTracks,
+      onAlbumPlay: handleAlbumPlay,
+      onBackToLibrary: onOpenLibrary,
+      onStartRadio: handlers.handleStartRadio,
+      onRemoveFromQueue: handlers.handleRemoveFromQueue,
+      onReorderQueue: handlers.handleReorderQueue,
+    };
+  }, [
     handlers,
     handleAlbumPlay,
     handlePlaylistSelect,
     handleOpenQuickAccessPanel,
-    handlePlayWithResumeDismiss,
-    handlePauseWithResumeDismiss,
-    handleOpenLibraryWithResumeDismiss,
+    handlePlayLikedTracks,
+    handleQueueLikedTracks,
+    withResumeDismiss,
   ]);
 
   const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -69,7 +69,7 @@ const AudioPlayerComponent = () => {
   const { accentColorBackgroundEnabled } = useAccentColorBackground();
   const { showVisualEffects, setShowVisualEffects } = useVisualEffectsToggle();
   const { tracks, selectedPlaylistId, setTracks, setOriginalTracks, setSelectedPlaylistId } = useTrackListContext();
-  const { currentTrack, currentTrackIndex, setCurrentTrackIndex, setShowQueue } = useCurrentTrackContext();
+  const { currentTrack, currentTrackIndex, setCurrentTrackIndex, showQueue, setShowQueue } = useCurrentTrackContext();
 
   const resolveDisplayProvider = useCallback((): import('@/types/domain').ProviderId | undefined => (
     (currentTrack?.provider as import('@/types/domain').ProviderId | undefined)
@@ -134,6 +134,27 @@ const AudioPlayerComponent = () => {
 
   const [qapToast, setQapToast] = useState<{ message: string; actionLabel?: string; onAction?: () => void } | null>(null);
   const handleQapToastDismiss = useCallback(() => setQapToast(null), []);
+
+  const [resumeToast, setResumeToast] = useState<{ message: string } | null>(null);
+  const dismissResumeToast = useCallback(() => setResumeToast(null), []);
+  const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack) => {
+    setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
+  }, []);
+  const handlePlayWithResumeDismiss = useCallback(() => {
+    setResumeToast(null);
+    handlers.handlePlay();
+  }, [handlers]);
+  const handlePauseWithResumeDismiss = useCallback(() => {
+    setResumeToast(null);
+    handlers.handlePause();
+  }, [handlers]);
+  const handleOpenLibraryWithResumeDismiss = useCallback(() => {
+    setResumeToast(null);
+    handlers.handleOpenLibrary();
+  }, [handlers]);
+  useEffect(() => {
+    if (resumeToast && showQueue) setResumeToast(null);
+  }, [resumeToast, showQueue]);
   const handleAddToQueueFromPanel = useCallback(
     async (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => {
       const result = await handlers.handleAddToQueue(id, name, provider);
@@ -177,12 +198,12 @@ const AudioPlayerComponent = () => {
   );
 
   const playbackHandlers = useMemo(() => ({
-    onPlay: handlers.handlePlay,
-    onPause: handlers.handlePause,
+    onPlay: handlePlayWithResumeDismiss,
+    onPause: handlePauseWithResumeDismiss,
     onNext: handlers.handleNext,
     onPrevious: handlers.handlePrevious,
     onTrackSelect: handlers.playTrack,
-    onOpenLibrary: handlers.handleOpenLibrary,
+    onOpenLibrary: handleOpenLibraryWithResumeDismiss,
     onCloseLibrary: handlers.handleCloseLibrary,
     onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
     onPlaylistSelect: handlePlaylistSelect,
@@ -190,11 +211,19 @@ const AudioPlayerComponent = () => {
     onPlayLikedTracks: handlePlayLikedTracks,
     onQueueLikedTracks: handleQueueLikedTracks,
     onAlbumPlay: handleAlbumPlay,
-    onBackToLibrary: handlers.handleOpenLibrary,
+    onBackToLibrary: handleOpenLibraryWithResumeDismiss,
     onStartRadio: handlers.handleStartRadio,
     onRemoveFromQueue: handlers.handleRemoveFromQueue,
     onReorderQueue: handlers.handleReorderQueue,
-  }), [handlers, handleAlbumPlay, handlePlaylistSelect, handleOpenQuickAccessPanel]);
+  }), [
+    handlers,
+    handleAlbumPlay,
+    handlePlaylistSelect,
+    handleOpenQuickAccessPanel,
+    handlePlayWithResumeDismiss,
+    handlePauseWithResumeDismiss,
+    handleOpenLibraryWithResumeDismiss,
+  ]);
 
   const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();
   // Setup is needed when no provider has been chosen yet and none are connected,
@@ -295,6 +324,7 @@ const AudioPlayerComponent = () => {
               onResume={handleResume}
               onOpenSettings={handleOpenSettings}
               onHydrate={handlers.handleHydrate}
+              onHydrateFired={handleHydrateFired}
             />
           </ProfiledComponent>
           {qapToast && (
@@ -392,6 +422,9 @@ const AudioPlayerComponent = () => {
         )}
         {qapToast && (
           <Toast message={qapToast.message} actionLabel={qapToast.actionLabel} onAction={qapToast.onAction} onDismiss={handleQapToastDismiss} />
+        )}
+        {resumeToast && (
+          <Toast message={resumeToast.message} onDismiss={dismissResumeToast} />
         )}
         {fallthroughNotification && (
           <Toast message={fallthroughNotification} onDismiss={dismissFallthroughNotification} />

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -197,8 +197,8 @@ const AudioPlayerComponent = () => {
     return {
       onPlay: withResumeDismiss(handlers.handlePlay),
       onPause: withResumeDismiss(handlers.handlePause),
-      onNext: handlers.handleNext,
-      onPrevious: handlers.handlePrevious,
+      onNext: withResumeDismiss(handlers.handleNext),
+      onPrevious: withResumeDismiss(handlers.handlePrevious),
       onTrackSelect: handlers.playTrack,
       onOpenLibrary,
       onCloseLibrary: handlers.handleCloseLibrary,

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -182,6 +182,7 @@ interface PlayerStateRendererProps {
   onResume: () => void;
   onOpenSettings: () => void;
   onHydrate: (session: SessionSnapshot) => Promise<void>;
+  onHydrateFired?: (track: MediaTrack) => void;
 }
 
 type IdleRoute = 'welcome' | 'qap' | 'hydrate' | 'library';
@@ -210,6 +211,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   onResume,
   onOpenSettings,
   onHydrate,
+  onHydrateFired,
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
@@ -227,8 +229,17 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
     if (route !== 'hydrate') return;
     if (!lastSession) return;
     hydrateFiredRef.current = true;
+    const { queueTracks, trackId, trackIndex } = lastSession;
+    if (queueTracks?.length) {
+      const targetIdx = trackId
+        ? queueTracks.findIndex(t => t.id === trackId)
+        : Math.min(trackIndex, queueTracks.length - 1);
+      const resolvedIdx = targetIdx >= 0 ? targetIdx : Math.min(trackIndex, queueTracks.length - 1);
+      const resolvedTrack = queueTracks[resolvedIdx];
+      if (resolvedTrack) onHydrateFired?.(resolvedTrack);
+    }
     void onHydrate(lastSession);
-  }, [route, lastSession, onHydrate]);
+  }, [route, lastSession, onHydrate, onHydrateFired]);
 
   const handleConnectClick = useCallback(() => {
     activeDescriptor?.auth.beginLogin();

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -181,7 +181,7 @@ interface PlayerStateRendererProps {
   lastSession: SessionSnapshot | null;
   onResume: () => void;
   onOpenSettings: () => void;
-  onHydrate: (session: SessionSnapshot) => Promise<void>;
+  onHydrate: (session: SessionSnapshot) => Promise<MediaTrack | null>;
   onHydrateFired?: (track: MediaTrack) => void;
 }
 
@@ -229,16 +229,9 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
     if (route !== 'hydrate') return;
     if (!lastSession) return;
     hydrateFiredRef.current = true;
-    const { queueTracks, trackId, trackIndex } = lastSession;
-    if (queueTracks?.length) {
-      const targetIdx = trackId
-        ? queueTracks.findIndex(t => t.id === trackId)
-        : Math.min(trackIndex, queueTracks.length - 1);
-      const resolvedIdx = targetIdx >= 0 ? targetIdx : Math.min(trackIndex, queueTracks.length - 1);
-      const resolvedTrack = queueTracks[resolvedIdx];
-      if (resolvedTrack) onHydrateFired?.(resolvedTrack);
-    }
-    void onHydrate(lastSession);
+    void onHydrate(lastSession).then((track) => {
+      if (track) onHydrateFired?.(track);
+    });
   }, [route, lastSession, onHydrate, onHydrateFired]);
 
   const handleConnectClick = useCallback(() => {

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -229,9 +229,14 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
     if (route !== 'hydrate') return;
     if (!lastSession) return;
     hydrateFiredRef.current = true;
-    void onHydrate(lastSession).then((track) => {
-      if (track) onHydrateFired?.(track);
-    });
+    void onHydrate(lastSession)
+      .then((track) => {
+        if (track) onHydrateFired?.(track);
+      })
+      .catch(() => {
+        // Hydrate errors are surfaced inside handleHydrate; swallow here so
+        // a rejected promise doesn't bubble up as an unhandled rejection.
+      });
   }, [route, lastSession, onHydrate, onHydrateFired]);
 
   const handleConnectClick = useCallback(() => {

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -7,6 +7,7 @@ import PlayerStateRenderer from '../PlayerStateRenderer';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
 import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
 import { STALE_SESSION_MS, type SessionSnapshot } from '@/services/sessionPersistence';
+import { makeMediaTrack } from '@/test/fixtures';
 
 vi.mock('@/hooks/useQapEnabled', () => ({
   useQapEnabled: vi.fn(),
@@ -252,7 +253,7 @@ describe('PlayerStateRenderer idle routing', () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
-    const resolvedTrack = { id: 't2', name: 'Second', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t2' };
+    const resolvedTrack = makeMediaTrack({ id: 't2', name: 'Second' });
     const onHydrate = vi.fn(async () => resolvedTrack);
     const onHydrateFired = vi.fn();
 

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -75,7 +75,7 @@ const defaultProps = {
   lastSession: null,
   onResume: vi.fn(),
   onOpenSettings: vi.fn(),
-  onHydrate: vi.fn(async () => {}),
+  onHydrate: vi.fn(async () => null),
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -248,27 +248,21 @@ describe('PlayerStateRenderer idle routing', () => {
     });
   });
 
-  it('calls onHydrateFired with the resolved track when hydrate fires', async () => {
+  it('calls onHydrateFired with the track returned by onHydrate', async () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const resolvedTrack = { id: 't2', name: 'Second', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t2' };
+    const onHydrate = vi.fn(async () => resolvedTrack);
     const onHydrateFired = vi.fn();
-    const sessionWithTrack: SessionSnapshot = {
-      ...freshSession,
-      trackId: 't2',
-      trackIndex: 1,
-      queueTracks: [
-        { id: 't1', name: 'First', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t1' },
-        { id: 't2', name: 'Second', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t2' },
-      ],
-    };
 
     // #when
     render(
       <Wrapper>
         <PlayerStateRenderer
           {...defaultProps}
-          lastSession={sessionWithTrack}
+          onHydrate={onHydrate}
+          lastSession={freshSession}
           onHydrateFired={onHydrateFired}
         />
       </Wrapper>,

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -248,6 +248,63 @@ describe('PlayerStateRenderer idle routing', () => {
     });
   });
 
+  it('calls onHydrateFired with the resolved track when hydrate fires', async () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrateFired = vi.fn();
+    const sessionWithTrack: SessionSnapshot = {
+      ...freshSession,
+      trackId: 't2',
+      trackIndex: 1,
+      queueTracks: [
+        { id: 't1', name: 'First', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t1' },
+        { id: 't2', name: 'Second', artists: 'A', album: 'Al', image: '', duration: 1, uri: '', provider: 'spotify', playbackRef: 'spotify:track:t2' },
+      ],
+    };
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          lastSession={sessionWithTrack}
+          onHydrateFired={onHydrateFired}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(onHydrateFired).toHaveBeenCalledTimes(1);
+    });
+    expect(onHydrateFired).toHaveBeenCalledWith(expect.objectContaining({ id: 't2', name: 'Second' }));
+  });
+
+  it('does not call onHydrateFired for a stale session', async () => {
+    // #given
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrateFired = vi.fn();
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          lastSession={staleSession}
+          onHydrateFired={onHydrateFired}
+        />
+      </Wrapper>,
+    );
+
+    // #then
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
+    expect(onHydrateFired).not.toHaveBeenCalled();
+  });
+
   it('does not call onHydrate for a stale session', async () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -4,16 +4,18 @@ import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { theme } from '@/styles/theme';
 import Toast from '../Toast';
-import { makeTrack } from '@/test/fixtures';
+import { makeMediaTrack } from '@/test/fixtures';
 import type { MediaTrack } from '@/types/domain';
+
+type HandlerKey = 'play' | 'pause' | 'next' | 'previous' | 'library';
 
 type ResumeToastHarnessHandle = {
   fireHydrate: (track: MediaTrack) => void;
-  pressUserAction: () => void;
+  invoke: (key: HandlerKey) => void;
 };
 
-// Mirrors the AudioPlayer resume-toast wire-up: state setter driven by
-// hydrate, user actions, and a showQueue effect, rendering the real Toast.
+// Mirrors the AudioPlayer resume-toast wire-up using the same withResumeDismiss
+// wrapping factory shape, so a drift in AudioPlayer's wiring surfaces here.
 const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueue: boolean }>(
   ({ showQueue }, ref) => {
     const [message, setMessage] = useState<string | null>(null);
@@ -23,13 +25,33 @@ const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueu
       setMessage(`Resuming '${track.name}' — press play to continue.`);
     }, []);
 
+    const withResumeDismiss = useCallback(
+      <T extends (...args: never[]) => unknown>(fn: T): T =>
+        ((...args) => {
+          setMessage(null);
+          return fn(...args);
+        }) as T,
+      [],
+    );
+
+    const handlers = React.useMemo(
+      () => ({
+        play: withResumeDismiss(() => {}),
+        pause: withResumeDismiss(() => {}),
+        next: withResumeDismiss(() => {}),
+        previous: withResumeDismiss(() => {}),
+        library: withResumeDismiss(() => {}),
+      }),
+      [withResumeDismiss],
+    );
+
     useEffect(() => {
       if (showQueue) setMessage(null);
     }, [showQueue]);
 
     React.useImperativeHandle(ref, () => ({
       fireHydrate: handleHydrateFired,
-      pressUserAction: dismiss,
+      invoke: (key) => handlers[key](),
     }));
 
     return message ? <Toast message={message} onDismiss={dismiss} /> : null;
@@ -51,6 +73,15 @@ const renderHarness = (initialShowQueue = false) => {
   };
 };
 
+const fireHydrateWith = (
+  ref: React.RefObject<ResumeToastHarnessHandle>,
+  trackName: string,
+) => {
+  act(() => {
+    ref.current?.fireHydrate(makeMediaTrack({ name: trackName }));
+  });
+};
+
 describe('Resume toast behavior', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -63,12 +94,9 @@ describe('Resume toast behavior', () => {
   it('appears with the hydrated track name when hydrate fires', () => {
     // #given
     const { ref } = renderHarness();
-    const track = makeTrack({ name: 'Bohemian Rhapsody' });
 
     // #when
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
+    fireHydrateWith(ref, 'Bohemian Rhapsody');
 
     // #then
     expect(
@@ -79,10 +107,7 @@ describe('Resume toast behavior', () => {
   it('auto-dismisses after ~5s', () => {
     // #given
     const { ref } = renderHarness();
-    const track = makeTrack({ name: 'Caravan' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
+    fireHydrateWith(ref, 'Caravan');
     expect(screen.getByText(/Resuming 'Caravan'/)).toBeInTheDocument();
 
     // #when — advance past the Toast's 5000ms auto-dismiss + exit animation
@@ -94,65 +119,28 @@ describe('Resume toast behavior', () => {
     expect(screen.queryByText(/Resuming 'Caravan'/)).not.toBeInTheDocument();
   });
 
-  it('dismisses immediately when the user presses play', () => {
-    // #given
-    const { ref } = renderHarness();
-    const track = makeTrack({ name: 'Take Five' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
-    expect(screen.getByText(/Resuming 'Take Five'/)).toBeInTheDocument();
+  it.each(['play', 'pause', 'next', 'previous', 'library'] as const)(
+    'dismisses when the user invokes the %s handler',
+    (handler) => {
+      // #given
+      const { ref } = renderHarness();
+      fireHydrateWith(ref, 'Take Five');
+      expect(screen.getByText(/Resuming 'Take Five'/)).toBeInTheDocument();
 
-    // #when
-    act(() => {
-      ref.current?.pressUserAction();
-    });
+      // #when
+      act(() => {
+        ref.current?.invoke(handler);
+      });
 
-    // #then
-    expect(screen.queryByText(/Resuming 'Take Five'/)).not.toBeInTheDocument();
-  });
-
-  it('dismisses immediately when the user presses pause', () => {
-    // #given
-    const { ref } = renderHarness();
-    const track = makeTrack({ name: 'So What' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
-
-    // #when
-    act(() => {
-      ref.current?.pressUserAction();
-    });
-
-    // #then
-    expect(screen.queryByText(/Resuming 'So What'/)).not.toBeInTheDocument();
-  });
-
-  it('dismisses immediately when the user navigates to the library', () => {
-    // #given
-    const { ref } = renderHarness();
-    const track = makeTrack({ name: 'Blue in Green' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
-
-    // #when
-    act(() => {
-      ref.current?.pressUserAction();
-    });
-
-    // #then
-    expect(screen.queryByText(/Resuming 'Blue in Green'/)).not.toBeInTheDocument();
-  });
+      // #then
+      expect(screen.queryByText(/Resuming 'Take Five'/)).not.toBeInTheDocument();
+    },
+  );
 
   it('dismisses immediately when the queue opens (showQueue flips true)', () => {
     // #given
     const { ref, rerender } = renderHarness(false);
-    const track = makeTrack({ name: 'Giant Steps' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
+    fireHydrateWith(ref, 'Giant Steps');
     expect(screen.getByText(/Resuming 'Giant Steps'/)).toBeInTheDocument();
 
     // #when
@@ -167,10 +155,7 @@ describe('Resume toast behavior', () => {
   it('dismisses when the Toast dismiss button is clicked', () => {
     // #given
     const { ref } = renderHarness();
-    const track = makeTrack({ name: 'Four on Six' });
-    act(() => {
-      ref.current?.fireHydrate(track);
-    });
+    fireHydrateWith(ref, 'Four on Six');
 
     // #when
     const dismissBtn = screen.getByRole('button', { name: /dismiss/i });

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -12,30 +12,27 @@ type ResumeToastHarnessHandle = {
   pressUserAction: () => void;
 };
 
-// Mirrors the AudioPlayer wire-up: state + dismissal triggers (play / pause /
-// openLibrary) plus a showQueue effect, rendering the real Toast component.
+// Mirrors the AudioPlayer resume-toast wire-up: state setter driven by
+// hydrate, user actions, and a showQueue effect, rendering the real Toast.
 const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueue: boolean }>(
   ({ showQueue }, ref) => {
-    const [resumeToast, setResumeToast] = useState<{ message: string } | null>(null);
-    const dismiss = useCallback(() => setResumeToast(null), []);
+    const [message, setMessage] = useState<string | null>(null);
+    const dismiss = useCallback(() => setMessage(null), []);
 
     const handleHydrateFired = useCallback((track: MediaTrack) => {
-      setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
+      setMessage(`Resuming '${track.name}' — press play to continue.`);
     }, []);
-    const dismissOnAction = useCallback(() => setResumeToast(null), []);
 
     useEffect(() => {
-      if (resumeToast && showQueue) setResumeToast(null);
-    }, [resumeToast, showQueue]);
+      if (showQueue) setMessage(null);
+    }, [showQueue]);
 
     React.useImperativeHandle(ref, () => ({
       fireHydrate: handleHydrateFired,
-      pressUserAction: dismissOnAction,
+      pressUserAction: dismiss,
     }));
 
-    return resumeToast ? (
-      <Toast message={resumeToast.message} onDismiss={dismiss} />
-    ) : null;
+    return message ? <Toast message={message} onDismiss={dismiss} /> : null;
   }
 );
 ResumeToastHarness.displayName = 'ResumeToastHarness';

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import Toast from '../Toast';
+import { makeTrack } from '@/test/fixtures';
+import type { MediaTrack } from '@/types/domain';
+
+type ResumeToastHarnessHandle = {
+  fireHydrate: (track: MediaTrack) => void;
+  press: (action: 'play' | 'pause' | 'library' | 'queue') => void;
+};
+
+// Mirrors the AudioPlayer wire-up: state + dismissal triggers (play / pause /
+// openLibrary) plus a showQueue effect, rendering the real Toast component.
+const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueue: boolean }>(
+  ({ showQueue }, ref) => {
+    const [resumeToast, setResumeToast] = useState<{ message: string } | null>(null);
+    const dismiss = useCallback(() => setResumeToast(null), []);
+
+    const handleHydrateFired = useCallback((track: MediaTrack) => {
+      setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
+    }, []);
+
+    const onPlay = useCallback(() => setResumeToast(null), []);
+    const onPause = useCallback(() => setResumeToast(null), []);
+    const onOpenLibrary = useCallback(() => setResumeToast(null), []);
+
+    useEffect(() => {
+      if (resumeToast && showQueue) setResumeToast(null);
+    }, [resumeToast, showQueue]);
+
+    React.useImperativeHandle(ref, () => ({
+      fireHydrate: handleHydrateFired,
+      press: (action) => {
+        if (action === 'play') onPlay();
+        if (action === 'pause') onPause();
+        if (action === 'library') onOpenLibrary();
+      },
+    }));
+
+    return resumeToast ? (
+      <Toast message={resumeToast.message} onDismiss={dismiss} />
+    ) : null;
+  }
+);
+ResumeToastHarness.displayName = 'ResumeToastHarness';
+
+const renderHarness = (initialShowQueue = false) => {
+  const ref = React.createRef<ResumeToastHarnessHandle>();
+  const Wrapper = ({ showQueue }: { showQueue: boolean }) => (
+    <ThemeProvider theme={theme}>
+      <ResumeToastHarness ref={ref} showQueue={showQueue} />
+    </ThemeProvider>
+  );
+  const utils = render(<Wrapper showQueue={initialShowQueue} />);
+  return {
+    ref,
+    rerender: (showQueue: boolean) => utils.rerender(<Wrapper showQueue={showQueue} />),
+  };
+};
+
+describe('Resume toast behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('appears with the hydrated track name when hydrate fires', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'Bohemian Rhapsody' });
+
+    // #when
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+
+    // #then
+    expect(
+      screen.getByText("Resuming 'Bohemian Rhapsody' — press play to continue."),
+    ).toBeInTheDocument();
+  });
+
+  it('auto-dismisses after ~5s', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'Caravan' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+    expect(screen.getByText(/Resuming 'Caravan'/)).toBeInTheDocument();
+
+    // #when — advance past the Toast's 5000ms auto-dismiss + exit animation
+    act(() => {
+      vi.advanceTimersByTime(5400);
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'Caravan'/)).not.toBeInTheDocument();
+  });
+
+  it('dismisses immediately when the user presses play', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'Take Five' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+    expect(screen.getByText(/Resuming 'Take Five'/)).toBeInTheDocument();
+
+    // #when
+    act(() => {
+      ref.current?.press('play');
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'Take Five'/)).not.toBeInTheDocument();
+  });
+
+  it('dismisses immediately when the user presses pause', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'So What' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+
+    // #when
+    act(() => {
+      ref.current?.press('pause');
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'So What'/)).not.toBeInTheDocument();
+  });
+
+  it('dismisses immediately when the user navigates to the library', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'Blue in Green' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+
+    // #when
+    act(() => {
+      ref.current?.press('library');
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'Blue in Green'/)).not.toBeInTheDocument();
+  });
+
+  it('dismisses immediately when the queue opens (showQueue flips true)', () => {
+    // #given
+    const { ref, rerender } = renderHarness(false);
+    const track = makeTrack({ name: 'Giant Steps' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+    expect(screen.getByText(/Resuming 'Giant Steps'/)).toBeInTheDocument();
+
+    // #when
+    act(() => {
+      rerender(true);
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'Giant Steps'/)).not.toBeInTheDocument();
+  });
+
+  it('dismisses when the Toast dismiss button is clicked', () => {
+    // #given
+    const { ref } = renderHarness();
+    const track = makeTrack({ name: 'Four on Six' });
+    act(() => {
+      ref.current?.fireHydrate(track);
+    });
+
+    // #when
+    const dismissBtn = screen.getByRole('button', { name: /dismiss/i });
+    act(() => {
+      fireEvent.click(dismissBtn);
+      vi.advanceTimersByTime(400);
+    });
+
+    // #then
+    expect(screen.queryByText(/Resuming 'Four on Six'/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -9,7 +9,7 @@ import type { MediaTrack } from '@/types/domain';
 
 type ResumeToastHarnessHandle = {
   fireHydrate: (track: MediaTrack) => void;
-  press: (action: 'play' | 'pause' | 'library' | 'queue') => void;
+  pressUserAction: () => void;
 };
 
 // Mirrors the AudioPlayer wire-up: state + dismissal triggers (play / pause /
@@ -22,10 +22,7 @@ const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueu
     const handleHydrateFired = useCallback((track: MediaTrack) => {
       setResumeToast({ message: `Resuming '${track.name}' — press play to continue.` });
     }, []);
-
-    const onPlay = useCallback(() => setResumeToast(null), []);
-    const onPause = useCallback(() => setResumeToast(null), []);
-    const onOpenLibrary = useCallback(() => setResumeToast(null), []);
+    const dismissOnAction = useCallback(() => setResumeToast(null), []);
 
     useEffect(() => {
       if (resumeToast && showQueue) setResumeToast(null);
@@ -33,11 +30,7 @@ const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueu
 
     React.useImperativeHandle(ref, () => ({
       fireHydrate: handleHydrateFired,
-      press: (action) => {
-        if (action === 'play') onPlay();
-        if (action === 'pause') onPause();
-        if (action === 'library') onOpenLibrary();
-      },
+      pressUserAction: dismissOnAction,
     }));
 
     return resumeToast ? (
@@ -115,7 +108,7 @@ describe('Resume toast behavior', () => {
 
     // #when
     act(() => {
-      ref.current?.press('play');
+      ref.current?.pressUserAction();
     });
 
     // #then
@@ -132,7 +125,7 @@ describe('Resume toast behavior', () => {
 
     // #when
     act(() => {
-      ref.current?.press('pause');
+      ref.current?.pressUserAction();
     });
 
     // #then
@@ -149,7 +142,7 @@ describe('Resume toast behavior', () => {
 
     // #when
     act(() => {
-      ref.current?.press('library');
+      ref.current?.pressUserAction();
     });
 
     // #then

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -9,7 +9,7 @@ import { useAutoAdvance } from '@/hooks/useAutoAdvance';
 import { useAccentColor } from '@/hooks/useAccentColor';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { useRadio } from '@/hooks/useRadio';
-import type { ProviderId } from '@/types/domain';
+import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
@@ -262,8 +262,8 @@ export function usePlayerLogic() {
     }
   }, [playTrack, getDrivingProviderId, getDrivingProviderDescriptor]);
 
-  const handleHydrate = useCallback(async (session: SessionSnapshot): Promise<void> => {
-    if (!session.queueTracks?.length) return;
+  const handleHydrate = useCallback(async (session: SessionSnapshot): Promise<MediaTrack | null> => {
+    if (!session.queueTracks?.length) return null;
     const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPositionMs } = session;
 
     const targetIdx = trackId
@@ -302,6 +302,8 @@ export function usePlayerLogic() {
       positionMs ?? 'NONE',
       providerId ?? 'NONE',
     );
+
+    return targetTrack ?? null;
   }, [
     setTracks,
     setOriginalTracks,


### PR DESCRIPTION
## Summary
- When `handleHydrate` restores a paused session, surface an informational toast naming the resumed track: `Resuming '<Track>' — press play to continue.`
- Toast auto-dismisses after ~5s (via the existing `Toast` component's built-in timer) and dismisses immediately on the first user action — play, pause, open library, or open queue.
- `usePlayerLogic.handleHydrate` now returns the resolved `MediaTrack | null`, and `PlayerStateRenderer` exposes an optional `onHydrateFired(track)` callback that `AudioPlayer` uses to populate the toast state.

## Test plan
- [ ] Start with a previously-saved session (paused at mid-track).
- [ ] On app load, observe the toast appears once, naming the restored track, without triggering autoplay.
- [ ] Wait ~5 seconds — toast auto-dismisses.
- [ ] Reload and press play before the timer expires — toast dismisses immediately.
- [ ] Reload and press pause — toast dismisses immediately.
- [ ] Reload and open the library via `L` / bottom bar — toast dismisses immediately.
- [ ] Reload and open the queue drawer — toast dismisses immediately.
- [ ] `npm run test:run` — all 1212 tests pass.

Closes #1171