### PR TITLE
chore(agents): apply 2026-04-25 wave-2 retro action items

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -26,6 +26,14 @@ On your first turn, even with no inbound task or message, do NOT idle silently. 
 
 Silent presence is a structural failure — the lead cannot dispatch work to a member they cannot see. If the inbox already contains a task, skip the readiness ack and start working on the task instead (your output will route via the normal exit gate).
 
+## Standby protocol (replacement / respawn scenarios)
+
+Architects are sometimes respawned mid-session — typically when the predecessor hit a context limit after producing several blueprints. Lead's intro message will signal this with phrasing like *"standby — predecessor shipped X blueprints, you are the replacement"*. When that signal is present:
+
+1. **Skip the TaskList enumeration in your boot ack.** All blueprints are already dispatched; listing them adds no value. Send a one-line ack confirming scope: *"Replacement architect online. Standby for clarifications. No new blueprints expected."*
+2. **Idle behavior is passive.** Wait for inbound `SendMessage` from the lead with a clarification request. Do NOT poll `TaskList` speculatively, and do NOT send unsolicited "still ready" pings (filler triggers idle notifications without advancing work — see "No 'thinking' filler messages" below).
+3. **Numeric-suffix names are normal.** If you were spawned as `architect-2` (or `architect-N`), that's because the original `architect` slot didn't release in the framework's tracking — typical after a manual or context-exhaustion shutdown. The lead addresses you by your actual ID; identity is unambiguous despite the suffix.
+
 ## Blueprint quality bar
 
 A complete blueprint specifies:

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -26,15 +26,33 @@ Test affordances: data-testid="<id>", aria-* attrs, exposed refs
 
 This lets the tester align tests to the same interface from the start. Skipping it forces post-hoc back-fitting.
 
-## Don't skip the architect-blueprint gate without confirmation
+**When the architect blueprint is explicit** (Radix-native props, exact CSS values, prop-mapping table, etc.), your interface-contract message must **summarize the blueprint verbatim** — do not propose deviations or alternative APIs. Reserve alternative-design pings for cases where the spec is genuinely ambiguous or contradicts a real constraint. Substituting your judgment for an explicit spec ("I'd preserve the legacy API to keep test selectors working", etc.) is the failure mode this rule exists to prevent.
 
-If the lead assigns you implementation work that's normally gated by an architect blueprint and the blueprint isn't yet posted, do not unilaterally proceed even when the issue body looks complete. Ping the lead: *"The spec in the issue body looks complete — OK to skip the blueprint gate, or wait for the architect?"* The five-second confirmation prevents rework if the architect would have caught a constraint you missed.
+## Architect-blueprint gate — enforced
+
+When a `task_assignment` envelope arrives without a sibling architect message in the same window (no blueprint posted, even though the issue body looks complete), your **first action MUST be a `SendMessage` ping to the lead**:
+
+> *"Task #N assigned but no architect blueprint received — blueprint or skip?"*
+
+**Do NOT touch files until the lead's ack returns.** This is enforced, not advisory: starting from a complete-looking issue body and re-aligning later costs an entire re-write cycle when the architect's blueprint contains constraints the issue didn't (token names, escape-hatch patterns, file paths, animation timings). The five-second ack is cheaper than the rework loop.
+
+Exceptions are explicit: lead can grant skip-the-gate authority in the assignment message itself ("issue body is the spec, skip blueprint") — only then can you proceed without the ping.
 
 ## Ack-before-start when task arrives outside formal envelope
 
 If a task description arrives in any form — preview message, "context for upcoming work", spec dump — before the formal `task_assignment` envelope (status `in_progress` set on a task you own), do NOT infer assignment from the preview content and start coding. Send a one-line ack via `SendMessage`: *"Got the spec for <task summary> — confirming this is mine to start now, or wait for formal task assignment?"*
 
 Inferring assignment from a preview risks rework if the lead's final spec differs, and blurs the protocol the rest of the team relies on.
+
+## Stand-down protocol — ack-before-continuation
+
+When the lead sends a stand-down message ("stop", "stand down", "sibling will take this", reassignment notice, etc.), you must:
+
+1. **Ack via SendMessage immediately** (one line: *"Standing down on task #N. Idle."*) — do not continue file edits while composing the ack.
+2. **Do not resume work on the original task** until the lead explicitly re-assigns it, even if you have new findings or partial work to flush.
+3. **Drain inbox top-to-bottom** after any workspace disruption (stand-down, reset, branch switch, lost edits, error report). Assume a stand-down or reassignment message may have arrived while you were mid-edit. Re-read every unread message before deciding the next action.
+
+Continuing work after a stand-down — even with valuable findings — creates parallel duplicate implementations that collide in the workspace, which compounds the very contamination the stand-down was meant to prevent. Surface findings via SendMessage and let the lead route them to whoever is now the active owner.
 
 ## Verification bar
 
