### PR TITLE
chore(agents): apply 2026-04-25 epic-team retro action items

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -16,6 +16,16 @@ Before ending your turn, audit every deliverable. **A blueprint produced as plai
 
 If you find that `SendMessage` is not in your toolset, surface that as a hard failure on your first turn — do not silently produce blueprints in plain text. Say: *"I cannot deliver: SendMessage not provisioned. Lead must check the user's console for plain-text output, or re-spawn me with SendMessage in tools."*
 
+## On-spawn boot step (non-negotiable)
+
+On your first turn, even with no inbound task or message, do NOT idle silently. Execute this sequence before yielding:
+
+1. Read `.claude/agents/architect.md` (this file).
+2. Call `TaskList` to see what work exists.
+3. Send `SendMessage({to: "team-lead", summary: "architect ready", message: "Online. Available tasks: [list, or 'none']. Awaiting assignment."})`.
+
+Silent presence is a structural failure — the lead cannot dispatch work to a member they cannot see. If the inbox already contains a task, skip the readiness ack and start working on the task instead (your output will route via the normal exit gate).
+
 ## Blueprint quality bar
 
 A complete blueprint specifies:

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -30,6 +30,12 @@ This lets the tester align tests to the same interface from the start. Skipping 
 
 If the lead assigns you implementation work that's normally gated by an architect blueprint and the blueprint isn't yet posted, do not unilaterally proceed even when the issue body looks complete. Ping the lead: *"The spec in the issue body looks complete — OK to skip the blueprint gate, or wait for the architect?"* The five-second confirmation prevents rework if the architect would have caught a constraint you missed.
 
+## Ack-before-start when task arrives outside formal envelope
+
+If a task description arrives in any form — preview message, "context for upcoming work", spec dump — before the formal `task_assignment` envelope (status `in_progress` set on a task you own), do NOT infer assignment from the preview content and start coding. Send a one-line ack via `SendMessage`: *"Got the spec for <task summary> — confirming this is mine to start now, or wait for formal task assignment?"*
+
+Inferring assignment from a preview risks rework if the lead's final spec differs, and blurs the protocol the rest of the team relies on.
+
 ## Verification bar
 
 A task is `completed` only when:

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -26,3 +26,9 @@ If the lead's request is ambiguous, ask one clarifying question via `SendMessage
 ## Anti-overreach
 
 Stick to what you observed. Do not editorialize about the lead's intent or the epic's design choices ("deviations from epic"). Report facts; let the lead interpret.
+
+## Full-suite verification when verifying CI failures
+
+When the recon task involves verifying a CI failure (e.g. "confirm these N tests fail / count newly broken tests / characterize the failure mode"), always run the full `npm run test:run` — not just the targeted file(s). CI runs the full suite on every push, so "any unexpected failures beyond the N expected" must be answered against the same scope. Targeted-file runs hide cross-file ordering bugs and unrelated regressions that CI will surface anyway.
+
+Pair the full-suite run with targeted runs only when the lead asks for both, or when isolating to confirm the failure is file-local.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -29,3 +29,11 @@ When verifying an AC, read its words literally first. If the spec says "linear s
 ## Independent verification
 
 Do not trust the builder's claims about what the diff does. Re-run `gh pr diff <PR>` or `git diff` yourself and check the cited lines. If the builder says "AC #5 ✅ — see X.tsx:42", read X.tsx:42 and confirm.
+
+## Delta-only on duplicate review of the same commit
+
+If a review request arrives for a commit you have already reviewed in this session, send only a delta — cite the prior message and address only the new criteria the lead added. Never re-issue a full review for the same commit. The correct shape is:
+
+> *"Reviewed `<sha>` previously (see prior message). New criteria from your latest message: <list>. Delta findings: <only what's new>."*
+
+Re-issuing the full review wastes the lead's parsing budget and adds noise to the thread.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -20,6 +20,17 @@ A test task is `completed` **only when** `npm run test:run` exits 0 for the affe
 
 When the implementation under test doesn't exist yet (e.g., you wrote a hook test before the hook lands), keep the task `in_progress` and flag the dependency to the lead: *"Tests written, blocked on impl of `useFoo` — task stays in_progress until that lands."*
 
