### PR TITLE
fix(player): smooth zen-mode exit animation

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -9,6 +9,7 @@ import { useVolume } from '@/hooks/useVolume';
 import { useTrackListContext, useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useZenMode } from '@/contexts/visualEffects';
 import { useBottomBarActions } from '@/contexts/BottomBarActionsContext';
+import { ZEN_EXIT_REENTRY_DELAY } from '@/constants/zenAnimation';
 import {
   VisualEffectsIcon,
   BackToLibraryIcon,
@@ -40,7 +41,10 @@ const BottomBar = React.memo(function BottomBar() {
   } = useBottomBarActions();
 
   const [barVisible, setBarVisible] = useState(!zenModeEnabled);
+  const [zenExiting, setZenExiting] = useState(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const zenExitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevZenModeRef = useRef(zenModeEnabled);
   const isHoveringRef = useRef(false);
   const touchLockedRef = useRef(false);
 
@@ -106,6 +110,37 @@ const BottomBar = React.memo(function BottomBar() {
     setBarVisible(true);
   }, [zenModeEnabled, clearHideTimer]);
 
+  // Track zen → normal transitions so we can delay the bar reveal until after
+  // the album art has finished shrinking. Uses a ref to detect the edge
+  // (true → false) without re-firing on unrelated re-renders.
+  useEffect(() => {
+    const prev = prevZenModeRef.current;
+    prevZenModeRef.current = zenModeEnabled;
+    if (prev && !zenModeEnabled) {
+      setZenExiting(true);
+      if (zenExitingTimerRef.current !== null) {
+        clearTimeout(zenExitingTimerRef.current);
+      }
+      zenExitingTimerRef.current = setTimeout(() => {
+        zenExitingTimerRef.current = null;
+        setZenExiting(false);
+      }, ZEN_EXIT_REENTRY_DELAY);
+    } else if (zenModeEnabled) {
+      if (zenExitingTimerRef.current !== null) {
+        clearTimeout(zenExitingTimerRef.current);
+        zenExitingTimerRef.current = null;
+      }
+      setZenExiting(false);
+    }
+  }, [zenModeEnabled]);
+
+  useEffect(() => () => {
+    if (zenExitingTimerRef.current !== null) {
+      clearTimeout(zenExitingTimerRef.current);
+      zenExitingTimerRef.current = null;
+    }
+  }, []);
+
   if (hidden) return null;
 
   const isHidden = !barVisible && zenModeEnabled;
@@ -125,6 +160,7 @@ const BottomBar = React.memo(function BottomBar() {
       )}
       <BottomBarContainer
         $hidden={isHidden}
+        $zenExiting={zenExiting}
         onMouseEnter={handleBarMouseEnter}
         onMouseLeave={handleBarMouseLeave}
       >

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ZEN_BAR_DURATION } from '@/constants/zenAnimation';
+import { ZEN_BAR_DURATION, ZEN_EXIT_REENTRY_DELAY } from '@/constants/zenAnimation';
 import { TOUCH_TARGET_MIN_PX } from '@/constants/a11y';
 
 export const BOTTOM_BAR_HEIGHT = 60;
@@ -9,8 +9,8 @@ const ZEN_GRIP_PILL_HEIGHT = '4px';
 const ZEN_GRIP_PILL_BOTTOM_OFFSET = '10px';
 
 export const BottomBarContainer = styled.div.withConfig({
-  shouldForwardProp: (prop) => prop !== '$hidden',
-})<{ $hidden?: boolean }>`
+  shouldForwardProp: (prop) => !['$hidden', '$zenExiting'].includes(prop),
+})<{ $hidden?: boolean; $zenExiting?: boolean }>`
   position: fixed;
   bottom: 0;
   left: 0;
@@ -24,7 +24,18 @@ export const BottomBarContainer = styled.div.withConfig({
   opacity: ${({ $hidden }) => $hidden ? 0 : 1};
   transform: ${({ $hidden }) => $hidden ? 'translateY(100%)' : 'translateY(0)'};
   pointer-events: ${({ $hidden }) => $hidden ? 'none' : 'auto'};
-  transition: opacity ${ZEN_BAR_DURATION}ms ease, transform ${ZEN_BAR_DURATION}ms ease;
+  /*
+   * $zenExiting is raised for the duration of the zen → normal transition so the bar
+   * delays its reveal (translateY 100% → 0, opacity 0 → 1) until after the album art
+   * has finished shrinking. During normal hover/touch reveals the delay is 0 so the
+   * affordance still feels responsive.
+   */
+  transition: opacity ${ZEN_BAR_DURATION}ms ease ${({ $zenExiting }) => $zenExiting ? `${ZEN_EXIT_REENTRY_DELAY}ms` : '0ms'},
+              transform ${ZEN_BAR_DURATION}ms ease ${({ $zenExiting }) => $zenExiting ? `${ZEN_EXIT_REENTRY_DELAY}ms` : '0ms'};
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `;
 
 export const BottomBarInner = styled.div`

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -26,15 +26,20 @@ import { useQapEnabled } from '@/hooks/useQapEnabled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useTransitionWillChange } from '@/hooks/useTransitionWillChange';
 import {
-  ZEN_CONTROLS_OPACITY_EXIT_DURATION,
-  ZEN_CONTROLS_OPACITY_EXIT_DELAY,
+  ZEN_ART_DURATION,
+  ZEN_CONTROLS_DURATION,
 } from '@/constants/zenAnimation';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState } from '@/types/radio';
 import { LoadingCard, ZenControlsWrapper, ZenControlsInner } from './styled';
 
+/**
+ * Maximum total time the zen controls need `will-change` set during exit:
+ * ZEN_ART_DURATION (art shrink delay) + ZEN_CONTROLS_DURATION (row expand + fade)
+ * + 100ms safety margin.
+ */
 const ZEN_CONTROLS_WILL_CHANGE_FALLBACK_MS =
-  ZEN_CONTROLS_OPACITY_EXIT_DURATION + ZEN_CONTROLS_OPACITY_EXIT_DELAY + 100;
+  ZEN_ART_DURATION + ZEN_CONTROLS_DURATION + 100;
 
 const VisualEffectsMenu = lazy(() => import('@/components/AppSettingsMenu/index'));
 const KeyboardShortcutsHelp = lazy(() => import('@/components/KeyboardShortcutsHelp'));

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -6,10 +6,7 @@ import {
   ZEN_ART_EASING,
   ZEN_ART_ENTER_DELAY,
   ZEN_CONTROLS_DURATION,
-  ZEN_CONTROLS_EXIT_DELAY,
-  ZEN_CONTROLS_OPACITY_EXIT_DURATION,
-  ZEN_CONTROLS_OPACITY_EXIT_DELAY,
-  ZEN_CONTROLS_TRANSFORM_EXIT_DELAY,
+  ZEN_EXIT_REENTRY_DELAY,
   ZEN_TRACK_INFO_ENTER_OPACITY_DURATION,
   ZEN_TRACK_INFO_ENTER_OPACITY_DELAY,
   ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION,
@@ -48,9 +45,20 @@ export const ContentWrapper = styled.div.withConfig({
   z-index: ${CONTENT_WRAPPER_Z};
   overflow: visible;
 
+  /*
+   * margin-bottom transitions between 0 (zen) and BOTTOM_BAR_HEIGHT (normal). The flex
+   * parent centers ContentWrapper's outer box, so any instant margin change would snap
+   * the content up or down. Entry ($zenMode true): margin shrinks 60→0 after
+   * ZEN_ART_ENTER_DELAY so layout stays stable while controls fade. Exit ($zenMode false):
+   * margin grows 0→60 after ZEN_EXIT_REENTRY_DELAY so the art shrink runs in a stable
+   * layout frame; the margin then grows in sync with the bottom bar sliding back in.
+   */
   transition: width ${props => props.$zenMode ? `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms` : `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING}`},
             padding ${props => props.transitionDuration}ms ${props => props.transitionEasing},
-            padding-bottom ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING};
+            padding-bottom ${ZEN_ART_DURATION}ms ${ZEN_ART_EASING},
+            margin-bottom ${props => props.$zenMode
+              ? `${ZEN_ART_DURATION}ms ${ZEN_ART_EASING} ${ZEN_ART_ENTER_DELAY}ms`
+              : `${ZEN_CONTROLS_DURATION}ms ${ZEN_ART_EASING} ${ZEN_EXIT_REENTRY_DELAY}ms`};
 
   container-type: inline-size;
   container-name: player;
@@ -123,13 +131,16 @@ export const ZenControlsWrapper = styled.div.withConfig({
    * while grid-template-rows stays 1fr, keeping PlayerStack's layout height stable so the
    * album art does not drift upward. After ZEN_ART_ENTER_DELAY, the row collapses in parallel
    * with PlayerStack's max-width growth so the art resizes in a single layout-isolated motion.
-   * Exiting zen: art shrinks first (ZEN_ART_DURATION), then controls expand + fade in.
+   * Exiting zen: all three properties wait ZEN_EXIT_REENTRY_DELAY (= ZEN_ART_DURATION) so the
+   * album art finishes shrinking in a stable layout before the row expands and the controls
+   * fade back in. Without this delay, the row-expansion and art-shrink overlap and the parent
+   * flex re-centers mid-animation, producing the downward jump.
    * --player-controls-height is pre-set synchronously via stableControlsHeightRef before the
    * state flip, so PlayerStack has the correct target from the first animation frame.
    */
   transition: ${({ $zenMode }) => $zenMode
     ? `grid-template-rows ${ZEN_ART_DURATION}ms ease ${ZEN_ART_ENTER_DELAY}ms, opacity ${ZEN_CONTROLS_DURATION}ms ease, transform ${ZEN_CONTROLS_DURATION}ms ease`
-    : `grid-template-rows ${ZEN_CONTROLS_EXIT_DELAY}ms ease ${ZEN_CONTROLS_EXIT_DELAY}ms, opacity ${ZEN_CONTROLS_OPACITY_EXIT_DURATION}ms ease ${ZEN_CONTROLS_OPACITY_EXIT_DELAY}ms, transform ${ZEN_CONTROLS_DURATION}ms ease ${ZEN_CONTROLS_TRANSFORM_EXIT_DELAY}ms`
+    : `grid-template-rows ${ZEN_CONTROLS_DURATION}ms ease ${ZEN_EXIT_REENTRY_DELAY}ms, opacity ${ZEN_CONTROLS_DURATION}ms ease ${ZEN_EXIT_REENTRY_DELAY}ms, transform ${ZEN_CONTROLS_DURATION}ms ease ${ZEN_EXIT_REENTRY_DELAY}ms`
   };
   pointer-events: ${({ $zenMode }) => $zenMode ? 'none' : 'auto'};
 

--- a/src/constants/zenAnimation.ts
+++ b/src/constants/zenAnimation.ts
@@ -3,10 +3,13 @@ export const ZEN_ART_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
 export const ZEN_ART_ENTER_DELAY = 300;
 
 export const ZEN_CONTROLS_DURATION = 300;
-export const ZEN_CONTROLS_EXIT_DELAY = 500;
-export const ZEN_CONTROLS_OPACITY_EXIT_DURATION = 700;
-export const ZEN_CONTROLS_OPACITY_EXIT_DELAY = 450;
-export const ZEN_CONTROLS_TRANSFORM_EXIT_DELAY = 200;
+/**
+ * Delay before bottom bar / controls begin re-entering on zen → normal exit.
+ * Matches ZEN_ART_DURATION so the album art finishes shrinking before controls
+ * and the bottom bar reappear, preventing the parent flex from re-centering
+ * mid-shrink. See orchestration notes in PlayerContent/styled.ts.
+ */
+export const ZEN_EXIT_REENTRY_DELAY = ZEN_ART_DURATION;
 
 export const ZEN_ART_MARGIN_H = 96;
 export const ZEN_ART_MARGIN_V = 196;


### PR DESCRIPTION
## Summary
- Symmetric counterpart to #1186: on `zen → normal`, the album art now shrinks back to its normal size **before** the player controls and bottom bar begin re-entering, eliminating the downward jump as the parent flex re-centered mid-shrink.
- `ZenControlsWrapper` exit: `grid-template-rows`, `opacity`, and `transform` all wait `ZEN_EXIT_REENTRY_DELAY` (= `ZEN_ART_DURATION`) before animating.
- `ContentWrapper` exit: `margin-bottom` transition deferred until `ZEN_EXIT_REENTRY_DELAY` so the 0 → 60 re-reservation lands in sync with the bar re-entering, not during the art shrink.
- `BottomBar` exit: a short-lived `$zenExiting` flag delays the opacity/transform reveal by `ZEN_EXIT_REENTRY_DELAY`. Scoped to the zen-exit edge so normal hover/touch reveals stay snappy.
- Retires four obsolete exit-stagger constants (`ZEN_CONTROLS_EXIT_DELAY`, `ZEN_CONTROLS_OPACITY_EXIT_DURATION`, `ZEN_CONTROLS_OPACITY_EXIT_DELAY`, `ZEN_CONTROLS_TRANSFORM_EXIT_DELAY`) in favor of the single `ZEN_EXIT_REENTRY_DELAY`.
- Respects `prefers-reduced-motion` on `ZenControlsWrapper`, `ContentWrapper`, and `BottomBarContainer`.

## Test plan
- [ ] Desktop: toggle zen on, then off via BottomBar zen button / `Z` key / overlay tap — album art shrinks smoothly first (1000 ms), then controls fade in and bottom bar slides in over the final ~300 ms with no downward jump.
- [ ] Mobile: same verification via BottomBar zen button — art shrink precedes bar reveal.
- [ ] Rapid toggle (on → off → on within the exit window): no stuck `$zenExiting` state, bar/controls reflect latest zen mode.
- [ ] `prefers-reduced-motion: reduce`: zen exit snaps instantly (no delay, no transitions).
- [ ] `npx tsc -b --noEmit` clean; `npm test -- --run` passes except the 6 pre-existing `spotifyPlaybackAdapterPrepareTrack.test.ts` failures noted in the epic handoff.

Closes #1187

Stacked on #1190 (base branch: `worktree-agent-1186`).