### PR TITLE
chore(agents): sync main meta-tooling to develop + reviewer branch-read patterns

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -32,7 +32,40 @@ Do not trust the builder's claims about what the diff does. Re-run `gh pr diff <
 
 ## Bash usage scope (read-only)
 
-You have `Bash` access for read-only verification only: `git diff`, `git log`, `git status`, `gh pr diff`, `gh pr view`, `grep -rn`, `find`, `ls`. Do NOT run write operations (no `Edit`/`Write` equivalents via shell, no `npm install`, no `git add`/`commit`/`push`, no `gh pr edit`/`merge`/`comment`). The reviewer role is strictly read-only; Bash is provisioned to let you self-serve cross-file traces (e.g. orphaned imports, lingering identifiers from a renamed prop, sibling test patterns) and confirm builder's claims without round-tripping through the lead.
+You have `Bash` access for read-only verification only: `git diff`, `git log`, `git status`, `gh pr diff`, `gh pr view`, `grep -rn`, `find`, `ls`, plus `git show` and `git worktree add` for branch-anchored reads (see next section). Do NOT run write operations (no `Edit`/`Write` equivalents via shell, no `npm install`, no `git add`/`commit`/`push`, no `gh pr edit`/`merge`/`comment`). The reviewer role is strictly read-only; Bash is provisioned to let you self-serve cross-file traces (e.g. orphaned imports, lingering identifiers from a renamed prop, sibling test patterns) and confirm builder's claims without round-tripping through the lead.
+
+## Read from the branch ref, NEVER the shared working tree
+
+The shared workspace is mutated continuously by parallel builders, the tester, and lead operations. Reading source files from `src/components/...` directly during a review will produce **false-positive findings** rooted in working-tree pollution rather than the actual commit. This has happened in production sessions; treat it as a hard rule.
+
+Default review pattern (in priority order):
+
+1. **Bash + `git show` (preferred for individual files)**:
+   ```bash
+   git fetch origin <branch-name>
+   git show origin/<branch-name>:<file-path>
+   git diff main...origin/<branch-name>            # all files
+   git diff main...origin/<branch-name> -- <path>  # one file
+   ```
+
+2. **Bash + `git worktree add` (for full PR review)**:
+   ```bash
+   git worktree add /tmp/review-<task-id> origin/<branch-name>
+   cd /tmp/review-<task-id>
+   # all reads here are committed branch state
+   # cleanup when done:
+   cd /Users/roman/src/vorbis-player && git worktree remove /tmp/review-<task-id>
+   ```
+
+3. **WebFetch (fallback when Bash is unavailable, branch must already be pushed):**
+   ```
+   https://raw.githubusercontent.com/rmpacheco/vorbis-player/<branch>/<path>
+   https://api.github.com/repos/rmpacheco/vorbis-player/compare/main...<branch>
+   ```
+
+4. **Local `Read`** is appropriate ONLY for stable config files (`.claude/agents/*.md`, `theme.ts`, `package.json` for dep verification) — never for files in `src/components/...` during a review.
+
+If you find yourself reading `src/components/...` via the local `Read` tool during a review, stop and switch to one of the patterns above. A finding that doesn't appear in `git diff main...<branch> -- <file>` is a working-tree artifact, not a real review concern, and must be discarded.
 
 ## Delta-only on duplicate review of the same commit
 

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -1,6 +1,6 @@
 ---
 name: spawn-team
-description: Bootstrap the canonical 6-role team (team-lead + explorer + architect + builder + reviewer + tester) for multi-file work in this repo. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
+description: Bootstrap the canonical team (team-lead + explorer + architect + N builders + reviewer + tester) for multi-file work in this repo. Creates the team via TeamCreate, spawns all specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Builder count is configurable (default 2) — see "Builder count" section. Idempotent — re-running with an existing team only spawns missing members.
 triggers:
   - Explicit user request: "spin up the team", "spawn the team", "create the team", "set up the agents", "/spawn-team"
   - Before starting any new multi-file work that benefits from parallel specialist work
@@ -9,22 +9,42 @@ allowed-tools: Bash, Read, Agent, SendMessage, TeamCreate
 
 # Spawn Team
 
-Recreate the standard 6-role team for multi-file work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+Recreate the standard team for multi-file work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
 
 The default team name is `vorbis-crew`. If a different team name is desired (e.g. for parallel teams), the user must say so explicitly; otherwise spawn under `vorbis-crew`.
 
