### PR TITLE
fix(spotify): suppress prepareTrack emit for next-track pre-warm

### DIFF
--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -72,6 +72,51 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
+  it('does NOT emit or transfer the device for the pre-warm intent (called without positionMs)', async () => {
+    // #given — the next-track pre-warm caller in useProviderPlayback.playTrack
+    // invokes prepareTrack(track) with no options. Emitting a PlaybackState
+    // with currentTrackId = nextTrack.id during pre-warm races the SDK's
+    // player_state_changed for the actually-playing track and flickers album
+    // art (#1199 / `vorbis:art-race`). The /me/player transfer also adds
+    // nothing in steady state — the next playTrack runs its own readiness
+    // check. Token warming is the only meaningful side effect.
+    const track = makeTrack();
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+
+    // #when
+    adapter.prepareTrack(track);
+
+    // #then — flush microtasks for the synchronous early-return + auth-warm
+    // .catch() chain, then assert no UI emission and no API calls.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(received.find((s) => s?.currentTrackId === track.id)).toBeUndefined();
+    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).not.toHaveBeenCalled();
+    expect(vi.mocked(spotifyPlayer.ensureDeviceIsActive)).not.toHaveBeenCalled();
+  });
+
+  it('still emits when positionMs is explicitly 0 (hydrate intent at the very start)', async () => {
+    // #given — saved sessions can have positionMs === 0 (track started but
+    // not advanced). The hydrate caller passes `{ positionMs: 0 }` which is
+    // semantically distinct from omitting options entirely: the seek bar
+    // still needs the staged emission to reflect the staged track.
+    const track = makeTrack();
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 0 });
+
+    // #then
+    await vi.waitFor(() => {
+      expect(received.find((s) => s?.currentTrackId === track.id)).toBeDefined();
+    });
+    const staged = received.find((s) => s?.currentTrackId === track.id)!;
+    expect(staged.positionMs).toBe(0);
+    expect(staged.isPlaying).toBe(false);
+  });
+
   it('does not start actual playback — no /me/player/play call and no pause()', async () => {
     // #given — the regression root cause (#1179): previously prepareTrack
     // called /me/player/play then pause, which could land playing on a fresh

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -297,8 +297,21 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     // Warm the auth token unconditionally so a token refresh delay can't stall
-    // the next transition even if the stage chain early-returns.
+    // the next transition even if the rest of the function early-returns.
     spotifyAuth.ensureValidToken().catch(() => {});
+
+    // Pre-warm intent (no positionMs): the next-track pre-warm caller in
+    // `useProviderPlayback.playTrack` doesn't pass options. The user is hearing
+    // a *different* track, so emitting a PlaybackState with
+    // `currentTrackId = nextTrack.id` would race the SDK's
+    // `player_state_changed` for the playing track and flicker album art
+    // (#1199 / `vorbis:art-race`). Device readiness is also unnecessary —
+    // the next `playTrack` call runs its own `ensurePlaybackReadyFastPath`,
+    // and the `/me/player` API call here adds nothing in steady state.
+    if (options?.positionMs === undefined) {
+      logArtRace('spotify.prepareTrack: skip (pre-warm intent) id=%s', track.id.slice(0, 8));
+      return;
+    }
 
     const uri = track.playbackRef.ref;
     if (this.preparedTrackRef === uri) {
@@ -307,11 +320,10 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     }
     this.preparedTrackRef = uri;
 
-    logArtRace('spotify.prepareTrack: enter id=%s positionMs=%d intent=%s',
-      track.id.slice(0, 8), options?.positionMs ?? 0,
-      options?.positionMs !== undefined ? 'hydrate' : 'pre-warm');
+    logArtRace('spotify.prepareTrack: enter id=%s positionMs=%d intent=hydrate',
+      track.id.slice(0, 8), options.positionMs);
 
-    void this.stageTrackPaused(track, options?.positionMs ?? 0).catch((err) => {
+    void this.stageTrackPaused(track, options.positionMs).catch((err) => {
       logSpotify('prepareTrack failed: %o', err);
       if (this.preparedTrackRef === uri) {
         this.preparedTrackRef = null;


### PR DESCRIPTION
## Summary
Closes the residual album-art flash on track transitions that survived #1201. The `vorbis:art-race` trace from #1204 confirmed the actual sequence:

```
SDK: emit track-1 playing       → guard matches → cleared (now null)
59ms later: pre-warm dispatch — guard already null
prepareTrack emits id=track-2  → subscription FALLBACK-ACCEPT → flip 1 → 2
75ms later: SDK emits track-1 again → flip 2 → 1   ← ~75ms of wrong art
```

The centralised guard in #1201 can't help here: `useProviderPlayback.playTrack` does `await descriptor.playback.playTrack(...)` before dispatching the pre-warm, and that await doesn't resolve until *after* the SDK has emitted "track-1 is now playing" — which clears the guard. By the time `prepareTrack(track2)` fires, there's no guard left to reject.

The two `prepareTrack` callers are semantically distinct:
- **hydrate** (`usePlayerLogic.handleHydrate`) passes `options.positionMs` — needs the emit so the seek bar can position to the saved offset before the user presses play. Load-bearing for f5689a4's hydrate UX.
- **pre-warm** (`useProviderPlayback.playTrack`) — no options arg; only wants device readiness for the upcoming track. The user is hearing a *different* track, so emitting `currentTrackId = nextTrack.id` is actively wrong.

Gating the emit on `options?.positionMs !== undefined` separates the intents at the source. `ensurePlaybackReady` still runs for both (device warming is harmless either way). Hydrate semantics are preserved — including `positionMs === 0`, which is hydrate intent at the very start of a saved session and still needs the seek-bar refresh.

Stacked on #1201 — retargets to `develop` automatically when that merges.

## Test plan
- `npx tsc -b --noEmit` passes.
- `npx vitest run src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts` — 8/14 pass; the 6 failures are the pre-existing `fetchMock not defined` issue in the `probePlayable` describe block (also fails on `develop`, unrelated).
- `npx vitest run src/hooks/ src/providers/` — 409/415 pass; same 6 pre-existing failures, no new regressions.
- New adapter contract tests (all passing):
  - `does NOT emit a PlaybackState for the pre-warm intent (called without positionMs)`
  - `still emits when positionMs is explicitly 0 (hydrate intent at the very start)`
  - existing `emits a PlaybackState with the saved positionMs, ...` continues to assert the hydrate happy path.
- Manual: with #1204's `vorbis:art-race` channel enabled, advance through tracks and confirm the `prepareTrack` line no longer appears for pre-warm and no `FALLBACK-ACCEPT flip` lines fire.