### PR TITLE
chore(ci): make Vercel preview deploy manual-only

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,9 +1,7 @@
 name: Vercel Preview Deploy
 
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Switch the Vercel preview workflow trigger from `push: branches: [develop]` to `workflow_dispatch:` so it only runs when explicitly invoked.

## Why
Auto-deploying on every develop push is overkill — most pushes don't need a hosted preview, and Vercel build minutes / commit-comment noise add up.

## Test plan
- After merge, push a commit to `develop` and confirm the workflow does **not** run automatically
- Trigger manually via `gh workflow run vercel-preview.yml --ref develop` (or the Actions UI) and confirm a preview deploys and the URL is commented on the dispatched commit