### PR TITLE
refactor(volume): migrate VolumeSlider to shadcn Slider primitive (#1238)

### DIFF
--- a/src/components/controls/VolumeControl/index.tsx
+++ b/src/components/controls/VolumeControl/index.tsx
@@ -1,14 +1,12 @@
-import { memo, useCallback, useState, useRef, useEffect, useLayoutEffect } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
-import { ControlButton } from '../styled';
+
+import { Slider } from '@/components/ui/slider';
 import { VolumeIcon, UnmuteIcon } from '@/components/icons/VolumeIcons';
-import {
-    PopoverContainer,
-    SliderTrack,
-    SliderThumb,
-    MuteButton,
-    VolumeLabel,
-} from './styled';
+
+import { ControlButton } from '../styled';
+import { MuteButton, PopoverContainer, VolumeLabel } from './styled';
 
 interface VolumeControlProps {
     isMuted: boolean;
@@ -18,6 +16,31 @@ interface VolumeControlProps {
     isMobile: boolean;
     isTablet: boolean;
 }
+
+/**
+ * `flexGrow: 0` overrides Radix Track's base `flex-grow:1`. Without this the
+ * Track expands to fill remaining flex space in the column-oriented Root and
+ * the explicit 120px height is ignored. Inline style beats the Tailwind class.
+ */
+const TRACK_STYLE: CSSProperties = {
+    width: '4px',
+    height: '120px',
+    flexGrow: 0,
+    borderRadius: '2px',
+    background: 'rgba(115, 115, 115, 0.3)',
+};
+
+const RANGE_STYLE: CSSProperties = {
+    background: 'var(--accent-color)',
+};
+
+const THUMB_STYLE: CSSProperties = {
+    width: '14px',
+    height: '14px',
+    background: 'var(--accent-color)',
+    border: 'none',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.3)',
+};
 
 const areVolumeControlPropsEqual = (
     prevProps: VolumeControlProps,
@@ -42,9 +65,7 @@ const VolumeControl = memo<VolumeControlProps>(({
     const [isOpen, setIsOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
-    const trackRef = useRef<HTMLDivElement>(null);
     const [popoverPos, setPopoverPos] = useState<{ left: number; top: number } | null>(null);
-    const draggingRef = useRef(false);
 
     const togglePopover = useCallback(() => {
         setIsOpen(prev => !prev);
@@ -77,48 +98,18 @@ const VolumeControl = memo<VolumeControlProps>(({
         };
     }, [isOpen]);
 
-    const volumeFromY = useCallback((clientY: number) => {
-        if (!trackRef.current) return;
-        const rect = trackRef.current.getBoundingClientRect();
-        const pct = 1 - (clientY - rect.top) / rect.height;
-        onVolumeChange(Math.round(Math.max(0, Math.min(100, pct * 100))));
-    }, [onVolumeChange]);
-
-    const handleTrackMouseDown = useCallback((e: React.MouseEvent) => {
-        e.preventDefault();
-        draggingRef.current = true;
-        volumeFromY(e.clientY);
-
-        const handleMove = (ev: MouseEvent) => {
-            if (draggingRef.current) volumeFromY(ev.clientY);
-        };
-        const handleUp = () => {
-            draggingRef.current = false;
-            document.removeEventListener('mousemove', handleMove);
-            document.removeEventListener('mouseup', handleUp);
-        };
-        document.addEventListener('mousemove', handleMove);
-        document.addEventListener('mouseup', handleUp);
-    }, [volumeFromY]);
-
-    const handleTrackTouchStart = useCallback((e: React.TouchEvent) => {
-        draggingRef.current = true;
-        volumeFromY(e.touches[0].clientY);
-
-        const handleMove = (ev: TouchEvent) => {
-            ev.preventDefault();
-            if (draggingRef.current) volumeFromY(ev.touches[0].clientY);
-        };
-        const handleEnd = () => {
-            draggingRef.current = false;
-            document.removeEventListener('touchmove', handleMove);
-            document.removeEventListener('touchend', handleEnd);
-        };
-        document.addEventListener('touchmove', handleMove, { passive: false });
-        document.addEventListener('touchend', handleEnd);
-    }, [volumeFromY]);
-
+    /**
+     * `displayVolume` (not `volume`) drives the slider so the thumb sits at 0
+     * while muted. `onVolumeChange` still updates the underlying volume on
+     * drag so unmuting restores the dragged level rather than the pre-mute one.
+     */
     const displayVolume = isMuted ? 0 : volume;
+
+    const sliderValue = useMemo(() => [displayVolume], [displayVolume]);
+
+    const handleSliderChange = useCallback(([next]: number[]) => {
+        onVolumeChange(next);
+    }, [onVolumeChange]);
 
     return (
         <>
@@ -147,14 +138,25 @@ const VolumeControl = memo<VolumeControlProps>(({
                 >
                     <VolumeLabel>{displayVolume}</VolumeLabel>
 
-                    <SliderTrack
-                        ref={trackRef}
-                        $fillPercent={displayVolume}
-                        onMouseDown={handleTrackMouseDown}
-                        onTouchStart={handleTrackTouchStart}
-                    >
-                        <SliderThumb $percent={displayVolume} />
-                    </SliderTrack>
+                    {/*
+                     * `w-[4px]` and `flex-col` override the base
+                     * `w-full`/row layout via tailwind-merge inside `cn()`.
+                     * `touch-none` from the base class supplies
+                     * `touch-action: none` for mobile drag.
+                     */}
+                    <Slider
+                        orientation="vertical"
+                        value={sliderValue}
+                        onValueChange={handleSliderChange}
+                        min={0}
+                        max={100}
+                        step={1}
+                        aria-label="Volume"
+                        className="flex-col justify-center w-[4px]"
+                        trackStyle={TRACK_STYLE}
+                        rangeStyle={RANGE_STYLE}
+                        thumbStyle={THUMB_STYLE}
+                    />
 
                     <MuteButton
                         $isMuted={isMuted}

--- a/src/components/controls/VolumeControl/styled.ts
+++ b/src/components/controls/VolumeControl/styled.ts
@@ -2,9 +2,6 @@ import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 
 const POPOVER_PADDING_Y = '12px';
-const SLIDER_TRACK_WIDTH = '4px';
-const SLIDER_TRACK_HEIGHT = '120px';
-const SLIDER_THUMB_SIZE = '14px';
 const VOLUME_LABEL_FONT_SIZE = '10px';
 const VOLUME_LABEL_MIN_WIDTH = '22px';
 const MUTE_BUTTON_ICON_SIZE = '16px';
@@ -23,41 +20,6 @@ export const PopoverContainer = styled.div`
   box-shadow: ${({ theme }) => theme.shadows.popover};
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-`;
-
-export const SliderTrack = styled.div<{ $fillPercent: number }>`
-  position: relative;
-  width: ${SLIDER_TRACK_WIDTH};
-  height: ${SLIDER_TRACK_HEIGHT};
-  background: ${({ theme }) => theme.colors.control.backgroundHover};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  cursor: pointer;
-  touch-action: none;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: ${({ $fillPercent }) => $fillPercent}%;
-    background: var(--accent-color);
-    border-radius: ${({ theme }) => theme.borderRadius.sm};
-    pointer-events: none;
-  }
-`;
-
-export const SliderThumb = styled.div<{ $percent: number }>`
-  position: absolute;
-  left: 50%;
-  bottom: ${({ $percent }) => $percent}%;
-  transform: translate(-50%, 50%);
-  width: ${SLIDER_THUMB_SIZE};
-  height: ${SLIDER_THUMB_SIZE};
-  background: var(--accent-color);
-  border-radius: 50%;
-  pointer-events: none;
-  box-shadow: ${({ theme }) => theme.shadows.xs};
 `;
 
 export const MuteButton = styled.button<{ $isMuted: boolean }>`


### PR DESCRIPTION
## Summary
- Migrate `controls/VolumeControl/index.tsx` to consume the existing shadcn `<Slider>` primitive (landed in #1232 / epic #1228) instead of the hand-rolled `SliderTrack`/`SliderThumb`/manual drag handlers
- Preserve `var(--accent-color)` tinting through `trackStyle`/`rangeStyle`/`thumbStyle` escape hatches (player chrome rule)
- Drag, touch, and keyboard interaction now owned by Radix Slider
- Popover container, mute button, volume label unchanged
- No call site changes — `BottomBar/index.tsx` continues unchanged

Closes #1238. Part of epic #1245 (shadcn primitives wave 2).

## Reviewer verdict
✅ APPROVED by reviewer-2 — all 8 ACs verified verbatim against architect blueprint. Pre-existing `areVolumeControlPropsEqual` LOW finding correctly dismissed (memo comparator omits callback identity, but that pattern matches main — not a regression).

## Test plan
- [x] `npx tsc -b --noEmit` exits 0
- [x] `npm run test:run` exits 0 — 1285/1285 (baseline preserved)
- [x] `BottomBar.test.tsx` (consumer) — 20/20
- [x] Manual smoke (post-merge): drag changes volume, muted shows 0 with underlying state still updates, vertical orientation correct, accent color survives

## Notes
- Implementation lead-driven by builder-2; re-aligned to architect blueprint after first pass
- Branch was cut from `main`; includes 2 spawn-team meta-tooling commits not yet on `develop` (#1246, #1247) which will back-merge cleanly