### PR TITLE
fix(spotify): ensure paused state settles after prepareTrack

### DIFF
--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -11,7 +11,6 @@ vi.mock('@/services/spotifyPlayer', () => ({
     transferPlaybackToDevice: vi.fn().mockResolvedValue(undefined),
     ensureDeviceIsActive: vi.fn().mockResolvedValue(true),
     pause: vi.fn().mockResolvedValue(undefined),
-    getCurrentState: vi.fn().mockResolvedValue({ paused: true }),
     onPlayerStateChanged: vi.fn().mockReturnValue(() => {}),
   },
 }));
@@ -33,23 +32,15 @@ const makeTrack = (overrides: Partial<MediaTrack> = {}): MediaTrack => ({
   ...overrides,
 });
 
-const findPlayCall = (mock: ReturnType<typeof vi.fn>) =>
-  mock.mock.calls.find(([url]) => typeof url === 'string' && url.includes('/me/player/play'));
-
-const countPlayCalls = (mock: ReturnType<typeof vi.fn>) =>
-  mock.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/me/player/play')).length;
-
 describe('SpotifyPlaybackAdapter.prepareTrack', () => {
   let adapter: SpotifyPlaybackAdapter;
-  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(spotifyPlayer.getIsReady).mockReturnValue(true);
     vi.mocked(spotifyPlayer.getDeviceId).mockReturnValue('device-1');
-    vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: true } as any);
-    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(spotifyPlayer.transferPlaybackToDevice).mockResolvedValue(undefined);
+    vi.mocked(spotifyPlayer.ensureDeviceIsActive).mockResolvedValue(true);
     adapter = new SpotifyPlaybackAdapter();
   });
 
@@ -57,23 +48,7 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     vi.unstubAllGlobals();
   });
 
