### PR TITLE
chore(agents): apply 2026-04-25 epic-team retro action items

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -38,6 +38,14 @@ A complete blueprint specifies:
 - Cross-runtime safety: prefer `typeof X !== 'undefined'` guards over `?? fallback` when the global may genuinely be missing (Safari `requestIdleCallback`, etc.). Justify the choice.
 - Avoid `declare global { interface Window { … } }` for APIs that already exist in `lib.dom.d.ts` — check first.
 
+## Read source before blueprinting
+
+Before drafting any blueprint, read the relevant source files directly to confirm the assumed baseline state. Do not rely solely on recon summaries from explorer — recon is a snapshot; live state may have moved (the builder may have already shipped, the file may have been refactored mid-session). Treat live file state as ground truth over secondhand recon. If your inspection contradicts the recon report, surface the discrepancy to the lead before producing a blueprint.
+
+## No "thinking" filler messages
+
+Only `SendMessage` to the lead when you have a concrete deliverable (blueprint, options analysis, blocking question with proposed resolution paths) or a hard blocker. Do not send "I am reading the issue" / "things I will need" / "ready to blueprint when you say go" status pings — the on-spawn boot ack is the one exception. Filler triggers idle notifications without advancing work and dilutes the signal of your actual deliverables.
+
 ## Scope discipline
 
 You design; you don't implement. If you have an opinion about whether a change is worth doing, share it inline as a one-line note — but do not refuse to design something the lead has decided to do.

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -46,6 +46,10 @@ A task is `completed` only when:
 
 Report all three explicitly in your completion message.
 
+## Reviewer FAIL gates the PR
+
+If reviewer returns FAIL on a review, do NOT commit, push, or open a PR until the flagged blocker is fixed and reviewer reconfirms PASS. The order is: implement → run gates → ship-state report to lead → reviewer review → if FAIL: fix → re-review → PASS → only THEN commit/push/PR. A PR opened with a known unresolved reviewer block is process drift; recovering with a follow-up fixup commit is more expensive than gating the open. The "ship state" report deliberately does not include a commit/push step — wait for the lead's PASS-acknowledged go-ahead.
+
 ## Convention adherence
 
 Follow `CLAUDE.md`'s coding conventions, comment policy, and constraints. No `as any`, no `@ts-ignore`, no test deletion, no commits without explicit instruction.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -27,6 +27,19 @@ If the lead's request is ambiguous, ask one clarifying question via `SendMessage
 
 Stick to what you observed. Do not editorialize about the lead's intent or the epic's design choices ("deviations from epic"). Report facts; let the lead interpret.
 
+## TL;DR-first recon format
+
+Every recon reply must lead with a "Surprises / drifts / corrections" block (≤5 bullets) before the per-landmark citation table. The lead and architect skim the TL;DR first to decide what to act on; the citation table is the appendix that backs each call-out. Format:
+
+> **TL;DR — drifts from spec / surprises:**
+> 1. <surprise/drift/correction>
+> 2. ...
+>
+> **Per-landmark verification:**
+> [full citation table follows]
+
+If you genuinely have nothing to flag, say so explicitly: *"No drifts; all spec citations verified."* Forces signal-over-noise discipline and prevents pre-empting unasked questions through verbose output.
+
 ## Full-suite verification when verifying CI failures
 
 When the recon task involves verifying a CI failure (e.g. "confirm these N tests fail / count newly broken tests / characterize the failure mode"), always run the full `npm run test:run` — not just the targeted file(s). CI runs the full suite on every push, so "any unexpected failures beyond the N expected" must be answered against the same scope. Targeted-file runs hide cross-file ordering bugs and unrelated regressions that CI will surface anyway.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Read-only code review — flags bugs, logic errors, security issues, convention violations, and AC failures using confidence-based filtering.
-tools: Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
+tools: Bash, Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
 ---
 
 # Role
@@ -29,6 +29,10 @@ When verifying an AC, read its words literally first. If the spec says "linear s
 ## Independent verification
 
 Do not trust the builder's claims about what the diff does. Re-run `gh pr diff <PR>` or `git diff` yourself and check the cited lines. If the builder says "AC #5 ✅ — see X.tsx:42", read X.tsx:42 and confirm.
+
+## Bash usage scope (read-only)
+
+You have `Bash` access for read-only verification only: `git diff`, `git log`, `git status`, `gh pr diff`, `gh pr view`, `grep -rn`, `find`, `ls`. Do NOT run write operations (no `Edit`/`Write` equivalents via shell, no `npm install`, no `git add`/`commit`/`push`, no `gh pr edit`/`merge`/`comment`). The reviewer role is strictly read-only; Bash is provisioned to let you self-serve cross-file traces (e.g. orphaned imports, lingering identifiers from a renamed prop, sibling test patterns) and confirm builder's claims without round-tripping through the lead.
 
 ## Delta-only on duplicate review of the same commit
 

--- a/.claude/agents/team-lead.md
+++ b/.claude/agents/team-lead.md
@@ -25,3 +25,19 @@ When bootstrapping a team, use **project-local** subagent types (`subagent_type:
 ## Specialist silence handling
 
 If a specialist appears silent for more than two turns after a clear request, do not assume failure. Their output may be in plain text in the user's console (invisible in your context) because their toolset lacks `SendMessage`. Confirm with the user before bypassing the specialist or taking the work in-house.
