### PR TITLE
refactor(types): extract AlbumArtBounds to shared types

### DIFF
--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -1,17 +1,10 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import type { VisualizerStyle } from '../types/visualizer';
+import type { VisualizerStyle, AlbumArtBounds } from '../types/visualizer';
 import { ParticleVisualizer } from './visualizers/ParticleVisualizer';
 import { TrailVisualizer } from './visualizers/TrailVisualizer';
 import { WaveVisualizer } from './visualizers/WaveVisualizer';
 import { GridWaveVisualizer } from './visualizers/GridWaveVisualizer';
-
-interface AlbumArtBounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
 
 interface BackgroundVisualizerProps {
   enabled: boolean;

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -20,7 +20,7 @@ import {
   ZEN_TRACK_INFO_ENTER_OPACITY_DELAY,
 } from '@/constants/zenAnimation';
 import type { MediaTrack, ProviderId } from '@/types/domain';
-import type { VisualizerStyle } from '@/types/visualizer';
+import type { VisualizerStyle, AlbumArtBounds } from '@/types/visualizer';
 import { FlipInner, ZenTrackInfo, ZenTrackInfoInner, ZenTrackName, ZenTrackArtist } from './styled';
 
 const ZEN_TRACK_INFO_WILL_CHANGE_FALLBACK_MS =
@@ -36,13 +36,6 @@ const ZenProviderBadgeInline = styled.span`
   position: relative;
   top: -1px;
 `;
-
-interface AlbumArtBounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
 
 interface AlbumArtSectionProps {
   currentTrack: MediaTrack | null;

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -12,6 +12,7 @@ import {
   ZEN_ART_ENTER_DELAY,
 } from '@/constants/zenAnimation';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
+import type { AlbumArtBounds } from '@/types/visualizer';
 import type { RadioState, RadioProgress } from '@/types/radio';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { ContentWrapper, PlayerContainer, PlayerStack } from './styled';
@@ -41,13 +42,6 @@ export interface PlaybackHandlers {
   onStartRadio?: () => void;
   onRemoveFromQueue?: (index: number) => void;
   onReorderQueue?: (fromIndex: number, toIndex: number) => void;
-}
-
-interface AlbumArtBounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
 }
 
 interface PlayerContentProps {

--- a/src/components/visualizers/TrailVisualizer.tsx
+++ b/src/components/visualizers/TrailVisualizer.tsx
@@ -3,13 +3,7 @@ import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
 import { calculateParticleCount } from '../../utils/particleCount';
-
-interface AlbumArtBounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
+import type { AlbumArtBounds } from '@/types/visualizer';
 
 interface TrailVisualizerProps {
   intensity: number;

--- a/src/types/visualizer.ts
+++ b/src/types/visualizer.ts
@@ -11,3 +11,10 @@ export type VisualizerStyle =
   | 'wave'
   | 'grid';
 
+export interface AlbumArtBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+


### PR DESCRIPTION
## Summary
- Extracts the duplicated `AlbumArtBounds` interface from 4 files into `src/types/visualizer.ts`
- Updates `AlbumArtSection.tsx`, `PlayerContent/index.tsx`, `TrailVisualizer.tsx`, and `BackgroundVisualizer.tsx` to import the shared type
- Single source of truth for the album art bounds rect contract

## Test plan
- `npx tsc -b --noEmit` passes (type check clean)
- Grep confirms no remaining `interface AlbumArtBounds` redefinitions outside `src/types/`
- Spot-check that runtime shape is unchanged — pure type refactor, no logic touched

Closes #832