-  it('transfers playback with the track uri and position_ms at the saved position', async () => {
-    // #given
-    const track = makeTrack();
-    const positionMs = 42_000;
-
-    // #when
-    adapter.prepareTrack(track, { positionMs });
-
-    // #then
-    await vi.waitFor(() => expect(findPlayCall(fetchMock)).toBeDefined());
-    const playCall = findPlayCall(fetchMock)!;
-    const body = JSON.parse(playCall[1].body as string);
-    expect(body).toEqual({ uris: ['spotify:track:abc'], position_ms: positionMs });
-    await vi.waitFor(() => expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1));
-  });
-
-  it('emits a PlaybackState with correct positionMs, durationMs, and isPlaying=false', async () => {
+  it('emits a PlaybackState with the saved positionMs, track durationMs, and isPlaying=false', async () => {
     // #given
     const track = makeTrack({ durationMs: 180_000 });
     const received: Array<PlaybackState | null> = [];
@@ -96,6 +71,33 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
+  it('does not start actual playback — no /me/player/play call and no pause()', async () => {
+    // #given — the regression root cause (#1179): previously prepareTrack
+    // called /me/player/play then pause, which could land playing on a fresh
+    // tab. The fix stages state locally without touching Spotify playback.
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const track = makeTrack();
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 10_000 });
+
+    // #then — wait for the stage emission to ensure the whole flow ran, then
+    // verify no audio-starting calls were made.
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+    await vi.waitFor(() => {
+      // Give the stage pipeline a beat to run.
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalled();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const playCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/me/player/play'),
+    );
+    expect(playCalls).toHaveLength(0);
+    expect(spotifyPlayer.pause).not.toHaveBeenCalled();
+  });
+
   it('does not double-emit when prepareTrack is called twice for the same track', async () => {
     // #given
     const track = makeTrack();
@@ -110,10 +112,10 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     adapter.prepareTrack(track, { positionMs: 10_000 });
     adapter.prepareTrack(track, { positionMs: 10_000 });
 
-    // #then
+    // #then — ensurePlaybackReady runs once because the second call hits the
+    // preparedTrackRef idempotency guard; emission fires exactly once.
     await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(countPlayCalls(fetchMock)).toBe(1);
-    expect(spotifyPlayer.pause).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1);
   });
 
   it('re-stages when prepareTrack is called for a different track', async () => {
@@ -136,7 +138,7 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
   });
 
   it('clears the idempotency guard on failure so a retry can re-stage', async () => {
-    // #given — first prepareTrack call fails at the play step
+    // #given — ensurePlaybackReady fails on the first prepareTrack call
     const track = makeTrack();
     const stageEmissions: Array<PlaybackState | null> = [];
     adapter.subscribe((state) => {
@@ -144,96 +146,26 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
         stageEmissions.push(state);
       }
     });
-    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    vi.mocked(spotifyPlayer.transferPlaybackToDevice)
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValue(undefined);
 
     // #when
     adapter.prepareTrack(track, { positionMs: 12_000 });
-    await vi.waitFor(() => expect(countPlayCalls(fetchMock)).toBe(1));
-
-    // Second call after failure should retry (not be treated as idempotent).
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+    );
+    // Second call after the failure — guard was reset, so this retries.
     adapter.prepareTrack(track, { positionMs: 12_000 });
 
     // #then
     await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(countPlayCalls(fetchMock)).toBe(2);
-  });
-
-  describe('stage-paused race (#1179)', () => {
-    it('re-issues pause when SDK still reports paused=false after the initial pause', async () => {
-      // #given — simulate Spotify's server state lagging: the first
-      // getCurrentState still reports playing, the next reports paused.
-      vi.mocked(spotifyPlayer.getCurrentState)
-        .mockResolvedValueOnce({ paused: false } as any)
-        .mockResolvedValue({ paused: true } as any);
-      const track = makeTrack();
-
-      // #when
-      adapter.prepareTrack(track, { positionMs: 10_000 });
-
-      // #then — initial pause + one re-issue = 2 pauses total
-      await vi.waitFor(() => expect(spotifyPlayer.pause).toHaveBeenCalledTimes(2));
-      await vi.waitFor(() => expect(spotifyPlayer.getCurrentState).toHaveBeenCalled());
-    });
-
-    it('stops at MAX_ATTEMPTS so hydrate is not blocked indefinitely', async () => {
-      // #given — SDK keeps reporting paused=false forever (stuck in playing).
-      // Isolate this adapter in a fresh instance to avoid any in-flight stage
-      // loop from a previous test sharing the mocked spotifyPlayer singleton.
-      vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: false } as any);
-      const isolatedAdapter = new SpotifyPlaybackAdapter();
-      const track = makeTrack();
-
-      // #when
-      isolatedAdapter.prepareTrack(track, { positionMs: 10_000 });
-
-      // Track how many pauses THIS stage emits by counting growth relative to
-      // the baseline when we started. We can't assert on absolute counts
-      // because earlier tests may leak one tail pause into this one; we only
-      // care that pause calls for THIS adapter are bounded.
-      const baseline = vi.mocked(spotifyPlayer.pause).mock.calls.length;
-
-      // #then — wait long enough for 5 * 100ms poll + margin, then assert
-      // the call count has stabilized (no unbounded growth).
-      await new Promise((resolve) => setTimeout(resolve, 1200));
-      const afterSettle = vi.mocked(spotifyPlayer.pause).mock.calls.length;
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      const afterWait = vi.mocked(spotifyPlayer.pause).mock.calls.length;
-
-      // Within the first 1200ms window, at most MAX_ATTEMPTS (5) re-pauses
-      // plus the initial pause = 6 pauses attributable to this stage. Allow
-      // slack for mid-flight cross-test pauses: bounded well under 20.
-      expect(afterSettle - baseline).toBeLessThan(15);
-      // And no more pauses land after the loop caps out.
-      expect(afterWait).toBe(afterSettle);
-    });
-
-    it('stops re-issuing pause when another track supersedes the stage', async () => {
-      // #given — SDK reports paused=false forever; first stage will loop
-      // unless the supersede guard fires it. Use a fresh adapter to avoid
-      // prior-test leakage confusing call counts.
-      vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: false } as any);
-      const isolatedAdapter = new SpotifyPlaybackAdapter();
-      const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
-      const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
-
-      // #when
-      isolatedAdapter.prepareTrack(trackA, { positionMs: 1_000 });
-      // Immediately supersede with trackB before A's loop can fully burn down.
-      isolatedAdapter.prepareTrack(trackB, { positionMs: 2_000 });
-
-      // #then — after settling, total pause calls are bounded. Without the
-      // supersede guard, both A and B would each run MAX_ATTEMPTS iterations.
-      // With the guard, A bails early once B supersedes its preparedTrackRef.
-      await new Promise((resolve) => setTimeout(resolve, 1200));
-      const pauseCount = vi.mocked(spotifyPlayer.pause).mock.calls.length;
-      // Upper bound: A's initial + up to 2 A loop retries (pre-supersede) +
-      // B's initial + B's 5 loop retries = 9. Leave slack for cross-test leak.
-      expect(pauseCount).toBeLessThan(20);
-    });
+    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2);
   });
 
   it('skips the stale stage emission when a different track is prepared mid-stage', async () => {
-    // #given — prepareTrack(A) is in flight when prepareTrack(B) overrides it
+    // #given — prepareTrack(A) is in flight when prepareTrack(B) overrides it.
+    // Slow-resolve the first transfer so the supersede wins the race.
     const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
     const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
     const stageEmissions: Array<PlaybackState | null> = [];
@@ -241,18 +173,20 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
       if (state && !state.isPlaying) stageEmissions.push(state);
     });
 
