### PR TITLE
test: fix mock setup in playback subscription and prepareTrack tests

### DIFF
--- a/src/hooks/__tests__/usePlaybackSubscription.test.ts
+++ b/src/hooks/__tests__/usePlaybackSubscription.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/providers/registry', () => ({
 
 vi.mock('@/lib/debugLog', () => ({
   logQueue: vi.fn(),
+  logArtRace: vi.fn(),
 }));
 
 import { usePlaybackSubscription } from '../usePlaybackSubscription';

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -35,6 +35,7 @@ const makeTrack = (overrides: Partial<MediaTrack> = {}): MediaTrack => ({
 
 describe('SpotifyPlaybackAdapter.prepareTrack', () => {
   let adapter: SpotifyPlaybackAdapter;
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,6 +43,8 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     vi.mocked(spotifyPlayer.getDeviceId).mockReturnValue('device-1');
     vi.mocked(spotifyPlayer.transferPlaybackToDevice).mockResolvedValue(undefined);
     vi.mocked(spotifyPlayer.ensureDeviceIsActive).mockResolvedValue(true);
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
     adapter = new SpotifyPlaybackAdapter();
   });
 
@@ -121,8 +124,6 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     // #given — the regression root cause (#1179): previously prepareTrack
     // called /me/player/play then pause, which could land playing on a fresh
     // tab. The fix stages state locally without touching Spotify playback.
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
-    vi.stubGlobal('fetch', fetchMock);
     const track = makeTrack();
 
     // #when


### PR DESCRIPTION
## Summary

- Adds missing `logArtRace: vi.fn()` to the `@/lib/debugLog` mock in `usePlaybackSubscription.test.ts` (matches the per-symbol stub pattern in `useRadioSession.test.ts`).
- Hoists `fetchMock` to suite scope in `spotifyPlaybackAdapterPrepareTrack.test.ts` with `vi.stubGlobal('fetch', fetchMock)` in `beforeEach`; existing `vi.unstubAllGlobals()` in `afterEach` already handled cleanup. Removes the now-redundant local `fetchMock` shadow inside the "does not start actual playback" test.

Fixes the 9 failing tests reported in #1211 (3 in `usePlaybackSubscription — expectedTrackIdRef guard`, 6 in `SpotifyPlaybackAdapter.prepareTrack > probePlayable`).

Fixes #1211

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1275/1275 passing, exit 0
- [x] Two cold runs (`rm -rf node_modules/.vite` between) — both green; CI starts cold every time, so the fix holds
- [x] All 9 originally-failing tests verified passing
- [x] No regressions in the rest of the suite