### PR TITLE
refactor(visualizers): use shared mobile breakpoint constant

### DIFF
--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -3,6 +3,7 @@ import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
 import { gridSpatialFactor, gridWaveProjection } from './math';
+import { BREAKPOINTS_PX } from '../../styles/theme';
 
 interface GridWaveVisualizerProps {
   intensity: number;
@@ -48,7 +49,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
 
   const getItemCount = useCallback(
     (width: number, _height: number, _intensity: number): number => {
-      const isMobile = width < 768;
+      const isMobile = width < BREAKPOINTS_PX.lg;
       return isMobile ? g.countBaseMobile : g.countBaseDesktop;
     },
     [g]
@@ -56,7 +57,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
 
   const initializeItems = useCallback(
     (count: number, width: number, height: number, baseColor: string): GridWaveState[] => {
-      const spacing = width < 768 ? g.spacingMobile : g.spacing;
+      const spacing = width < BREAKPOINTS_PX.lg ? g.spacingMobile : g.spacing;
       const amplitude = g.amplitudeBase * Math.min(width, height);
       const margin = Math.ceil(amplitude / spacing);
 

--- a/src/components/visualizers/WaveVisualizer.tsx
+++ b/src/components/visualizers/WaveVisualizer.tsx
@@ -3,6 +3,7 @@ import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
 import { layerRatio, waveLayerPhaseSpeed, waveY } from './math';
+import { BREAKPOINTS_PX } from '../../styles/theme';
 
 interface WaveVisualizerProps {
   intensity: number;
@@ -37,7 +38,7 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
 
   const initializeItems = useCallback(
     (count: number, width: number, height: number, baseColor: string): Wave[] => {
-      const isMobile = width < 768;
+      const isMobile = width < BREAKPOINTS_PX.lg;
       const amplitudeScale = isMobile ? 0.65 : 1.0;
 
       return Array.from({ length: count }, (_, i) => {
@@ -62,7 +63,7 @@ export const WaveVisualizer: React.FC<WaveVisualizerProps> = ({
     (waves: Wave[], deltaTime: number, playing: boolean, width: number, height: number): void => {
       const speedMult = (playing ? 1.0 : w.pausedSpeedMult) * (speed ?? 1.0);
       const dt = deltaTime / 16;
-      const isMobile = width < 768;
+      const isMobile = width < BREAKPOINTS_PX.lg;
       const amplitudeScale = isMobile ? 0.65 : 1.0;
       const count = waves.length;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -177,6 +177,16 @@ export const theme = {
     '2xl': '1536px',
     '3xl': '1920px'
   },
+
+  breakpointPixels: {
+    xs: 320,
+    sm: 375,
+    md: 480,
+    lg: 700,
+    xl: 1280,
+    '2xl': 1536,
+    '3xl': 1920
+  },
   
   
   // Container query breakpoints for component-level responsive behavior
@@ -253,4 +263,6 @@ export const theme = {
     transitionEasing: 'cubic-bezier(0.4, 0, 0.2, 1)'
   }
 } as const;
+
+export const BREAKPOINTS_PX = theme.breakpointPixels;
 


### PR DESCRIPTION
## Summary
- Adds `BREAKPOINTS_PX` named export to `src/styles/theme.ts` (mirroring the existing CSS-string `breakpoints` block with numeric pixel values)
- Adds `breakpointPixels` inside the `theme` object so styled-components can access it via `useTheme()`
- Replaces hardcoded `width < 768` checks in `GridWaveVisualizer` and `WaveVisualizer` with `width < BREAKPOINTS_PX.lg` (= 700)
- Aligns visualizer mobile detection with the canonical app-wide mobile breakpoint (700px)

## Test plan
- `npx tsc -b --noEmit` passes (verified)
- Visual smoke: load player on mobile-width viewport, confirm visualizer count/amplitude scaling kicks in at 700px (was 768px)
- Confirm no other 768 literals remain in visualizer files

Closes #831