-    let resolveFirstPlay!: () => void;
-    fetchMock.mockImplementationOnce(
-      () => new Promise<Response>((resolve) => {
-        resolveFirstPlay = () => resolve(new Response(null, { status: 204 }));
-      }),
-    );
+    let resolveFirstTransfer!: () => void;
+    vi.mocked(spotifyPlayer.transferPlaybackToDevice)
+      .mockImplementationOnce(
+        () => new Promise<void>((resolve) => {
+          resolveFirstTransfer = () => resolve();
+        }),
+      )
+      .mockResolvedValue(undefined);
 
     // #when
     adapter.prepareTrack(trackA, { positionMs: 1_000 });
-    await vi.waitFor(() => expect(resolveFirstPlay).toBeTypeOf('function'));
+    await vi.waitFor(() => expect(resolveFirstTransfer).toBeTypeOf('function'));
     adapter.prepareTrack(trackB, { positionMs: 2_000 });
-    resolveFirstPlay();
+    resolveFirstTransfer();
 
     // #then — only B's staged state should reach subscribers
     await vi.waitFor(() => {

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/services/spotifyPlayer', () => ({
     transferPlaybackToDevice: vi.fn().mockResolvedValue(undefined),
     ensureDeviceIsActive: vi.fn().mockResolvedValue(true),
     pause: vi.fn().mockResolvedValue(undefined),
+    getCurrentState: vi.fn().mockResolvedValue({ paused: true }),
     onPlayerStateChanged: vi.fn().mockReturnValue(() => {}),
   },
 }));
@@ -46,6 +47,7 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     vi.clearAllMocks();
     vi.mocked(spotifyPlayer.getIsReady).mockReturnValue(true);
     vi.mocked(spotifyPlayer.getDeviceId).mockReturnValue('device-1');
+    vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: true } as any);
     fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);
     adapter = new SpotifyPlaybackAdapter();
@@ -154,6 +156,80 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     // #then
     await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
     expect(countPlayCalls(fetchMock)).toBe(2);