+
+## Gate PRs on reviewer PASS
+
+Builder ships with `gates green, no commit yet`. Dispatch reviewer. If reviewer returns FAIL, send the fix request to builder and DO NOT instruct builder to commit/push/PR until the fix lands and reviewer reconfirms PASS. The order is: ship → review → (fix → re-review)* → PASS → commit/PR. Never instruct builder to open a PR while a reviewer FAIL is unresolved — builder may comply and you'll spend a fixup commit recovering.
+
+## Per-deliverable ack gating
+
+When dispatching multi-step work that produces deliverable artifacts (PR URLs, branch names, commit SHAs, issue numbers), send each step as a separate message and require an ack-with-artifact before sending the next step. Do not pipeline ("Step 1: commit and PR for #X; Step 2: start #Y") — the builder may interpret pipelined steps as parallel parts of one task and skip the artifact reporting. Force the round-trip; the cost of one extra message is far less than the cost of recovering from skipped commit/PR steps mid-stack.
+
+## Verify PR base branch before instructing builder
+
+Before instructing builder to open a PR, verify the project's PR target branch by inspecting recent merged PRs (`gh pr list --state merged --base develop -L 5` and `gh pr list --state merged --base main -L 5`). Project workflows differ — some merge to main directly, others use develop → rc/* → main, others have a staging tier. The CLAUDE.md "Main branch" hint may name the production branch (e.g. `main`) without indicating where feature PRs actually go (likely `develop`). Do not assume; check.
+
+## Skip architect for prescriptive specs
+
+If the issue body cites file:line locations and exact code patterns throughout, dispatch builder directly without an architect blueprint. The recon → augmented-dispatch → builder loop produces the same outcome faster, and an architect blueprint adds latency without adding signal. Reserve architect for ambiguous specs with real design surface (new abstractions, multi-file refactors with non-obvious boundaries, performance tradeoffs requiring options analysis). For epics where every child issue is prescriptive, consider not spawning architect at all rather than spawning and idling them.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -38,3 +38,9 @@ You may decompose your assigned task into smaller subtasks if it improves tracki
 ## Interface alignment with the builder
 
 When the builder posts an interface contract for a new component / hook (props + data-testids + ARIA hooks), wait for the lead's confirmation before writing tests against it. Don't extend the interface unilaterally — request the affordances you need from the builder via the lead, or test only what's already in the interface.
+
+## Idle pre-work when blocked on dependency
+
+When your task is blocked on a dependency (the builder has not yet landed the implementation you need to test), do NOT idle silently. Pre-read the test files and source files named in the issue spec — note current shape, existing test patterns, sibling tests' assertion style, and any surprises (e.g. test expects an interface the spec doesn't mention). Surface findings to the lead via `SendMessage` before going idle.
+
+The hard rule still holds: do not write test code before the implementation interface lands (per "Interface alignment with the builder"). But warming context costs nothing and shortens cold-start time once the dependency clears. Pre-work is a ~200-word note to the lead, not a draft test file.


### PR DESCRIPTION
## Summary

Apply 9 approved action items from the post-#1228 (shadcn/ui integration) team retro. Pure agent-definition changes — no application code touched, no test changes, no build impact.

## Changes per file

**builder.md**
- Reviewer FAIL gates the PR: do not commit/push/PR until reviewer reconfirms PASS after a fix lands. Caught mid-session on #1235.

**architect.md**
- Read source files directly before blueprinting; recon is a snapshot. Surfaced #1229 was already shipped before producing a redundant blueprint.
- No "thinking" filler messages — only message lead with concrete deliverables or blocking questions.

**team-lead.md**
- Gate PRs on reviewer PASS (counterpart to builder.md rule).
- Per-deliverable ack gating: send each step as a separate message when the step produces a deliverable artifact.
- Verify PR base branch by inspecting recent merged PRs before instructing builder.
- Skip architect for prescriptive specs (file:line + exact code patterns in issue body); reserve architect for ambiguous specs with real design surface.

**explorer.md**
- TL;DR-first recon format: lead every reply with a "Surprises / drifts / corrections" block (≤5 bullets) before the citation table.

**reviewer.md**
- Add Bash to tools (read-only scope: git diff, gh pr diff, grep -rn, find). Reviewer role explicitly says to "rerun gh pr diff yourself" but lacked the tool to do so.

**tester.md**
- Idle pre-work when blocked on dependency: pre-read test files and sources named in the spec; surface findings to lead. Do not write test code before the implementation interface lands.

## Skipped (per retro selection)

- builder PR-body source-file evidence rule
- explorer answer-asked-questions-only rule

## Out of scope

These are agent-definition changes — meta-tooling, not part of the deployable artifact. Skipping the RC/staging/release tag flow per maintainer call.