+## Builder count
+
+Builder is the only role for which multiple parallel instances are routinely useful — implementation is the bottleneck on most epics, and well-decomposed work parallelizes cleanly. Other roles (architect, reviewer, tester, explorer) stay at one instance because their throughput is rarely the gating constraint and duplicate instances would split context across the same review/test surface.
+
+Pick the count from the nature of the work *before* spawn:
+
+| Situation | Builders | Rationale |
+|---|---|---|
+| Work scope unknown at spawn time (default) | **2** | Two builders can either parallelize or pair-via-lead-handoff. One sits idle if scope turns out small; cheaper than respawning if scope is large. |
+| Single-issue, sequential, or tight dependency chain | 1 | Extra builders would block on the same files. Naming stays as singleton `builder` (no suffix). |
+| Known wave with N independent issues (e.g. swarm-style epic) | min(N, 5) | One builder per parallelizable workstream. Cap at 5 — context across more becomes hard for the lead to track. |
+| Very small, single-file mechanical fix | 0 (skip skill) | Lead can do it directly. See "When to spawn the full team" below. |
+
+The user may override the count explicitly: *"spawn the team with 3 builders"*, *"just 1 builder, this is sequential"*. Honor the explicit number.
+
+**Naming convention:**
+- Count = 1: name is `builder` (no suffix). Preserves the historical singleton convention.
+- Count > 1: names are `builder-1`, `builder-2`, ... `builder-N`. Numbered from 1 (not 0). The `-N` suffix here is **intentional and stable**, distinct from the spawn-flake `-2` ghost-name pattern that arises from failed retries.
+
 ## When to spawn the full team — proportionality
 
-The 5-specialist team is sized for **multi-file epics with non-trivial design surface**. Skip it for mechanical work:
+The full specialist team is sized for **multi-file epics with non-trivial design surface**. Skip it for mechanical work:
 
 | Scope | Right team |
 |---|---|
-| Multi-file feature, new abstractions, multi-AC spec | Full 5-specialist team |
-| Single-file or 2-file fix with no design surface (test-mock fixes, dep bumps, file renames, single-export tweaks) | Lead-only or lead + builder + tester |
-| Refactor across 1 module with clear pattern | Lead + builder + reviewer |
+| Multi-file feature, new abstractions, multi-AC spec | Full team (default 2 builders) |
+| Known parallel wave (N independent issues) | Full team with min(N, 5) builders |
+| Single-file or 2-file fix with no design surface (test-mock fixes, dep bumps, file renames, single-export tweaks) | Lead-only or lead + 1 builder + tester |
+| Refactor across 1 module with clear pattern | Lead + 1 builder + reviewer |
 | Pure investigation / code reading | Lead + explorer |
 
-Spawning architect for mechanical fixes leaves the role idle the entire session, which surfaces silent-presence bugs (no inbound task → no SendMessage → invisible to lead). When in doubt, start smaller — additional specialists can be spawned later via this same skill (idempotent on existing members).
+Spawning architect for mechanical fixes leaves the role idle the entire session, which surfaces silent-presence bugs (no inbound task → no SendMessage → invisible to lead). When in doubt, start smaller — additional specialists (including more builders) can be spawned later via this same skill (idempotent on existing members).
 
 ## Pre-conditions
 
@@ -33,15 +53,26 @@ Spawning architect for mechanical fixes leaves the role idle the entire session,
 
 ## Process
 
-### Phase 1 — Check existing team
+### Phase 1 — Decide builder count, then check existing team
 
