### PR TITLE
docs(claudemd): document multi-agent team workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,3 +396,26 @@ For structured feature development, see `.claude/rules/`:
 - `generate_prd.md` — PRD creation process: asks clarifying questions, then generates a structured requirements doc
 - `generate_tasks_from_prd.md` — breaks a PRD into a detailed parent/subtask list; waits for "Go" confirmation before generating subtasks
 - `process_tasks.md` — task execution protocol: one subtask at a time, with test + commit gates before marking parent complete
+
+## Multi-Agent Team Workflows
+
+For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester) defined in `.claude/agents/*.md`. Spawn it on demand and run retros against it.
+
+### Skills
+
+- **`/spawn-epic-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-epic/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
+- **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
+
+### Agent definitions
+
+`.claude/agents/*.md` files specify each role's tools, role description, and operating rules. Notable conventions:
+
+- **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
+- **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
+- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-epic-team` skill handles this automatically.
+- **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
+
+### When to use
+
+- **`/spawn-epic-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains).
+- **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.


### PR DESCRIPTION
## Summary

Adds a **Multi-Agent Team Workflows** section to `CLAUDE.md` so future sessions can discover the `/spawn-epic-team` and `/agent-team-retro` skills and the `.claude/agents/*.md` role-definition convention without spelunking through `.claude/`.

Distilled from the epic #1218 retrospective. Companion to PR #1221 (which added the actual skills + agent files).

## What's documented

- **Skills** — `/spawn-epic-team` and `/agent-team-retro`, with one-line behavior summaries
- **Agent definitions** — the universal exit-gate rule, the explicit-tools-allowlist convention (and why: `feature-dev:*` upstream types omit `SendMessage`), the project-local `subagent_type` spawn pattern, and the role-specific guardrails (interface-contract-first, test-exit-0 completion bar, etc.)
- **When to use each** — practical guidance: `/spawn-epic-team` for 3+ child-issue epics with distinct domains; `/agent-team-retro` before tearing down a team

## Test plan

- [ ] Read the new section in context — does a new contributor understand the team workflow?
- [ ] Cross-check that all referenced files exist (`.claude/agents/*.md`, `.claude/skills/spawn-epic-team/`, `.claude/skills/agent-team-retro/`)

## Refs

- PR #1221 (the skills and agent definitions this documents)
- Epic #1218 retrospective (origin of the conventions)