### PR TITLE
feat(ui): migrate TimelineSlider to shadcn Slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2312,11 +2313,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
@@ -2392,6 +2443,21 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2576,6 +2642,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -2669,6 +2768,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -56,9 +56,9 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
     currentPosition,
     duration,
     handleLikeToggle,
-    handleSliderChange,
-    handleSliderMouseDown,
-    handleSliderMouseUp,
+    handleSeekDuringScrub,
+    handleScrubStart,
+    handleScrubEnd,
     formatTime,
   } = useSpotifyControls({
     currentTrack,
@@ -108,9 +108,9 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
         currentPosition={currentPosition}
         duration={duration}
         formatTime={formatTime}
-        onSliderChange={handleSliderChange}
-        onSliderMouseDown={handleSliderMouseDown}
-        onSliderMouseUp={handleSliderMouseUp}
+        onSeek={handleSeekDuringScrub}
+        onScrubStart={handleScrubStart}
+        onScrubEnd={handleScrubEnd}
         trackId={currentTrack?.id}
         isLiked={effectiveIsLiked}
         isLikePending={effectiveIsLikePending}

--- a/src/components/TimelineSlider.tsx
+++ b/src/components/TimelineSlider.tsx
@@ -1,64 +1,11 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import styled from 'styled-components';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
-
-const TimelineSliderInput = styled.input.withConfig({
-  shouldForwardProp: (prop) => !['sliderHeight', 'thumbSize'].includes(prop),
-}).attrs<{ value: number; max: number; sliderHeight: number; thumbSize: number }>(
-  ({ value, max }: { value: number; max: number }) => ({
-    style: {
-      background: `linear-gradient(
-        to right,
-        var(--accent-color) 0%,
-        var(--accent-color) ${value && max ? (Number(value) / Number(max)) * 100 : 0}%,
-        rgba(115, 115, 115, 0.3) ${value && max ? (Number(value) / Number(max)) * 100 : 0}%,
-        rgba(115, 115, 115, 0.3) 100%
-      )`
-    }
-  })
-) <{ value: number; max: number; sliderHeight: number; thumbSize: number }>`
-  flex: 1;
-  height: ${({ sliderHeight }) => sliderHeight}px;
-  border-radius: ${({ sliderHeight }) => sliderHeight / 2}px;
-  outline: none;
-  cursor: pointer;
-
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: ${({ thumbSize }) => thumbSize}px;
-    height: ${({ thumbSize }) => thumbSize}px;
-    background: var(--accent-color) !important;
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: none;
-    transition: all 0.2s ease;
-
-    &:hover {
-      transform: scale(1.2);
-    }
-  }
-
-  &::-moz-range-thumb {
-    width: ${({ thumbSize }) => thumbSize}px;
-    height: ${({ thumbSize }) => thumbSize}px;
-    background: var(--accent-color) !important;
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: none;
-    transition: all 0.2s ease;
-
-    &:hover {
-      transform: scale(1.2);
-    }
-  }
-`;
+import { Slider } from '@/components/ui/slider';
 
 const TimeLabel = styled.span.withConfig({
   shouldForwardProp: (prop) => !['minWidth'].includes(prop),
-}) <{ minWidth: number }>`
+})<{ minWidth: number }>`
   color: ${({ theme }) => theme.colors.gray[400]};
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-family: monospace;
@@ -74,19 +21,25 @@ const TimelineRow = styled.div`
   margin: 0;
 `;
 
+const SliderWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+`;
+
 interface TimelineSliderProps {
   currentPosition: number;
   duration: number;
   formatTime: (ms: number) => string;
-  onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onSliderMouseDown: () => void;
-  onSliderMouseUp: (e: React.MouseEvent<HTMLInputElement>) => void;
+  onSeek: (position: number) => void;
+  onScrubStart: () => void;
+  onScrubEnd: (position: number) => void;
   children?: React.ReactNode;
 }
 
 const areTimelineSliderPropsEqual = (
   prevProps: TimelineSliderProps,
-  nextProps: TimelineSliderProps
+  nextProps: TimelineSliderProps,
 ): boolean => {
   return (
     prevProps.currentPosition === nextProps.currentPosition &&
@@ -99,49 +52,92 @@ const TimelineSlider = memo<TimelineSliderProps>(({
   currentPosition,
   duration,
   formatTime,
-  onSliderChange,
-  onSliderMouseDown,
-  onSliderMouseUp,
-  children
+  onSeek,
+  onScrubStart,
+  onScrubEnd,
+  children,
 }) => {
   const { isMobile, isTablet } = usePlayerSizingContext();
+  const isScrubbingRef = useRef(false);
 
   const dimensions = useMemo(() => {
     if (isMobile) {
-      return {
-        sliderHeight: 3,
-        thumbSize: 10,
-        minWidth: 35
-      };
+      return { sliderHeight: 3, thumbSize: 10, minWidth: 35 };
     }
     if (isTablet) {
-      return {
-        sliderHeight: 4,
-        thumbSize: 12,
-        minWidth: 40
-      };
+      return { sliderHeight: 4, thumbSize: 12, minWidth: 40 };
     }
-    return {
-      sliderHeight: 4,
-      thumbSize: 12,
-      minWidth: 40
-    };
+    return { sliderHeight: 4, thumbSize: 12, minWidth: 40 };
   }, [isMobile, isTablet]);
+
+  const handleValueChange = useCallback(
+    (values: number[]) => {
+      const next = values[0] ?? 0;
+      if (!isScrubbingRef.current) {
+        isScrubbingRef.current = true;
+        onScrubStart();
+      }
+      onSeek(next);
+    },
+    [onSeek, onScrubStart],
+  );
+
+  const handleValueCommit = useCallback(
+    (values: number[]) => {
+      const next = values[0] ?? 0;
+      isScrubbingRef.current = false;
+      onScrubEnd(next);
+    },
+    [onScrubEnd],
+  );
+
+  const sliderMax = duration > 0 ? duration : 1;
+  const sliderValue = Math.min(currentPosition, sliderMax);
+
+  const trackStyle = useMemo<React.CSSProperties>(
+    () => ({
+      height: dimensions.sliderHeight,
+      borderRadius: dimensions.sliderHeight / 2,
+      background: 'rgba(115, 115, 115, 0.3)',
+    }),
+    [dimensions.sliderHeight],
+  );
+
+  const rangeStyle = useMemo<React.CSSProperties>(
+    () => ({ background: 'var(--accent-color)' }),
+    [],
+  );
+
+  const thumbStyle = useMemo<React.CSSProperties>(
+    () => ({
+      width: dimensions.thumbSize,
+      height: dimensions.thumbSize,
+      background: 'var(--accent-color)',
+      borderColor: 'var(--accent-color)',
+      boxShadow: 'none',
+    }),
+    [dimensions.thumbSize],
+  );
+
   return (
     <TimelineRow>
       {children}
       <TimeLabel minWidth={dimensions.minWidth}>{formatTime(currentPosition)}</TimeLabel>
-      <TimelineSliderInput
-        type="range"
-        min="0"
-        max={duration}
-        value={currentPosition}
-        sliderHeight={dimensions.sliderHeight}
-        thumbSize={dimensions.thumbSize}
-        onChange={onSliderChange}
-        onMouseDown={onSliderMouseDown}
-        onMouseUp={onSliderMouseUp}
-      />
+      <SliderWrapper>
+        <Slider
+          value={[sliderValue]}
+          min={0}
+          max={sliderMax}
+          step={1}
+          disabled={duration <= 0}
+          onValueChange={handleValueChange}
+          onValueCommit={handleValueCommit}
+          trackStyle={trackStyle}
+          rangeStyle={rangeStyle}
+          thumbStyle={thumbStyle}
+          aria-label="Seek timeline"
+        />
+      </SliderWrapper>
       <TimeLabel minWidth={dimensions.minWidth}>{formatTime(duration)}</TimeLabel>
     </TimelineRow>
   );

--- a/src/components/__tests__/TimelineSlider.test.tsx
+++ b/src/components/__tests__/TimelineSlider.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import TimelineSlider from '../TimelineSlider';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: () => ({ isMobile: false, isTablet: false }),
+}));
+
+beforeAll(() => {
+  // Radix Slider's useSize uses ResizeObserver, which jsdom does not implement.
+  // A no-op stub is enough for keyboard interaction tests.
+  if (typeof window.ResizeObserver === 'undefined') {
+    window.ResizeObserver = class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  }
+});
+
+function renderSlider(overrides?: Partial<{
+  currentPosition: number;
+  duration: number;
+  onSeek: (position: number) => void;
+  onScrubStart: () => void;
+  onScrubEnd: (position: number) => void;
+}>) {
+  const props = {
+    currentPosition: 30_000,
+    duration: 180_000,
+    formatTime: (ms: number) => `${Math.floor(ms / 1000)}s`,
+    onSeek: vi.fn(),
+    onScrubStart: vi.fn(),
+    onScrubEnd: vi.fn(),
+    ...overrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <TimelineSlider {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('TimelineSlider', () => {
+  it('fires onScrubStart + onSeek + onScrubEnd when ArrowRight nudges the thumb', () => {
+    // #given
+    const onSeek = vi.fn();
+    const onScrubStart = vi.fn();
+    const onScrubEnd = vi.fn();
+    renderSlider({ onSeek, onScrubStart, onScrubEnd });
+    const thumb = screen.getByRole('slider');
+
+    // #when — Radix Slider Arrow nudge: onValueChange and onValueCommit fire
+    // together in a single tick, so the wrapper collapses scrub start + seek
+    // + scrub end into one immediate-seek sequence.
+    thumb.focus();
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    // #then
+    expect(onScrubStart).toHaveBeenCalledOnce();
+    expect(onSeek).toHaveBeenCalledOnce();
+    expect(onScrubEnd).toHaveBeenCalledOnce();
+
+    // The bumped position is one step (1ms) above the starting 30_000ms.
+    const seekedTo = onSeek.mock.calls[0][0] as number;
+    const committedAt = onScrubEnd.mock.calls[0][0] as number;
+    expect(seekedTo).toBeGreaterThan(30_000);
+    expect(committedAt).toBe(seekedTo);
+  });
+
+  it('does not exceed the duration ceiling when ArrowRight is held at the end', () => {
+    // #given
+    const onSeek = vi.fn();
+    renderSlider({ currentPosition: 180_000, duration: 180_000, onSeek });
+    const thumb = screen.getByRole('slider');
+
+    // #when
+    thumb.focus();
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    // #then — Radix clamps to max; if onSeek fires it must not exceed duration
+    if (onSeek.mock.calls.length > 0) {
+      expect(onSeek.mock.calls[0][0]).toBeLessThanOrEqual(180_000);
+    }
+  });
+});

--- a/src/components/controls/TimelineControls.tsx
+++ b/src/components/controls/TimelineControls.tsx
@@ -7,9 +7,9 @@ interface TimelineControlsProps {
     currentPosition: number;
     duration: number;
     formatTime: (ms: number) => string;
-    onSliderChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    onSliderMouseDown: () => void;
-    onSliderMouseUp: (e: React.MouseEvent<HTMLInputElement>) => void;
+    onSeek: (position: number) => void;
+    onScrubStart: () => void;
+    onScrubEnd: (position: number) => void;
     trackId?: string;
     isLiked: boolean;
     isLikePending: boolean;
@@ -37,9 +37,9 @@ const TimelineControls = memo<TimelineControlsProps>(({
     currentPosition,
     duration,
     formatTime,
-    onSliderChange,
-    onSliderMouseDown,
-    onSliderMouseUp,
+    onSeek,
+    onScrubStart,
+    onScrubEnd,
     trackId,
     isLiked,
     isLikePending,
@@ -53,9 +53,9 @@ const TimelineControls = memo<TimelineControlsProps>(({
                 currentPosition={currentPosition}
                 duration={duration}
                 formatTime={formatTime}
-                onSliderChange={onSliderChange}
-                onSliderMouseDown={onSliderMouseDown}
-                onSliderMouseUp={onSliderMouseUp}
+                onSeek={onSeek}
+                onScrubStart={onScrubStart}
+                onScrubEnd={onScrubEnd}
             />
 
             <TimelineRight>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Per-part style escape hatches — required by `TimelineSlider`, which paints
+ * the filled range and thumb with the runtime `var(--accent-color)` derived
+ * from album art and overrides the default track height for responsive
+ * sizing. Do not strip these as "unused": removing them re-forks the slider.
+ *
+ * Default Slider stays neutral (uses shadcn `--primary`); pass these props
+ * only when you need accent tinting or custom dimensions.
+ */
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  trackStyle?: React.CSSProperties
+  rangeStyle?: React.CSSProperties
+  thumbStyle?: React.CSSProperties
+}
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  SliderProps
+>(({ className, trackStyle, rangeStyle, thumbStyle, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track
+      className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20"
+      style={trackStyle}
+    >
+      <SliderPrimitive.Range
+        className="absolute h-full bg-primary"
+        style={rangeStyle}
+      />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb
+      className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+      style={thumbStyle}
+    />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -159,17 +159,15 @@ export const useSpotifyControls = ({
     }
   }, [getPlayingDescriptor]);
 
-  const handleSliderChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const position = parseInt(e.target.value);
+  const handleSeekDuringScrub = useCallback((position: number) => {
     dispatchTiming({ type: 'position', positionMs: position });
   }, []);
 
-  const handleSliderMouseDown = useCallback(() => {
+  const handleScrubStart = useCallback(() => {
     setIsDragging(true);
   }, []);
 
-  const handleSliderMouseUp = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
-    const position = parseInt((e.target as HTMLInputElement).value);
+  const handleScrubEnd = useCallback((position: number) => {
     setIsDragging(false);
     handleSeek(position);
   }, [handleSeek]);
@@ -191,9 +189,9 @@ export const useSpotifyControls = ({
     handlePlayPause,
     handleLikeToggle: onLikeToggle,
     handleSeek,
-    handleSliderChange,
-    handleSliderMouseDown,
-    handleSliderMouseUp,
+    handleSeekDuringScrub,
+    handleScrubStart,
+    handleScrubEnd,
     formatTime,
     onNext,
     onPrevious,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom'],
-          radix: ['@radix-ui/react-dialog'],
+          radix: ['@radix-ui/react-dialog', '@radix-ui/react-slider'],
           styled: ['styled-components']
         }
       }


### PR DESCRIPTION
Closes #1232. Final task in epic #1228. Stacked on #1235 (#1231 — flag mechanism), which is stacked on #1234 (#1230 — dialogs), which is stacked on #1233 (#1229 — scaffold).

Replaces the bespoke `<input type="range">` + styled-components gradient with a Radix Slider primitive, behind a thin `TimelineSlider` wrapper. The filled range and thumb continue to render the runtime `--accent-color` (album-art derived) — TimelineSlider is the **one shadcn-migrated component that intentionally consumes player chrome accent**, per the rules added in #1231's CLAUDE.md "shadcn/ui integration" section.

## Deliverables

| File | Purpose |
|---|---|
| `src/components/ui/slider.tsx` | shadcn Slider primitive + three optional inline-style escape hatches (`trackStyle`, `rangeStyle`, `thumbStyle`). Documenting comment names `TimelineSlider` as the consumer and warns against stripping the props |
| `src/components/TimelineSlider.tsx` | Full rewrite as `<Slider>` wrapper. New prop shape `onSeek / onScrubStart / onScrubEnd`. `isScrubbingRef` ensures `onScrubStart` fires exactly once per drag session |
| `src/components/controls/TimelineControls.tsx` | Prop interface + JSX cascade rename (pure pass-through wrapper) |
| `src/components/SpotifyPlayerControls.tsx` | Call-site rewire to the renamed handlers |
| `src/hooks/useSpotifyControls.ts` | `handleSliderChange / handleSliderMouseDown / handleSliderMouseUp` → `handleSeekDuringScrub / handleScrubStart / handleScrubEnd`. Internal `setIsDragging` + `dispatchTiming` + `handleSeek` semantics preserved 1:1 |
| `src/components/__tests__/TimelineSlider.test.tsx` | 2 new keyboard-interaction tests, BDD `// #given /// #when /// #then` |
| `vite.config.ts` | `manualChunks.radix` extended to `['@radix-ui/react-dialog', '@radix-ui/react-slider']` |
| `package.json` | `@radix-ui/react-slider` added |

## 4-file edit footprint + cascade rename

The seek-commit chain — `useSpotifyControls.handleSliderMouseUp` → `handleSeek(position)` → `playback.seek(position)` — propagates a position number, but the legacy interface fabricated synthetic events through 4 hops. The rename collapses that to a number throughout. `parseInt(e.target.value)` plumbing is gone; the wrapper passes a real number from the start.

## Accent preservation (intentional exception to bridge isolation)

The default `<Slider>` from `src/components/ui/slider.tsx` stays neutral (uses shadcn `--primary`). TimelineSlider opts into accent tinting via the three style props:

```ts
rangeStyle = { background: 'var(--accent-color)' };
thumbStyle = {
  background: 'var(--accent-color)',
  borderColor: 'var(--accent-color)',
  width: dimensions.thumbSize,
  height: dimensions.thumbSize,
  boxShadow: 'none',
};
trackStyle = {
  height: dimensions.sliderHeight,
  borderRadius: dimensions.sliderHeight / 2,
  background: 'rgba(115, 115, 115, 0.3)',
};
```

The `slider.tsx` comment names TimelineSlider as the consumer and warns against stripping the props as "unused" — important since this is the one entry point for accent-tinting any future shadcn surface that legitimately wants player accent.

## Drag-detection logic

The wrapper holds `isScrubbingRef`. First `onValueChange` of a session fires `onScrubStart()` + `onSeek(value)`; subsequent `onValueChange` calls fire `onSeek(value)` only; `onValueCommit` fires `onScrubEnd(value)` and resets the ref. Keyboard nudges (Arrow / Home / End) fire `onValueChange + onValueCommit` together — the wrapper collapses to start + seek + end in one tick, which is the correct immediate-seek behavior. **Verified by test #1.**

## Edge-case guards

- `sliderMax = duration > 0 ? duration : 1` — Radix requires `max > min`
- `sliderValue = Math.min(currentPosition, sliderMax)` — value never overshoots
- `disabled={duration <= 0}` — Radix doesn't choke on zero-duration tracks before metadata loads

## Tests

Spec marked tests optional; lead preferred locking the new prop API against future regressions. Two BDD-style cases:

1. **ArrowRight nudge** — fires `onScrubStart + onSeek + onScrubEnd` exactly once each, with `onSeek` and `onScrubEnd` agreeing on the bumped position. Validates the `isScrubbingRef` + keyboard-collapse logic in a single test.
2. **Duration-ceiling clamping** — ArrowRight at `currentPosition === duration` never seeks past `duration`. Validates Radix's clamping + the wrapper's `sliderMax` guard.

**Test setup notes:**
- Mocks `@/contexts/PlayerSizingContext` (returns `{ isMobile: false, isTablet: false }`) — avoids the full provider tree.
- Stubs `window.ResizeObserver` locally — Radix Slider's `useSize` uses ResizeObserver which jsdom does not implement. No-op stub is sufficient for keyboard tests; did not touch shared `src/test/setup.ts`.

## Verification

- `npx tsc -b --noEmit` → exit 0, no output
- `npm run build` → success, ✓ built in 2.49s
  - `radix` chunk: 34.83 kB → **45.55 kB / 15.24 kB gzip** (+10.72 kB / +3.37 kB gzip — the `@radix-ui/react-slider` runtime, exactly the bundle gain the chunk strategy was set up for)
  - main entry: +27 kB (TimelineSlider now imports the shadcn Slider wrapper)
  - CSS bundle: +0.35 kB (Slider Tailwind classes)
- `npm run test:run` → **1285/1285 passing across 108 files** (1283/107 pre-task baseline + 2 new TimelineSlider tests; zero regressions)
- Pre-existing dynamic-vs-static-import warnings unchanged

## Manual smoke needed before merge

- [ ] Filled portion + thumb tinted with album-art accent; retints when track changes
- [ ] Click anywhere on track jumps playback to that position
- [ ] Drag thumb scrubs visually (UI updates), release commits the seek to the provider
- [ ] Keyboard: ArrowLeft/Right nudges, Home/End jump to start/end
- [ ] Mobile DevTools touch drag works; thumb is 10px on mobile, 12px on desktop/tablet
- [ ] Time labels update during scrub (current side updates as the thumb moves)
- [ ] Sanity: dialog chrome stays neutral when a track is playing while the slider underneath stays accent-tinted (confirms shadcn `--primary` decoupled from `--accent-color`)

## Follow-up flagged for separate issue

Slider `step={1}` (1ms granularity) matches the legacy `<input type=range>` default. Keyboard Arrow nudges by 1ms per press, which is imperceptible. A UX tweak — e.g. `step={5000}` for ±5s nudges, or a custom `onKeyDown` interceptor — is a separate concern outside #1232's behavior-parity scope. Reviewer noted this; lead has filed it for post-merge.