-1. `cat ~/.claude/teams/vorbis-crew/config.json 2>/dev/null` to detect a pre-existing team.
-2. If the team exists:
-   - Enumerate `members[]` and compare against the canonical 5 specialist names.
-   - Identify any missing specialists.
-   - If all 5 are present, report "Team already up — all 5 specialists registered" and exit. Do not re-spawn — duplicates would conflict.
-   - If some are missing, proceed to Phase 3 to spawn only the missing members.
-3. If the team does not exist, proceed to Phase 2.
+1. **Resolve target builder count** before touching team state. Apply, in order:
+   - User's explicit number (e.g. *"3 builders"*) → use it (clamp to 1–5; warn if > 5).
+   - Known parallelizable workstream count (swarm-style epic with N independent issues) → `min(N, 5)`.
+   - Otherwise → `2` (default for unknown scope).
+   Record the resolved count as `BUILDER_COUNT`.
+
+2. `cat ~/.claude/teams/vorbis-crew/config.json 2>/dev/null` to detect a pre-existing team.
+3. If the team exists:
+   - Enumerate `members[]`. Treat any name matching `^builder(-\d+)?$` as a builder; collect the rest by exact role name (`explorer`, `architect`, `reviewer`, `tester`).
+   - Compute `EXISTING_BUILDERS` = count of builder-matching members.
+   - Identify missing non-builder specialists (set difference against `{explorer, architect, reviewer, tester}`).
+   - Decide builder action:
+     - `EXISTING_BUILDERS == BUILDER_COUNT` → no builder spawns needed.
+     - `EXISTING_BUILDERS < BUILDER_COUNT` → spawn `BUILDER_COUNT - EXISTING_BUILDERS` additional builders. Pick names from the lowest unused index in the `builder-N` sequence, skipping any already alive. If `EXISTING_BUILDERS == 1` and the existing name is the singleton `builder` (no suffix), keep it as-is and add `builder-2`, `builder-3`, etc.
+     - `EXISTING_BUILDERS > BUILDER_COUNT` → **do not auto-shutdown.** Warn the user with the existing list and the requested count, and ask whether to (a) leave the surplus alive, or (b) explicitly shut down the named extras (separate operation, not part of this skill).
+   - If all required members (non-builder set + builder count) are present, report `"Team already up — N specialists registered (M builders)"` and exit.
+   - Otherwise proceed to Phase 3 to spawn only the missing members.
+4. If the team does not exist, proceed to Phase 2.
 
 ### Phase 2 — Create the team
 
@@ -57,15 +88,18 @@ The current session becomes the team-lead by default.
 
 ### Phase 3 — Spawn specialists in parallel
 
-For each specialist not already alive, spawn via `Agent` in a single message with multiple parallel tool calls (background mode so the lead can continue):
+For each specialist not already alive, spawn via `Agent` in a single message with multiple parallel tool calls (background mode so the lead can continue). Builders are templated — instantiate one `Agent` call per builder name resolved in Phase 1.
 
 | Role | `subagent_type` | `name` | `model` (override) |
 |---|---|---|---|
 | explorer | `explorer` | `explorer` | (default) |
 | architect | `architect` | `architect` | `sonnet` |
-| builder | `builder` | `builder` | `opus` |
+| builder (singleton, count=1) | `builder` | `builder` | `opus` |
+| builder (multi, count>1) | `builder` | `builder-1`, `builder-2`, … `builder-N` | `opus` |
 | reviewer | `reviewer` | `reviewer` | `sonnet` |
 | tester | `tester` | `tester` | `sonnet` |
+
+All builder instances share the same `subagent_type` (`builder`) and the same `.claude/agents/builder.md` definition — they're parallel workers, not differentiated specialists. The `name` is the only thing that varies.
 
 **Use the project-local `subagent_type`** (the lowercase role name matching the `.claude/agents/{name}.md` file). This loads the agent definition with the correct tools (including `SendMessage` for architect and reviewer — the upstream `feature-dev:*` types omit it, which structurally breaks team communication).
 
@@ -79,30 +113,33 @@ If a project-local `subagent_type` is not resolved by Claude Code, fall back per
 | reviewer | `feature-dev:code-reviewer` | **Missing SendMessage — agent will appear silent.** Warn the user. |
 | tester | `test-engineer` | All tools — works |
 
-For each spawn, the prompt should be terse — the agent's behavior is fully described in `.claude/agents/{name}.md`. Sample:
+For each spawn, the prompt should be terse — the agent's behavior is fully described in `.claude/agents/{role}.md` (where `{role}` is the role file, e.g. `builder.md` for any `builder-N` instance). Sample:
 
 ```
 You are "{name}" on the vorbis-crew team. Your full role definition is in
-.claude/agents/{name}.md — read it now.
+.claude/agents/{role}.md — read it now.
 
 Acknowledge in one sentence (do not preload the codebase yet — wait for a specific task).
 Then go idle. Tasks will arrive via SendMessage from "team-lead" and the team task list.
 ```
 
-Set `team_name: vorbis-crew` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
+For multi-builder spawns, append one extra line to disambiguate: *"You are one of {N} builders on this team — sibling instances are {sibling-names}. The lead may dispatch independent work to each of you in parallel."* This prevents a builder from assuming it owns the whole queue.
+
+Set `team_name: vorbis-crew` and `name: {name}` on every Agent call so the spawned agent joins as a teammate. The `{name}` is the per-instance name (e.g. `builder-1`), not the role.
 
 ### Phase 4 — Confirm ready
 
