### PR TITLE
chore(diagnostics): timestamped trace channel for fresh-load art race

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,9 @@ In the browser devtools console:
 localStorage.debug = 'vorbis:*'; location.reload()
 ```
 
-Subset examples: `vorbis:queue`, `vorbis:spotify`, `vorbis:radio`, `vorbis:dropbox-sync`, `vorbis:app`, `vorbis:sw`. Disable: `localStorage.removeItem('debug'); location.reload()`.
+Subset examples: `vorbis:queue`, `vorbis:spotify`, `vorbis:radio`, `vorbis:dropbox-sync`, `vorbis:app`, `vorbis:sw`, `vorbis:art-race`. Disable: `localStorage.removeItem('debug'); location.reload()`.
+
+The `vorbis:art-race` channel is a focused trace for the fresh-load album-art race: every event that can flip `currentTrackIndex` during a `playTrack` transition (guard set/clear, `prepareTrack` pre-warm/hydrate emit, subscription accept/reject/fallback) is logged with an absolute `performance.now()` timestamp so the ordering can be reconstructed deterministically from a single console capture. Reproduce by enabling the channel, loading a fresh collection, and grepping the log for `[t=…ms]` entries in order.
 
 In Node (e.g. one-off scripts): `DEBUG=vorbis:* node …`.
 

--- a/src/hooks/usePlaybackSubscription.ts
+++ b/src/hooks/usePlaybackSubscription.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type { PlaybackState, ProviderId, MediaTrack } from '@/types/domain';
 import type { PlaybackProvider } from '@/types/providers';
 import { providerRegistry } from '@/providers/registry';
-import { logQueue } from '@/lib/debugLog';
+import { logQueue, logArtRace } from '@/lib/debugLog';
 
 interface UsePlaybackSubscriptionProps {
   activeDescriptor: { id: ProviderId; playback: PlaybackProvider } | undefined;
@@ -46,13 +46,21 @@ export function usePlaybackSubscription({
           const trackId = state.currentTrackId;
           const currentTracks = tracksRef.current;
           const trackIndex = currentTracks.findIndex((t: MediaTrack) => t.id === trackId);
-          if (expectedTrackIdRef.current !== null) {
-            if (trackId === expectedTrackIdRef.current) {
+          const expected = expectedTrackIdRef.current;
+          if (expected !== null) {
+            if (trackId === expected) {
+              logArtRace('subscription: expected arrived → guard cleared (id=%s, idx=%d)',
+                trackId.slice(0, 8), trackIndex);
               logQueue('Provider state — expected track arrived: %s', trackId.slice(0, 8));
               expectedTrackIdRef.current = null;
+            } else {
+              logArtRace('subscription: REJECT (id=%s, expected=%s, wouldFlipTo=%d, currentIdx=%d)',
+                trackId.slice(0, 8), expected.slice(0, 8), trackIndex, currentTrackIndexRef.current);
             }
             // while waiting for the expected track, ignore provider index updates
           } else if (trackIndex !== -1 && trackIndex !== currentTrackIndexRef.current) {
+            logArtRace('subscription: FALLBACK-ACCEPT flip %d → %d (id=%s, guard=null)',
+              currentTrackIndexRef.current, trackIndex, trackId.slice(0, 8));
             logQueue(
               'Provider state — index sync: %d → %d (trackId=%s, queueLen=%d)',
               currentTrackIndexRef.current,
@@ -61,6 +69,9 @@ export function usePlaybackSubscription({
               currentTracks.length,
             );
             setCurrentTrackIndex(trackIndex);
+          } else {
+            logArtRace('subscription: NOOP (id=%s, idx=%d, currentIdx=%d, guard=null)',
+              trackId.slice(0, 8), trackIndex, currentTrackIndexRef.current);
           }
 
           if (state.trackMetadata && trackIndex !== -1) {

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -3,7 +3,7 @@ import type { ProviderDescriptor } from '@/types/providers';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
-import { logQueue } from '@/lib/debugLog';
+import { logQueue, logArtRace } from '@/lib/debugLog';
 import { SKIP_ON_ERROR_DELAY_MS } from '@/constants/timing';
 
 interface UseProviderPlaybackProps {
@@ -80,6 +80,8 @@ export const useProviderPlayback = ({
     // load at index 0, empty-queue append, next/previous, etc.
     if (expectedTrackIdRef) {
       expectedTrackIdRef.current = mediaTrack.id;
+      logArtRace('playTrack guard set: expected=%s (idx=%d, provider=%s)',
+        mediaTrack.id.slice(0, 8), index, trackProvider);
     }
 
     pausePreviousProvider(trackProvider);
@@ -99,7 +101,12 @@ export const useProviderPlayback = ({
       const nextTrack = tracks[nextIndex];
       if (nextTrack && nextIndex !== index) {
         const nextDescriptor = providerRegistry.get(nextTrack.provider);
-        nextDescriptor?.playback.prepareTrack?.(nextTrack);
+        if (nextDescriptor?.playback.prepareTrack) {
+          logArtRace('pre-warm dispatch: next=%s (idx=%d, provider=%s) — guard still=%s',
+            nextTrack.id.slice(0, 8), nextIndex, nextTrack.provider,
+            expectedTrackIdRef?.current ? expectedTrackIdRef.current.slice(0, 8) : 'null');
+          nextDescriptor.playback.prepareTrack(nextTrack);
+        }
       }
     } catch (error) {
       if (error instanceof AuthExpiredError) {

--- a/src/lib/debugLog.ts
+++ b/src/lib/debugLog.ts
@@ -21,3 +21,16 @@ export const logApp = createDebug('vorbis:app');
 export const logSw = createDebug('vorbis:sw');
 export const logLibrary = createDebug('vorbis:library');
 export const logSession = createDebug('vorbis:session');
+
+/**
+ * Focused trace for the fresh-load album-art race: every event that can flip
+ * `currentTrackIndex` during a playTrack transition (guard set/clear,
+ * prepareTrack emit, subscription accept/reject) is logged with an absolute
+ * `performance.now()` timestamp so the ordering can be reconstructed
+ * deterministically from a single console capture.
+ *
+ * Enable with: localStorage.debug = 'vorbis:art-race' (or 'vorbis:*').
+ */
+const _logArtRace = createDebug('vorbis:art-race');
+export const logArtRace = (fmt: string, ...args: unknown[]) =>
+  _logArtRace(`[t=%sms] ${fmt}`, performance.now().toFixed(1), ...args);

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -10,6 +10,7 @@ import { DropboxCatalogAdapter } from './dropboxCatalogAdapter';
 import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import { putDurationMs, putTagMetadata } from './dropboxArtCache';
+import { logArtRace } from '@/lib/debugLog';
 
 const PLAYBACK_POLL_INTERVAL_MS = 250;
 const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
@@ -210,6 +211,9 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   }
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
+    logArtRace('dropbox.prepareTrack: enter id=%s positionMs=%d intent=%s',
+      track.id.slice(0, 8), options?.positionMs ?? 0,
+      options?.positionMs !== undefined ? 'hydrate' : 'pre-warm');
     this.catalog.prefetchTemporaryLink(track.playbackRef.ref);
     this.primeAudioForHydrate(track, options?.positionMs).catch(() => {
       // Hydration is best-effort; playTrack will retry when invoked.
@@ -221,7 +225,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     const audio = this.audio!;
     // Only prime audio when nothing is loaded — during next-track pre-warm
     // the current src is mid-playback and must not be replaced.
-    if (audio.src && this.currentTrack) return;
+    if (audio.src && this.currentTrack) {
+      logArtRace('dropbox.prepareTrack: skip emit (audio already loaded for current track) id=%s',
+        track.id.slice(0, 8));
+      return;
+    }
 
     const generation = ++this.prepareGeneration;
 
@@ -348,6 +356,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
   private notifyListeners(): void {
     const state = this.getStateSync();
+    if (state) {
+      logArtRace('dropbox.notify: emitState currentTrackId=%s isPlaying=%s positionMs=%d',
+        state.currentTrackId ? state.currentTrackId.slice(0, 8) : 'null',
+        String(state.isPlaying), state.positionMs);
+    }
     for (const listener of this.listeners) {
       try {
         listener(state);

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -12,7 +12,7 @@ import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotif
 import { SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { spotifyQueueSync } from './spotifyQueueSync';
-import { logSpotify } from '@/lib/debugLog';
+import { logSpotify, logArtRace } from '@/lib/debugLog';
 
 /** Map a SpotifyPlaybackState to the provider-agnostic PlaybackState. */
 function mapPlaybackState(state: SpotifyPlaybackState | null): PlaybackState | null {
@@ -253,7 +253,12 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   private ensureSdkSubscription(): void {
     if (this.sdkUnsubscribe) return;
     this.sdkUnsubscribe = spotifyPlayer.onPlayerStateChanged((spotifyState) => {
-      this.emitState(mapPlaybackState(spotifyState));
+      const mapped = mapPlaybackState(spotifyState);
+      logArtRace('spotify.sdk: emitState source=SDK currentTrackId=%s isPlaying=%s positionMs=%d',
+        mapped?.currentTrackId ? mapped.currentTrackId.slice(0, 8) : 'null',
+        String(mapped?.isPlaying ?? 'null'),
+        mapped?.positionMs ?? -1);
+      this.emitState(mapped);
     });
   }
 
@@ -297,9 +302,14 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
     const uri = track.playbackRef.ref;
     if (this.preparedTrackRef === uri) {
+      logArtRace('spotify.prepareTrack: skip (already prepared) id=%s', track.id.slice(0, 8));
       return;
     }
     this.preparedTrackRef = uri;
+
+    logArtRace('spotify.prepareTrack: enter id=%s positionMs=%d intent=%s',
+      track.id.slice(0, 8), options?.positionMs ?? 0,
+      options?.positionMs !== undefined ? 'hydrate' : 'pre-warm');
 
     void this.stageTrackPaused(track, options?.positionMs ?? 0).catch((err) => {
       logSpotify('prepareTrack failed: %o', err);
@@ -326,6 +336,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     const uri = track.playbackRef.ref;
     if (this.preparedTrackRef !== uri) return;
 
+    logArtRace('spotify.stageTrackPaused: emitState currentTrackId=%s positionMs=%d',
+      track.id.slice(0, 8), Math.floor(positionMs));
     this.emitState({
       isPlaying: false,
       positionMs: Math.floor(positionMs),


### PR DESCRIPTION
## Summary
Adds a focused `vorbis:art-race` debug channel for diagnosing the residual album-art flash some users still see on a fresh `loadCollection` after PR #1201. Every event that can flip `currentTrackIndex` during a `playTrack` transition is logged with an absolute `performance.now()` timestamp so the ordering can be reconstructed deterministically from a single console capture — useful for both this race and future playback-timing investigations.

Instrumented callsites:
- `useProviderPlayback.playTrack` — guard set + pre-warm dispatch (with the current guard value at dispatch time)
- `usePlaybackSubscription.handleProviderStateChange` — state receipt with outcome: `match-clear`, `REJECT` (mismatched id while guard held), `FALLBACK-ACCEPT` (guard null, would flip), or `NOOP` (guard null, no flip)
- Spotify adapter — `prepareTrack` entry (with `intent=hydrate|pre-warm`), `stageTrackPaused` emit, and the SDK `player_state_changed` emit
- Dropbox adapter — `prepareTrack` entry / skip, and `notifyListeners` emit

Stacked on #1201 so this can be pulled with the centralised guard already in place — the diagnostics are most informative when run against the post-fix code.

## Test plan
- `npx tsc -b --noEmit` passes.
- `npx vitest run` — 1240/1246 pass; the 6 failing tests are the pre-existing `spotifyPlaybackAdapterPrepareTrack.test.ts` failures (`fetchMock is not defined`) confirmed unrelated on `origin/develop` by the #1195 agent.
- Manual: `localStorage.debug = 'vorbis:art-race'; location.reload()` then load a fresh playlist and grep the console for `[t=…ms]` entries to read the sequence.