### PR TITLE
test(ui): unit tests for wave-2 shadcn primitives

### DIFF
--- a/src/components/ui/__tests__/accordion.test.tsx
+++ b/src/components/ui/__tests__/accordion.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '../accordion';
+
+function renderAccordion(options?: {
+  title?: string;
+  content?: string;
+  defaultValue?: string;
+}) {
+  const { title = 'Section Title', content = 'Section content body', defaultValue } = options ?? {};
+  return render(
+    <Accordion type="single" collapsible defaultValue={defaultValue}>
+      <AccordionItem value="item1">
+        <AccordionTrigger>{title}</AccordionTrigger>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+    </Accordion>,
+  );
+}
+
+describe('Accordion', () => {
+  describe('initial closed state', () => {
+    it('trigger has aria-expanded="false" when closed', () => {
+      // #when
+      renderAccordion();
+
+      // #then
+      expect(screen.getByRole('button', { name: /Section Title/i })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
+    });
+
+    it('content is not in the DOM when closed', () => {
+      // #when
+      renderAccordion();
+
+      // #then
+      expect(screen.queryByText('Section content body')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('open state', () => {
+    it('trigger has aria-expanded="true" after click', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #then
+      expect(screen.getByRole('button', { name: /Section Title/i })).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
+    });
+
+    it('content enters the DOM after clicking the trigger', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #then
+      expect(screen.getByText('Section content body')).toBeInTheDocument();
+    });
+
+    it('content is removed again after a second click (collapsible)', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #then
+      expect(screen.queryByText('Section content body')).not.toBeInTheDocument();
+    });
+
+    it('opens on mount when defaultValue matches item value', () => {
+      // #when
+      renderAccordion({ defaultValue: 'item1' });
+
+      // #then
+      expect(screen.getByText('Section content body')).toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA', () => {
+    it('trigger resolves via getByRole("button") with its label text', () => {
+      // #when
+      renderAccordion({ title: 'My Section' });
+
+      // #then
+      expect(screen.getByRole('button', { name: /My Section/i })).toBeInTheDocument();
+    });
+
+    it('open content has role="region"', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #then
+      expect(screen.getByRole('region')).toBeInTheDocument();
+    });
+
+    it('trigger is nested inside an h3 element (AccordionPrimitive.Header)', () => {
+      // #when
+      renderAccordion();
+      const trigger = screen.getByRole('button', { name: /Section Title/i });
+
+      // #then
+      expect(trigger.closest('h3')).not.toBeNull();
+    });
+  });
+
+  describe('chevron SVG', () => {
+    it('trigger contains a chevron SVG with aria-hidden', () => {
+      // #when
+      renderAccordion();
+      const svg = screen.getByRole('button', { name: /Section Title/i }).querySelector('svg');
+
+      // #then
+      expect(svg).not.toBeNull();
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('trigger className includes rotate-180 open-state class for the chevron', () => {
+      // #when
+      renderAccordion();
+      const trigger = screen.getByRole('button', { name: /Section Title/i });
+
+      // #then
+      expect(trigger.className).toContain('[&[data-state=open]>svg]:rotate-180');
+    });
+
+    it('trigger className includes motion-reduce svg transition override', () => {
+      // #when
+      renderAccordion();
+      const trigger = screen.getByRole('button', { name: /Section Title/i });
+
+      // #then
+      expect(trigger.className).toContain('motion-reduce:[&>svg]:transition-none');
+    });
+  });
+
+  describe('animation classes', () => {
+    it('content element has accordion-down and accordion-up animation classes', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+
+      // #when
+      const contentEl = screen.getByRole('region');
+
+      // #then
+      expect(contentEl.className).toContain('data-[state=open]:animate-accordion-down');
+      expect(contentEl.className).toContain('data-[state=closed]:animate-accordion-up');
+    });
+
+    it('content element has motion-reduce animation overrides', async () => {
+      // #given
+      const user = userEvent.setup();
+      renderAccordion();
+      await user.click(screen.getByRole('button', { name: /Section Title/i }));
+      const contentEl = screen.getByRole('region');
+
+      // #then
+      expect(contentEl.className).toContain('motion-reduce:data-[state=open]:animate-none');
+      expect(contentEl.className).toContain('motion-reduce:data-[state=closed]:animate-none');
+    });
+  });
+
+  describe('multiple independent Accordion roots', () => {
+    it('opening one accordion does not close the other (separate Roots)', async () => {
+      // #given
+      const user = userEvent.setup();
+      render(
+        <>
+          <Accordion type="single" collapsible>
+            <AccordionItem value="a">
+              <AccordionTrigger>First</AccordionTrigger>
+              <AccordionContent>First content</AccordionContent>
+            </AccordionItem>
+          </Accordion>
+          <Accordion type="single" collapsible>
+            <AccordionItem value="b">
+              <AccordionTrigger>Second</AccordionTrigger>
+              <AccordionContent>Second content</AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </>,
+      );
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /First/i }));
+      await user.click(screen.getByRole('button', { name: /Second/i }));
+
+      // #then
+      expect(screen.getByText('First content')).toBeInTheDocument();
+      expect(screen.getByText('Second content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/__tests__/popover.test.tsx
+++ b/src/components/ui/__tests__/popover.test.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverClose,
+} from '../popover';
+
+describe('Popover', () => {
+  describe('open / closed state', () => {
+    it('content is absent from the DOM when closed', () => {
+      // #when
+      render(
+        <Popover open={false}>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Popover body</PopoverContent>
+        </Popover>,
+      );
+
+      // #then
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('content is present in the DOM when open', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Popover body</PopoverContent>
+        </Popover>,
+      );
+
+      // #then
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('trigger click opens popover in uncontrolled mode', async () => {
+      // #given
+      const user = userEvent.setup();
+      render(
+        <Popover>
+          <PopoverTrigger>Toggle</PopoverTrigger>
+          <PopoverContent>Popover body</PopoverContent>
+        </Popover>,
+      );
+
+      // #when
+      await user.click(screen.getByRole('button', { name: /Toggle/i }));
+
+      // #then
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('onOpenChange(false) fires when Escape is pressed', async () => {
+      // #given
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Popover open={true} onOpenChange={onOpenChange}>
+          <PopoverContent>
+            <button>Inside</button>
+          </PopoverContent>
+        </Popover>,
+      );
+      screen.getByRole('button', { name: /Inside/i }).focus();
+
+      // #when
+      await user.keyboard('{Escape}');
+
+      // #then
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('portal rendering', () => {
+    it('content is portaled to document.body, not inside the render container', () => {
+      // #given / #when
+      const { container } = render(
+        <Popover open={true}>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Portal content</PopoverContent>
+        </Popover>,
+      );
+
+      // #then
+      const dialog = screen.getByRole('dialog');
+      expect(container).not.toContainElement(dialog);
+      expect(document.body).toContainElement(dialog);
+    });
+  });
+
+  describe('z-index', () => {
+    it('content has z-index 1500 (theme.zIndex.popover, above dialogs at 1405)', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+
+      // #then
+      expect(screen.getByRole('dialog')).toHaveStyle({ zIndex: 1500 });
+    });
+  });
+
+  describe('neutral palette classes', () => {
+    it('content has bg-popover, text-popover-foreground, and border classes', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+      const dialog = screen.getByRole('dialog');
+
+      // #then
+      expect(dialog.className).toContain('bg-popover');
+      expect(dialog.className).toContain('text-popover-foreground');
+      expect(dialog.className).toContain('border');
+    });
+  });
+
+  describe('animation classes', () => {
+    it('content className includes animate-in and animate-out data-state variants', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+      const dialog = screen.getByRole('dialog');
+
+      // #then
+      expect(dialog.className).toContain('data-[state=open]:animate-in');
+      expect(dialog.className).toContain('data-[state=closed]:animate-out');
+    });
+
+    it('content className includes motion-reduce animation overrides', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+      const dialog = screen.getByRole('dialog');
+
+      // #then
+      expect(dialog.className).toContain('motion-reduce:data-[state=open]:animate-none');
+      expect(dialog.className).toContain('motion-reduce:data-[state=closed]:animate-none');
+    });
+  });
+
+  describe('default positioning props', () => {
+    it('content has data-side="bottom" and data-align="center" by default', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+      const dialog = screen.getByRole('dialog');
+
+      // #then
+      expect(dialog).toHaveAttribute('data-side', 'bottom');
+      expect(dialog).toHaveAttribute('data-align', 'center');
+    });
+  });
+
+  describe('PopoverClose', () => {
+    it('PopoverClose inside content invokes onOpenChange(false) when clicked', async () => {
+      // #given
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Popover open={true} onOpenChange={onOpenChange}>
+          <PopoverContent>
+            <PopoverClose data-testid="close-btn">Close</PopoverClose>
+          </PopoverContent>
+        </Popover>,
+      );
+
+      // #when
+      await user.click(screen.getByTestId('close-btn'));
+
+      // #then
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('PopoverAnchor', () => {
+    it('renders an anchor element as positioning reference alongside open content', () => {
+      // #when
+      render(
+        <Popover open={true}>
+          <PopoverAnchor asChild>
+            <div data-testid="anchor-div">anchor</div>
+          </PopoverAnchor>
+          <PopoverContent>Content</PopoverContent>
+        </Popover>,
+      );
+
+      // #then
+      expect(screen.getByTestId('anchor-div')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/__tests__/switch.test.tsx
+++ b/src/components/ui/__tests__/switch.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+import { Switch } from '../switch';
+
+describe('Switch', () => {
+  describe('a11y', () => {
+    it('renders a role="switch" element', () => {
+      // #when
+      render(<Switch aria-label="Toggle feature" />);
+
+      // #then
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+    });
+
+    it('aria-checked is false when unchecked', () => {
+      // #when
+      render(<Switch aria-label="Toggle" checked={false} onCheckedChange={vi.fn()} />);
+
+      // #then
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('aria-checked is true when checked', () => {
+      // #when
+      render(<Switch aria-label="Toggle" checked={true} onCheckedChange={vi.fn()} />);
+
+      // #then
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('aria-label resolves via getByLabelText', () => {
+      // #when
+      render(<Switch aria-label="Enable notifications" />);
+
+      // #then
+      expect(screen.getByLabelText('Enable notifications')).toBeInTheDocument();
+    });
+
+    it('disabled prop marks the button as disabled', () => {
+      // #when
+      render(<Switch aria-label="Toggle" disabled />);
+
+      // #then
+      expect(screen.getByRole('switch')).toBeDisabled();
+    });
+  });
+
+  describe('callbacks', () => {
+    it('onCheckedChange fires with the new boolean value on click', async () => {
+      // #given
+      const onCheckedChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Switch aria-label="Toggle" onCheckedChange={onCheckedChange} />);
+
+      // #when
+      await user.click(screen.getByRole('switch'));
+
+      // #then
+      expect(onCheckedChange).toHaveBeenCalledOnce();
+      expect(onCheckedChange).toHaveBeenCalledWith(true);
+    });
+
+    it('disabled switch does not invoke onCheckedChange on click', async () => {
+      // #given
+      const onCheckedChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Switch aria-label="Toggle" disabled onCheckedChange={onCheckedChange} />);
+
+      // #when
+      await user.click(screen.getByRole('switch'));
+
+      // #then
+      expect(onCheckedChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('variant="accent" (default)', () => {
+    it('track className contains accent-color checked-state class', () => {
+      // #when
+      render(<Switch aria-label="Toggle" checked onCheckedChange={vi.fn()} />);
+
+      // #then
+      expect(screen.getByRole('switch').className).toContain(
+        'data-[state=checked]:bg-[var(--accent-color)]',
+      );
+    });
+
+    it('track className contains bg-input/40 unchecked-state class', () => {
+      // #when
+      render(<Switch aria-label="Toggle" checked={false} onCheckedChange={vi.fn()} />);
+
+      // #then
+      expect(screen.getByRole('switch').className).toContain(
+        'data-[state=unchecked]:bg-input/40',
+      );
+    });
+  });
+
+  describe('variant="neutral"', () => {
+    it('track className contains bg-primary checked-state class', () => {
+      // #when
+      render(<Switch aria-label="Toggle" variant="neutral" checked onCheckedChange={vi.fn()} />);
+
+      // #then
+      expect(screen.getByRole('switch').className).toContain('data-[state=checked]:bg-primary');
+    });
+
+    it('track className contains bg-input unchecked-state class', () => {
+      // #when
+      render(
+        <Switch aria-label="Toggle" variant="neutral" checked={false} onCheckedChange={vi.fn()} />,
+      );
+
+      // #then
+      expect(screen.getByRole('switch').className).toContain('data-[state=unchecked]:bg-input');
+    });
+  });
+
+  describe('state-aware thumb colors', () => {
+    it('thumb className contains bg-background for the checked state', () => {
+      // #given
+      render(<Switch aria-label="Toggle" checked onCheckedChange={vi.fn()} />);
+      const thumb = screen.getByRole('switch').querySelector('span');
+
+      // #then
+      expect(thumb?.className).toContain('data-[state=checked]:bg-background');
+    });
+
+    it('thumb className contains bg-foreground for the unchecked state', () => {
+      // #given
+      render(<Switch aria-label="Toggle" checked={false} onCheckedChange={vi.fn()} />);
+      const thumb = screen.getByRole('switch').querySelector('span');
+
+      // #then
+      expect(thumb?.className).toContain('data-[state=unchecked]:bg-foreground');
+    });
+  });
+
+  describe('style escape hatches', () => {
+    it('trackStyle applies as inline style on the root button', () => {
+      // #when
+      render(<Switch aria-label="Toggle" trackStyle={{ background: 'red' }} />);
+
+      // #then
+      expect(screen.getByRole('switch')).toHaveStyle({ background: 'red' });
+    });
+
+    it('thumbStyle applies as inline style on the thumb span', () => {
+      // #when
+      render(<Switch aria-label="Toggle" thumbStyle={{ border: '2px solid blue' }} />);
+      const thumb = screen.getByRole('switch').querySelector('span');
+
+      // #then
+      expect(thumb).toHaveStyle({ border: '2px solid blue' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wave-2 primitive coverage — unit tests for `Switch`, `Accordion`, and `Popover`. Companion to epic #1245 (the implementation PRs landed earlier — #1248-#1252).

Tests live in `src/components/ui/__tests__/` (colocated with primitives) and use BDD `// #given / #when / #then` per CLAUDE.md.

Adds `@testing-library/user-event@14.6.1` to devDependencies for keyboard/pointer interaction tests.

## Coverage

- `switch.test.tsx` — variants (accent / neutral), state-aware thumb, ARIA (role=switch, aria-checked, aria-label), disabled, callback semantics, escape-hatch props
- `accordion.test.tsx` — independent state across sibling Roots, type=single collapsible, content unmount on close (Radix-correct), chevron rotation, motion-reduce variants
- `popover.test.tsx` — controlled mode, portal, z-index 1500 inline, neutral palette, dismiss callbacks, anchor-based positioning

## Test plan

- [x] `npm run test:run` exits 0 with new tests passing