-1. Wait for each spawned agent's first message (acknowledgment) — they should send via `SendMessage` per their role definition's exit gate.
-2. If any agent goes silent for two turns (no ack), warn the user — likely a `SendMessage` provisioning gap (the architect/reviewer fallback caveat).
-3. Report final state: which specialists are alive, which (if any) failed to ack.
+1. Wait for each spawned agent's first message (acknowledgment) — they should send via `SendMessage` per their role definition's exit gate. Each builder instance acks independently.
+2. If any agent goes silent for two turns (no ack), warn the user — likely a `SendMessage` provisioning gap (the architect/reviewer fallback caveat) or a spawn-flake. Name the silent agent(s) explicitly so the user can decide whether to respawn.
+3. Report final state with builder count broken out: e.g. `"Team ready: explorer, architect, builder-1, builder-2, reviewer, tester (6 specialists, 2 builders)"`. List any failed acks separately.
 
 ## Constraints
 
-- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-crew/config.json` first.
+- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-crew/config.json` first. For builders, "duplicate" means a name collision — `builder-2` already alive cannot be re-spawned, but `builder-3` may be added on top.
 - **Never spawn the team-lead as a subagent.** The lead is the running session.
 - **Use project-local `subagent_type` first.** Fallback to upstream types only if the local resolution fails, and warn the user about the SendMessage gap when falling back to `feature-dev:*` types.
-- **Spawn in parallel via a single message** with multiple `Agent` tool calls — sequential spawning is wasted time.
+- **Spawn in parallel via a single message** with multiple `Agent` tool calls — sequential spawning is wasted time. This includes multiple builder instances in the same batch.
 - **Use `run_in_background: true` on every spawn** so the lead can continue without waiting for each agent's setup turn.
-- **Do not assign work in this skill.** The skill only bootstraps the team. Task dispatch is a separate concern.
-- **Do not modify `.claude/agents/*.md` files.** This skill consumes them; only `agent-team-retro` writes to them.
+- **Do not assign work in this skill.** The skill only bootstraps the team. Task dispatch (including which builder gets which task) is a separate concern handled by the lead after this skill exits.
+- **Do not auto-shutdown surplus builders.** If `EXISTING_BUILDERS > BUILDER_COUNT`, surface the mismatch and let the user decide. Tearing down a busy builder mid-task corrupts the team.
+- **Do not modify `.claude/agents/*.md` files.** This skill consumes them; only `agent-team-retro` writes to them. The single `builder.md` definition serves all builder instances — there is no per-instance specialization.

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -1,15 +1,17 @@
 ---
-name: spawn-epic-team
-description: Bootstrap the canonical 6-role epic team (team-lead + explorer + architect + builder + reviewer + tester) for working on an epic. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
+name: spawn-team
+description: Bootstrap the canonical 6-role team (team-lead + explorer + architect + builder + reviewer + tester) for multi-file work in this repo. Creates the team via TeamCreate, spawns all 5 specialists in parallel using the project-local agent definitions in `.claude/agents/`, waits for acknowledgments, and reports ready. Idempotent — re-running with an existing team only spawns missing members.
 triggers:
-  - Explicit user request: "spin up the team", "spawn the epic team", "create the team", "set up the agents for this epic", "/spawn-epic-team"
-  - Before starting any new epic that benefits from parallel specialist work
+  - Explicit user request: "spin up the team", "spawn the team", "create the team", "set up the agents", "/spawn-team"
+  - Before starting any new multi-file work that benefits from parallel specialist work
 allowed-tools: Bash, Read, Agent, SendMessage, TeamCreate
 ---
 
-# Spawn Epic Team
+# Spawn Team
 
-Recreate the standard 6-role team for epic work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+Recreate the standard 6-role team for multi-file work in this repo. The team's behavior, role boundaries, and tool allowlists are defined in the project-local `.claude/agents/*.md` files — this skill orchestrates the spawn; the agent files orchestrate the agents.
+
+The default team name is `vorbis-crew`. If a different team name is desired (e.g. for parallel teams), the user must say so explicitly; otherwise spawn under `vorbis-crew`.
 
 ## When to spawn the full team — proportionality
 
@@ -33,7 +35,7 @@ Spawning architect for mechanical fixes leaves the role idle the entire session,
 
 ### Phase 1 — Check existing team
 
-1. `cat ~/.claude/teams/vorbis-epic/config.json 2>/dev/null` to detect a pre-existing team.
+1. `cat ~/.claude/teams/vorbis-crew/config.json 2>/dev/null` to detect a pre-existing team.
 2. If the team exists:
    - Enumerate `members[]` and compare against the canonical 5 specialist names.
    - Identify any missing specialists.
