### PR TITLE
fix(ci): build via vercel CLI and grant write perms for commit comment

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: write
+
 concurrency:
   group: vercel-preview-${{ github.ref }}
   cancel-in-progress: true
@@ -24,17 +27,6 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-        env:
-          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
-          VITE_SPOTIFY_REDIRECT_URI: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI }}
-          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
-          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
-
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
@@ -44,10 +36,20 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+      - name: Build with Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
+          VITE_SPOTIFY_REDIRECT_URI: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI }}
+          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
+          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
+
       - name: Deploy prebuilt output to Vercel
         id: deploy
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tail -n1)
+          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Replace `npm ci` + `npm run build` with `vercel build` so the prebuilt output lands in `.vercel/output/` where `vercel deploy --prebuilt` expects it. The Vite build was producing `dist/`, causing `vercel deploy --prebuilt` to error with `no prebuilt output found in ".vercel/output"`.
- Add `permissions: contents: write` at the workflow level so `actions/github-script` can call `repos.createCommitComment` to post the preview URL. Default `GITHUB_TOKEN` permissions are `contents: read`, which produced a 403 on the comment step.

## Context
Initial run of the Vercel preview workflow (added in #1209) failed at the deploy step because `--prebuilt` requires `vercel build`, not Vite's `npm run build`. The error string was then captured as the "URL" and posted to the comment step, which itself 403'd because the token lacked write permission.

## Test plan
- After merge, push a commit to `develop`
- Verify: `vercel build` succeeds, `vercel deploy --prebuilt` returns a deployment URL on stdout, and a commit comment appears on the head commit reading "🔍 **Vercel Preview:** https://..."