### PR TITLE
feat(ui): add ?ui=v2 flag mechanism + integration docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,51 @@ Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` 
 
 `Q` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.
 
+### shadcn/ui integration
+
+vorbis-player uses a hybrid styling stack: **styled-components for bespoke surfaces, shadcn/ui (Radix primitives + Tailwind) for chrome**. Both coexist permanently — there is no migration goal to remove styled-components.
+
+**Stack coexistence rule** — pick by surface type:
+
+| Surface type | Stack | Examples |
+|---|---|---|
+| Visualizers, animations, gestures | styled-components (forever) | `BackgroundVisualizer`, zen-mode orchestration in `PlayerContent/styled.ts`, swipe gestures, album-art flip menu, `BottomBar` |
+| Standard chrome (modals, sliders, popovers, switches, toasts) | shadcn primitives | `src/components/ui/*.tsx`, currently `dialog.tsx`, `button.tsx` |
+| Whole-screen redesigns | shadcn, gated behind `?ui=v2` | future `SettingsV2`, `OnboardingV2`, command palette |
+
+**Theme bridge — `--accent-color` is player chrome ONLY:**
+
+The runtime `--accent-color` / `--accent-contrast-color` (injected on `document.documentElement` by `ColorContext.tsx:83-87`) belong exclusively to player chrome that intentionally retints with the playing track:
+
+- `BottomBar` (background tint, control hover states)
+- `LikeButton` (filled state)
+- `TimelineSlider` (fill + thumb gradient)
+- Glow effects (`--glow-intensity`, `--glow-rate`, `--glow-opacity`)
+- Accent color overrides menu in `VisualEffectsMenu`
+
+**shadcn primitives use the neutral palette** defined in `src/styles/shadcn-tokens.css` (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, etc.). shadcn's `--accent` token is a static neutral surface and is **not** the same as the player's `--accent-color`. Never wire shadcn's `--primary` or `--accent` to `var(--accent-color)` — dialogs, popovers, and other chrome must stay neutral so they don't retint per track.
+
+**`?ui=v2` flag mechanism:**
+
+The `useUiV2()` hook (`src/hooks/useUiV2.ts`) returns `true` when EITHER:
+- `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in for staging deploys), OR
+- the URL contains `?ui=v2` (per-session opt-in for testing).
+
+It subscribes to `popstate` so SPA navigation flips the flag without a reload. SSR-safe.
+
+Convention for flagged screens:
+- Components consuming the flag render the **legacy** path by default.
+- The v2 branch lives under `if (uiV2) { … }`.
+- Future redesign components are colocated next to the legacy file as `<ScreenName>V2.tsx` (e.g. `Settings.tsx` + `SettingsV2.tsx`). The parent component picks one or the other via `useUiV2()`.
+
+**Migration scope (current):**
+- `Dialog` cluster (`ProviderDisconnectDialog`, `ConfirmDeleteDialog`, `SaveQueueDialog`, `KeyboardShortcutsHelp`) → shadcn `Dialog` (landed unflagged — behavior parity).
+- `TimelineSlider` → wrapper around shadcn / Radix `Slider` (in flight; survives as a wrapper because the accent fill/thumb gradient is bespoke).
+
+**Out of scope for the foundation epic:** `Popover`, `Switch`, `Toast`, `Filter sidebar`, `Settings v2`, `Cmd-K`, `Onboarding v2`. Each is a separate future epic.
+
+**z-index for shadcn modals:** shadcn defaults to `z-50`. The player's `BottomBar` uses up to `theme.zIndex.modal` = 1400. `src/components/ui/dialog.tsx` overrides the overlay + content `z-index` to `1405` so dialogs always cover the BottomBar.
+
 ## Tech Stack
 
 See README.md for the full tech stack.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For radio recommendations, also set `VITE_LASTFM_API_KEY` in `.env.local` (see `
 
 ## Tech Stack
 
-React 18 · TypeScript 5 · Vite 6 · styled-components · Radix UI · Vitest
+React 18 · TypeScript 5 · Vite 6 · styled-components · Tailwind CSS · shadcn/ui · Radix UI · Vitest
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2312,11 +2313,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
@@ -2392,6 +2443,21 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2576,6 +2642,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -2669,6 +2768,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -56,9 +56,9 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
     currentPosition,
     duration,
     handleLikeToggle,
-    handleSliderChange,
-    handleSliderMouseDown,
-    handleSliderMouseUp,
+    handleSeekDuringScrub,
+    handleScrubStart,
+    handleScrubEnd,
     formatTime,
   } = useSpotifyControls({
     currentTrack,
@@ -108,9 +108,9 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         currentPosition={currentPosition}
         duration={duration}
         formatTime={formatTime}
-        onSliderChange={handleSliderChange}
-        onSliderMouseDown={handleSliderMouseDown}
-        onSliderMouseUp={handleSliderMouseUp}
+        onSeek={handleSeekDuringScrub}
+        onScrubStart={handleScrubStart}
+        onScrubEnd={handleScrubEnd}
         trackId={currentTrack?.id}
         isLiked={effectiveIsLiked}
         isLikePending={effectiveIsLikePending}

--- a/src/components/TimelineSlider.tsx
+++ b/src/components/TimelineSlider.tsx
@@ -1,64 +1,11 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import styled from 'styled-components';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
-
-const TimelineSliderInput = styled.input.withConfig({
-  shouldForwardProp: (prop) => !['sliderHeight', 'thumbSize'].includes(prop),
-}).attrs<{ value: number; max: number; sliderHeight: number; thumbSize: number }>(
-  ({ value, max }: { value: number; max: number }) => ({
-    style: {
-      background: `linear-gradient(
-        to right,
-        var(--accent-color) 0%,
-        var(--accent-color) ${value && max ? (Number(value) / Number(max)) * 100 : 0}%,
-        rgba(115, 115, 115, 0.3) ${value && max ? (Number(value) / Number(max)) * 100 : 0}%,
-        rgba(115, 115, 115, 0.3) 100%
-      )`
-    }
-  })
-) <{ value: number; max: number; sliderHeight: number; thumbSize: number }>`
-  flex: 1;
-  height: ${({ sliderHeight }) => sliderHeight}px;
-  border-radius: ${({ sliderHeight }) => sliderHeight / 2}px;
-  outline: none;
-  cursor: pointer;
-
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: ${({ thumbSize }) => thumbSize}px;
-    height: ${({ thumbSize }) => thumbSize}px;
-    background: var(--accent-color) !important;
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: none;
-    transition: all 0.2s ease;
-
-    &:hover {
-      transform: scale(1.2);
-    }
-  }
-
-  &::-moz-range-thumb {
-    width: ${({ thumbSize }) => thumbSize}px;
-    height: ${({ thumbSize }) => thumbSize}px;
-    background: var(--accent-color) !important;
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: none;
-    transition: all 0.2s ease;
-
-    &:hover {
-      transform: scale(1.2);
-    }
-  }
-`;
+import { Slider } from '@/components/ui/slider';
 
 const TimeLabel = styled.span.withConfig({
   shouldForwardProp: (prop) => !['minWidth'].includes(prop),
-}) <{ minWidth: number }>`
+})<{ minWidth: number }>`
   color: ${({ theme }) => theme.colors.gray[400]};
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-family: monospace;
@@ -74,19 +21,25 @@ const TimelineRow = styled.div`
   margin: 0;
 `;
 
+const SliderWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+`;
+
 interface TimelineSliderProps {
   currentPosition: number;
   duration: number;
   formatTime: (ms: number) => string;
-  onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onSliderMouseDown: () => void;
-  onSliderMouseUp: (e: React.MouseEvent<HTMLInputElement>) => void;
+  onSeek: (position: number) => void;
+  onScrubStart: () => void;
+  onScrubEnd: (position: number) => void;
   children?: React.ReactNode;
 }
 
 const areTimelineSliderPropsEqual = (
   prevProps: TimelineSliderProps,
-  nextProps: TimelineSliderProps
+  nextProps: TimelineSliderProps,
 ): boolean => {
   return (
     prevProps.currentPosition === nextProps.currentPosition &&
@@ -99,49 +52,92 @@ const TimelineSlider = memo<TimelineSliderProps>(({
   currentPosition,
   duration,
   formatTime,
-  onSliderChange,
-  onSliderMouseDown,
-  onSliderMouseUp,
-  children
+  onSeek,
+  onScrubStart,
+  onScrubEnd,
+  children,
 }) => {
   const { isMobile, isTablet } = usePlayerSizingContext();
+  const isScrubbingRef = useRef(false);
 
   const dimensions = useMemo(() => {
     if (isMobile) {
-      return {
-        sliderHeight: 3,
-        thumbSize: 10,
-        minWidth: 35
-      };
+      return { sliderHeight: 3, thumbSize: 10, minWidth: 35 };
     }
     if (isTablet) {
-      return {
-        sliderHeight: 4,
-        thumbSize: 12,
-        minWidth: 40
-      };
+      return { sliderHeight: 4, thumbSize: 12, minWidth: 40 };
     }
-    return {
-      sliderHeight: 4,
-      thumbSize: 12,
-      minWidth: 40
-    };
+    return { sliderHeight: 4, thumbSize: 12, minWidth: 40 };
   }, [isMobile, isTablet]);
+
+  const handleValueChange = useCallback(
+    (values: number[]) => {
+      const next = values[0] ?? 0;
+      if (!isScrubbingRef.current) {
+        isScrubbingRef.current = true;
+        onScrubStart();
+      }
+      onSeek(next);
+    },
+    [onSeek, onScrubStart],
+  );
+
+  const handleValueCommit = useCallback(
+    (values: number[]) => {
+      const next = values[0] ?? 0;
+      isScrubbingRef.current = false;
+      onScrubEnd(next);
+    },
+    [onScrubEnd],
+  );
+
+  const sliderMax = duration > 0 ? duration : 1;
+  const sliderValue = Math.min(currentPosition, sliderMax);
+
+  const trackStyle = useMemo<React.CSSProperties>(
+    () => ({
+      height: dimensions.sliderHeight,
+      borderRadius: dimensions.sliderHeight / 2,
+      background: 'rgba(115, 115, 115, 0.3)',
+    }),
+    [dimensions.sliderHeight],
+  );
+
+  const rangeStyle = useMemo<React.CSSProperties>(
+    () => ({ background: 'var(--accent-color)' }),
+    [],
+  );
+
+  const thumbStyle = useMemo<React.CSSProperties>(
+    () => ({
+      width: dimensions.thumbSize,
+      height: dimensions.thumbSize,
+      background: 'var(--accent-color)',
+      borderColor: 'var(--accent-color)',
+      boxShadow: 'none',
+    }),
+    [dimensions.thumbSize],
+  );
+
   return (
     <TimelineRow>
       {children}
       <TimeLabel minWidth={dimensions.minWidth}>{formatTime(currentPosition)}</TimeLabel>
-      <TimelineSliderInput
-        type="range"
-        min="0"
-        max={duration}
-        value={currentPosition}
-        sliderHeight={dimensions.sliderHeight}
-        thumbSize={dimensions.thumbSize}
-        onChange={onSliderChange}
-        onMouseDown={onSliderMouseDown}
-        onMouseUp={onSliderMouseUp}
-      />
+      <SliderWrapper>
+        <Slider
+          value={[sliderValue]}
+          min={0}
+          max={sliderMax}
+          step={1}
+          disabled={duration <= 0}
+          onValueChange={handleValueChange}
+          onValueCommit={handleValueCommit}
+          trackStyle={trackStyle}
+          rangeStyle={rangeStyle}
+          thumbStyle={thumbStyle}
+          aria-label="Seek timeline"
+        />
+      </SliderWrapper>
       <TimeLabel minWidth={dimensions.minWidth}>{formatTime(duration)}</TimeLabel>
     </TimelineRow>
   );

--- a/src/components/__tests__/TimelineSlider.test.tsx
+++ b/src/components/__tests__/TimelineSlider.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import TimelineSlider from '../TimelineSlider';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: () => ({ isMobile: false, isTablet: false }),
+}));
+
+beforeAll(() => {
+  // Radix Slider's useSize uses ResizeObserver, which jsdom does not implement.
+  // A no-op stub is enough for keyboard interaction tests.
+  if (typeof window.ResizeObserver === 'undefined') {
+    window.ResizeObserver = class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  }
+});
+
+function renderSlider(overrides?: Partial<{
+  currentPosition: number;
+  duration: number;
+  onSeek: (position: number) => void;
+  onScrubStart: () => void;
+  onScrubEnd: (position: number) => void;
+}>) {
+  const props = {
+    currentPosition: 30_000,
+    duration: 180_000,
+    formatTime: (ms: number) => `${Math.floor(ms / 1000)}s`,
+    onSeek: vi.fn(),
+    onScrubStart: vi.fn(),
+    onScrubEnd: vi.fn(),
+    ...overrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <TimelineSlider {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('TimelineSlider', () => {
+  it('fires onScrubStart + onSeek + onScrubEnd when ArrowRight nudges the thumb', () => {
+    // #given
+    const onSeek = vi.fn();
+    const onScrubStart = vi.fn();
+    const onScrubEnd = vi.fn();
+    renderSlider({ onSeek, onScrubStart, onScrubEnd });
+    const thumb = screen.getByRole('slider');
+
+    // #when — Radix Slider Arrow nudge: onValueChange and onValueCommit fire
+    // together in a single tick, so the wrapper collapses scrub start + seek
+    // + scrub end into one immediate-seek sequence.
+    thumb.focus();
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    // #then
+    expect(onScrubStart).toHaveBeenCalledOnce();
+    expect(onSeek).toHaveBeenCalledOnce();
+    expect(onScrubEnd).toHaveBeenCalledOnce();
+
+    // The bumped position is one step (1ms) above the starting 30_000ms.
+    const seekedTo = onSeek.mock.calls[0][0] as number;
+    const committedAt = onScrubEnd.mock.calls[0][0] as number;
+    expect(seekedTo).toBeGreaterThan(30_000);
+    expect(committedAt).toBe(seekedTo);
+  });
+
+  it('does not exceed the duration ceiling when ArrowRight is held at the end', () => {
+    // #given
+    const onSeek = vi.fn();
+    renderSlider({ currentPosition: 180_000, duration: 180_000, onSeek });
+    const thumb = screen.getByRole('slider');
+
+    // #when
+    thumb.focus();
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    // #then — Radix clamps to max; if onSeek fires it must not exceed duration
+    if (onSeek.mock.calls.length > 0) {
+      expect(onSeek.mock.calls[0][0]).toBeLessThanOrEqual(180_000);
+    }
+  });
+});

--- a/src/components/controls/TimelineControls.tsx
+++ b/src/components/controls/TimelineControls.tsx
@@ -7,9 +7,9 @@ interface TimelineControlsProps {
     currentPosition: number;
     duration: number;
     formatTime: (ms: number) => string;
-    onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    onSliderMouseDown: () => void;
-    onSliderMouseUp: (e: React.MouseEvent<HTMLInputElement>) => void;
+    onSeek: (position: number) => void;
+    onScrubStart: () => void;
+    onScrubEnd: (position: number) => void;
     trackId?: string;
     isLiked: boolean;
     isLikePending: boolean;
@@ -37,9 +37,9 @@ const TimelineControls = memo<TimelineControlsProps>(({
     currentPosition,
     duration,
     formatTime,
-    onSliderChange,
-    onSliderMouseDown,
-    onSliderMouseUp,
+    onSeek,
+    onScrubStart,
+    onScrubEnd,
     trackId,
     isLiked,
     isLikePending,
@@ -53,9 +53,9 @@ const TimelineControls = memo<TimelineControlsProps>(({
                 currentPosition={currentPosition}
                 duration={duration}
                 formatTime={formatTime}
-                onSliderChange={onSliderChange}
-                onSliderMouseDown={onSliderMouseDown}
-                onSliderMouseUp={onSliderMouseUp}
+                onSeek={onSeek}
+                onScrubStart={onScrubStart}
+                onScrubEnd={onScrubEnd}
             />
 
             <TimelineRight>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Per-part style escape hatches — required by `TimelineSlider`, which paints
+ * the filled range and thumb with the runtime `var(--accent-color)` derived
+ * from album art and overrides the default track height for responsive
+ * sizing. Do not strip these as "unused": removing them re-forks the slider.
+ *
+ * Default Slider stays neutral (uses shadcn `--primary`); pass these props
+ * only when you need accent tinting or custom dimensions.
+ */
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  trackStyle?: React.CSSProperties
+  rangeStyle?: React.CSSProperties
+  thumbStyle?: React.CSSProperties
+}
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  SliderProps
+>(({ className, trackStyle, rangeStyle, thumbStyle, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track
+      className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20"
+      style={trackStyle}
+    >
+      <SliderPrimitive.Range
+        className="absolute h-full bg-primary"
+        style={rangeStyle}
+      />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb
+      className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+      style={thumbStyle}
+    />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/src/hooks/__tests__/useUiV2.test.ts
+++ b/src/hooks/__tests__/useUiV2.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useUiV2 } from '../useUiV2';
+
+function setSearch(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, search },
+    writable: true,
+  });
+}
+
+describe('useUiV2', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setSearch('');
+  });
+
+  it('returns false when neither env nor query param is set', () => {
+    // #given — default test setup leaves search empty and VITE_UI_V2 unset
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when VITE_UI_V2 env var is set to "true"', () => {
+    // #given
+    vi.stubEnv('VITE_UI_V2', 'true');
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when VITE_UI_V2 is set to a non-"true" value', () => {
+    // #given
+    vi.stubEnv('VITE_UI_V2', 'false');
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when location.search contains ui=v2', () => {
+    // #given
+    setSearch('?ui=v2');
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when ui=v2 is one of several query params', () => {
+    // #given
+    setSearch('?foo=bar&ui=v2&baz=1');
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for ui values other than "v2"', () => {
+    // #given
+    setSearch('?ui=v3');
+
+    // #when
+    const { result } = renderHook(() => useUiV2());
+
+    // #then
+    expect(result.current).toBe(false);
+  });
+
+  it('re-evaluates on popstate when query param changes mid-session', () => {
+    // #given
+    setSearch('');
+    const { result } = renderHook(() => useUiV2());
+    expect(result.current).toBe(false);
+
+    // #when — SPA navigation flips the flag without a reload
+    act(() => {
+      setSearch('?ui=v2');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    // #then
+    expect(result.current).toBe(true);
+  });
+
+  it('removes its popstate listener on unmount', () => {
+    // #given
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    // #when
+    const { unmount } = renderHook(() => useUiV2());
+    unmount();
+
+    // #then
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -159,17 +159,15 @@ export const useSpotifyControls = ({
     }
   }, [getPlayingDescriptor]);
 
-  const handleSliderChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const position = parseInt(e.target.value);
+  const handleSeekDuringScrub = useCallback((position: number) => {
     dispatchTiming({ type: 'position', positionMs: position });
   }, []);
 
-  const handleSliderMouseDown = useCallback(() => {
+  const handleScrubStart = useCallback(() => {
     setIsDragging(true);
   }, []);
 
-  const handleSliderMouseUp = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
-    const position = parseInt((e.target as HTMLInputElement).value);
+  const handleScrubEnd = useCallback((position: number) => {
     setIsDragging(false);
     handleSeek(position);
   }, [handleSeek]);
@@ -191,9 +189,9 @@ export const useSpotifyControls = ({
     handlePlayPause,
     handleLikeToggle: onLikeToggle,
     handleSeek,
-    handleSliderChange,
-    handleSliderMouseDown,
-    handleSliderMouseUp,
+    handleSeekDuringScrub,
+    handleScrubStart,
+    handleScrubEnd,
     formatTime,
     onNext,
     onPrevious,

--- a/src/hooks/useUiV2.ts
+++ b/src/hooks/useUiV2.ts
@@ -23,6 +23,9 @@ export function useUiV2(): boolean {
       setEnabled(readFlag());
     };
 
+    // pushState/replaceState do not fire popstate natively — only browser
+    // back/forward navigation triggers this listener. Programmatic URL
+    // mutations need window.dispatchEvent(new PopStateEvent('popstate')).
     window.addEventListener('popstate', handlePopState);
     return () => {
       window.removeEventListener('popstate', handlePopState);

--- a/src/hooks/useUiV2.ts
+++ b/src/hooks/useUiV2.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * `?ui=v2` flag — opt-in mechanism for whole-screen redesigns shipped behind
+ * a feature gate.
+ *
+ * Returns `true` when EITHER:
+ *   - `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in), OR
+ *   - the current URL contains `?ui=v2` (per-session opt-in via query string).
+ *
+ * Subscribes to `popstate` so SPA navigation that changes the query string
+ * re-evaluates the flag without a full page reload.
+ *
+ * SSR-safe: returns `false` during a render where `window` is undefined.
+ */
+export function useUiV2(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => readFlag());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handlePopState = (): void => {
+      setEnabled(readFlag());
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  return enabled;
+}
+
+function readFlag(): boolean {
+  if (import.meta.env.VITE_UI_V2 === 'true') return true;
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('ui') === 'v2';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom'],
-          radix: ['@radix-ui/react-dialog'],
+          radix: ['@radix-ui/react-dialog', '@radix-ui/react-slider'],
           styled: ['styled-components']
         }
       }


### PR DESCRIPTION
Closes #1231. Stacked on PR #1234 (#1230 — dialog migration), which is stacked on PR #1233 (#1229 — scaffold).

Lands the gating mechanism for whole-screen redesigns (Settings v2, Onboarding v2, command palette) so they can ship behind a flag without touching the legacy idle/landing path. Plus the architecture docs that future flagged screens will reference.

## Deliverables

| File | Purpose |
|---|---|
| `src/hooks/useUiV2.ts` | `useUiV2(): boolean` — reads `import.meta.env.VITE_UI_V2 === 'true'` OR `?ui=v2` query param. Subscribes to `popstate` so SPA-style nav re-evaluates without reload. SSR-safe via `typeof window` guard. State seeded synchronously in `useState` initializer (no flicker) |
| `src/hooks/__tests__/useUiV2.test.ts` | 8 tests, project BDD `// #given /// #when /// #then` convention |
| `CLAUDE.md` | New "shadcn/ui integration" subsection under Architecture |
| `README.md` | Tech-stack line gains "Tailwind CSS · shadcn/ui" |

## Test coverage (8 cases)

1. Neither set → `false`
2. `VITE_UI_V2='true'` → `true`
3. `VITE_UI_V2='false'` → `false` (truthy-string guard)
4. `?ui=v2` → `true`
5. Multi-param URL with `ui=v2` → `true`
6. `?ui=v3` → `false` (only literal `"v2"` counts)
7. `popstate` flips `false` → `true` mid-session (SPA nav scenario)
8. `removeEventListener('popstate', ...)` on unmount

## Convention for flagged screens

- Components consuming the flag render the **legacy** path by default.
- The v2 branch lives under `if (uiV2) { … }`.
- Future redesign components are colocated next to the legacy file as `<ScreenName>V2.tsx` (e.g. `Settings.tsx` + `SettingsV2.tsx`). The parent picks one or the other via `useUiV2()`.

## CLAUDE.md "shadcn/ui integration" section covers

- **Stack coexistence rule** — table mapping surface type to stack: bespoke surfaces (visualizers, zen-mode orchestration, swipe gestures, flip menu, BottomBar) stay styled-components forever; standard chrome (modals, sliders, popovers, switches, toasts) uses shadcn; whole-screen redesigns use shadcn behind `?ui=v2`.
- **Theme bridge — `--accent-color` is player chrome ONLY**: enumerated consumers are `BottomBar`, `LikeButton`, `TimelineSlider` fill+thumb, glow effects (`--glow-intensity` / `--glow-rate` / `--glow-opacity`), and accent-overrides menu. shadcn primitives use the neutral palette in `src/styles/shadcn-tokens.css`. shadcn's `--accent` token is a static neutral surface and is NOT the same as the player's runtime `--accent-color` — the namespaces are explicitly disjoint.
- **`?ui=v2` mechanics** — env vs query param vs popstate subscription.
- **Migration scope (current)** — Dialog cluster landed unflagged in #1230 (behavior parity), TimelineSlider migrating in #1232 as a *wrapper* around Radix Slider (since the accent fill/thumb gradient is bespoke).
- **Out of scope for the foundation epic** — Popover, Switch, Toast, Filter sidebar, Settings v2, Cmd-K, Onboarding v2.
- **z-index 1405 override** — explained alongside the BottomBar 1350 conflict.

## Verification

- `npx tsc -b --noEmit` → exit 0, no output
- `npm run build` → success, ✓ built in 2.31s. **No new runtime chunks** — hook is bundled into the main entry because no consumer imports it yet, by design (same posture as #1229's empty `src/components/ui/`)
- `npm run test:run` → **1283/1283 passing across 107 files** (1275/106 baseline + the 8 new `useUiV2.test.ts` cases; zero regressions elsewhere). Targeted suite runs in 16ms standalone
- Pre-existing dynamic-vs-static-import warnings unchanged

## Notes / follow-ups

- Hook only re-evaluates on `popstate`. URL changes via `pushState` / `replaceState` won't fire `popstate` natively — same caveat that React Router faces. If we ever ship in-app navigation that flips `?ui=v2`, callers will need to dispatch a synthetic `popstate` after `pushState`. Documented in the hook's behavior; not relevant for any current consumer.
- `.env.example` / Vercel env config for `VITE_UI_V2` not added — out of scope for this PR. Easy to add when the first staging deploy needs it.

## Test plan

- [ ] CI: tsc, build, vitest all green
- [ ] Visit a preview deploy with `?ui=v2` in the URL — confirm zero visible UI difference (no consumers yet)
- [ ] Same preview without query — confirm zero visible UI difference

Closes #1232