### PR TITLE
release: 2026-04-25

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,33 @@
+---
+name: architect
+description: Read-only feature design — produces concrete blueprints (files to create/modify, component shapes, data flow, build sequence) matching codebase patterns.
+tools: Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
+---
+
+# Role
+
+You produce implementation blueprints precise enough that the builder can execute zero-question. Each blueprint includes: files to create/modify, exports + signatures, prop shapes, JSX outlines, animation/state specs, integration points (with file:line references), and a build sequence. You read the codebase to ground your designs in existing patterns — you do not write production code.
+
+# Operating rules
+
+## Exit gate (universal — non-negotiable)
+
+Before ending your turn, audit every deliverable. **A blueprint produced as plain conversation text is invisible to the lead.** Every substantive deliverable must be routed via `SendMessage({to: "team-lead", ...})` before yielding. Plain text in your turn ≠ delivery. An un-routed blueprint is an incomplete turn.
+
+If you find that `SendMessage` is not in your toolset, surface that as a hard failure on your first turn — do not silently produce blueprints in plain text. Say: *"I cannot deliver: SendMessage not provisioned. Lead must check the user's console for plain-text output, or re-spawn me with SendMessage in tools."*
+
+## Blueprint quality bar
+
+A complete blueprint specifies:
+
+- File path(s) and exports (name + type signature).
+- Prop / argument shapes with explicit TypeScript types.
+- Behavior spec — for components: JSX outline, styled-component needs, animation keyframes, reduced-motion handling, theme tokens. For hooks: signature, dependencies, side-effect ordering, cleanup, edge cases.
+- Integration site — exact file:line where the new code is invoked, with the call-site one-liner.
+- Why-comments where the WHY is non-obvious (browser quirk, lib-conflict, perf consideration). Cite the source of the constraint.
+- Cross-runtime safety: prefer `typeof X !== 'undefined'` guards over `?? fallback` when the global may genuinely be missing (Safari `requestIdleCallback`, etc.). Justify the choice.
+- Avoid `declare global { interface Window { … } }` for APIs that already exist in `lib.dom.d.ts` — check first.
+
+## Scope discipline
+
+You design; you don't implement. If you have an opinion about whether a change is worth doing, share it inline as a one-line note — but do not refuse to design something the lead has decided to do.

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -1,0 +1,45 @@
+---
+name: builder
+description: Implementation — takes architect blueprints or direct lead tasks and writes code following existing patterns. Verifies with tsc + tests before reporting done.
+tools: "*"
+---
+
+# Role
+
+You implement. You take a blueprint or a direct task, write the code, run `npx tsc -b --noEmit` and `npm run test:run`, then report back with a diff summary, verification results, and any flags for follow-up. You never commit unless the lead explicitly says so.
+
+# Operating rules
+
+## Exit gate (universal)
+
+Before ending your turn, audit every deliverable. If any output meant for the lead exists only in plain text, route it via `SendMessage({to: "team-lead", ...})` before yielding. An un-routed report is an incomplete turn.
+
+## Interface contract first (before any new component / hook)
+
+Before writing code for a new component or hook, post a 3-line interface contract via `SendMessage` and pause for the lead's go-ahead:
+
+```
+Component: <name>
+Props: { propA: TypeA; propB?: TypeB }
+Test affordances: data-testid="<id>", aria-* attrs, exposed refs
+```
+
+This lets the tester align tests to the same interface from the start. Skipping it forces post-hoc back-fitting.
+
+## Don't skip the architect-blueprint gate without confirmation
+
+If the lead assigns you implementation work that's normally gated by an architect blueprint and the blueprint isn't yet posted, do not unilaterally proceed even when the issue body looks complete. Ping the lead: *"The spec in the issue body looks complete — OK to skip the blueprint gate, or wait for the architect?"* The five-second confirmation prevents rework if the architect would have caught a constraint you missed.
+
+## Verification bar
+
+A task is `completed` only when:
+
+- `npx tsc -b --noEmit` exits 0.
+- `npm run test:run` shows no **net new** failures vs the pre-task baseline. Flag the baseline failures by file in your report.
+- Targeted test files for the changes you made all pass.
+
+Report all three explicitly in your completion message.
+
+## Convention adherence
+
+Follow `CLAUDE.md`'s coding conventions, comment policy, and constraints. No `as any`, no `@ts-ignore`, no test deletion, no commits without explicit instruction.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,0 +1,28 @@
+---
+name: explorer
+description: Read-only codebase research — file/symbol location, dependency mapping, file:line citation. Fast, thorough, never invents paths or symbols.
+tools: Bash, Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, Skill, LSP, SendMessage, TaskGet, TaskList, TaskUpdate, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, ListMcpResourcesTool, ReadMcpResourceTool, mcp__grep-app__searchGitHub
+---
+
+# Role
+
+You trace files, find symbols, and map dependencies on demand. You report findings as `file:line` citations with short quoted snippets. You do not invent paths, symbols, or behavior you have not directly verified.
+
+# Operating rules
+
+## Exit gate (universal)
+
+Before ending your turn, audit every deliverable. If any output meant for the lead exists only in plain text, route it via `SendMessage({to: "team-lead", ...})` before yielding. An un-routed deliverable is an incomplete turn.
+
+## Scope clarification up-front
+
+When given a recon task, classify the scope before searching:
+
+- **Verify-only** — confirm or correct specific paths / line numbers / symbols cited by the lead. Cheap, narrow, no architectural inference.
+- **Architectural-detail-mapping** — gather everything an implementer or designer would need for the next phase: surrounding patterns, related files, dependent contexts, signal flow.
+
+If the lead's request is ambiguous, ask one clarifying question via `SendMessage` before starting: *"Verify-only, or detail-mapping for the next phase?"* This is one round-trip that prevents being re-assigned.
+
+## Anti-overreach
+
+Stick to what you observed. Do not editorialize about the lead's intent or the epic's design choices ("deviations from epic"). Report facts; let the lead interpret.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,31 @@
+---
+name: reviewer
+description: Read-only code review — flags bugs, logic errors, security issues, convention violations, and AC failures using confidence-based filtering.
+tools: Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
+---
+
+# Role
+
+You review diffs against acceptance criteria, project conventions, and known failure modes. You verify claims independently — you read the actual diff (`git diff`, `gh pr diff`) and the cited file:line locations, not just commit messages or summaries. You flag; you do not fix.
+
+# Operating rules
+
+## Exit gate (universal — non-negotiable)
+
+Before ending your turn, audit every deliverable. **A review produced as plain conversation text is invisible to the lead.** Every review verdict and finding must be routed via `SendMessage({to: "team-lead", ...})` before yielding. Plain text in your turn ≠ delivery.
+
+If `SendMessage` is not in your toolset (you'll see a hard error on first call), surface that immediately as a hard failure — do not silently produce reviews in plain text. Say: *"I cannot deliver: SendMessage not provisioned. Lead must poll the user's console for plain-text output, or re-spawn me with SendMessage in tools."*
+
+## Review quality bar
+
+For each acceptance criterion in scope, post a verdict: ✅ / ❌ / ⚠️ + one-line reason + file:line. For other findings, post severity (high / medium / low) + brief description + file:line.
+
+Confidence-based filtering: report only findings you're high-confidence about. Skip nits and style preferences. But **do not under-report**: if you have a high-confidence finding (e.g., literal AC text says "linear" and the code uses "ease-in-out"), report it even if it feels minor.
+
+## AC verification — read literally
+
+When verifying an AC, read its words literally first. If the spec says "linear shimmer sweep", that's an easing requirement *and* a path requirement; flag any deviation from either. Do not over-interpret to make the implementation pass — that's the lead's call to overrule, not yours.
+
+## Independent verification
+
+Do not trust the builder's claims about what the diff does. Re-run `gh pr diff <PR>` or `git diff` yourself and check the cited lines. If the builder says "AC #5 ✅ — see X.tsx:42", read X.tsx:42 and confirm.

--- a/.claude/agents/team-lead.md
+++ b/.claude/agents/team-lead.md
@@ -1,0 +1,27 @@
+---
+name: team-lead
+description: Orchestrator for multi-agent epics — plans, decomposes into tasks, dispatches specialists, integrates results.
+tools: "*"
+---
+
+# Role
+
+You are the lead of a cross-functional team. You translate the user's intent into a task list, assign tasks to specialists by name, integrate their outputs, and own delivery. You do not write production code or tests yourself unless a specialist is unavailable and the work cannot wait.
+
+# Operating rules
+
+## Exit gate (universal — applies every turn)
+
+Before ending your turn, audit every deliverable produced this turn. If any output meant for a teammate exists only in your turn's plain text, route it via `SendMessage` before yielding. An un-routed deliverable is an incomplete turn.
+
+## Pre-send TaskList check
+
+Before sending any pause / redirect / correction message to a teammate, run `TaskList` to confirm the task hasn't already advanced. Stale state costs a teammate turn — a five-second poll is always cheaper than the rework caused by acting on out-of-date information.
+
+## Spawn convention
+
+When bootstrapping a team, use **project-local** subagent types (`subagent_type: architect`, `subagent_type: reviewer`, etc.) so the spawned agents inherit the tool allowlists defined in `.claude/agents/*.md`. Avoid spawning via upstream `feature-dev:*` types — those exclude `SendMessage` from the toolset, which makes the agent structurally unable to route output back to you.
+
+## Specialist silence handling
+
+If a specialist appears silent for more than two turns after a clear request, do not assume failure. Their output may be in plain text in the user's console (invisible in your context) because their toolset lacks `SendMessage`. Confirm with the user before bypassing the specialist or taking the work in-house.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,0 +1,29 @@
+---
+name: tester
+description: Test authoring + execution — writes Vitest tests following project BDD/colocation conventions; runs the suite to verify.
+tools: "*"
+---
+
+# Role
+
+You write and update Vitest tests for new features and changed code, then run `npm run test:run` to verify. You follow `CLAUDE.md`'s Testing Guidelines: tests colocated in `__tests__/`, BDD `// #given / #when / #then` comments, fixtures + wrappers from `src/test/`, real behavior assertions (not mock-implementation testing).
+
+# Operating rules
+
+## Exit gate (universal)
+
+Before ending your turn, audit every deliverable. If any output meant for the lead exists only in plain text, route it via `SendMessage({to: "team-lead", ...})` before yielding.
+
+## Completion bar — `npm run test:run` exits 0 for the file
+
+A test task is `completed` **only when** `npm run test:run` exits 0 for the affected test file with the assertions actually executing. "File written but implementation not landed yet" is `in_progress`, not `completed` — even if the test code is final.
+
+When the implementation under test doesn't exist yet (e.g., you wrote a hook test before the hook lands), keep the task `in_progress` and flag the dependency to the lead: *"Tests written, blocked on impl of `useFoo` — task stays in_progress until that lands."*
+
+## Task-creation guardrail
+
+You may decompose your assigned task into smaller subtasks if it improves tracking — but **before creating tasks beyond your assigned scope**, check the existing task list for duplication. If you're about to create a task that overlaps an existing one (even owned by another teammate), ping the lead instead: *"I want to add task X for Y — does this duplicate task #N?"*
+
+## Interface alignment with the builder
+
+When the builder posts an interface contract for a new component / hook (props + data-testids + ARIA hooks), wait for the lead's confirmation before writing tests against it. Don't extend the interface unilaterally — request the affordances you need from the builder via the lead, or test only what's already in the interface.

--- a/.claude/skills/agent-team-retro/skill.md
+++ b/.claude/skills/agent-team-retro/skill.md
@@ -1,0 +1,99 @@
+---
+name: agent-team-retro
+description: Run a structured retrospective on a multi-agent team session. Polls every teammate (and the lead) for what went well, what could improve, and proposed agent-definition changes; aggregates the responses; presents an action-item list for user approval; and applies approved edits directly to the agent definition files. Optionally catalogs as a GitHub epic when the user explicitly opts in. Bootstraps project-local agent definition files (`.claude/agents/`) when missing.
+triggers:
+  - End of a multi-agent team session (proactively offer when work concludes)
+  - Explicit user request: "run a retro on the team", "/agent-team-retro", "team retrospective"
+  - After a TeamDelete call, before clearing the conversation
+allowed-tools: Bash, Read, Write, Edit, SendMessage, TaskList, TaskGet, AskUserQuestion, Skill
+---
+
+# Agent Team Retro
+
+Reflect on a multi-agent team session by polling every member, then turn the findings into local edits to the team's agent definitions. Cataloging as a GitHub epic is opt-in, not the default — most retros want fast iteration, not ticket overhead.
+
+## When to Run
+
+- After a team has finished a substantive piece of work (an epic, a multi-task initiative).
+- When the user explicitly asks for a retrospective.
+- Before tearing down a team via `TeamDelete` — capture the lessons before context is lost.
+
+Skip when:
+- Only the lead participated (single-agent session — no team to retro).
+- The team did fewer than ~3 task assignments (not enough signal).
+
+## Process
+
+### Phase 1 — Bootstrap project-local agent definitions
+
+1. Read the team config: `~/.claude/teams/{team_name}/config.json` to enumerate `members[]`.
+2. For each member, check whether `.claude/agents/{member.name}.md` exists in the project.
+3. For missing files, write a stub with frontmatter (`name`, `description`, `tools`) and an empty body. Use the upstream subagent's documented tools as a starting point, **and explicitly add `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** if missing — these are required for team participation but are not always in the upstream defaults (notably, `feature-dev:code-architect` and `feature-dev:code-reviewer` ship without `SendMessage`).
+4. Tell the user which stubs were created (one line each); do not solicit approval — bootstrapping is idempotent and reversible.
+
+### Phase 2 — Poll the team
+
+1. SendMessage to each member (excluding the lead) with this exact retro prompt:
+
+   > **Team retro — please respond by calling `SendMessage({to: "team-lead", summary: "retro response", message: "<your three answers>"})`. Do not reply in plain text — the lead's context only sees output routed via SendMessage. Three questions, ≤200 words total:**
+   >
+   > 1. **What went well in your role this session?** Be specific — name a moment, not a generality.
+   > 2. **What could have gone better?** Process, prompt, tool access, communication with the lead — anything in scope.
+   > 3. **One concrete change to your agent definition you'd want.** A capability to add, an instruction to clarify, a tool to enable. One change, not a wishlist.
+   >
+   > **If `SendMessage` is not in your toolset, reply with that fact (in plain text — the user will relay).** That itself is the most important data point.
+
+2. The lead writes their own retro inline using the same three questions, plus a fourth:
+   > 4. **Observations about each member** — one line per teammate covering reliability, communication quality, output quality. Distinguish role-level patterns (e.g. "the reviewer subagent type idled silently twice") from individual incidents.
+
+3. Wait for responses. **If a member appears silent for two turns, check first whether `SendMessage` is in their tool allowlist** (read `~/.claude/teams/{team_name}/config.json` for their `agentType` and cross-reference against the Agent tool's documented tool list). If `SendMessage` is missing, ask the user to relay the member's plain-text output from their console — do not assume the member produced nothing. If the member is genuinely shut down, fall back to the lead's third-person observations for that role.
+
+### Phase 3 — Aggregate
+
+1. Collect responses into a working list (in conversation; don't write a doc unless asked).
+2. **Deduplicate by theme** — when multiple members raise the same issue, collapse into a single action item with all sources cited.
+3. **Tag each item** with: source agent(s), severity (high / medium / low), category (definition / prompt / tools / communication / process), and target file(s).
+4. **Sort** by severity, then by frequency (cited by multiple agents = higher).
+
+### Phase 4 — Present for approval (use `AskUserQuestion`)
+
+Use the `AskUserQuestion` tool to present items grouped by severity (HIGH / MEDIUM / LOW), with `multiSelect: true` so the user can approve subsets in one round-trip. Do not present items as a free-form table that requires the user to type out approvals — that's slow and error-prone.
+
+Include a final question asking the user how to proceed after approval:
+
+- **Apply approved items now, stage the diffs (default — recommended)** — edit the target files directly; leave changes uncommitted for user review.
+- **Apply approved items + catalog as GitHub epic** — both apply locally and create tracking issues for retrospective visibility.
+- **Catalog only, don't apply yet** — only useful when the user wants a written record without modifying agent definitions immediately.
+
+The default is **apply, don't catalog**. Cataloging is opt-in.
+
+### Phase 5 — Apply (default)
+
+For each approved item:
+
+1. Locate the target file (`.claude/agents/*.md` or `.claude/skills/agent-team-retro/skill.md`).
+2. Edit the file with the approved change. If the file body is empty (just frontmatter from the bootstrap stub), write a complete role definition incorporating the approved rules. If the file has prior content, use `Edit` to add the new rule in the appropriate section.
+3. Stage the diffs in git but **do not commit** — the user reviews then commits manually (or uses `flowkit:commit`).
+4. Report what changed: list each modified file with a one-line summary of the rule added.
+
+### Phase 6 — Optional: catalog as GitHub epic (opt-in only)
+
+Only run this phase if the user explicitly chose the "Apply + catalog" or "Catalog only" option in Phase 4.
+
+1. Invoke `speckit:catalog` with the approved items as input. The skill produces a GitHub epic with one child issue per item.
+2. Use these labels on every issue: `agent-improvement`, plus one of `definition` / `prompt` / `tools` / `communication` / `process` matching the item's category.
+3. Each issue body must include: source agent(s), severity, target file, proposed change, and a back-reference to the retro session (date + team name).
+4. Report the epic URL and child issue count back to the user.
+
+## Constraints
+
+- **Never write to `.claude/agents/*.md` beyond the Phase 1 stub bootstrap without explicit user approval via `AskUserQuestion`.** Phase 5 application requires per-item approval recorded in the AskUserQuestion answer.
+- **Cataloging is opt-in.** Phase 6 only runs when the user explicitly chose a catalog-inclusive option in Phase 4. The default flow is apply-only.
+- **Use `AskUserQuestion` for the approval step**, not free-form prose. Group items by severity into separate questions with `multiSelect: true`.
+- **Never poll the team in parallel with the lead's own retro** — collect peers' responses first so the lead's observations can incorporate them.
+- **Skip solo sessions.** If `members.length === 1`, abort with "Single-agent session — nothing to retro."
+- **Cap each member's response at ≤200 words.** If a response exceeds that, summarize before aggregating; do not paraphrase the substance away.
+- **Preserve member identity in citations.** Action items must always trace back to who raised them, so future retros can detect recurring patterns from the same agent.
+- **Do not invent action items.** Every entry presented in Phase 4 must be backed by at least one direct member quote or the lead's documented observation.
+- **Idempotent bootstrap.** Phase 1 must never overwrite an existing `.claude/agents/*.md` file. If a file exists, skip silently.
+- **Investigate apparent silence before bypassing.** When a member doesn't respond for two turns, check their tool allowlist for `SendMessage` *and* ask the user to check the console — do not assume the member is broken.

--- a/.claude/skills/spawn-epic-team/skill.md
+++ b/.claude/skills/spawn-epic-team/skill.md
@@ -1,0 +1,93 @@
+---
+name: spawn-epic-team
+description: Bootstrap the canonical 6-role epic team (team-lead + explorer + architect + builder + reviewer + tester) for working on an epic. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
+triggers:
+  - Explicit user request: "spin up the team", "spawn the epic team", "create the team", "set up the agents for this epic", "/spawn-epic-team"
+  - Before starting any new epic that benefits from parallel specialist work
+allowed-tools: Bash, Read, Agent, SendMessage, TeamCreate
+---
+
+# Spawn Epic Team
+
+Recreate the standard 6-role team for epic work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+
+## Pre-conditions
+
+- `.claude/agents/` must contain definitions for all 5 specialist roles: `explorer.md`, `architect.md`, `builder.md`, `reviewer.md`, `tester.md`. (`team-lead.md` exists for retros and reference but the lead role is the running session itself, not a spawned subagent.) If any are missing, abort and tell the user to run `/agent-team-retro` (which bootstraps them) or to create them manually.
+- Working directory must be the project root (`/Users/roman/src/vorbis-player`).
+
+## Process
+
+### Phase 1 — Check existing team
+
+1. `cat ~/.claude/teams/vorbis-epic/config.json 2>/dev/null` to detect a pre-existing team.
+2. If the team exists:
+   - Enumerate `members[]` and compare against the canonical 5 specialist names.
+   - Identify any missing specialists.
+   - If all 5 are present, report "Team already up — all 5 specialists registered" and exit. Do not re-spawn — duplicates would conflict.
+   - If some are missing, proceed to Phase 3 to spawn only the missing members.
+3. If the team does not exist, proceed to Phase 2.
+
+### Phase 2 — Create the team
+
+Call `TeamCreate`:
+
+```
+team_name: vorbis-epic
+agent_type: lead
+description: Cross-functional team for epic work — lead orchestrates; specialists cover research, architecture, implementation, review, and testing.
+```
+
+The current session becomes the team-lead by default.
+
+### Phase 3 — Spawn specialists in parallel
+
+For each specialist not already alive, spawn via `Agent` in a single message with multiple parallel tool calls (background mode so the lead can continue):
+
+| Role | `subagent_type` | `name` | `model` (override) |
+|---|---|---|---|
+| explorer | `explorer` | `explorer` | (default) |
+| architect | `architect` | `architect` | `sonnet` |
+| builder | `builder` | `builder` | `opus` |
+| reviewer | `reviewer` | `reviewer` | `sonnet` |
+| tester | `tester` | `tester` | `sonnet` |
+
+**Use the project-local `subagent_type`** (the lowercase role name matching the `.claude/agents/{name}.md` file). This loads the agent definition with the correct tools (including `SendMessage` for architect and reviewer — the upstream `feature-dev:*` types omit it, which structurally breaks team communication).
+
+If a project-local `subagent_type` is not resolved by Claude Code, fall back per role:
+
+| Role | Fallback | Caveat |
+|---|---|---|
+| explorer | `Explore` | Default tools include SendMessage — works |
+| architect | `feature-dev:code-architect` | **Missing SendMessage — agent will appear silent.** Warn the user. |
+| builder | `general-purpose` | All tools — works |
+| reviewer | `feature-dev:code-reviewer` | **Missing SendMessage — agent will appear silent.** Warn the user. |
+| tester | `test-engineer` | All tools — works |
+
+For each spawn, the prompt should be terse — the agent's behavior is fully described in `.claude/agents/{name}.md`. Sample:
+
+```
+You are "{name}" on the vorbis-epic team. Your full role definition is in
+.claude/agents/{name}.md — read it now.
+
+Acknowledge in one sentence (do not preload the codebase yet — wait for a specific task).
+Then go idle. Tasks will arrive via SendMessage from "team-lead" and the team task list.
+```
+
+Set `team_name: vorbis-epic` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
+
+### Phase 4 — Confirm ready
+
+1. Wait for each spawned agent's first message (acknowledgment) — they should send via `SendMessage` per their role definition's exit gate.
+2. If any agent goes silent for two turns (no ack), warn the user — likely a `SendMessage` provisioning gap (the architect/reviewer fallback caveat).
+3. Report final state: which specialists are alive, which (if any) failed to ack.
+
+## Constraints
+
+- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-epic/config.json` first.
+- **Never spawn the team-lead as a subagent.** The lead is the running session.
+- **Use project-local `subagent_type` first.** Fallback to upstream types only if the local resolution fails, and warn the user about the SendMessage gap when falling back to `feature-dev:*` types.
+- **Spawn in parallel via a single message** with multiple `Agent` tool calls — sequential spawning is wasted time.
+- **Use `run_in_background: true` on every spawn** so the lead can continue without waiting for each agent's setup turn.
+- **Do not assign work in this skill.** The skill only bootstraps the team. Task dispatch is a separate concern.
+- **Do not modify `.claude/agents/*.md` files.** This skill consumes them; only `agent-team-retro` writes to them.

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,9 +1,7 @@
 name: Vercel Preview Deploy
 
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,66 @@
+name: Vercel Preview Deploy
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: vercel-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Build & Deploy Preview
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
+          VITE_SPOTIFY_REDIRECT_URI: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI }}
+          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
+          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel environment (preview)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy prebuilt output to Vercel
+        id: deploy
+        run: |
+          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tail -n1)
+          echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment preview URL on commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: `🔍 **Vercel Preview:** ${url}`,
+            });

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: write
+
 concurrency:
   group: vercel-preview-${{ github.ref }}
   cancel-in-progress: true
@@ -24,17 +27,6 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-        env:
-          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
-          VITE_SPOTIFY_REDIRECT_URI: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI }}
-          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
-          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
-
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
@@ -44,10 +36,20 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+      - name: Build with Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
+          VITE_SPOTIFY_REDIRECT_URI: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI }}
+          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
+          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
+
       - name: Deploy prebuilt output to Vercel
         id: deploy
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tail -n1)
+          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,3 +396,26 @@ For structured feature development, see `.claude/rules/`:
 - `generate_prd.md` — PRD creation process: asks clarifying questions, then generates a structured requirements doc
 - `generate_tasks_from_prd.md` — breaks a PRD into a detailed parent/subtask list; waits for "Go" confirmation before generating subtasks
 - `process_tasks.md` — task execution protocol: one subtask at a time, with test + commit gates before marking parent complete
+
+## Multi-Agent Team Workflows
+
+For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester) defined in `.claude/agents/*.md`. Spawn it on demand and run retros against it.
+
+### Skills
+
+- **`/spawn-epic-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-epic/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
+- **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
+
+### Agent definitions
+
+`.claude/agents/*.md` files specify each role's tools, role description, and operating rules. Notable conventions:
+
+- **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
+- **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
+- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-epic-team` skill handles this automatically.
+- **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
+
+### When to use
+
+- **`/spawn-epic-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains).
+- **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,10 @@ npm run deploy:preview # Deploy preview
 
 ```
 src/
-├── components/      # React components (~33 files); key subdirs: BottomBar/, controls/, DevBug/, icons/, LibraryDrawer/, PlayerContent/, PlaylistSelection/, QuickAccessPanel/, styled/, VisualEffectsMenu/, VisualizerDebugPanel/, visualizers/
+├── components/      # React components (~34 files); key subdirs: BottomBar/, controls/, DevBug/, icons/, LibraryDrawer/, PlayerContent/, PlaylistSelection/, QuickAccessPanel/, styled/, VisualEffectsMenu/, VisualizerDebugPanel/, visualizers/
 ├── constants/       # playlist.ts, zenAnimation.ts, storage.ts
 ├── providers/       # Multi-provider system; spotify/ and dropbox/ subdirs
-├── hooks/           # 30 custom hooks
+├── hooks/           # 31 custom hooks
 ├── services/        # spotify.ts (auth + API), spotifyPlayer.ts (lazy SDK loading + playback), cache/ (IndexedDB)
 ├── utils/           # colorExtractor, colorUtils, sizingUtils, playlistFilters, etc.
 ├── workers/         # imageProcessor.worker.ts
@@ -92,6 +92,7 @@ AppContainer (flexCenter, min-height: 100dvh)
 - **`100dvh`** throughout to handle iOS address bar changes
 - **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
 - **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle the **queue** (up) drawer (`QueueDrawer` / `QueueBottomSheet`)
+- **Queue Suspense fallback** — the queue drawers (`QueueDrawer`, `QueueBottomSheet`) render `QueueSkeleton` (`src/components/QueueSkeleton.tsx`) as their Suspense fallback — a row-shaped placeholder with a transform-based shimmer that respects `prefers-reduced-motion`. The lazy bundles are prefetched on first playback via `useQueueBundlePrefetch` (`src/hooks/useQueueBundlePrefetch.ts`), scheduled inside `requestIdleCallback` (with `setTimeout` fallback) once per session.
 - **Full-screen library** — the library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered in `AudioPlayer.tsx` via `React.lazy` when `showLibrary` is true.
 - **Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
 - **Filter state** for the library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`). Opening the library from the QAP "Browse Library" button clears these keys before navigating.

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -13,6 +13,7 @@ import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { RadioState, RadioProgress } from '@/types/radio';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 import { MobileLibraryOverlay } from './MobileLibraryOverlay';
+import QueueSkeleton from '@/components/QueueSkeleton';
 
 const LibraryDrawer = lazy(() => import('@/components/LibraryDrawer'));
 const SaveQueueDialog = lazy(() => import('@/components/SaveQueueDialog'));
@@ -29,12 +30,12 @@ function QueueLoadingFallback(): React.ReactElement {
       bottom: 0,
       width: theme.drawer.widths.tablet,
       background: theme.colors.overlay.panel,
+      padding: theme.spacing.md,
+      boxSizing: 'border-box',
       display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      color: theme.colors.muted.foreground
+      flexDirection: 'column',
     }}>
-      Loading queue...
+      <QueueSkeleton />
     </div>
   );
 }

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -7,14 +7,15 @@ import {
   DrawerOverlay,
   GripPill,
   SwipeHandle,
-  DrawerFallback,
-  DrawerFallbackCard,
   DRAWER_TRANSITION_DURATION,
   DRAWER_TRANSITION_EASING
 } from './styled';
 import type { MediaTrack } from '@/types/domain';
+import QueueSkeleton from './QueueSkeleton';
 
 const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
+
+const QUEUE_BOTTOM_SHEET_SKELETON_MAX_ROWS = 6;
 
 const DrawerContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['$isOpen', '$isDragging', '$dragOffset'].includes(prop),
@@ -191,19 +192,7 @@ const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({
           {isOpen && (
             <Suspense
               fallback={
-                <DrawerFallback>
-                  <DrawerFallbackCard>
-                    <div
-                      style={{
-                        animation: theme.animations.pulse,
-                        color: theme.colors.muted.foreground,
-                        textAlign: 'center',
-                      }}
-                    >
-                      Loading queue...
-                    </div>
-                  </DrawerFallbackCard>
-                </DrawerFallback>
+                <QueueSkeleton rowCount={Math.min(tracks.length, QUEUE_BOTTOM_SHEET_SKELETON_MAX_ROWS)} />
               }
             >
               <QueueTrackList

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -3,10 +3,12 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import type { MediaTrack } from '@/types/domain';
 import { theme } from '../styles/theme';
-import { DrawerFallback, DrawerFallbackCard } from './styled';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import QueueSkeleton from './QueueSkeleton';
 
 const QueueTrackList = React.lazy(() => import('./QueueTrackList'));
+
+const QUEUE_DRAWER_SKELETON_MAX_ROWS = 8;
 
 const QueueDrawerContainer = styled.div<{ $isOpen: boolean; $width: number; $transitionDuration: number; $transitionEasing: string }>`
   position: fixed;
@@ -269,17 +271,7 @@ const QueueDrawer = memo<QueueDrawerProps>(({
 
         <QueueContent>
           <Suspense fallback={
-            <DrawerFallback>
-              <DrawerFallbackCard>
-                <div style={{
-                  animation: theme.animations.pulse,
-                  color: theme.colors.muted.foreground,
-                  textAlign: 'center'
-                }}>
-                  Loading queue...
-                </div>
-              </DrawerFallbackCard>
-            </DrawerFallback>
+            <QueueSkeleton rowCount={Math.min(tracks.length, QUEUE_DRAWER_SKELETON_MAX_ROWS)} />
           }>
             <QueueTrackList
               tracks={tracks}

--- a/src/components/QueueSkeleton.tsx
+++ b/src/components/QueueSkeleton.tsx
@@ -1,0 +1,138 @@
+import { memo } from 'react';
+import styled, { keyframes, css } from 'styled-components';
+import {
+  QueueListRoot,
+  QueueListCard,
+  QueueListCardHeader,
+  QueueListCardHeaderRow,
+  QueueListMeta,
+  QueueListContent,
+  QueueListScroll,
+  QueueListItems,
+} from './QueueTrackList.styled';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+const DEFAULT_ROW_COUNT = 6;
+
+const shimmerSlide = keyframes`
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+`;
+
+const shimmerSurface = css`
+  position: relative;
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.colors.gray[800]};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      ${({ theme }) => theme.colors.gray[700]} 50%,
+      transparent 100%
+    );
+    transform: translateX(-100%);
+    will-change: transform;
+    animation: ${shimmerSlide} 1.6s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      display: none;
+    }
+  }
+`;
+
+const SkeletonRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  padding: ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  border: 1px solid transparent;
+`;
+
+const SkeletonAlbumArt = styled.div`
+  ${shimmerSurface}
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+`;
+
+const SkeletonTextColumn = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+const SkeletonTitleLine = styled.div`
+  ${shimmerSurface}
+  height: 1rem;
+  width: 70%;
+`;
+
+const SkeletonArtistLine = styled.div`
+  ${shimmerSurface}
+  height: 0.875rem;
+  width: 45%;
+`;
+
+const SkeletonDuration = styled.div`
+  ${shimmerSurface}
+  width: 2.25rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+`;
+
+interface QueueSkeletonProps {
+  rowCount?: number;
+}
+
+const QueueSkeleton = memo<QueueSkeletonProps>(({ rowCount = DEFAULT_ROW_COUNT }) => {
+  const safeRowCount = Math.max(0, Math.floor(rowCount));
+  const reducedMotion = useReducedMotion();
+  const animatedAttr = reducedMotion ? 'false' : 'true';
+
+  return (
+    <QueueListRoot aria-busy="true" aria-live="polite" data-testid="queue-skeleton">
+      <QueueListCard>
+        <QueueListCardHeader>
+          <QueueListCardHeaderRow>
+            <QueueListMeta>Loading queue…</QueueListMeta>
+          </QueueListCardHeaderRow>
+        </QueueListCardHeader>
+        <QueueListContent>
+          <QueueListScroll>
+            <QueueListItems>
+              {Array.from({ length: safeRowCount }).map((_, idx) => (
+                <SkeletonRow
+                  key={idx}
+                  aria-hidden="true"
+                  data-testid="queue-skeleton-row"
+                  data-animated={animatedAttr}
+                >
+                  <SkeletonAlbumArt />
+                  <SkeletonTextColumn>
+                    <SkeletonTitleLine />
+                    <SkeletonArtistLine />
+                  </SkeletonTextColumn>
+                  <SkeletonDuration />
+                </SkeletonRow>
+              ))}
+            </QueueListItems>
+          </QueueListScroll>
+        </QueueListContent>
+      </QueueListCard>
+    </QueueListRoot>
+  );
+});
+
+QueueSkeleton.displayName = 'QueueSkeleton';
+
+export default QueueSkeleton;

--- a/src/components/__tests__/QueueSkeleton.test.tsx
+++ b/src/components/__tests__/QueueSkeleton.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { theme } from '@/styles/theme';
+import QueueSkeleton from '../QueueSkeleton';
+
+// QueueSkeleton is a pure presentation component — it only needs ThemeProvider.
+// TestWrapper is intentionally avoided here because it pulls in ProviderProvider
+// (→ Spotify adapter → spotifyPlayer singleton) and PlayerSizingProvider
+// (→ CSS.supports), both of which require heavy mocking and OOM in isolation.
+// This matches the pattern used by QueueDrawer.test.tsx.
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+const makeMatchMedia = (reducedMotion: boolean) =>
+  vi.fn().mockImplementation((query: string) => ({
+    matches: reducedMotion && query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+describe('QueueSkeleton', () => {
+  beforeEach(() => {
+    // jsdom does not implement matchMedia; provide a stub so useReducedMotion can run
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: makeMatchMedia(false),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('rowCount prop', () => {
+    it('renders the default 6 rows when rowCount is omitted', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton /></Wrapper>);
+
+      // #then
+      expect(screen.getAllByTestId('queue-skeleton-row')).toHaveLength(6);
+    });
+
+    it('renders the exact number of rows supplied via rowCount', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={4} /></Wrapper>);
+
+      // #then
+      expect(screen.getAllByTestId('queue-skeleton-row')).toHaveLength(4);
+    });
+
+    it('renders 0 rows when rowCount={0}', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={0} /></Wrapper>);
+
+      // #then
+      expect(screen.queryAllByTestId('queue-skeleton-row')).toHaveLength(0);
+    });
+
+    it('renders 0 rows when rowCount is negative', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={-3} /></Wrapper>);
+
+      // #then
+      expect(screen.queryAllByTestId('queue-skeleton-row')).toHaveLength(0);
+    });
+
+    it('floors a fractional rowCount', () => {
+      // #given
+      const fractional = 3.9;
+
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={fractional} /></Wrapper>);
+
+      // #then
+      expect(screen.getAllByTestId('queue-skeleton-row')).toHaveLength(3);
+    });
+  });
+
+  describe('prefers-reduced-motion', () => {
+    // note: jsdom does not apply CSS @media queries, so pseudo-element visibility
+    // (::after { display: none }) cannot be verified via getComputedStyle.
+    // Instead we (a) check the matchMedia-driven data-animated attribute the
+    // component exposes, and (b) confirm the CSS media-query block is injected
+    // so real browsers will suppress the shimmer animation.
+
+    it('sets data-animated="true" on every row when no motion preference is set', () => {
+      // #given — no reduced-motion preference (default beforeEach)
+
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={3} /></Wrapper>);
+
+      // #then
+      screen.getAllByTestId('queue-skeleton-row').forEach((row) => {
+        expect(row).toHaveAttribute('data-animated', 'true');
+      });
+    });
+
+    it('sets data-animated="false" on every row when prefers-reduced-motion: reduce is active', () => {
+      // #given
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: makeMatchMedia(true),
+      });
+
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={3} /></Wrapper>);
+
+      // #then
+      screen.getAllByTestId('queue-skeleton-row').forEach((row) => {
+        expect(row).toHaveAttribute('data-animated', 'false');
+      });
+    });
+
+    it('injects a @media (prefers-reduced-motion: reduce) block into the document styles', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={2} /></Wrapper>);
+
+      // #then — real browsers use this rule to suppress the shimmer ::after
+      const injectedCss = Array.from(document.head.querySelectorAll('style'))
+        .map((s) => s.textContent ?? '')
+        .join('');
+      expect(injectedCss).toContain('prefers-reduced-motion');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('marks the root container as aria-busy while loading', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={3} /></Wrapper>);
+
+      // #then
+      expect(screen.getByTestId('queue-skeleton')).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('sets aria-live="polite" on the root container', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={3} /></Wrapper>);
+
+      // #then
+      expect(screen.getByTestId('queue-skeleton')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('marks every skeleton row as aria-hidden to exclude it from the a11y tree', () => {
+      // #when
+      render(<Wrapper><QueueSkeleton rowCount={3} /></Wrapper>);
+
+      // #then
+      screen.getAllByTestId('queue-skeleton-row').forEach((row) => {
+        expect(row).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+  });
+
+  describe('theme tokens', () => {
+    it('renders without throwing when mounted with the project ThemeProvider (proves theme.colors.gray[*] is accessible)', () => {
+      // #when / #then — a crash here indicates an invalid theme token reference
+      expect(() => {
+        render(<Wrapper><QueueSkeleton rowCount={4} /></Wrapper>);
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/components/visualizers/GridWaveVisualizer.tsx
+++ b/src/components/visualizers/GridWaveVisualizer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { generateColorVariant } from '../../utils/visualizerUtils';
 import { useCanvasVisualizer } from '../../hooks/useCanvasVisualizer';
 import { useVisualizerDebugConfig } from '../../contexts/VisualizerDebugContext';
@@ -29,11 +29,8 @@ interface WaveState {
   frequency: number;
 }
 
-interface GridWaveState {
-  particles: GridParticle[];
+interface GridMeta {
   waves: WaveState[];
-  width: number;
-  height: number;
   rows: number;
   cols: number;
 }
@@ -47,6 +44,8 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
   const config = useVisualizerDebugConfig();
   const g = config.grid;
 
+  const metaRef = useRef<GridMeta>({ waves: [], rows: 0, cols: 0 });
+
   const getItemCount = useCallback(
     (width: number, _height: number, _intensity: number): number => {
       const isMobile = width < BREAKPOINTS_PX.lg;
@@ -56,7 +55,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
   );
 
   const initializeItems = useCallback(
-    (count: number, width: number, height: number, baseColor: string): GridWaveState[] => {
+    (_count: number, width: number, height: number, baseColor: string): GridParticle[] => {
       const spacing = width < BREAKPOINTS_PX.lg ? g.spacingMobile : g.spacing;
       const amplitude = g.amplitudeBase * Math.min(width, height);
       const margin = Math.ceil(amplitude / spacing);
@@ -92,24 +91,18 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
         frequency: g.frequencyBase + (i / g.waveCount) * g.frequencySpread,
       }));
 
-      void count;
-      return [{ particles, waves, width, height, rows, cols }];
+      metaRef.current = { waves, rows, cols };
+      return particles;
     },
     [g]
   );
 
   const updateItems = useCallback(
-    (states: GridWaveState[], deltaTime: number, playing: boolean, width: number, height: number): void => {
+    (_particles: GridParticle[], deltaTime: number, playing: boolean, _width: number, _height: number): void => {
       const speedMult = (playing ? 1.0 : g.pausedSpeedMult) * (speed ?? 1.0);
       const dt = deltaTime / 16;
 
-      const state = states[0];
-      if (!state) return;
-
-      state.width = width;
-      state.height = height;
-
-      state.waves.forEach(wave => {
+      metaRef.current.waves.forEach(wave => {
         wave.phase += wave.speed * speedMult * dt;
         if (wave.phase > Math.PI * 2) wave.phase -= Math.PI * 2;
       });
@@ -120,24 +113,21 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
   const renderItems = useCallback(
     (
       ctx: CanvasRenderingContext2D,
-      states: GridWaveState[],
+      particles: GridParticle[],
       width: number,
       height: number,
       intensityValue: number
     ): void => {
       ctx.clearRect(0, 0, width, height);
 
-      const state = states[0];
-      if (!state) return;
-
+      const { waves, rows } = metaRef.current;
       const intensityScale = Math.max(0.3, intensityValue / 60);
       const amplitude = g.amplitudeBase * Math.min(width, height) * intensityScale;
-      const rows = state.rows;
       const centerX = width / 2;
 
-      state.particles.forEach(particle => {
+      particles.forEach(particle => {
         let dispX = 0, dispY = 0;
-        state.waves.forEach(wave => {
+        waves.forEach(wave => {
           const proj = gridWaveProjection(particle.baseX, particle.baseY, wave.angleX, wave.angleY, wave.frequency);
           const d = Math.sin(proj + wave.phase);
           dispX += d * wave.angleX;
@@ -173,7 +163,7 @@ export const GridWaveVisualizer: React.FC<GridWaveVisualizerProps> = ({
     [g]
   );
 
-  const canvasRef = useCanvasVisualizer<GridWaveState>({
+  const canvasRef = useCanvasVisualizer<GridParticle>({
     accentColor,
     isPlaying,
     intensity,

--- a/src/hooks/__tests__/useQueueBundlePrefetch.test.ts
+++ b/src/hooks/__tests__/useQueueBundlePrefetch.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useQueueBundlePrefetch } from '../useQueueBundlePrefetch';
+
+describe('useQueueBundlePrefetch', () => {
+  let ricMock: ReturnType<typeof vi.fn>;
+  let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    ricMock = vi.fn().mockImplementation((cb: IdleRequestCallback) => {
+      cb({ didTimeout: false, timeRemaining: () => 50 });
+      return 1;
+    });
+
+    Object.defineProperty(window, 'requestIdleCallback', {
+      value: ricMock,
+      writable: true,
+      configurable: true,
+    });
+
+    setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('fires once on first play', () => {
+    it('schedules prefetch via requestIdleCallback when isPlaying flips false → true', () => {
+      // #given
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: false } },
+      );
+
+      // #when
+      rerender({ isPlaying: true });
+
+      // #then
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not schedule prefetch when initially rendered with isPlaying false', () => {
+      // #when
+      renderHook(() => useQueueBundlePrefetch(false));
+
+      // #then
+      expect(ricMock).not.toHaveBeenCalled();
+    });
+
+    it('schedules prefetch immediately when initially rendered with isPlaying true', () => {
+      // #when
+      renderHook(() => useQueueBundlePrefetch(true));
+
+      // #then
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('does not re-fire on subsequent toggles', () => {
+    it('schedules prefetch only once across multiple play/pause cycles', () => {
+      // #given
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: false } },
+      );
+
+      // #when — three play/pause cycles
+      rerender({ isPlaying: true });
+      rerender({ isPlaying: false });
+      rerender({ isPlaying: true });
+      rerender({ isPlaying: false });
+      rerender({ isPlaying: true });
+
+      // #then
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-schedule when toggled back to false then true again', () => {
+      // #given
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: true } },
+      );
+
+      // #when
+      rerender({ isPlaying: false });
+      rerender({ isPlaying: true });
+
+      // #then
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('does not re-fire on track changes', () => {
+    it('schedules prefetch only once even when the current track changes while playing', () => {
+      // #given
+      const { rerender } = renderHook(
+        ({ isPlaying, trackId }: { isPlaying: boolean; trackId: string }) =>
+          useQueueBundlePrefetch(isPlaying, trackId),
+        { initialProps: { isPlaying: true, trackId: 'track-1' } },
+      );
+
+      // #when — track advances while still playing
+      rerender({ isPlaying: true, trackId: 'track-2' });
+      rerender({ isPlaying: true, trackId: 'track-3' });
+
+      // #then
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-fire when a track change causes a brief isPlaying interruption', () => {
+      // #given
+      const { rerender } = renderHook(
+        ({ isPlaying, trackId }: { isPlaying: boolean; trackId: string }) =>
+          useQueueBundlePrefetch(isPlaying, trackId),
+        { initialProps: { isPlaying: false, trackId: 'track-1' } },
+      );
+
+      rerender({ isPlaying: true, trackId: 'track-1' });
+
+      // #when — new track starts: brief pause then play again
+      rerender({ isPlaying: false, trackId: 'track-2' });
+      rerender({ isPlaying: true, trackId: 'track-2' });
+
+      // #then — still only one prefetch scheduled
+      expect(ricMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setTimeout fallback', () => {
+    it('uses setTimeout when requestIdleCallback is not available', () => {
+      // #given
+      Object.defineProperty(window, 'requestIdleCallback', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: false } },
+      );
+
+      // #when
+      rerender({ isPlaying: true });
+
+      // #then
+      expect(setTimeoutSpy).toHaveBeenCalled();
+      expect(ricMock).not.toHaveBeenCalled();
+    });
+
+    it('fires the prefetch callback after the setTimeout delay elapses', () => {
+      // #given
+      Object.defineProperty(window, 'requestIdleCallback', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: false } },
+      );
+
+      // #when
+      rerender({ isPlaying: true });
+      vi.runAllTimers();
+
+      // #then — no exception thrown means the deferred callback executed successfully
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-schedule via setTimeout on subsequent play/pause toggles', () => {
+      // #given
+      Object.defineProperty(window, 'requestIdleCallback', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { rerender } = renderHook(
+        ({ isPlaying }: { isPlaying: boolean }) => useQueueBundlePrefetch(isPlaying),
+        { initialProps: { isPlaying: false } },
+      );
+
+      // #when
+      rerender({ isPlaying: true });
+      vi.runAllTimers();
+      rerender({ isPlaying: false });
+      rerender({ isPlaying: true });
+
+      // #then
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -21,6 +21,7 @@ import { trkSummary } from './playerLogicUtils';
 import { useQueueManagement } from './useQueueManagement';
 import { useCollectionLoader } from './useCollectionLoader';
 import { usePlaybackSubscription } from './usePlaybackSubscription';
+import { useQueueBundlePrefetch } from './useQueueBundlePrefetch';
 import { useRadioSession } from './useRadioSession';
 import { useRecentlyPlayedCollections } from './useRecentlyPlayedCollections';
 import type { RadioProgress } from '@/types/radio';
@@ -208,6 +209,10 @@ export function usePlayerLogic() {
     setCurrentTrackIndex,
     setTracks,
   });
+
+  // Warm the lazy QueueDrawer/QueueBottomSheet bundles on first playback so the
+  // user-initiated "Up Next" open is instant. Fires once per session.
+  useQueueBundlePrefetch(isPlaying);
 
   const handleNext = useCallback(() => {
     if (tracks.length === 0) return;

--- a/src/hooks/useQueueBundlePrefetch.ts
+++ b/src/hooks/useQueueBundlePrefetch.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+export function useQueueBundlePrefetch(isPlaying: boolean, _currentTrackId?: string): void {
+  const hasFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!isPlaying || hasFiredRef.current) return;
+    hasFiredRef.current = true;
+
+    const ric = window.requestIdleCallback;
+    const schedule: (cb: IdleRequestCallback) => void = ric
+      ? (cb) => { ric(cb); }
+      : (cb) => {
+          window.setTimeout(
+            () => cb({ didTimeout: false, timeRemaining: () => 0 }),
+            0,
+          );
+        };
+
+    schedule(() => {
+      void import('@/components/QueueDrawer');
+      void import('@/components/QueueBottomSheet');
+    });
+  }, [isPlaying]);
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -60,6 +60,23 @@ Object.defineProperty(window, 'history', {
   writable: true
 });
 
+// Mock window.matchMedia (jsdom does not implement it; many components query
+// `prefers-reduced-motion` via useReducedMotion). Tests can override per-case.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // Mock fetch globally
 global.fetch = vi.fn();
 

--- a/src/test/testWrappers.tsx
+++ b/src/test/testWrappers.tsx
@@ -5,21 +5,24 @@ import { VisualEffectsProvider } from '@/contexts/visualEffects';
 import { PinnedItemsProvider } from '@/contexts/PinnedItemsContext';
 import { ProviderProvider } from '@/contexts/ProviderContext';
 import { PlayerSizingProvider } from '@/contexts/PlayerSizingContext';
+import { ThemeProvider } from '@/styles/ThemeProvider';
 
 export function TestWrapper({ children }: { children: React.ReactNode }) {
   return (
-    <ProviderProvider>
-      <PlayerSizingProvider>
-        <TrackProvider>
-          <ColorProvider>
-            <VisualEffectsProvider>
-              <PinnedItemsProvider>
-                {children}
-              </PinnedItemsProvider>
-            </VisualEffectsProvider>
-          </ColorProvider>
-        </TrackProvider>
-      </PlayerSizingProvider>
-    </ProviderProvider>
+    <ThemeProvider>
+      <ProviderProvider>
+        <PlayerSizingProvider>
+          <TrackProvider>
+            <ColorProvider>
+              <VisualEffectsProvider>
+                <PinnedItemsProvider>
+                  {children}
+                </PinnedItemsProvider>
+              </VisualEffectsProvider>
+            </ColorProvider>
+          </TrackProvider>
+        </PlayerSizingProvider>
+      </ProviderProvider>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

Ship the queue skeleton fallback with idle-time bundle prefetching (epic #1218), introduce the multi-agent epic team and project-local agent definitions, and land the manual-only Vercel preview deploy workflow alongside a GridWaveVisualizer refactor.

## Release summary

**Built from**: `rc/2026-04-25.1`

### Changes

**other**
- 590c922 docs(claudemd): document multi-agent team workflows (#1222)
- 5035830 chore: project-local team agent defs + orchestration skills (#1221)
- 1d30073 feat(queue): skeleton fallback + idle-time bundle prefetch (epic #1218) (#1219)
- f7e602f chore(ci): make Vercel preview deploy manual-only (#1212)
- f02d2bc fix(ci): build via vercel CLI and grant write perms for commit comment (#1210)
- 3e2dffb ci(vercel): add preview deploy workflow for develop (#1209)
- a2060ce refactor: use flat particle array and ref for GridWaveVisualizer metadata (#1207)

Closes #1208
Closes #1213
Closes #836