+  });
+
+  describe('stage-paused race (#1179)', () => {
+    it('re-issues pause when SDK still reports paused=false after the initial pause', async () => {
+      // #given — simulate Spotify's server state lagging: the first
+      // getCurrentState still reports playing, the next reports paused.
+      vi.mocked(spotifyPlayer.getCurrentState)
+        .mockResolvedValueOnce({ paused: false } as any)
+        .mockResolvedValue({ paused: true } as any);
+      const track = makeTrack();
+
+      // #when
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+
+      // #then — initial pause + one re-issue = 2 pauses total
+      await vi.waitFor(() => expect(spotifyPlayer.pause).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(spotifyPlayer.getCurrentState).toHaveBeenCalled());
+    });
+
+    it('stops at MAX_ATTEMPTS so hydrate is not blocked indefinitely', async () => {
+      // #given — SDK keeps reporting paused=false forever (stuck in playing).
+      // Isolate this adapter in a fresh instance to avoid any in-flight stage
+      // loop from a previous test sharing the mocked spotifyPlayer singleton.
+      vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: false } as any);
+      const isolatedAdapter = new SpotifyPlaybackAdapter();
+      const track = makeTrack();
+
+      // #when
+      isolatedAdapter.prepareTrack(track, { positionMs: 10_000 });
+
+      // Track how many pauses THIS stage emits by counting growth relative to
+      // the baseline when we started. We can't assert on absolute counts
+      // because earlier tests may leak one tail pause into this one; we only
+      // care that pause calls for THIS adapter are bounded.
+      const baseline = vi.mocked(spotifyPlayer.pause).mock.calls.length;
+
+      // #then — wait long enough for 5 * 100ms poll + margin, then assert
+      // the call count has stabilized (no unbounded growth).
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      const afterSettle = vi.mocked(spotifyPlayer.pause).mock.calls.length;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const afterWait = vi.mocked(spotifyPlayer.pause).mock.calls.length;
+
+      // Within the first 1200ms window, at most MAX_ATTEMPTS (5) re-pauses
+      // plus the initial pause = 6 pauses attributable to this stage. Allow
+      // slack for mid-flight cross-test pauses: bounded well under 20.
+      expect(afterSettle - baseline).toBeLessThan(15);
+      // And no more pauses land after the loop caps out.
+      expect(afterWait).toBe(afterSettle);
+    });
+
+    it('stops re-issuing pause when another track supersedes the stage', async () => {
+      // #given — SDK reports paused=false forever; first stage will loop
+      // unless the supersede guard fires it. Use a fresh adapter to avoid
+      // prior-test leakage confusing call counts.
+      vi.mocked(spotifyPlayer.getCurrentState).mockResolvedValue({ paused: false } as any);
+      const isolatedAdapter = new SpotifyPlaybackAdapter();
+      const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
+      const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
+
+      // #when
+      isolatedAdapter.prepareTrack(trackA, { positionMs: 1_000 });
+      // Immediately supersede with trackB before A's loop can fully burn down.
+      isolatedAdapter.prepareTrack(trackB, { positionMs: 2_000 });
+
+      // #then — after settling, total pause calls are bounded. Without the
+      // supersede guard, both A and B would each run MAX_ATTEMPTS iterations.
+      // With the guard, A bails early once B supersedes its preparedTrackRef.
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      const pauseCount = vi.mocked(spotifyPlayer.pause).mock.calls.length;
+      // Upper bound: A's initial + up to 2 A loop retries (pre-supersede) +
+      // B's initial + B's 5 loop retries = 9. Leave slack for cross-test leak.
+      expect(pauseCount).toBeLessThan(20);
+    });
   });
 
   it('skips the stale stage emission when a different track is prepared mid-stage', async () => {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -6,7 +6,6 @@
 import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
-import { apiPlayTrack } from '@/services/spotifyPlayerPlayback';
 import { spotifyAuth } from '@/services/spotify';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
@@ -292,48 +291,29 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   }
 
   private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
+    // ensurePlaybackReady transfers Spotify Connect to this device with
+    // `play: false`, which paused-transfers any existing session and leaves
+    // the SDK ready. That's all the staging we need for hydrate — we do NOT
+    // call apiPlayTrack, because /me/player/play starts audio and Spotify's
+    // eventually-consistent server state makes a subsequent pause() race
+    // the just-started playback (leaked audio on a fresh tab).
+    //
+    // The UI staging (scrubbed seek bar + duration) is purely local: emit
+    // the expected paused state to subscribers. Actual audio playback is
+    // deferred to the user's next `playTrack` call, which starts from the
+    // saved position via handlePlay consuming hydratedPendingPlayRef.
     await this.ensurePlaybackReady();
 
-    const deviceId = spotifyPlayer.getDeviceId();
-    if (!deviceId) return;
-
     const uri = track.playbackRef.ref;
-    const positionFloor = Math.floor(positionMs);
-    await apiPlayTrack(deviceId, uri, undefined, positionFloor);
-    await spotifyPlayer.pause();
-    await this.ensurePausedLanded(uri);
-
     if (this.preparedTrackRef !== uri) return;
 
     this.emitState({
       isPlaying: false,
-      positionMs: positionFloor,
+      positionMs: Math.floor(positionMs),
       durationMs: track.durationMs ?? 0,
       currentTrackId: track.id,
       currentPlaybackRef: track.playbackRef,
     });
-  }
-
-  /**
-   * Spotify's server state is eventually-consistent: on a fresh tab where the
-   * account was last playing, a single pause() can race with SDK state events
-   * that re-establish play. Poll the SDK state and re-issue pause() until the
-   * adapter observes `paused=true`, with a bounded cap so we never block hydrate
-   * indefinitely. If the prepare has been superseded (another track staged),
-   * bail immediately.
-   */
-  private async ensurePausedLanded(uri: string): Promise<void> {
-    const MAX_ATTEMPTS = 5;
-    const POLL_MS = 100;
-    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
-      if (this.preparedTrackRef !== uri) return;
-      const state = await spotifyPlayer.getCurrentState();
-      if (!state || state.paused) return;
-      logSpotify('stage pause race detected, re-issuing pause (attempt %d/%d)', attempt + 1, MAX_ATTEMPTS);
-      await spotifyPlayer.pause();
-      await new Promise((resolve) => setTimeout(resolve, POLL_MS));
-    }
-    logSpotify('stage pause did not settle after %d attempts', MAX_ATTEMPTS);
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -301,6 +301,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     const positionFloor = Math.floor(positionMs);
     await apiPlayTrack(deviceId, uri, undefined, positionFloor);
     await spotifyPlayer.pause();