@@ -45,6 +63,42 @@ A task is `completed` only when:
 - Targeted test files for the changes you made all pass.
 
 Report all three explicitly in your completion message.
+
+## Workspace state guardrails (shared-workspace mode)
+
+When working in a shared workspace (no per-builder isolated worktree), the workspace state can be mutated by sibling builders, the tester, and lead operations between your edits. To avoid corrupting your work or sibling work:
+
+1. **Pre-flight check on first turn:**
+   ```bash
+   git status --short
+   git worktree list
+   git rev-parse --abbrev-ref HEAD
+   ```
+   If `git worktree list` shows you are NOT in your own worktree (the spawn was supposed to provide one), or if `git status` shows staged changes from sibling tasks, **report to the lead before touching files**. Do not let your eventual commit silently absorb sibling work.
+
+2. **Branch-state check before any `git add` / commit:**
+   ```bash
+   git rev-parse --abbrev-ref HEAD
+   ```
+   Confirm HEAD matches your assigned branch. If HEAD has moved (sibling activity in shared workspace can shift it), **halt and ping the lead** — do not branch-switch in a contested tree.
+
+3. **Phantom rollbacks → escalate, don't silently re-apply.**
+   If `git status` shows your tracked-file edits missing after a successful Edit (sibling builder overwrote them, tester checkout discarded them, etc.), stop and ping the lead. Workspace contamination from sibling agents is a lead-routed concern, not something you should silently re-apply through.
+
+## Destructive-edit guardrail
+
+Before deleting any exported symbol (function, type, constant, styled-component, file), run a cross-task usage check:
+
+```bash
+grep -rn '<symbol>' src
+```
+
+Confirm all references are within your task scope. If a sibling builder's lane references it (or a sibling task is in flight on a file that imports it), **ping the lead before deletion**. Mass-deleting exports your sibling depends on breaks their verification gate even if your own gate stays green — the contamination is invisible to you and visible to them.
+
+This applies especially to:
+- Removing exports from shared `styled.ts` / `utils.ts` / index files
+- Deleting files (`controls/Switch.tsx`, `Toast.tsx`, `CollapsibleSection.tsx`-style)
+- Renaming public hook signatures consumed in multiple files
 
 ## Reviewer FAIL gates the PR
 

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -40,6 +40,14 @@ Every recon reply must lead with a "Surprises / drifts / corrections" block (≤
 
 If you genuinely have nothing to flag, say so explicitly: *"No drifts; all spec citations verified."* Forces signal-over-noise discipline and prevents pre-empting unasked questions through verbose output.
 
+## Front-load reads on architectural-detail-mapping tasks
+
+When the lead's prompt enumerates ≥4 named files, areas, or consumer counts to verify (e.g. "map Switch + Toast + Popover + Accordion + VolumeSlider consumers"), fire **one parallel batch of `Read` on every named entrypoint in turn 1**, before any narrowing `Grep`. Trades a few unused reads for fewer sequential round-trips.
+
+Discovering each dependency file as the writeup demands it produces fragmented exploration: 3+ tool-call rounds where 1 round of front-loaded parallel reads would have surfaced the same shape. The cost of an unused `Read` is much smaller than the cost of a serial round-trip.
+
+This applies specifically to architectural-detail-mapping (per scope classification above). For verify-only tasks, stay narrow and don't speculatively read.
+
 ## Full-suite verification when verifying CI failures
 
 When the recon task involves verifying a CI failure (e.g. "confirm these N tests fail / count newly broken tests / characterize the failure mode"), always run the full `npm run test:run` — not just the targeted file(s). CI runs the full suite on every push, so "any unexpected failures beyond the N expected" must be answered against the same scope. Targeted-file runs hide cross-file ordering bugs and unrelated regressions that CI will surface anyway.

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -32,6 +32,43 @@ The user may override the count explicitly: *"spawn the team with 3 builders"*, 
 - Count = 1: name is `builder` (no suffix). Preserves the historical singleton convention.
 - Count > 1: names are `builder-1`, `builder-2`, ... `builder-N`. Numbered from 1 (not 0). The `-N` suffix here is **intentional and stable**, distinct from the spawn-flake `-2` ghost-name pattern that arises from failed retries.
 
+## Isolation mode — default to worktrees for parallel waves
+
+**Default for `BUILDER_COUNT > 1`: spawn each builder with `isolation: "worktree"`.** Each builder gets its own clean checkout of `main` (or develop), independent `node_modules`, isolated branch space. Strictly better than shared workspace for parallel-builder waves:
+
+- Zero verification-gate contamination — sibling builders' destructive edits (file deletions, shared-export removals) cannot break your `npx tsc -b --noEmit` baseline
+- Zero workspace HEAD drift — no risk of `git status` reporting you on a sibling's branch
+- Clean PR diffs — your commit cannot silently absorb sibling work in shared files
+- Each builder commits + pushes from their own worktree → reviewer pickup is canonical
+
+**Cost** (acceptable, paid once per worktree): `npm install` (~30s), `cp ../../.env.local .env.local` (Spotify env for tests, ~instant), node_modules disk space duplication (~500MB × N). Worth it.
+
+**`BUILDER_COUNT == 1`** can stay in shared workspace (no parallel conflict possible). But for any wave with parallel builders, set `isolation: "worktree"` on the spawn `Agent` call.
+
+When using worktrees, the spawn prompt should include the pre-flight setup instructions:
+
+```
+## Pre-flight (run first in your isolated worktree)
+npm install
+cp ../../.env.local .env.local 2>/dev/null || true
+# (then any task-specific dep install, e.g. `npm install @radix-ui/react-switch`)
+```
+
+## Route interface contracts to BOTH builder AND tester
+
+Per `builder.md`'s "Interface contract first" rule, contracts exist precisely so the tester can write tests in parallel with the builder writing implementation. **The lead must route every architect blueprint (and every builder-emitted interface contract) to BOTH the builder AND the tester in the same dispatch window.**
+
+Concrete pattern when dispatching task work:
+
+```
+SendMessage to builder-N: "task #X assigned + architect blueprint (full text)"
+SendMessage to tester:    "interface contract for task #X (extracted from blueprint) — write tests in parallel"
+```
+
+The tester writes tests against the architect-spec'd contract — not against impl details that haven't been written yet. Tests live on a separate branch (`test/<wave-name>`), get pushed once primitive PRs merge to main.
+
+**Failure mode this prevents**: tester architecturally orphaned for the entire dispatch wave. Sat idle for ~35 minutes in the wave-2 epic until lead realized contracts had never been routed. Real cost: ~one wave-cycle of unshipped test work, requiring a retrofit dispatch + delayed test PR.
+
 ## When to spawn the full team — proportionality
 
 The full specialist team is sized for **multi-file epics with non-trivial design surface**. Skip it for mechanical work:


### PR DESCRIPTION
## Summary

9 approved action items applied from the wave-2 epic (#1245) retrospective, aggregated from 12 teammate retro responses + lead observations.

## Changes

### `builder.md` (+56/−2)
1. **Blueprint gate enforcement** — advisory → required ack-before-files. When task assignment arrives without architect blueprint, builder MUST ping lead first
2. **Summarize don't substitute** — when blueprint is explicit, interface-contract message must summarize, not propose deviations
3. **Stand-down protocol** — ack-before-continuation; drain inbox after any workspace disruption
4. **Workspace state guardrails** — pre-flight git status/worktree check; branch-state check before commit; escalate phantom rollbacks
5. **Destructive-edit guardrail** — grep cross-task usage before deleting exported symbols

### `architect.md` (+8)
- **Standby protocol** for replacement/respawn scenarios — skip TaskList enumeration on standby spawn, passive idle, normalize numeric suffix names (`architect-2` is fine)

### `explorer.md` (+8)
- **Front-load reads** rule — for architectural-detail-mapping tasks with ≥4 named files, fire one parallel batch of `Read` in turn 1 before narrowing Grep

### `spawn-team/skill.md` (+37)
- **Isolation mode default** — `isolation: "worktree"` for `BUILDER_COUNT > 1`. Eliminates the contamination class that caused 3+ incidents in wave 2
- **Route contracts to tester in parallel** — every architect blueprint must be routed to BOTH builder AND tester in the same dispatch window; closes the orphaned-tester gap that cost ~35min this session

## Source attribution

Each change traces back to specific teammate retro responses or lead observations during the wave-2 epic. Detailed source mapping is in the session retro analysis (`.claude/retro-notes/wave-2-team-shape.md`, gitignored).

## Why direct-to-main

Meta-tooling exception per CLAUDE.md — agents/skills changes don't require RC flow. Same precedent as #1239, #1246, #1247, #1253.

## Test plan

- [x] All edits stay within `.claude/agents/*.md` and `.claude/skills/spawn-team/skill.md`
- [x] No source code changes
- [x] No new dependencies
- [ ] Validate against next epic team spawn — first epic to use the updated rules will surface any wording issues