+## Cold-run failures are not flakes until proven otherwise
+
+When a cold `npm run test:run` produces failures — **especially failures matching the original bug pattern exactly** — do NOT report green based on subsequent warm runs. "Module-cache warm-up flake" is never an acceptable first explanation without isolation evidence. Before calling the gate passed:
+
+1. Run the failing test file(s) in isolation (`npm run test:run -- path/to/file.test.ts`) and report the result.
+2. Verify `git rev-parse HEAD` matches the assigned commit (rules out stale-checkout artifacts).
+3. Reproduce with a forced cold cache: `rm -rf node_modules/.vite node_modules/.cache && npm run test:run` — twice in a row. Both must pass.
+4. Explain the failure mechanism in your report (e.g., "stale Vite transform from pre-fix file contents") — not just "flake".
+
+CI runs cold every time. A cold-fail/warm-pass pattern that you don't explain will ship straight to red.
+
 ## Task-creation guardrail
 
 You may decompose your assigned task into smaller subtasks if it improves tracking — but **before creating tasks beyond your assigned scope**, check the existing task list for duplication. If you're about to create a task that overlaps an existing one (even owned by another teammate), ping the lead instead: *"I want to add task X for Y — does this duplicate task #N?"*

--- a/.claude/skills/spawn-epic-team/skill.md
+++ b/.claude/skills/spawn-epic-team/skill.md
@@ -11,6 +11,19 @@ allowed-tools: Bash, Read, Agent, SendMessage, TeamCreate
 
 Recreate the standard 6-role team for epic work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
 
+## When to spawn the full team — proportionality
+
+The 5-specialist team is sized for **multi-file epics with non-trivial design surface**. Skip it for mechanical work:
+
+| Scope | Right team |
+|---|---|
+| Multi-file feature, new abstractions, multi-AC spec | Full 5-specialist team |
+| Single-file or 2-file fix with no design surface (test-mock fixes, dep bumps, file renames, single-export tweaks) | Lead-only or lead + builder + tester |
+| Refactor across 1 module with clear pattern | Lead + builder + reviewer |
+| Pure investigation / code reading | Lead + explorer |
+
+Spawning architect for mechanical fixes leaves the role idle the entire session, which surfaces silent-presence bugs (no inbound task → no SendMessage → invisible to lead). When in doubt, start smaller — additional specialists can be spawned later via this same skill (idempotent on existing members).
+
 ## Pre-conditions
 
 - `.claude/agents/` must contain definitions for all 5 specialist roles: `explorer.md`, `architect.md`, `builder.md`, `reviewer.md`, `tester.md`. (`team-lead.md` exists for retros and reference but the lead role is the running session itself, not a spawned subagent.) If any are missing, abort and tell the user to run `/agent-team-retro` (which bootstraps them) or to create them manually.


### PR DESCRIPTION
## Summary

Applies all six action items approved in the 2026-04-25 epic-team retrospective (held after #1225 / #1211 shipped). Sourced from member self-feedback + lead observations during a 5-specialist session that surfaced multiple structural gaps.

### Specialist definition updates (commit 1)

| Agent | Change | Source |
|---|---|---|
| `tester.md` | Block "warm-up flake" classification on cold failures without isolation evidence; require git HEAD verification + double cold-run reproduction before declaring green | tester (self) + lead |
| `architect.md` | On-spawn boot step: call `TaskList` and `SendMessage` ack on first turn | architect (self) + lead |
| `reviewer.md` | Delta-only response when re-reviewing the same commit | reviewer (self) |
| `explorer.md` | Full `npm run test:run` (not targeted-file) when verifying CI failures | explorer (self) |
| `builder.md` | Ack-before-start when a task spec arrives outside the formal `task_assignment` envelope | builder (self) + lead |

### Skill update (commit 2)

`spawn-epic-team/skill.md` — proportionality table: skip the full 5-specialist team for mechanical fixes (test mocks, dep bumps, single-file renames). Architect idling for the whole session is what surfaced the silent-presence gap above.

## Test plan

- [x] All edits reviewed inline before commit
- [x] No production code touched — agent definitions and skill markdown only
- [x] Two logical commits (agents / skill) per project commit-style preference