### PR TITLE
chore(agents): rename spawn-epic-team to spawn-team

### DIFF
--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -1,15 +1,17 @@
 ---
-name: spawn-epic-team
-description: Bootstrap the canonical 6-role epic team (team-lead + explorer + architect + builder + reviewer + tester) for working on an epic. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
+name: spawn-team
+description: Bootstrap the canonical 6-role team (team-lead + explorer + architect + builder + reviewer + tester) for multi-file work in this repo. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
 triggers:
-  - Explicit user request: "spin up the team", "spawn the epic team", "create the team", "set up the agents for this epic", "/spawn-epic-team"
-  - Before starting any new epic that benefits from parallel specialist work
+  - Explicit user request: "spin up the team", "spawn the team", "create the team", "set up the agents", "/spawn-team"
+  - Before starting any new multi-file work that benefits from parallel specialist work
 allowed-tools: Bash, Read, Agent, SendMessage, TeamCreate
 ---
 
-# Spawn Epic Team
+# Spawn Team
 
-Recreate the standard 6-role team for epic work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+Recreate the standard 6-role team for multi-file work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+
+The default team name is `vorbis-crew`. If a different team name is desired (e.g. for parallel teams), the user must say so explicitly; otherwise spawn under `vorbis-crew`.
 
 ## When to spawn the full team — proportionality
 
@@ -33,7 +35,7 @@ Spawning architect for mechanical fixes leaves the role idle the entire session,
 
 ### Phase 1 — Check existing team
 
-1. `cat ~/.claude/teams/vorbis-epic/config.json 2>/dev/null` to detect a pre-existing team.
+1. `cat ~/.claude/teams/vorbis-crew/config.json 2>/dev/null` to detect a pre-existing team.
 2. If the team exists:
    - Enumerate `members[]` and compare against the canonical 5 specialist names.
    - Identify any missing specialists.
@@ -46,7 +48,7 @@ Spawning architect for mechanical fixes leaves the role idle the entire session,
 Call `TeamCreate`:
 
 ```
-team_name: vorbis-epic
+team_name: vorbis-crew
 agent_type: lead
 description: Cross-functional team for epic work — lead orchestrates; specialists cover research, architecture, implementation, review, and testing.
 ```
@@ -80,14 +82,14 @@ If a project-local `subagent_type` is not resolved by Claude Code, fall back per
 For each spawn, the prompt should be terse — the agent's behavior is fully described in `.claude/agents/{name}.md`. Sample:
 
 ```
-You are "{name}" on the vorbis-epic team. Your full role definition is in
+You are "{name}" on the vorbis-crew team. Your full role definition is in
 .claude/agents/{name}.md — read it now.
 
 Acknowledge in one sentence (do not preload the codebase yet — wait for a specific task).
 Then go idle. Tasks will arrive via SendMessage from "team-lead" and the team task list.
 ```
 
-Set `team_name: vorbis-epic` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
+Set `team_name: vorbis-crew` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
 
 ### Phase 4 — Confirm ready
 
@@ -97,7 +99,7 @@ Set `team_name: vorbis-epic` and `name: {role}` on every Agent call so the spawn
 
 ## Constraints
 
-- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-epic/config.json` first.
+- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-crew/config.json` first.
 - **Never spawn the team-lead as a subagent.** The lead is the running session.
 - **Use project-local `subagent_type` first.** Fallback to upstream types only if the local resolution fails, and warn the user about the SendMessage gap when falling back to `feature-dev:*` types.
 - **Spawn in parallel via a single message** with multiple `Agent` tool calls — sequential spawning is wasted time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,7 +448,7 @@ For epics that benefit from parallel specialist work, this project ships a six-r
 
 ### Skills
 
-- **`/spawn-epic-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-epic/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
+- **`/spawn-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-crew/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
 - **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
 
 ### Agent definitions
@@ -457,10 +457,10 @@ For epics that benefit from parallel specialist work, this project ships a six-r
 
 - **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
 - **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
-- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-epic-team` skill handles this automatically.
+- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-team` skill handles this automatically.
 - **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
 
 ### When to use
 
-- **`/spawn-epic-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains).
+- **`/spawn-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains). The default team name is `vorbis-crew`.
 - **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.


### PR DESCRIPTION
## Summary

- Renames the team-spawning skill `.claude/skills/spawn-epic-team/` → `.claude/skills/spawn-team/`. Drops "epic" from the name since the team is general multi-file work coordination, not strictly epic-scoped.
- Default team name changes from `vorbis-epic` → `vorbis-crew`.
- Updates `CLAUDE.md` references (3 spots) to match the new skill and team names.

Meta-tooling change — agent definitions/orchestration. Bypassing the RC flow per the same precedent as PR #1239 (retro action items).

## Test plan

- [x] `git mv` preserves history (rename detected at 79% similarity).
- [x] Internal `vorbis-epic` references in skill body all swept to `vorbis-crew`.
- [x] Skill registers correctly under the new name (verified live: skill listed as "spawn-team" in available-skills).
- [x] New team `vorbis-crew` spawned successfully via the renamed skill (5/5 specialists ack'd).