### PR TITLE
fix(player): skip to next playable track when hydrate fails

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -97,7 +97,7 @@ const AudioPlayerComponent = () => {
     return ps?.positionMs ?? null;
   }, [playbackProviderRef]);
 
-  const { lastSession } = useSessionPersistence(
+  const { lastSession, resetLastSession } = useSessionPersistence(
     selectedPlaylistId,
     collectionNameRef.current,
     collectionProviderRef.current,
@@ -144,8 +144,9 @@ const AudioPlayerComponent = () => {
     setResumeToastMessage(message);
   }, []);
   const handleHydrateFailed = useCallback(() => {
+    resetLastSession();
     setResumeToastMessage(`Couldn't resume your last session.`);
-  }, []);
+  }, [resetLastSession]);
   const withResumeDismiss = useCallback(
     <T extends (...args: never[]) => unknown>(fn: T): T => ((...args) => {
       setResumeToastMessage(null);

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -137,8 +137,14 @@ const AudioPlayerComponent = () => {
 
   const [resumeToastMessage, setResumeToastMessage] = useState<string | null>(null);
   const dismissResumeToast = useCallback(() => setResumeToastMessage(null), []);
-  const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack) => {
-    setResumeToastMessage(`Resuming '${track.name}' — press play to continue.`);
+  const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack, skipped: boolean) => {
+    const message = skipped
+      ? `Couldn't resume previous track — starting from next in queue.`
+      : `Resuming '${track.name}' — press play to continue.`;
+    setResumeToastMessage(message);
+  }, []);
+  const handleHydrateFailed = useCallback(() => {
+    setResumeToastMessage(`Couldn't resume your last session.`);
   }, []);
   const withResumeDismiss = useCallback(
     <T extends (...args: never[]) => unknown>(fn: T): T => ((...args) => {
@@ -323,6 +329,7 @@ const AudioPlayerComponent = () => {
               onOpenSettings={handleOpenSettings}
               onHydrate={handlers.handleHydrate}
               onHydrateFired={handleHydrateFired}
+              onHydrateFailed={handleHydrateFailed}
             />
           </ProfiledComponent>
           {qapToast && (

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -235,6 +235,10 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
     void onHydrate(lastSession)
       .then((result) => {
         if (result.totalFailure) {
+          // Route past the hydrate spinner immediately — the resolved lastSession
+          // prop may still read as valid for a tick until the caller resets it,
+          // and the override wins over the idle-route check.
+          setLibraryOverride(true);
           onHydrateFailed?.();
           return;
         }

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react
 import styled, { keyframes } from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import { isSessionStale, type SessionSnapshot } from '@/services/sessionPersistence';
+import type { HydrateResult } from '@/hooks/usePlayerLogic';
 import { Card, CardHeader, CardContent } from '../components/styled';
 import { Button } from '../components/styled';
 import { Alert, AlertDescription } from '../components/styled';
@@ -181,8 +182,9 @@ interface PlayerStateRendererProps {
   lastSession: SessionSnapshot | null;
   onResume: () => void;
   onOpenSettings: () => void;
-  onHydrate: (session: SessionSnapshot) => Promise<MediaTrack | null>;
-  onHydrateFired?: (track: MediaTrack) => void;
+  onHydrate: (session: SessionSnapshot) => Promise<HydrateResult>;
+  onHydrateFired?: (track: MediaTrack, skipped: boolean) => void;
+  onHydrateFailed?: () => void;
 }
 
 type IdleRoute = 'welcome' | 'qap' | 'hydrate' | 'library';
@@ -212,6 +214,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   onOpenSettings,
   onHydrate,
   onHydrateFired,
+  onHydrateFailed,
 }) => {
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
@@ -230,14 +233,18 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
     if (!lastSession) return;
     hydrateFiredRef.current = true;
     void onHydrate(lastSession)
-      .then((track) => {
-        if (track) onHydrateFired?.(track);
+      .then((result) => {
+        if (result.totalFailure) {
+          onHydrateFailed?.();
+          return;
+        }
+        if (result.track) onHydrateFired?.(result.track, result.skipped);
       })
       .catch(() => {
         // Hydrate errors are surfaced inside handleHydrate; swallow here so
         // a rejected promise doesn't bubble up as an unhandled rejection.
       });
-  }, [route, lastSession, onHydrate, onHydrateFired]);
+  }, [route, lastSession, onHydrate, onHydrateFired, onHydrateFailed]);
 
   const handleConnectClick = useCallback(() => {
     activeDescriptor?.auth.beginLogin();

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -76,7 +76,7 @@ const defaultProps = {
   lastSession: null,
   onResume: vi.fn(),
   onOpenSettings: vi.fn(),
-  onHydrate: vi.fn(async () => null),
+  onHydrate: vi.fn(async () => ({ track: null, skipped: false, totalFailure: false })),
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -161,7 +161,7 @@ describe('PlayerStateRenderer idle routing', () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
-    const onHydrate = vi.fn(async () => {});
+    const onHydrate = vi.fn(async () => ({ track: null, skipped: false, totalFailure: false }));
 
     // #when
     const { rerender } = render(
@@ -254,7 +254,7 @@ describe('PlayerStateRenderer idle routing', () => {
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
     const resolvedTrack = makeMediaTrack({ id: 't2', name: 'Second' });
-    const onHydrate = vi.fn(async () => resolvedTrack);
+    const onHydrate = vi.fn(async () => ({ track: resolvedTrack, skipped: false, totalFailure: false }));
     const onHydrateFired = vi.fn();
 
     // #when
@@ -273,7 +273,10 @@ describe('PlayerStateRenderer idle routing', () => {
     await waitFor(() => {
       expect(onHydrateFired).toHaveBeenCalledTimes(1);
     });
-    expect(onHydrateFired).toHaveBeenCalledWith(expect.objectContaining({ id: 't2', name: 'Second' }));
+    expect(onHydrateFired).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 't2', name: 'Second' }),
+      false,
+    );
   });
 
   it('does not call onHydrateFired for a stale session', async () => {
@@ -304,7 +307,7 @@ describe('PlayerStateRenderer idle routing', () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
-    const onHydrate = vi.fn(async () => {});
+    const onHydrate = vi.fn(async () => ({ track: null, skipped: false, totalFailure: false }));
 
     // #when
     render(
@@ -328,7 +331,7 @@ describe('PlayerStateRenderer idle routing', () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([false, vi.fn()]);
     mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
-    const onHydrate = vi.fn(async () => {});
+    const onHydrate = vi.fn(async () => ({ track: null, skipped: false, totalFailure: false }));
 
     // #when
     render(

--- a/src/components/__tests__/PlayerStateRenderer.test.tsx
+++ b/src/components/__tests__/PlayerStateRenderer.test.tsx
@@ -279,6 +279,40 @@ describe('PlayerStateRenderer idle routing', () => {
     );
   });
 
+  it('routes to LibraryPage and calls onHydrateFailed when onHydrate returns totalFailure', async () => {
+    // #given — the whole saved queue is unplayable. handleHydrate resolves with
+    // totalFailure; the renderer must not remain on the "Restoring Your Session"
+    // spinner even though `lastSession` prop is still valid for a tick.
+    mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);
+    mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+    const onHydrate = vi.fn(async () => ({ track: null, skipped: false, totalFailure: true }));
+    const onHydrateFailed = vi.fn();
+    const onHydrateFired = vi.fn();
+
+    // #when
+    render(
+      <Wrapper>
+        <PlayerStateRenderer
+          {...defaultProps}
+          onHydrate={onHydrate}
+          onHydrateFailed={onHydrateFailed}
+          onHydrateFired={onHydrateFired}
+          lastSession={freshSession}
+        />
+      </Wrapper>,
+    );
+
+    // #then — totalFailure triggers the failed callback and unblocks the library view
+    await waitFor(() => {
+      expect(onHydrateFailed).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-selection')).toBeInTheDocument();
+    });
+    expect(onHydrateFired).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Restoring Your Session/i)).not.toBeInTheDocument();
+  });
+
   it('does not call onHydrateFired for a stale session', async () => {
     // #given
     mockUseWelcomeSeen.mockReturnValue([true, vi.fn()]);

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -10,7 +10,8 @@ import type { MediaTrack } from '@/types/domain';
 type HandlerKey = 'play' | 'pause' | 'next' | 'previous' | 'library';
 
 type ResumeToastHarnessHandle = {
-  fireHydrate: (track: MediaTrack) => void;
+  fireHydrate: (track: MediaTrack, skipped?: boolean) => void;
+  fireHydrateFailed: () => void;
   invoke: (key: HandlerKey) => void;
 };
 
@@ -21,8 +22,16 @@ const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueu
     const [message, setMessage] = useState<string | null>(null);
     const dismiss = useCallback(() => setMessage(null), []);
 
-    const handleHydrateFired = useCallback((track: MediaTrack) => {
-      setMessage(`Resuming '${track.name}' — press play to continue.`);
+    const handleHydrateFired = useCallback((track: MediaTrack, skipped = false) => {
+      setMessage(
+        skipped
+          ? `Couldn't resume previous track — starting from next in queue.`
+          : `Resuming '${track.name}' — press play to continue.`,
+      );
+    }, []);
+
+    const handleHydrateFailed = useCallback(() => {
+      setMessage(`Couldn't resume your last session.`);
     }, []);
 
     const withResumeDismiss = useCallback(
@@ -51,6 +60,7 @@ const ResumeToastHarness = React.forwardRef<ResumeToastHarnessHandle, { showQueu
 
     React.useImperativeHandle(ref, () => ({
       fireHydrate: handleHydrateFired,
+      fireHydrateFailed: handleHydrateFailed,
       invoke: (key) => handlers[key](),
     }));
 
@@ -166,5 +176,37 @@ describe('Resume toast behavior', () => {
 
     // #then
     expect(screen.queryByText(/Resuming 'Four on Six'/)).not.toBeInTheDocument();
+  });
+
+  it('shows the partial-failure message when hydrate skipped to a later track', () => {
+    // #given
+    const { ref } = renderHarness();
+
+    // #when
+    act(() => {
+      ref.current?.fireHydrate(makeMediaTrack({ name: 'Skipped Track' }), true);
+    });
+
+    // #then
+    expect(
+      screen.getByText("Couldn't resume previous track — starting from next in queue."),
+    ).toBeInTheDocument();
+    // The specific track name must not leak into the partial-failure copy.
+    expect(screen.queryByText(/Skipped Track/)).not.toBeInTheDocument();
+  });
+
+  it('shows the full-failure message when hydrate could not prepare any track', () => {
+    // #given
+    const { ref } = renderHarness();
+
+    // #when
+    act(() => {
+      ref.current?.fireHydrateFailed();
+    });
+
+    // #then
+    expect(
+      screen.getByText("Couldn't resume your last session."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
@@ -1,9 +1,11 @@
 /**
- * Tests for usePlayerLogic.handleHydrate — restores session state without autoplay.
+ * Tests for usePlayerLogic.handleHydrate fallback behavior — when the saved
+ * track can't be loaded, the player should skip forward through the queue
+ * until a playable track is found, or reset to the library if none is.
  */
 
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { usePlayerLogic } from '../usePlayerLogic';
 import { TrackProvider } from '@/contexts/TrackContext';
@@ -11,10 +13,13 @@ import { VisualEffectsProvider } from '@/contexts/visualEffects';
 import { ColorProvider } from '@/contexts/ColorContext';
 import { ProviderProvider } from '@/contexts/ProviderContext';
 import { makeMediaTrack } from '@/test/fixtures';
+import { UnavailableTrackError } from '@/providers/errors';
+import * as sessionPersistence from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 const playTrackSpy = vi.fn();
 const mockPrepareTrack = vi.fn();
+const mockIsAuthenticated = vi.fn(() => true);
 
 vi.mock('@/hooks/usePlaylistManager', () => ({
   usePlaylistManager: vi.fn(() => ({ handlePlaylistSelect: vi.fn() })),
@@ -52,7 +57,7 @@ const mockDescriptor = {
   id: 'spotify' as const,
   catalog: { listTracks: vi.fn().mockResolvedValue([]) },
   auth: {
-    isAuthenticated: vi.fn().mockReturnValue(true),
+    isAuthenticated: mockIsAuthenticated,
     beginLogin: vi.fn(),
     logout: vi.fn(),
   },
@@ -144,152 +149,139 @@ function makeSession(overrides?: Partial<SessionSnapshot>): SessionSnapshot {
     collectionId: 'playlist-xyz',
     collectionName: 'My Playlist',
     collectionProvider: 'spotify',
-    trackIndex: 1,
-    trackId: 'track-b',
+    trackIndex: 0,
+    trackId: 'track-a',
     queueTracks: [trackA, trackB],
     playbackPosition: 42_000,
     ...overrides,
   };
 }
 
-describe('usePlayerLogic — handleHydrate', () => {
+describe('usePlayerLogic — handleHydrate fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     playTrackSpy.mockClear();
     mockPrepareTrack.mockClear();
+    mockIsAuthenticated.mockReturnValue(true);
   });
 
-  it('restores queue state and paused position without calling playTrack', async () => {
-    // #given
+  it('skips to the next track when prepareTrack throws on the saved track', async () => {
+    // #given — first track's prepareTrack throws UnavailableTrackError, second succeeds
+    mockPrepareTrack
+      .mockImplementationOnce(() => { throw new UnavailableTrackError('Song A'); })
+      .mockImplementationOnce(() => {});
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
     // #when
+    let hydrateResult!: Awaited<ReturnType<typeof result.current.handlers.handleHydrate>>;
+    await act(async () => {
+      hydrateResult = await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then — landed on second track, flagged as skipped
+    expect(hydrateResult.track?.id).toBe('track-b');
+    expect(hydrateResult.skipped).toBe(true);
+    expect(hydrateResult.totalFailure).toBe(false);
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(2);
+    expect(mockPrepareTrack.mock.calls[0][0].id).toBe('track-a');
+    expect(mockPrepareTrack.mock.calls[1][0].id).toBe('track-b');
+  });
+
+  it('omits the saved positionMs when falling back to a later track', async () => {
+    // #given
+    mockPrepareTrack
+      .mockImplementationOnce(() => { throw new Error('boom'); })
+      .mockImplementationOnce(() => {});
+    const session = makeSession({ playbackPosition: 120_000 });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then — first call had positionMs, second had undefined
+    expect(mockPrepareTrack.mock.calls[0][1]).toEqual({ positionMs: 120_000 });
+    expect(mockPrepareTrack.mock.calls[1][1]).toBeUndefined();
+  });
+
+  it('updates currentTrackIndex to the first playable candidate', async () => {
+    // #given — three-track queue, first two throw, third succeeds
+    mockPrepareTrack
+      .mockImplementationOnce(() => { throw new UnavailableTrackError('a'); })
+      .mockImplementationOnce(() => { throw new UnavailableTrackError('b'); })
+      .mockImplementationOnce(() => {});
+    const trackA = makeMediaTrack({ id: 'track-a' });
+    const trackB = makeMediaTrack({ id: 'track-b' });
+    const trackC = makeMediaTrack({ id: 'track-c' });
+    const session = makeSession({ queueTracks: [trackA, trackB, trackC], trackId: 'track-a', trackIndex: 0 });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
     await act(async () => {
       await result.current.handlers.handleHydrate(session);
     });
 
     // #then
-    expect(result.current.state.tracks).toHaveLength(2);
-    expect(result.current.state.tracks[0].id).toBe('track-a');
-    expect(result.current.state.tracks[1].id).toBe('track-b');
-    expect(result.current.state.selectedPlaylistId).toBe('playlist-xyz');
-    expect(result.current.state.isPlaying).toBe(false);
-    expect(result.current.state.playbackPosition).toBe(42_000);
-    expect(playTrackSpy).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.state.tracks).toHaveLength(3);
+    });
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(3);
+    expect(mockPrepareTrack.mock.calls[2][0].id).toBe('track-c');
   });
 
-  it('calls prepareTrack with the resolved track and saved positionMs', async () => {
-    // #given
+  it('routes to the library and clears the session when every track fails', async () => {
+    // #given — both tracks throw
+    mockPrepareTrack.mockImplementation(() => { throw new UnavailableTrackError('nope'); });
+    const clearSessionSpy = vi.spyOn(sessionPersistence, 'clearSession');
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
     // #when
+    let hydrateResult!: Awaited<ReturnType<typeof result.current.handlers.handleHydrate>>;
     await act(async () => {
-      await result.current.handlers.handleHydrate(session);
+      hydrateResult = await result.current.handlers.handleHydrate(session);
     });
 
-    // #then
-    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
-    const [passedTrack, passedOptions] = mockPrepareTrack.mock.calls[0];
-    expect(passedTrack.id).toBe('track-b');
-    expect(passedOptions).toEqual({ positionMs: 42_000 });
-  });
-
-  it('omits positionMs option when saved position is missing or zero', async () => {
-    // #given
-    const session = makeSession({ playbackPosition: 0 });
-    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
-
-    // #when
-    await act(async () => {
-      await result.current.handlers.handleHydrate(session);
+    // #then — full-failure result, queue cleared, session dropped
+    expect(hydrateResult.track).toBeNull();
+    expect(hydrateResult.skipped).toBe(false);
+    expect(hydrateResult.totalFailure).toBe(true);
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(2);
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(result.current.state.tracks).toHaveLength(0);
+      expect(result.current.state.selectedPlaylistId).toBeNull();
     });
-
-    // #then
-    expect(result.current.state.playbackPosition).toBe(0);
-    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
-    const passedOptions = mockPrepareTrack.mock.calls[0][1];
-    expect(passedOptions).toBeUndefined();
   });
 
-  it('resolves target index by trackId when it exists in the queue', async () => {
-    // #given — trackIndex points at 0, but trackId matches track at position 1
-    const session = makeSession({ trackIndex: 0, trackId: 'track-b' });
-    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
-
-    // #when
-    await act(async () => {
-      await result.current.handlers.handleHydrate(session);
-    });
-
-    // #then
-    expect(mockPrepareTrack.mock.calls[0][0].id).toBe('track-b');
-  });
-
-  it('triggers playTrack with saved positionMs on the next handlePlay', async () => {
-    // #given
+  it('treats unauthenticated providers as a total failure and routes to the library', async () => {
+    // #given — every candidate's descriptor reports unauthenticated, so no track
+    // can be prepared. The only way to force this reliably is to flip the mock
+    // to always return false for this test — the ProviderProvider also consumes
+    // isAuthenticated during render, so per-call flipping is racey.
+    mockIsAuthenticated.mockReturnValue(false);
+    const clearSessionSpy = vi.spyOn(sessionPersistence, 'clearSession');
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
-    await act(async () => {
-      await result.current.handlers.handleHydrate(session);
-    });
-    playTrackSpy.mockClear();
-
     // #when
+    let hydrateResult!: Awaited<ReturnType<typeof result.current.handlers.handleHydrate>>;
     await act(async () => {
-      await result.current.handlers.handlePlay();
+      hydrateResult = await result.current.handlers.handleHydrate(session);
     });
 
-    // #then
-    expect(playTrackSpy).toHaveBeenCalledTimes(1);
-    const [index, skipOnError, options] = playTrackSpy.mock.calls[0];
-    expect(index).toBe(1);
-    expect(skipOnError).toBe(false);
-    expect(options).toEqual({ positionMs: 42_000 });
-  });
-
-  it('does not re-trigger playTrack on a second handlePlay after hydrate', async () => {
-    // #given
-    const session = makeSession();
-    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
-
-    await act(async () => {
-      await result.current.handlers.handleHydrate(session);
-      await result.current.handlers.handlePlay();
-    });
-    playTrackSpy.mockClear();
-
-    // #when — a second press should fall through to the normal resume path
-    await act(async () => {
-      await result.current.handlers.handlePlay();
-    });
-
-    // #then
-    expect(playTrackSpy).not.toHaveBeenCalled();
-    expect(mockDescriptor.playback.resume).toHaveBeenCalled();
-  });
-
-  it('no-ops when session has no queueTracks', async () => {
-    // #given
-    const session = makeSession({ queueTracks: [] });
-    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
-
-    // #when
-    await act(async () => {
-      await result.current.handlers.handleHydrate(session);
-    });
-
-    // #then
-    expect(result.current.state.tracks).toHaveLength(0);
-    expect(result.current.state.selectedPlaylistId).toBeNull();
+    // #then — prepareTrack never ran; session wiped; total failure
+    expect(hydrateResult.totalFailure).toBe(true);
+    expect(hydrateResult.track).toBeNull();
     expect(mockPrepareTrack).not.toHaveBeenCalled();
-    expect(playTrackSpy).not.toHaveBeenCalled();
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('discards a pending hydrate when handleNext runs first', async () => {
+  it('clears the pending hydrate ref on total failure so handlePlay does not resurrect it', async () => {
     // #given
+    mockPrepareTrack.mockImplementation(() => { throw new UnavailableTrackError('nope'); });
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
@@ -298,19 +290,38 @@ describe('usePlayerLogic — handleHydrate', () => {
     });
     playTrackSpy.mockClear();
 
-    // #when — user skips to next, consuming playback routing without the hydrate options
-    await act(async () => {
-      result.current.handlers.handleNext();
-    });
-    const nextCall = playTrackSpy.mock.calls.at(-1);
-    playTrackSpy.mockClear();
+    // #when — user hits play after hydrate wipes out
     await act(async () => {
       await result.current.handlers.handlePlay();
     });
 
-    // #then — handleNext took over; subsequent handlePlay uses resume, not a hydrated start
-    expect(nextCall?.[0]).toBe(0); // wrapped around from index 1 -> 0 in a 2-track queue
+    // #then — no pending hydrate was consumed; nothing plays
     expect(playTrackSpy).not.toHaveBeenCalled();
-    expect(mockDescriptor.playback.resume).toHaveBeenCalled();
+  });
+
+  it('lets a subsequent handlePlay start the fallback track at position 0', async () => {
+    // #given — first throws, second succeeds; fallback should lose the saved position
+    mockPrepareTrack
+      .mockImplementationOnce(() => { throw new UnavailableTrackError('Song A'); })
+      .mockImplementationOnce(() => {});
+    const session = makeSession({ playbackPosition: 90_000 });
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    await act(async () => {
+      await result.current.handlers.handleHydrate(session);
+    });
+    playTrackSpy.mockClear();
+
+    // #when
+    await act(async () => {
+      await result.current.handlers.handlePlay();
+    });
+
+    // #then — handlePlay consumed the pending-play ref at index 1 with no positionMs
+    expect(playTrackSpy).toHaveBeenCalledTimes(1);
+    const [idx, skipOnError, options] = playTrackSpy.mock.calls[0];
+    expect(idx).toBe(1);
+    expect(skipOnError).toBe(false);
+    expect(options).toBeUndefined();
   });
 });

--- a/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
@@ -14,11 +14,11 @@ import { ColorProvider } from '@/contexts/ColorContext';
 import { ProviderProvider } from '@/contexts/ProviderContext';
 import { makeMediaTrack } from '@/test/fixtures';
 import { UnavailableTrackError } from '@/providers/errors';
-import * as sessionPersistence from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
 const playTrackSpy = vi.fn();
 const mockPrepareTrack = vi.fn();
+const mockProbePlayable = vi.fn();
 const mockIsAuthenticated = vi.fn(() => true);
 
 vi.mock('@/hooks/usePlaylistManager', () => ({
@@ -69,6 +69,7 @@ const mockDescriptor = {
     getState: vi.fn().mockResolvedValue(null),
     subscribe: vi.fn(() => vi.fn()),
     prepareTrack: mockPrepareTrack,
+    probePlayable: mockProbePlayable,
   },
   capabilities: { hasSaveTrack: true, hasExternalLink: true, hasLikedCollection: true },
 };
@@ -162,6 +163,8 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
     vi.clearAllMocks();
     playTrackSpy.mockClear();
     mockPrepareTrack.mockClear();
+    mockProbePlayable.mockClear();
+    mockProbePlayable.mockResolvedValue(true);
     mockIsAuthenticated.mockReturnValue(true);
   });
 
@@ -231,10 +234,9 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
     expect(mockPrepareTrack.mock.calls[2][0].id).toBe('track-c');
   });
 
-  it('routes to the library and clears the session when every track fails', async () => {
+  it('routes to the library and flags total failure when every track fails', async () => {
     // #given — both tracks throw
     mockPrepareTrack.mockImplementation(() => { throw new UnavailableTrackError('nope'); });
-    const clearSessionSpy = vi.spyOn(sessionPersistence, 'clearSession');
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
@@ -244,12 +246,11 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
       hydrateResult = await result.current.handlers.handleHydrate(session);
     });
 
-    // #then — full-failure result, queue cleared, session dropped
+    // #then — full-failure result, queue cleared (persistence cleanup is the caller's job)
     expect(hydrateResult.track).toBeNull();
     expect(hydrateResult.skipped).toBe(false);
     expect(hydrateResult.totalFailure).toBe(true);
     expect(mockPrepareTrack).toHaveBeenCalledTimes(2);
-    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
     await waitFor(() => {
       expect(result.current.state.tracks).toHaveLength(0);
       expect(result.current.state.selectedPlaylistId).toBeNull();
@@ -262,7 +263,6 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
     // to always return false for this test — the ProviderProvider also consumes
     // isAuthenticated during render, so per-call flipping is racey.
     mockIsAuthenticated.mockReturnValue(false);
-    const clearSessionSpy = vi.spyOn(sessionPersistence, 'clearSession');
     const session = makeSession();
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
@@ -272,11 +272,10 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
       hydrateResult = await result.current.handlers.handleHydrate(session);
     });
 
-    // #then — prepareTrack never ran; session wiped; total failure
+    // #then — prepareTrack never ran; total failure
     expect(hydrateResult.totalFailure).toBe(true);
     expect(hydrateResult.track).toBeNull();
     expect(mockPrepareTrack).not.toHaveBeenCalled();
-    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
   });
 
   it('clears the pending hydrate ref on total failure so handlePlay does not resurrect it', async () => {
@@ -297,6 +296,49 @@ describe('usePlayerLogic — handleHydrate fallback', () => {
 
     // #then — no pending hydrate was consumed; nothing plays
     expect(playTrackSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips tracks the adapter reports as unplayable via probePlayable without calling prepareTrack', async () => {
+    // #given — first candidate probes as unplayable (file moved / market-restricted),
+    // second probes playable. Because real adapters swallow prepareTrack errors
+    // internally, probePlayable is the real skip signal.
+    mockPrepareTrack.mockReset();
+    mockProbePlayable
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    let hydrateResult!: Awaited<ReturnType<typeof result.current.handlers.handleHydrate>>;
+    await act(async () => {
+      hydrateResult = await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then — advanced to the second track; prepareTrack only ran for the playable one
+    expect(hydrateResult.track?.id).toBe('track-b');
+    expect(hydrateResult.skipped).toBe(true);
+    expect(mockProbePlayable).toHaveBeenCalledTimes(2);
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
+    expect(mockPrepareTrack.mock.calls[0][0].id).toBe('track-b');
+  });
+
+  it('aborts to library when probePlayable throws AuthExpiredError on every candidate', async () => {
+    // #given — provider auth is stale; probes throw for each candidate
+    const { AuthExpiredError } = await import('@/providers/errors');
+    mockProbePlayable.mockRejectedValue(new AuthExpiredError('spotify'));
+    const session = makeSession();
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    let hydrateResult!: Awaited<ReturnType<typeof result.current.handlers.handleHydrate>>;
+    await act(async () => {
+      hydrateResult = await result.current.handlers.handleHydrate(session);
+    });
+
+    // #then
+    expect(hydrateResult.totalFailure).toBe(true);
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
   });
 
   it('lets a subsequent handlePlay start the fallback track at position 0', async () => {

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -10,7 +10,7 @@ import { useAccentColor } from '@/hooks/useAccentColor';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { useRadio } from '@/hooks/useRadio';
 import type { MediaTrack, ProviderId } from '@/types/domain';
-import { type SessionSnapshot, clearSession } from '@/services/sessionPersistence';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
 import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
@@ -357,6 +357,32 @@ export function usePlayerLogic() {
 
       const positionMs = offset === 0 && savedPositionIsValid ? savedPositionMs : undefined;
 
+      // Probe playability before we commit to this candidate. `prepareTrack`
+      // on both real adapters is fire-and-forget (internal promise; its errors
+      // don't surface to the caller), so without a probe the iterator would
+      // never advance against real provider failures like a market-restricted
+      // Spotify track or a moved Dropbox file.
+      if (descriptor.playback.probePlayable) {
+        try {
+          const playable = await descriptor.playback.probePlayable(candidateTrack);
+          if (!playable) {
+            logQueue(
+              'handleHydrate probePlayable=false on index=%d, track=%s',
+              candidateIdx,
+              trkSummary(candidateTrack),
+            );
+            continue;
+          }
+        } catch (error) {
+          if (error instanceof AuthExpiredError) {
+            logQueue('handleHydrate probePlayable AuthExpiredError on index=%d, provider=%s', candidateIdx, providerId);
+          } else {
+            logQueue('handleHydrate probePlayable threw on index=%d: %o', candidateIdx, error);
+          }
+          continue;
+        }
+      }
+
       try {
         descriptor.playback.prepareTrack?.(
           candidateTrack,
@@ -392,10 +418,10 @@ export function usePlayerLogic() {
       return { track: candidateTrack, skipped: offset > 0, totalFailure: false };
     }
 
-    // No track could be prepared — fully drop the session and route to library.
+    // No track could be prepared — drop the queue and let the caller clear the
+    // saved session via onHydrateFailed (AudioPlayer owns the session state).
     logQueue('handleHydrate — total failure, resetting to library');
     hydratedPendingPlayRef.current = null;
-    clearSession();
     handleBackToLibrary();
     return { track: null, skipped: false, totalFailure: true };
   }, [

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -10,9 +10,10 @@ import { useAccentColor } from '@/hooks/useAccentColor';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import { useRadio } from '@/hooks/useRadio';
 import type { MediaTrack, ProviderId } from '@/types/domain';
-import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { type SessionSnapshot, clearSession } from '@/services/sessionPersistence';
 import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
+import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { logQueue } from '@/lib/debugLog';
 import { useQueueThumbnailLoader } from '@/hooks/useQueueThumbnailLoader';
 import { useQueueDurationLoader } from '@/hooks/useQueueDurationLoader';
@@ -23,6 +24,15 @@ import { usePlaybackSubscription } from './usePlaybackSubscription';
 import { useRadioSession } from './useRadioSession';
 import { useRecentlyPlayedCollections } from './useRecentlyPlayedCollections';
 import type { RadioProgress } from '@/types/radio';
+
+export interface HydrateResult {
+  /** Track the player landed on, or null when the whole queue was unplayable. */
+  track: MediaTrack | null;
+  /** True when the saved track was unplayable and a later track in the queue was used instead. */
+  skipped: boolean;
+  /** True when no track in the queue could be prepared; the player was reset to the library. */
+  totalFailure: boolean;
+}
 
 export function usePlayerLogic() {
   // Terminology used in this hook:
@@ -262,58 +272,6 @@ export function usePlayerLogic() {
     }
   }, [playTrack, getDrivingProviderId, getDrivingProviderDescriptor]);
 
-  const handleHydrate = useCallback(async (session: SessionSnapshot): Promise<MediaTrack | null> => {
-    if (!session.queueTracks?.length) return null;
-    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPositionMs } = session;
-
-    const targetIdx = trackId
-      ? queueTracks.findIndex(t => t.id === trackId)
-      : Math.min(trackIndex, queueTracks.length - 1);
-    const resolvedIdx = targetIdx >= 0 ? targetIdx : Math.min(trackIndex, queueTracks.length - 1);
-
-    setTracks(queueTracks);
-    setOriginalTracks(queueTracks);
-    setSelectedPlaylistId(collectionId);
-    setCurrentTrackIndex(resolvedIdx);
-    mediaTracksRef.current = queueTracks;
-    expectedTrackIdRef.current = queueTracks[resolvedIdx]?.id ?? null;
-
-    const positionMs = savedPositionMs && savedPositionMs > 0 ? savedPositionMs : undefined;
-    setPlaybackPosition(positionMs ?? 0);
-    setIsPlaying(false);
-
-    const targetTrack = queueTracks[resolvedIdx];
-    const providerId = targetTrack?.provider ?? activeDescriptor?.id;
-    if (providerId && targetTrack) {
-      drivingProviderRef.current = providerId;
-      const descriptor = providerRegistry.get(providerId);
-      descriptor?.playback.prepareTrack?.(
-        targetTrack,
-        positionMs ? { positionMs } : undefined,
-      );
-    }
-
-    hydratedPendingPlayRef.current = { index: resolvedIdx, positionMs };
-
-    logQueue(
-      'handleHydrate — index=%d, track=%s, positionMs=%s, provider=%s',
-      resolvedIdx,
-      trkSummary(targetTrack),
-      positionMs ?? 'NONE',
-      providerId ?? 'NONE',
-    );
-
-    return targetTrack ?? null;
-  }, [
-    setTracks,
-    setOriginalTracks,
-    setSelectedPlaylistId,
-    setCurrentTrackIndex,
-    mediaTracksRef,
-    activeDescriptor,
-    drivingProviderRef,
-  ]);
-
   const handlePause = useCallback(() => {
     const drivingId = getDrivingProviderId();
     logQueue('handlePause — drivingProvider=%s, index=%d', drivingId, currentTrackIndexRef.current);
@@ -355,6 +313,101 @@ export function usePlayerLogic() {
     setShowQueue(false);
     setShowVisualEffects(false);
   }, [handlePause, stopRadio, setSelectedPlaylistId, setTracks, setCurrentTrackIndex, setShowQueue, setShowVisualEffects]);
+
+  const handleHydrate = useCallback(async (session: SessionSnapshot): Promise<HydrateResult> => {
+    if (!session.queueTracks?.length) {
+      return { track: null, skipped: false, totalFailure: false };
+    }
+    const { queueTracks, trackId, trackIndex, collectionId, playbackPosition: savedPositionMs } = session;
+
+    const fallbackIdx = Math.max(0, Math.min(trackIndex, queueTracks.length - 1));
+    const matchedIdx = trackId ? queueTracks.findIndex(t => t.id === trackId) : -1;
+    const startIdx = matchedIdx >= 0 ? matchedIdx : fallbackIdx;
+
+    setTracks(queueTracks);
+    setOriginalTracks(queueTracks);
+    setSelectedPlaylistId(collectionId);
+    mediaTracksRef.current = queueTracks;
+
+    const savedPositionIsValid = savedPositionMs !== undefined && savedPositionMs > 0;
+
+    // Iterate through the queue starting at the saved index. If a candidate's
+    // provider is missing/unauthenticated or prepareTrack throws, advance to the
+    // next track and retry — bounded by queueTracks.length to avoid infinite
+    // loops on a fully-broken queue. Only the first candidate gets the saved
+    // position; subsequent fallbacks start at zero.
+    for (let offset = 0; offset < queueTracks.length; offset += 1) {
+      const candidateIdx = (startIdx + offset) % queueTracks.length;
+      const candidateTrack = queueTracks[candidateIdx];
+      if (!candidateTrack) continue;
+
+      const providerId = candidateTrack.provider ?? activeDescriptor?.id;
+      const descriptor = providerId ? providerRegistry.get(providerId) : undefined;
+      const providerAuthed = descriptor?.auth.isAuthenticated() ?? false;
+
+      if (!providerId || !descriptor || !providerAuthed) {
+        logQueue(
+          'handleHydrate skip — index=%d, track=%s, reason=%s',
+          candidateIdx,
+          trkSummary(candidateTrack),
+          !providerId ? 'no-provider' : !descriptor ? 'no-descriptor' : 'unauthenticated',
+        );
+        continue;
+      }
+
+      const positionMs = offset === 0 && savedPositionIsValid ? savedPositionMs : undefined;
+
+      try {
+        descriptor.playback.prepareTrack?.(
+          candidateTrack,
+          positionMs ? { positionMs } : undefined,
+        );
+      } catch (error) {
+        if (error instanceof AuthExpiredError) {
+          logQueue('handleHydrate AuthExpiredError on index=%d, provider=%s', candidateIdx, providerId);
+        } else if (error instanceof UnavailableTrackError) {
+          logQueue('handleHydrate UnavailableTrackError on index=%d: %s', candidateIdx, error.message);
+        } else {
+          logQueue('handleHydrate prepareTrack threw on index=%d: %o', candidateIdx, error);
+        }
+        continue;
+      }
+
+      setCurrentTrackIndex(candidateIdx);
+      expectedTrackIdRef.current = candidateTrack.id;
+      drivingProviderRef.current = providerId;
+      setPlaybackPosition(positionMs ?? 0);
+      setIsPlaying(false);
+      hydratedPendingPlayRef.current = { index: candidateIdx, positionMs };
+
+      logQueue(
+        'handleHydrate — index=%d, track=%s, positionMs=%s, provider=%s, skipped=%s',
+        candidateIdx,
+        trkSummary(candidateTrack),
+        positionMs ?? 'NONE',
+        providerId,
+        offset > 0 ? 'YES' : 'NO',
+      );
+
+      return { track: candidateTrack, skipped: offset > 0, totalFailure: false };
+    }
+
+    // No track could be prepared — fully drop the session and route to library.
+    logQueue('handleHydrate — total failure, resetting to library');
+    hydratedPendingPlayRef.current = null;
+    clearSession();
+    handleBackToLibrary();
+    return { track: null, skipped: false, totalFailure: true };
+  }, [
+    setTracks,
+    setOriginalTracks,
+    setSelectedPlaylistId,
+    setCurrentTrackIndex,
+    mediaTracksRef,
+    activeDescriptor,
+    drivingProviderRef,
+    handleBackToLibrary,
+  ]);
 
   // Initialize queue management handlers
   const { handleAddToQueue, queueTracksDirectly, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
-import { saveSession, loadSession } from '@/services/sessionPersistence';
+import { saveSession, loadSession, clearSession } from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { logSession } from '@/lib/debugLog';
 
@@ -19,7 +19,7 @@ export function useSessionPersistence(
   trackImage: string | undefined,
   playbackPosition: number,
   getLivePosition?: () => Promise<number | null>,
-): { lastSession: SessionSnapshot | null } {
+): { lastSession: SessionSnapshot | null; resetLastSession: () => void } {
   const [lastSession, setLastSession] = useState<SessionSnapshot | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -126,5 +126,11 @@ export function useSessionPersistence(
     };
   }, []);
 
-  return { lastSession };
+  const resetLastSession = useCallback(() => {
+    clearSession();
+    snapshotRef.current = null;
+    setLastSession(null);
+  }, []);
+
+  return { lastSession, resetLastSession };
 }

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -378,4 +378,54 @@ describe('DropboxPlaybackAdapter', () => {
       expect(findHydrateCall(listener, 'track-fail')).toBeUndefined();
     });
   });
+
+  describe('probePlayable', () => {
+    it('returns true when getTemporaryLink resolves', async () => {
+      // #given — live file: catalog hands back a fresh download link
+      const track = makeMediaTrack({
+        id: 'track-ok',
+        playbackRef: { provider: 'dropbox', ref: '/Music/ok.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!).mockResolvedValueOnce('https://example.com/ok.mp3');
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then
+      expect(result).toBe(true);
+      expect(mockCatalog.getTemporaryLink).toHaveBeenCalledWith('/Music/ok.mp3');
+    });
+
+    it('returns false when getTemporaryLink rejects (file moved/gone)', async () => {
+      // #given — catalog couldn't find the file (moved/renamed/deleted)
+      const track = makeMediaTrack({
+        id: 'track-gone',
+        playbackRef: { provider: 'dropbox', ref: '/Music/gone.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(
+        new Error('path_lookup/not_found'),
+      );
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then
+      expect(result).toBe(false);
+    });
+
+    it('rethrows AuthExpiredError so the caller can abort hydrate', async () => {
+      // #given — Dropbox refresh-token exchange failed mid-probe
+      const { AuthExpiredError } = await import('@/providers/errors');
+      const track = makeMediaTrack({
+        id: 'track-auth',
+        playbackRef: { provider: 'dropbox', ref: '/Music/auth.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(
+        new AuthExpiredError('dropbox'),
+      );
+
+      // #when / #then
+      await expect(adapter.probePlayable(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+  });
 });

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -5,6 +5,7 @@
 
 import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
+import { AuthExpiredError } from '@/providers/errors';
 import { DropboxCatalogAdapter } from './dropboxCatalogAdapter';
 import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
@@ -196,6 +197,16 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     doEnrich().catch(() => {
       // Metadata enrichment is best-effort; ignore failures
     });
+  }
+
+  async probePlayable(track: MediaTrack): Promise<boolean> {
+    try {
+      await this.catalog.getTemporaryLink(track.playbackRef.ref);
+      return true;
+    } catch (error) {
+      if (error instanceof AuthExpiredError) throw error;
+      return false;
+    }
   }
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SpotifyPlaybackAdapter } from '@/providers/spotify/spotifyPlaybackAdapter';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
+import { AuthExpiredError } from '@/providers/errors';
 import type { MediaTrack, PlaybackState } from '@/types/domain';
 
 vi.mock('@/services/spotifyPlayer', () => ({
@@ -154,6 +155,84 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     // #then
     await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
     expect(countPlayCalls(fetchMock)).toBe(2);
+  });
+
+  describe('probePlayable', () => {
+    const findTrackProbeCall = (mock: ReturnType<typeof vi.fn>) =>
+      mock.mock.calls.find(([url]) => typeof url === 'string' && url.includes('/v1/tracks/'));
+
+    it('returns true when the track responds with is_playable=true', async () => {
+      // #given
+      const track = makeTrack();
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ is_playable: true }), { status: 200 }),
+      );
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then
+      expect(result).toBe(true);
+      const probe = findTrackProbeCall(fetchMock)!;
+      expect(probe[0]).toContain('/v1/tracks/abc');
+      expect(probe[0]).toContain('market=from_token');
+    });
+
+    it('returns false when is_playable is explicitly false (market-restricted)', async () => {
+      // #given
+      const track = makeTrack();
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ is_playable: false }), { status: 200 }),
+      );
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the track endpoint responds with 404', async () => {
+      // #given — Spotify removed the track from the catalog
+      const track = makeTrack();
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the playback ref is not a spotify:track URI', async () => {
+      // #given — malformed ref (e.g., stale Spotify URI coming from a legacy session)
+      const track = makeTrack({ playbackRef: { provider: 'spotify', ref: 'spotify:episode:xyz' } });
+
+      // #when
+      const result = await adapter.probePlayable(track);
+
+      // #then — we never even hit fetch
+      expect(result).toBe(false);
+      expect(findTrackProbeCall(fetchMock)).toBeUndefined();
+    });
+
+    it('throws AuthExpiredError on 401 so the caller can abort hydrate', async () => {
+      // #given
+      const track = makeTrack();
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+      // #when / #then
+      await expect(adapter.probePlayable(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+
+    it('throws on unexpected non-ok responses (e.g. 500) to surface transient errors', async () => {
+      // #given
+      const track = makeTrack();
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+      // #when / #then
+      await expect(adapter.probePlayable(track)).rejects.toThrow(/probePlayable failed: 500/);
+    });
   });
 
   it('skips the stale stage emission when a different track is prepared mid-stage', async () => {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -272,6 +272,25 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     return spotifyPlayer.lastPlayTrackTime;
   }
 
+  async probePlayable(track: MediaTrack): Promise<boolean> {
+    const uri = track.playbackRef.ref;
+    const match = /^spotify:track:([A-Za-z0-9]+)$/.exec(uri);
+    if (!match) return false;
+    const trackId = match[1];
+    const token = await spotifyAuth.ensureValidToken();
+    const res = await fetch(
+      `https://api.spotify.com/v1/tracks/${trackId}?market=from_token`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (res.status === 401) throw new AuthExpiredError('spotify');
+    if (res.status === 404) return false;
+    if (!res.ok) {
+      throw new Error(`Spotify probePlayable failed: ${res.status}`);
+    }
+    const body = (await res.json()) as { is_playable?: boolean };
+    return body.is_playable !== false;
+  }
+
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     // Warm the auth token unconditionally so a token refresh delay can't stall
     // the next transition even if the stage chain early-returns.

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -81,6 +81,14 @@ export interface PlaybackProvider {
   subscribe(listener: (state: PlaybackState | null) => void): () => void;
   /** Optional: pre-warm resources for an upcoming track (e.g. fetch temporary links). Supplying positionMs lets the adapter prepare to resume at that offset. */
   prepareTrack?(track: MediaTrack, options?: { positionMs?: number }): void;
+  /**
+   * Optional: quickly verify that a track can still be played by this provider
+   * without starting playback. Used by session hydrate to skip tracks that have
+   * become unavailable (file moved, market-restricted, removed from catalog).
+   * Return `false` for known-unplayable tracks; throw for transient errors
+   * (auth, network) that should abort the whole hydrate iteration.
+   */
+  probePlayable?(track: MediaTrack): Promise<boolean>;
   /** Optional: re-fetch album art for the currently playing track. */
   refreshCurrentTrackArt?(): void;
   /** Optional: epoch ms of the last playTrack call (used by auto-advance cooldown). */


### PR DESCRIPTION
## Summary
- `usePlayerLogic.handleHydrate` now iterates through the saved queue: if the candidate track's provider is missing/unauthenticated or unplayable, it advances to the next track. The saved `playbackPosition` only applies to the originally-targeted track so fallbacks start from zero.
- New `PlaybackProvider.probePlayable(track)` capability (implemented on both Spotify and Dropbox adapters). Hydrate awaits it before `prepareTrack` so the skip-forward actually fires against real adapter failures: the underlying `prepareTrack` is fire-and-forget and swallowed its own errors, which meant the iterator's try/catch only exercised fabricated mocks. probePlayable returns `false` for known-unplayable tracks (404, `is_playable: false`, file moved) and throws `AuthExpiredError` for transient auth failures.
- On total failure, the hydrate spinner is no longer sticky: `PlayerStateRenderer` flips `libraryOverride=true` on the same tick so the user routes to the library immediately. `AudioPlayer.handleHydrateFailed` now calls a new `useSessionPersistence.resetLastSession()` that clears both localStorage **and** the cached React state, so subsequent renders see no session at all.
- Partial-fail toast (`"Couldn't resume previous track — starting from next in queue."`) and total-fail toast (`"Couldn't resume your last session."`) surface through the existing resume-toast mechanism — no new toast subsystem.

## Test plan
- [x] First-track fails, second succeeds: `HydrateResult.skipped === true`, saved `positionMs` applied only to the first attempt.
- [x] All-tracks-fail path sets `totalFailure: true`, resets to library, and clears the pending-play ref.
- [x] `probePlayable=false` on a candidate advances without calling `prepareTrack` (real-world skip path).
- [x] `probePlayable` throwing `AuthExpiredError` on every candidate still routes to total failure.
- [x] Spotify adapter `probePlayable`: true (is_playable=true), false (is_playable=false, 404, non-track URI), throws (401, 500).
- [x] Dropbox adapter `probePlayable`: true (getTemporaryLink resolves), false (rejects for missing file), rethrows `AuthExpiredError`.
- [x] Total-failure result renders the library, not the "Restoring Your Session" spinner; `onHydrateFailed` is called.
- [x] `handlePlay` after total failure does not play anything (ref cleared).
- [x] Resume-toast copies asserted by exact string.
- [x] `npx tsc -b --noEmit` and `npm run build` clean.

## Review fixes (post-review)
Two issues surfaced in post-self-review code review, both addressed:
1. **Blocker**: total-failure branch stranded the user on the hydrate spinner because `clearSession()` only cleared localStorage while the React `lastSession` state remained. Fixed by (a) flipping `libraryOverride` in `PlayerStateRenderer.tsx` and (b) exposing `resetLastSession()` from `useSessionPersistence` so AudioPlayer invalidates both layers.
2. **Major**: the iterator's try/catch around `prepareTrack` was dead code in production — both real adapters' `prepareTrack` are fire-and-forget and swallow errors internally. Added the `probePlayable` capability + adapter implementations; iterator now awaits it as the real skip signal.

Closes #1172