@@ -46,7 +48,7 @@ Spawning architect for mechanical fixes leaves the role idle the entire session,
 Call `TeamCreate`:
 
 ```
-team_name: vorbis-epic
+team_name: vorbis-crew
 agent_type: lead
 description: Cross-functional team for epic work — lead orchestrates; specialists cover research, architecture, implementation, review, and testing.
 ```
@@ -80,14 +82,14 @@ If a project-local `subagent_type` is not resolved by Claude Code, fall back per
 For each spawn, the prompt should be terse — the agent's behavior is fully described in `.claude/agents/{name}.md`. Sample:
 
 ```
-You are "{name}" on the vorbis-epic team. Your full role definition is in
+You are "{name}" on the vorbis-crew team. Your full role definition is in
 .claude/agents/{name}.md — read it now.
 
 Acknowledge in one sentence (do not preload the codebase yet — wait for a specific task).
 Then go idle. Tasks will arrive via SendMessage from "team-lead" and the team task list.
 ```
 
-Set `team_name: vorbis-epic` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
+Set `team_name: vorbis-crew` and `name: {role}` on every Agent call so the spawned agent joins as a teammate.
 
 ### Phase 4 — Confirm ready
 
@@ -97,7 +99,7 @@ Set `team_name: vorbis-epic` and `name: {role}` on every Agent call so the spawn
 
 ## Constraints
 
-- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-epic/config.json` first.
+- **Never spawn duplicate members.** Always check `~/.claude/teams/vorbis-crew/config.json` first.
 - **Never spawn the team-lead as a subagent.** The lead is the running session.
 - **Use project-local `subagent_type` first.** Fallback to upstream types only if the local resolution fails, and warn the user about the SendMessage gap when falling back to `feature-dev:*` types.
 - **Spawn in parallel via a single message** with multiple `Agent` tool calls — sequential spawning is wasted time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,7 +448,7 @@ For epics that benefit from parallel specialist work, this project ships a six-r
 
 ### Skills
 
-- **`/spawn-epic-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-epic/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
+- **`/spawn-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-crew/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
 - **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
 
 ### Agent definitions
@@ -457,10 +457,10 @@ For epics that benefit from parallel specialist work, this project ships a six-r
 
 - **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
 - **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
-- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-epic-team` skill handles this automatically.
+- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-team` skill handles this automatically.
 - **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
 
 ### When to use
 
-- **`/spawn-epic-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains).
+- **`/spawn-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains). The default team name is `vorbis-crew`.
 - **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.


### PR DESCRIPTION
## Summary

Back-merges 2 main-only meta-tooling commits to develop + adds a small reviewer.md improvement. Filed separately so the wave-2 feature PRs (#1248–#1252) show only their wave-2 work, not entangled meta-tooling.

### Cherry-picked from main (already shipped via direct-to-main PRs)
- **#1246** `chore(agents): rename spawn-epic-team to spawn-team, default vorbis-crew`
- **#1247** `chore(agents): support N builders in /spawn-team (default 2)`

Both landed direct to main earlier this session per the project's meta-tooling exception (agents/skills/CLAUDE.md may go direct to develop OR main without RC). Develop just hadn't been back-merged yet.

### New change in this PR
- **`.claude/agents/reviewer.md`** — adds "Read from the branch ref, NEVER the shared working tree" section documenting three review patterns (git show / git worktree add / WebFetch fallback) in priority order. Discovered live during wave-2 review when reviewers reading the polluted working tree produced false-positive HIGH findings; reviewer-2 invented the WebFetch + raw URL workaround that's now codified here.

## Why this PR exists

All five wave-2 feature PRs (#1248–#1252) were inadvertently cut from `main` instead of `develop`, so their diff vs develop included these 3 unrelated meta-tooling files (`.claude/skills/spawn-epic-team/skill.md`, `.claude/skills/spawn-team/skill.md`, `CLAUDE.md`). Once this PR merges, those entries fall out of the wave-2 PRs' diffs cleanly via git's 3-way merge.

## Test plan

- [ ] Merge cleanly to develop (cherry-picks of merged commits should produce no conflicts)
- [ ] After merge, verify wave-2 PR diffs (#1248-#1252) drop the 3 meta-tooling files from their file lists
- [ ] reviewer.md changes are passive documentation — no runtime behavior to test

## Notes

- This PR adds NO new functionality to the application — it is purely meta-tooling sync
- Wave-2 implementation PRs continue to wait for sequential merge after this one lands