+    await this.ensurePausedLanded(uri);
 
     if (this.preparedTrackRef !== uri) return;
 
@@ -311,6 +312,28 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       currentTrackId: track.id,
       currentPlaybackRef: track.playbackRef,
     });
+  }
+
+  /**
+   * Spotify's server state is eventually-consistent: on a fresh tab where the
+   * account was last playing, a single pause() can race with SDK state events
+   * that re-establish play. Poll the SDK state and re-issue pause() until the
+   * adapter observes `paused=true`, with a bounded cap so we never block hydrate
+   * indefinitely. If the prepare has been superseded (another track staged),
+   * bail immediately.
+   */
+  private async ensurePausedLanded(uri: string): Promise<void> {
+    const MAX_ATTEMPTS = 5;
+    const POLL_MS = 100;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+      if (this.preparedTrackRef !== uri) return;
+      const state = await spotifyPlayer.getCurrentState();
+      if (!state || state.paused) return;
+      logSpotify('stage pause race detected, re-issuing pause (attempt %d/%d)', attempt + 1, MAX_ATTEMPTS);
+      await spotifyPlayer.pause();
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+    }
+    logSpotify('stage pause did not settle after %d attempts', MAX_ATTEMPTS);
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {


### PR DESCRIPTION
## Summary
- Fixes the fresh-tab autoplay bug on Spotify: after hydrate, the player stays paused even when the account's server-side state was last `playing`.
- Drop the `apiPlayTrack` + `pause()` round-trip from `stageTrackPaused` entirely. That approach is fundamentally racy — audio leaks out in the window between `/me/player/play` starting playback and `pause()` landing, because Spotify's server state is eventually-consistent and the SDK can emit playing state from the just-started playback. A retry loop on `pause()` does not close the gap.
- Instead, rely on `ensurePlaybackReady` (which calls `transferPlaybackToDevice` with `play: false`) to pause-transfer any existing session. Emit the UI-visible staged state (scrubbed seek bar + full duration) purely to local subscribers without touching Spotify playback. Actual audio starts when the user presses play — `handlePlay` consumes `hydratedPendingPlayRef` and calls `playTrack` with the saved position.
- Mirrors how Dropbox already handles hydrate: `primeAudioForHydrate` sets `audio.src` but never calls `audio.play()`.

## Test plan
- [x] Staged emission carries saved `positionMs`, track `durationMs`, `isPlaying: false`, and the track's `currentPlaybackRef`.
- [x] **Regression guard**: `prepareTrack` does NOT call `/me/player/play` and does NOT call `spotifyPlayer.pause()`.
- [x] Idempotent for the same URI (second `prepareTrack` skips `transferPlaybackToDevice` on re-entry via `preparedTrackRef`).
- [x] Re-stages when a different URI is prepared.
- [x] Idempotency guard resets on failure so a retry can stage again.
- [x] Stale stage emission is skipped when a different track is prepared mid-stage.
- [x] `npx tsc -b --noEmit` clean; `npm run build` clean.

## Manual repro
1. Log in with Spotify. Start playing a track. Let it play ~30s.
2. Close the tab (no manual pause).
3. Reopen the app.
4. Expected: resume toast shows; player is paused; no audio plays until the user presses play.

Closes #1179