### PR TITLE
docs: split CLAUDE.md into focused architecture references

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,22 @@
+# Multi-Agent Team Workflows
+
+For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester) defined in `.claude/agents/*.md`. Spawn it on demand and run retros against it.
+
+## Skills
+
+- **`/spawn-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-crew/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
+- **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
+
+## Agent definitions
+
+`.claude/agents/*.md` files specify each role's tools, role description, and operating rules. Notable conventions:
+
+- **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
+- **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
+- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-team` skill handles this automatically.
+- **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
+
+## When to use
+
+- **`/spawn-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains). The default team name is `vorbis-crew`.
+- **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,26 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 
 Key capabilities: multi-provider auth/catalog/playback adapters, unified liked songs, cross-provider playback handoff, Last.fm-powered radio queue generation, background visualizers, album art flip menu, bottom bar, swipe gestures (queue drawer / full-screen library), keyboard shortcuts, IndexedDB caching, responsive layout.
 
+## Architecture docs
+
+Deep-dive references — load on demand:
+
+| Topic | Doc |
+|---|---|
+| Layout, idle routing, hydrate flow, zen mode, visualizers, responsive sizing | `docs/architecture/layout.md` |
+| Multi-provider model, toggle behavior, radio, Spotify/Dropbox internals | `docs/architecture/providers.md` |
+| Playback flow + queue mutation flow | `docs/architecture/playback.md` |
+| shadcn/ui integration, theme bridge, canonical patterns, z-index | `docs/architecture/shadcn.md` |
+
+User-facing docs live in `docs/features/` and `docs/providers/`. Troubleshooting (provider issues, layout pitfalls, debug logging) is in `docs/troubleshooting.md`.
+
 ## Build Verification
 
-Always verify the build compiles cleanly after removing dependencies, refactoring imports, or making multi-file changes:
+Verify the build compiles cleanly after removing dependencies, refactoring imports, or making multi-file changes:
 
 ```bash
 npx tsc -b --noEmit       # TypeScript check
-npm run build          # Full build
+npm run build             # Full build
 ```
 
 Check for dangling references in `vite.config.ts`, `tsconfig.json`, etc.
@@ -27,7 +40,7 @@ Make the minimal change first, confirm it works visually, then iterate. Do not c
 
 ## Git & PR Workflow
 
-Run `npm test` before `git push` and before creating any PR.
+Run `npm test` before `git push` and before creating any PR. Feature branches from main (`feature/name`, `fix/name`). Atomic commits with conventional format. Reference issue numbers.
 
 ## Worktree Setup
 
@@ -53,315 +66,49 @@ npm run deploy         # Deploy to production
 npm run deploy:preview # Deploy preview
 ```
 
-## Architecture
+## Source Layout
 
-### Queue vs playlist (terminology)
+```
+src/
+├── components/      # React components; key subdirs: ui/ (shadcn primitives), PlayerContent/, BottomBar/, PlaylistSelection/, QuickAccessPanel/, AppSettingsMenu/, controls/, visualizers/
+├── contexts/        # React context providers (TrackContext, ColorContext, etc.)
+├── providers/       # Multi-provider system; spotify/ and dropbox/ subdirs
+├── hooks/           # Custom hooks
+├── services/        # spotify.ts (auth + API), spotifyPlayer.ts (lazy SDK + playback), cache/ (IndexedDB)
+├── constants/       # playlist.ts, zenAnimation.ts, storage.ts
+├── utils/           # colorExtractor, sizingUtils, playlistFilters, etc.
+├── workers/         # imageProcessor.worker.ts
+├── types/           # domain.ts, providers.ts, filters.ts
+├── styles/          # theme.ts, ThemeProvider, shadcn-tokens.css, global styles
+└── lib/utils.ts
+```
+
+## Terminology
 
 - **Queue** — tracks scheduled to play next (reorder/remove in `QueueDrawer` / `QueueBottomSheet`; list UI in `QueueTrackList.tsx`).
 - **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `PlaylistSelection` and loaded through `usePlaylistManager` / catalog APIs.
 
-### Source Layout
-
-```
-src/
-├── components/      # React components (~34 files); key subdirs: BottomBar/, controls/, DevBug/, icons/, LibraryDrawer/, PlayerContent/, PlaylistSelection/, QuickAccessPanel/, styled/, VisualEffectsMenu/, VisualizerDebugPanel/, visualizers/
-├── constants/       # playlist.ts, zenAnimation.ts, storage.ts
-├── providers/       # Multi-provider system; spotify/ and dropbox/ subdirs
-├── hooks/           # 31 custom hooks
-├── services/        # spotify.ts (auth + API), spotifyPlayer.ts (lazy SDK loading + playback), cache/ (IndexedDB)
-├── utils/           # colorExtractor, colorUtils, sizingUtils, playlistFilters, etc.
-├── workers/         # imageProcessor.worker.ts
-├── types/           # domain.ts, providers.ts, filters.ts
-├── styles/          # theme.ts, ThemeProvider, CSS modules, global styles
-└── lib/utils.ts
-```
-
-### Layout Architecture (Critical)
-
-The centering system is a flex chain:
-
-```
-AppContainer (flexCenter, min-height: 100dvh)
-  → AudioPlayer (flexCenter, min-height: 100dvh)
-    → ContentWrapper (position: relative, z-index: 2, overflow: visible)
-      → PlayerContainer (flex column, centered)
-```
-
-- **`ContentWrapper` must use `position: relative`** — not absolute — so parent flex containers can center it
-- **`overflow: visible` is required on ContentWrapper** — `container-type: inline-size` creates containment that clips absolutely-positioned children
-- **`100dvh`** throughout to handle iOS address bar changes
-- **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom
-- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle the **queue** (up) drawer (`QueueDrawer` / `QueueBottomSheet`)
-- **Queue Suspense fallback** — the queue drawers (`QueueDrawer`, `QueueBottomSheet`) render `QueueSkeleton` (`src/components/QueueSkeleton.tsx`) as their Suspense fallback — a row-shaped placeholder with a transform-based shimmer that respects `prefers-reduced-motion`. The lazy bundles are prefetched on first playback via `useQueueBundlePrefetch` (`src/hooks/useQueueBundlePrefetch.ts`), scheduled inside `requestIdleCallback` (with `setTimeout` fallback) once per session.
-- **Full-screen library** — the library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered in `AudioPlayer.tsx` via `React.lazy` when `showLibrary` is true.
-- **Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
-- **Filter state** for the library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`). Opening the library from the QAP "Browse Library" button clears these keys before navigating.
-- **Recently Played history** is tracked by `useRecentlyPlayedCollections` (`src/hooks/useRecentlyPlayedCollections.ts`). It exposes `history: RecentlyPlayedEntry[]` and `record(ref, name)`. Successful collection loads via `useCollectionLoader.loadCollection` call `record` automatically. History is stored under `vorbis-player-recently-played` (localStorage), capped at 5 entries, deduped by `CollectionRef` key, newest first. `FilterSidebar` renders a "Recently Played" section with up to 5 clickable shortcuts on desktop; the section is hidden when history is empty.
-- **Mobile library overlay** renders `MobileLibraryBottomBar` (full-width search input + trailing sort dropdown) instead of the provider chip row. Mobile intentionally bypasses `providerFilters` — `ignoreProviderFilters = isMobile` in `useLibraryRoot.ts` ensures items from every enabled provider are always shown. Desktop behavior is unchanged: `FilterSidebar` provides provider chips, sort, genre, and recently-played controls.
-- **Idle/home routing** — when no track is loaded, `PlayerStateRenderer` (`src/components/PlayerStateRenderer.tsx`) picks a landing view via `resolveIdleRoute(welcomeSeen, qapEnabled, hasValidSession)`:
-
-  | Condition | Landing view |
-  |---|---|
-  | `welcomeSeen === false` | `WelcomeScreen` (supersedes all other inputs) |
-  | valid `lastSession` + `qapEnabled` | `QuickAccessPanel` (with Resume hero) |
-  | valid `lastSession` + `!qapEnabled` | player hydrated via `handleHydrate` (paused) |
-  | no/stale session + `qapEnabled` | `QuickAccessPanel` |
-  | no/stale session + `!qapEnabled` | `LibraryPage` |
-
-  QAP is opt-in via the "Quick Access Panel" On/Off control in `VisualEffectsMenu`; preference persists under `vorbis-player-qap-enabled` (default `false`) via `useQapEnabled()`. Clicking "Browse Library" from QAP or Welcome flips a local `libraryOverride` flag — once engaged, the idle view stays on `LibraryPage` for the rest of the session (one-way door).
-- **Welcome screen** — `WelcomeScreen` (`src/components/WelcomeScreen/index.tsx`) shows once for new users with a per-provider status summary and context-aware primary CTA (*Connect a provider* when `connectedProviderIds.length === 0`, *Browse your library* otherwise). The dismiss-for-good flag persists via `useWelcomeSeen` (`src/hooks/useWelcomeSeen.ts`) under the `vorbis-player-welcome-seen` localStorage key (default `false`).
-- **Stale session cutoff** — `isSessionStale(session, now?)` from `src/services/sessionPersistence.ts` returns true when the session is absent, missing `savedAt`, or older than `STALE_SESSION_MS` (30 days). Stale sessions are treated as no session for landing routing and resume affordances.
-- **Hydrate without autoplay** — `handleHydrate(session): Promise<HydrateResult>` in `usePlayerLogic` (`src/hooks/usePlayerLogic.ts`) restores `tracks` / `originalTracks` / `mediaTracksRef` / `currentTrackIndex` / `selectedPlaylistId`, sets the seek bar to `savedPositionMs`, and calls `prepareTrack(track, { positionMs })` on the driving provider — but does NOT call `play()`. A `hydratedPendingPlayRef = { index, positionMs }` records the target so the next user-initiated `handlePlay` starts from the saved offset. Any call into `playTrack` (next/previous/new collection) clears the ref.
-  - `HydrateResult` shape: `{ track: MediaTrack | null, skipped: boolean, totalFailure: boolean }`.
-  - **prepareTrack is emit-only** — both adapters emit a `PlaybackState` event with `positionMs` + `durationMs` so the seek bar reflects the saved position before any user action. No audio actually starts.
-    - Spotify (`stageTrackPaused`): calls `ensurePlaybackReady` which transfers Spotify Connect to this device with `play: false`. Does NOT call `/me/player/play` — that API starts audio and Spotify's eventual consistency makes a subsequent `pause()` race against the just-started playback, leaking audio on fresh tabs.
-    - Dropbox: sets `audio.src` to the stream URL and seeks to `positionMs`. Does NOT call `audio.play()`.
-  - **probePlayable iterator** — before calling `prepareTrack`, `handleHydrate` optionally calls `descriptor.playback.probePlayable(track): Promise<boolean>` (defined on `PlaybackProvider` in `src/types/providers.ts`). Returns `false` for known-unplayable tracks (Spotify market-restricted / 404, Dropbox file moved); throws `AuthExpiredError` for transient auth failures. If `probePlayable` returns false or throws, the iterator skips to the next track in the queue. The iterator is bounded by `queueTracks.length` to prevent infinite loops.
-  - **Partial-skip toast** — when `skipped === true` (saved track was unplayable, a later track was used): `"Couldn't resume previous track — starting from next in queue."`.
-  - **Total-failure path** — when no track in the queue could be prepared: `handleHydrate` calls `handleBackToLibrary` and returns `totalFailure: true`. `AudioPlayer.handleHydrateFailed` then calls `useSessionPersistence.resetLastSession()` (clears both localStorage AND the cached React `lastSession` state) and surfaces `"Couldn't resume your last session."`. `PlayerStateRenderer` on `totalFailure` flips `libraryOverride = true` so the user routes to the library immediately.
-  - **Resume toast** — `ResumeToast` surfaces on normal hydrate with `"Resuming '<Track>' — press play to continue."`. Auto-dismisses on next/previous/open-library/open-queue.
-  - `PlayerStateRenderer` routes to the hydrate loading card; on mount fires `onHydrate(session)` exactly once via `hydrateFiredRef`.
-  - Distinct from `handleResume` (in `AudioPlayer.tsx`), which autoplays from the saved position.
-- **Resume hero** — `ResumeHero` (`src/components/QuickAccessPanel/ResumeHero.tsx`) renders at the top of `QuickAccessPanel` (above `PinRing`) when a valid `lastSession` is present; clicking the Resume CTA invokes `onResume` (autoplay). The footer `ResumeCard` is suppressed inside QAP to avoid duplicate affordances; it still renders as the `footer` prop of `LibraryPage` on the idle library route.
-- **Settings gear on idle views** — `SettingsGearButton` (`src/components/SettingsGearButton/index.tsx`) is mounted top-right by `PlayerStateRenderer` on `WelcomeScreen`, idle `LibraryPage`, and `QuickAccessPanel` via the `onOpenSettings` prop, opening the existing `VisualEffectsMenu`. Hidden during loading and error states. The active-player gear continues to live in `BottomBar` / `PlayerControlsSection`.
-- **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout
-- **Zen mode overlays** (`ZenClickZoneOverlay`, `ZenLikeOverlay`): hover-activated on desktop (pointer devices only), hidden when flip menu is open (`isFlipped`), with vertical dead zones (top/bottom 20% of album art ignored). Mobile zen uses touch gestures instead (`useZenTouchGestures`). BottomBar in zen mode shows via grip pill tap with tap-outside-to-dismiss backdrop.
-- **Zen mode entry/exit orchestration** — timing constants live in `src/constants/zenAnimation.ts`; CSS transitions in `PlayerContent/styled.ts` (`ContentWrapper`, `PlayerStack`, `ZenControlsWrapper`) and `BottomBar/styled.ts`. Entry and exit sequences are asymmetric on purpose:
-  - **Entry** (normal → zen): controls fade in place over `ZEN_CONTROLS_DURATION`; after `ZEN_ART_ENTER_DELAY` the art grows (`PlayerStack.max-width`) in parallel with the controls row collapsing (`grid-template-rows 1fr → 0fr`) over `ZEN_ART_DURATION`.
-  - **Exit** (zen → normal): art shrink, `ContentWrapper.margin-bottom` growth, `CardContent.transform` shift, and controls row expansion (`grid-template-rows 0fr → 1fr`) all animate in parallel over `ZEN_ART_DURATION`. Opacity/transform on the controls and the `BottomBar` slide-up are delayed by `ZEN_EXIT_REENTRY_DELAY` (= `ZEN_ART_DURATION`) so they appear after the art has settled.
-  - **`--player-controls-height` freeze during transitions** — `PlayerContent` holds a `zenTransitioningRef` that gates the `ResizeObserver` on the controls element. Without this, the row expanding `0 → 220px` on exit would push the CSS variable through every intermediate frame, moving `PlayerStack.max-width`'s target mid-transition and causing the art to chase it. The ref is raised in `handleZenModeToggle`, cleared via `setTimeout` after `ZEN_ART_DURATION + ZEN_ART_ENTER_DELAY + 50ms`.
-  - `prefers-reduced-motion: reduce` short-circuits transitions on `PlayerStack`, `ZenControlsWrapper`, and `BottomBarContainer`. Per-element transition rationale is inlined in `PlayerContent/styled.ts` and `BottomBar/styled.ts`.
-
-### Multi-Provider Architecture
-
-#### Provider Model
-
-Defined in `src/types/providers.ts` and `src/types/domain.ts`.
-
-**Provider interfaces**: `AuthProvider`, `CatalogProvider`, `PlaybackProvider`
-**Registration**: `src/providers/registry.ts` — singleton `providerRegistry`; providers self-register on import
-**Dropbox** only registers when `VITE_DROPBOX_CLIENT_ID` is set
-
-**Domain types** (`src/types/domain.ts`):
-- `MediaTrack` — provider-agnostic track with `playbackRef`
-- `MediaCollection` — provider-agnostic collection (playlist or album)
-- `CollectionRef` — `{ provider, kind, id }`; serialized via `collectionRefToKey` / `keyToCollectionRef`
-
-**Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`). Both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection`.
-
-**Provider toggle (Music Sources section in settings)**:
-- Each provider row has a single on/off toggle — there is no separate Reconnect button.
-- `enabledProviderIds` — localStorage-persisted set of providers the user has opted into.
-- `connectedProviderIds` — derived set: `enabledProviderIds` ∩ authenticated providers. Used by cross-provider features (Unified Liked Songs, radio resolver).
-- Toggle-OFF: opens `ProviderDisconnectDialog` showing the provider name and count of queued tracks that will be removed. Confirming calls `logout()`, removes the provider from `enabledProviderIds`, and cleans up queue/playback state. The last enabled provider's toggle is disabled to prevent a zero-provider state.
-- Toggle-ON when already authenticated: silently adds to `enabledProviderIds`.
-- Toggle-ON when not authenticated: calls `beginLogin({ popup: true })` immediately. The provider is added to `enabledProviderIds` only after the OAuth popup reports success via `AUTH_COMPLETE_EVENT`.
-- OAuth cancel/failure: toggle reverts; a toast shows `"Couldn't connect to {provider}. Try again."`.
-- Mid-session unrecoverable 401: `logout()` is called automatically; a toast shows `"{Provider} disconnected — session expired."`.
-- Implementation: `src/components/VisualEffectsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
-
-**Unified playback across providers**:
-- Queue items are represented as provider-agnostic `MediaTrack` records and can mix Spotify + Dropbox tracks in one queue.
-- Provider model:
-  - **Active provider** = selected provider context for browsing/catalog actions.
-  - **Driving provider** = provider currently controlling audio output.
-  - These can differ in mixed queues (Unified Liked Songs, radio, cross-provider handoff).
-- Playback controls (`play`, `pause`, `next`, `previous`) route via the **driving provider**, not just the active provider.
-- Provider state subscriptions are multiplexed and filtered by the **driving provider** so visualizer/play state stays in sync.
-- Routing structure:
-  - `useProviderPlayback` resolves provider per index (`track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback).
-  - `usePlayerLogic` owns control actions and playback-state synchronization using `getDrivingProviderId()`.
-  - `useAutoAdvance` advances based on events from the current driving provider.
-- Unified liked songs can merge liked tracks from all connected providers (`connectedProviderIds`) and sort by `addedAt`.
-
-**Radio generation**:
-- Radio is a one-shot action (not a sticky toggle) that builds a playlist from the current track.
-- `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
-- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated and Spotify is in `connectedProviderIds`.
-- Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
-- **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
-
-#### Provider Implementation Details
-
-**Dropbox folder structure**:
-```
-Dropbox root/
-└── <Artist>/<Album>/
-    ├── cover.jpg     # also: album.jpg, folder.jpg, front.jpg
-    └── 01 - Track.mp3
-```
-Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended.
-
-**Dropbox "All Music" card**: `useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. `AllMusicCard` (`src/components/PlaylistSelection/AllMusicCard.tsx`) renders the row in the **playlist grid** at the top anchor slot, alongside `LikedSongsCard`. The card uses a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph in both grid and list layouts; subtitle is `"{N} tracks • Shuffled"`. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
-
-**All Music shuffle-by-default**: Loading or appending the All Music aggregate always shuffles, independently of the global `shuffleEnabled` toggle. Detection uses `isAllMusicRef(collectionRef)` from `src/constants/playlist.ts`. `useCollectionLoader.applyTracks` accepts a `forceShuffle` option that ORs with `shuffleEnabled`; `loadCollection` passes `{ forceShuffle: isAllMusicRef(ref) }`. `useQueueManagement.handleAddToQueue` shuffles the fetched tracks with `shuffleArray()` before deduping and appending. The user's `shuffleEnabled` preference is not mutated — it remains whatever they set globally.
-
-**Dropbox Liked Songs**: Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
-
-**Dropbox preferences sync**: Pins (unified playlists/albums) and accent overrides/custom colors are synced to `/.vorbis/preferences.json`. Merge is last-write-wins by `updatedAt`. `dropboxPreferencesSync.ts` provides `initPreferencesSync(auth)`, `getPreferencesSync()`, `initialSync()`, and `schedulePush()` (2s debounce). PinnedItemsContext and ColorContext call `schedulePush()` after local changes; App and provider trigger `initialSync()` after Dropbox OAuth and when already authenticated.
-
-**Token refresh**: Both providers preserve refresh tokens during transient failures and proactively refresh before expiry. Spotify uses a 5-minute buffer; Dropbox uses a 60-second buffer. On 401/400 errors Dropbox performs full logout; on 5xx or network errors it preserves the refresh token for retry.
-
-**Spotify SDK loading**: The Spotify Web Playback SDK is loaded lazily by `SpotifyPlayerService.loadSDK()` — no global script tag in `index.html`. The SDK is only injected when the Spotify provider activates.
-
-**Spotify API batching**: `checkTrackSaved` in `src/services/spotify/tracks.ts` uses microtask-based batching — concurrent calls within the same render cycle are collected and flushed as a single `/me/tracks/contains` request (up to 50 IDs per Spotify API limit), preventing 429 rate limiting.
-
-### Playback Flow
-
-User action to audio output follows this chain:
-
-1. **User triggers play/next/previous** — `usePlayerLogic` dispatches via `handlePlay` / `handleNext` / `handlePrevious`
-2. **Provider resolution** — `useProviderPlayback.playTrack(index)` resolves the provider for the track at that index: `track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback
-3. **Cross-provider handoff** — `pausePreviousProvider()` pauses the old provider if the driving provider changed, then updates `currentPlaybackProviderRef`
-4. **Adapter playback** — calls `descriptor.playback.playTrack(mediaTrack)` on the resolved `PlaybackProvider` (Spotify SDK or HTML5 Audio)
-5. **Next-track pre-warm** — after successful play, `prepareTrack()` is called on the next track's provider
-6. **State subscription** — `usePlaybackSubscription` subscribes to all registered providers, filters events by driving provider, and syncs `isPlaying`, `playbackPosition`, and `currentTrackIndex` back to React state. Uses `expectedTrackIdRef` to ignore stale provider index updates during transitions. Also listens for `visibilitychange` events — when the tab returns to foreground, it clears `expectedTrackIdRef` (stale transition guards) and calls `getState()` on the driving provider to resync track info, album art, and playback position.
-   - **`expectedTrackIdRef` ownership** — `useProviderPlayback.playTrack` is the single owner: it sets `expectedTrackIdRef.current` to the target track's id *before* calling the adapter's `playTrack` (and before the next-track pre-warm's `prepareTrack`). This covers every normal entry point — `handleNext`, `handlePrevious`, fresh `loadCollection` → `playTrack(0)`, and empty-queue append — so callers no longer set the ref themselves. Without this guard a `loadCollection` → `playTrack(0)` path is racey: the pre-warm's emitted `PlaybackState` can flip `currentTrackIndex` before the real play-state arrives, causing album art to mismatch the playing audio. **Exception**: `handleHydrate` in `usePlayerLogic` sets `expectedTrackIdRef.current` directly because the hydrate path calls `descriptor.playback.prepareTrack` (emit-only, no `playTrack` invocation), so the centralised guard in `useProviderPlayback` does not apply.
-7. **Auto-advance** — `useAutoAdvance` subscribes to all providers and detects track end via two signals: `timeRemaining <= endThreshold` (near-end) or `wasPlaying && isPaused && position === 0` (natural end). A 5-second cooldown (`PLAY_COOLDOWN_MS`) prevents false triggers during buffering
-8. **Error recovery** — `UnavailableTrackError` and generic errors trigger auto-skip to the next track when `skipOnError` is true. `AuthExpiredError` surfaces a re-auth prompt
-
-Key files: `usePlayerLogic.ts` → `useProviderPlayback.ts` → `PlaybackProvider` (interface in `types/providers.ts`) → `usePlaybackSubscription.ts` → `useAutoAdvance.ts`
-
-### Queue Mutation Flow
-
-Queue state lives in `TrackContext` (`tracks`, `originalTracks`, `currentTrackIndex`, `shuffleEnabled`) and is mutated through `TrackOperations` (defined in `types/trackOperations.ts`). A parallel `mediaTracksRef` keeps an imperative mirror for index-based playback without waiting for React renders.
-
-**Loading a collection** (`useCollectionLoader.loadCollection`):
-- Resolves the target provider and collection ref
-- Fetches tracks via `catalog.listTracks(collectionRef)`
-- Calls `applyTracks()` which stores `originalTracks`, optionally shuffles, sets `tracks` + `mediaTracksRef`, resets `currentTrackIndex` to 0, then calls `playTrack(0)`
-- Unified Liked Songs path merges tracks from all connected providers sorted by `addedAt`
-
-**Adding to queue** (`useQueueManagement.handleAddToQueue`):
-- If queue is empty, delegates to `loadCollection` (full load + autoplay)
-- Otherwise fetches tracks via `catalog.listTracks` and appends to `tracks`, `originalTracks`, and `mediaTracksRef` without resetting `currentTrackIndex`
-- Deduplicates by track ID before appending — tracks already in the queue are skipped
-
-**Removing from queue** (`handleRemoveFromQueue`):
-- Blocks removal of the currently playing track (`index === currentTrackIndex`)
-- Removes by index from `tracks`, by ID from `originalTracks` and `mediaTracksRef`
-- Decrements `currentTrackIndex` if the removed track was before the current one
-- If only one track remains, calls `handleBackToLibrary` (full reset)
-
-**Reordering** (`handleReorderQueue`):
-- Uses `moveItemInArray` on `tracks`, then syncs `mediaTracksRef` via `reorderMediaTracksToMatchTracks`
-- Recalculates `currentTrackIndex` by finding the playing track's ID in the new order
-- Only updates `originalTracks` when shuffle is off
-
-**Shuffle interaction** (`TrackContext.handleShuffleToggle`):
-- Enable: shuffles `originalTracks` (excluding current track), places current track first, resets index to 0
-- Disable: restores `originalTracks`, finds current track's original index
-- Persisted via `useLocalStorage`
-
-**Queue change notification**: `usePlayerLogic` calls `descriptor.playback.onQueueChanged?(tracks, currentTrackIndex)` whenever `tracks` or `currentTrackIndex` change, allowing providers with native queue sync (Spotify) to stay aligned.
-
-### Background Visualizers
-
-Four animated background styles, selectable via the flip menu's Speed/Style controls. All share a `speed` prop (multiplier from `VisualEffectsContext`) and per-visualizer tuning in `src/constants/visualizerDebugConfig.ts`.
-
-| Style key | Component | Description |
-|-----------|-----------|-------------|
-| `fireflies` | `ParticleVisualizer` | Drifting particles with pulsing opacity |
-| `comet` | `TrailVisualizer` | Ships leaving fading particle trails |
-| `wave` | `WaveVisualizer` | Layered sine waves spread vertically |
-| `grid` | `GridWaveVisualizer` | Dot grid distorted by traveling waves |
-
-Type: `VisualizerStyle` in `src/types/visualizer.ts`. Components in `src/components/visualizers/`.
-
-### Debug logging (optional)
-
-Debug logging uses the [`debug`](https://www.npmjs.com/package/debug) package via `src/lib/debugLog.ts` with namespace `vorbis:*`. See `docs/troubleshooting.md` for usage.
-
-### Responsive Sizing
-
-Breakpoints and exact values are in `src/styles/theme.ts`. Sizing calculations are in `src/utils/sizingUtils.ts` and `src/hooks/usePlayerSizing.ts`.
-
-- Mobile: < 700px, Tablet: 700–1024px, Desktop: ≥ 1024px
-- Uses `usePlayerSizing` hook for viewport-aware dimensions
-
-### Keyboard Shortcuts
-
-Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` media queries (not viewport width) to detect device type.
-
-| Key | Desktop | Touch-only |
-|-----|---------|------------|
-| `Space` | Play/Pause | Play/Pause |
-| `←` / `→` | Prev/Next track | Prev/Next track |
-| `↑` / `Q` | Toggle queue | Volume up (↑ only) |
-| `↓` / `L` | Toggle library | Volume down (↓ only) |
-| `V` / `G` / `S` / `T` | Visualizer / Glow / Shuffle / Translucence | same |
-| `Z` | Toggle zen mode | same |
-| `O` / `K` / `M` | Effects menu / Like / Mute | same |
-| `?` / `/` | Keyboard help | same |
-| `Escape` | Close all menus | same |
-
-`Q` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.
-
-### shadcn/ui integration
-
-vorbis-player uses a hybrid styling stack: **styled-components for bespoke surfaces, shadcn/ui (Radix primitives + Tailwind) for chrome**. Both coexist permanently — there is no migration goal to remove styled-components.
-
-**Stack coexistence rule** — pick by surface type:
-
-| Surface type | Stack | Examples |
-|---|---|---|
-| Visualizers, animations, gestures | styled-components (forever) | `BackgroundVisualizer`, zen-mode orchestration in `PlayerContent/styled.ts`, swipe gestures, album-art flip menu, `BottomBar` |
-| Standard chrome (modals, sliders, popovers, switches, toasts) | shadcn primitives | `src/components/ui/*.tsx`, currently `dialog.tsx`, `button.tsx` |
-| Whole-screen redesigns | shadcn, gated behind `?ui=v2` | future `SettingsV2`, `OnboardingV2`, command palette |
-
-**Theme bridge — `--accent-color` is player chrome ONLY:**
-
-The runtime `--accent-color` / `--accent-contrast-color` (injected on `document.documentElement` by `ColorContext.tsx:83-87`) belong exclusively to player chrome that intentionally retints with the playing track:
-
-- `BottomBar` (background tint, control hover states)
-- `LikeButton` (filled state)
-- `TimelineSlider` (fill + thumb gradient)
-- Glow effects (`--glow-intensity`, `--glow-rate`, `--glow-opacity`)
-- Accent color overrides menu in `VisualEffectsMenu`
-
-**shadcn primitives use the neutral palette** defined in `src/styles/shadcn-tokens.css` (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, etc.). shadcn's `--accent` token is a static neutral surface and is **not** the same as the player's `--accent-color`. Never wire shadcn's `--primary` or `--accent` to `var(--accent-color)` — dialogs, popovers, and other chrome must stay neutral so they don't retint per track.
-
-**`?ui=v2` flag mechanism:**
-
-The `useUiV2()` hook (`src/hooks/useUiV2.ts`) returns `true` when EITHER:
-- `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in for staging deploys), OR
-- the URL contains `?ui=v2` (per-session opt-in for testing).
-
-It subscribes to `popstate` so SPA navigation flips the flag without a reload. SSR-safe.
-
-Convention for flagged screens:
-- Components consuming the flag render the **legacy** path by default.
-- The v2 branch lives under `if (uiV2) { … }`.
-- Future redesign components are colocated next to the legacy file as `<ScreenName>V2.tsx` (e.g. `Settings.tsx` + `SettingsV2.tsx`). The parent component picks one or the other via `useUiV2()`.
-
-**Migration scope (current):**
-- `Dialog` cluster (`ProviderDisconnectDialog`, `ConfirmDeleteDialog`, `SaveQueueDialog`, `KeyboardShortcutsHelp`) → shadcn `Dialog` (landed unflagged — behavior parity).
-- `TimelineSlider` → wrapper around shadcn / Radix `Slider` (in flight; survives as a wrapper because the accent fill/thumb gradient is bespoke).
-
-**Out of scope for the foundation epic:** `Popover`, `Switch`, `Toast`, `Filter sidebar`, `Settings v2`, `Cmd-K`, `Onboarding v2`. Each is a separate future epic.
-
-**z-index for shadcn modals:** shadcn defaults to `z-50`. The player's `BottomBar` uses up to `theme.zIndex.modal` = 1400. `src/components/ui/dialog.tsx` overrides the overlay + content `z-index` to `1405` so dialogs always cover the BottomBar.
-
 ## Tech Stack
 
-See README.md for the full tech stack.
-
-Build: ES2020, esbuild, manual chunks (vendor/radix/styled)
+See README.md for the full tech stack. Build: ES2020, esbuild, manual chunks (vendor/radix/styled).
 
 ## Environment Configuration
 
 Required in `.env.local`:
+
 ```
 VITE_SPOTIFY_CLIENT_ID="your_spotify_client_id"
 VITE_SPOTIFY_REDIRECT_URI="http://127.0.0.1:3000/auth/spotify/callback"
 ```
 
 Optional (enables Dropbox):
+
 ```
 VITE_DROPBOX_CLIENT_ID="your_dropbox_app_key"
 ```
 
 Optional (enables radio recommendations):
+
 ```
 VITE_LASTFM_API_KEY="your_lastfm_api_key"
 ```
@@ -378,52 +125,17 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 - `useLocalStorage` hook for persistence with `'vorbis-player-'` key prefix
 - Strict TypeScript; `import type` when possible; types in `src/types/`
 
-## Common Issues & Solutions
+## Testing
 
-**Layout:**
-- Player not centered → `ContentWrapper` must use `position: relative`
-- Elements clipped → ensure `overflow: visible` on `ContentWrapper`
-- Mobile viewport bouncing → use `100dvh` not `100vh`
+Run with `npm run test:run`. Tests are colocated with source files in `__tests__/` subdirectories. Verify actual behavior, not mock implementations. See `docs/testing.md` for test utilities (`src/test/`) and the BDD `// #given / #when / #then` comment convention.
 
-For provider-specific issues (Spotify, Dropbox, Radio), see `docs/troubleshooting.md`.
+## Keyboard Shortcuts
 
-## Testing Guidelines
+See `docs/keyboard.md` for the full table. Centralized in `useKeyboardShortcuts.ts`.
 
-Run with `npm run test:run`. Tests are colocated with source files in `__tests__/` subdirectories.
+## Common Issues
 
-- Verify actual behavior, not mock implementations
-- Every test should have meaningful assertions
-
-### Test Utilities (`src/test/`)
-
-| File | Purpose |
-|------|---------|
-| `setup.ts` | Global test setup: mocks `localStorage`, `sessionStorage`, `window.location`, `history`, `fetch`, `crypto` (for PKCE), `btoa`/`atob`; imports `fake-indexeddb/auto` and `@testing-library/jest-dom`; clears all mocks in `afterEach` |
-| `fixtures.ts` | Factory functions for domain objects: `makeTrack()`, `makeMediaTrack()`, `makePlaylistInfo()`, `makeAlbumInfo()`, `makeProviderDescriptor()` — all accept partial overrides |
-| `testWrappers.tsx` | `TestWrapper` component that nests all app context providers (`ProviderProvider`, `PlayerSizingProvider`, `TrackProvider`, `ColorProvider`, `VisualEffectsProvider`, `PinnedItemsProvider`) for component/hook tests |
-| `providerTestUtils.tsx` | `ProviderWrapper` — lighter wrapper with only `ProviderProvider`, for hooks that only need provider context |
-
-### BDD Comment Convention
-
-Tests use `// #given`, `// #when`, `// #then` comments to mark the Arrange-Act-Assert phases:
-
-```ts
-it('loads volume from localStorage on init', () => {
-  // #given
-  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
-    if (key === 'vorbis-player-volume') return '75';
-    return null;
-  });
-
-  // #when
-  const { result } = renderHook(() => useVolume(), { wrapper: ProviderWrapper });
-
-  // #then
-  expect(result.current.volume).toBe(75);
-});
-```
-
-Use this pattern in all new tests. The `#given` section is optional when there is no setup beyond what `beforeEach` provides.
+See `docs/troubleshooting.md` for layout, provider, and radio issues. Layout invariants are documented in `docs/architecture/layout.md`.
 
 ## Command Instructions
 
@@ -431,36 +143,14 @@ Use this pattern in all new tests. The `#given` section is optional when there i
 - `/doc` — Update README.md
 - `/comdoc` — Update README.md then commit
 
-**Documentation updates**: Update this file when adding new architectural patterns or conventions.
-
-**Git workflow**: Feature branches from main (`feature/name`, `fix/name`). Atomic commits with conventional format. Reference issue numbers.
-
 ## AI Workflow Rules
 
 For structured feature development, see `.claude/rules/`:
+
 - `generate_prd.md` — PRD creation process: asks clarifying questions, then generates a structured requirements doc
 - `generate_tasks_from_prd.md` — breaks a PRD into a detailed parent/subtask list; waits for "Go" confirmation before generating subtasks
 - `process_tasks.md` — task execution protocol: one subtask at a time, with test + commit gates before marking parent complete
 
 ## Multi-Agent Team Workflows
 
-For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester) defined in `.claude/agents/*.md`. Spawn it on demand and run retros against it.
-
-### Skills
-
-- **`/spawn-team`** — bootstraps the six-role team via `TeamCreate` + parallel `Agent` calls. Idempotent: checks `~/.claude/teams/vorbis-crew/config.json` first; only spawns missing members. Uses project-local `subagent_type` names (`architect`, `reviewer`, etc.) so spawned agents inherit the `.claude/agents/*.md` tool allowlists.
-- **`/agent-team-retro`** — structured retrospective on a multi-agent team session. Polls every teammate via `SendMessage`, aggregates into action items, presents via `AskUserQuestion`, and applies approved edits directly to the agent definition files. Cataloging as a GitHub epic via `speckit:catalog` is opt-in.
-
-### Agent definitions
-
-`.claude/agents/*.md` files specify each role's tools, role description, and operating rules. Notable conventions:
-
-- **Universal exit-gate rule** (every agent file): before yielding a turn, audit deliverables; route via `SendMessage` or the turn is incomplete. Plain-text output is invisible to the lead.
-- **Tool allowlists explicitly include `SendMessage`, `TaskGet`, `TaskList`, `TaskUpdate`** — required for team participation. The architect and reviewer files restore these because the upstream `feature-dev:code-architect` and `feature-dev:code-reviewer` subagent types omit `SendMessage`, which structurally breaks team communication.
-- **Spawn via project-local `subagent_type`**, not upstream `feature-dev:*` types, so the agent inherits the local definition. The `spawn-team` skill handles this automatically.
-- **Role-specific guardrails** (interface-contract-first for builder, `npm run test:run` exit-0 completion bar for tester, scope-clarification-up-front for explorer, `TaskList`-before-redirect for lead) — see each `.md` file for the full set.
-
-### When to use
-
-- **`/spawn-team`** at the start of a multi-issue epic when parallel specialist work would help (typically 3+ child issues with distinct domains). The default team name is `vorbis-crew`.
-- **`/agent-team-retro`** at the end of a substantive team session, especially before tearing down via `TeamDelete`. Captures lessons before context is lost and iterates the agent definitions.
+For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester). See `.claude/agents/README.md` for spawn/retro skills (`/spawn-team`, `/agent-team-retro`), agent-definition conventions, and when to use the team.

--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -1,0 +1,109 @@
+# Layout Architecture
+
+The centering system is a flex chain:
+
+```
+AppContainer (flexCenter, min-height: 100dvh)
+  → AudioPlayer (flexCenter, min-height: 100dvh)
+    → ContentWrapper (position: relative, z-index: 2, overflow: visible)
+      → PlayerContainer (flex column, centered)
+```
+
+## Core invariants
+
+- **`ContentWrapper` must use `position: relative`** — not absolute — so parent flex containers can center it.
+- **`overflow: visible` is required on ContentWrapper** — `container-type: inline-size` creates containment that clips absolutely-positioned children.
+- **`100dvh`** throughout to handle iOS address bar changes.
+- **BottomBar** renders via `createPortal()` to `document.body`, fixed at bottom.
+- **Drawers** use fixed positioning with slide animations and swipe-to-dismiss; vertical swipes on album art toggle the **queue** (up) drawer (`QueueDrawer` / `QueueBottomSheet`).
+- **BackgroundVisualizer and AccentColorBackground** are `position: fixed` with low z-index, don't affect layout.
+
+## Queue Suspense fallback
+
+The queue drawers (`QueueDrawer`, `QueueBottomSheet`) render `QueueSkeleton` (`src/components/QueueSkeleton.tsx`) as their Suspense fallback — a row-shaped placeholder with a transform-based shimmer that respects `prefers-reduced-motion`. The lazy bundles are prefetched on first playback via `useQueueBundlePrefetch` (`src/hooks/useQueueBundlePrefetch.ts`), scheduled inside `requestIdleCallback` (with `setTimeout` fallback) once per session.
+
+## Full-screen library
+
+The library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered in `AudioPlayer.tsx` via `React.lazy` when `showLibrary` is true.
+
+**Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
+
+**Filter state** for the library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`). Opening the library from the QAP "Browse Library" button clears these keys before navigating.
+
+**Recently Played history** is tracked by `useRecentlyPlayedCollections` (`src/hooks/useRecentlyPlayedCollections.ts`). It exposes `history: RecentlyPlayedEntry[]` and `record(ref, name)`. Successful collection loads via `useCollectionLoader.loadCollection` call `record` automatically. History is stored under `vorbis-player-recently-played` (localStorage), capped at 5 entries, deduped by `CollectionRef` key, newest first. `FilterSidebar` renders a "Recently Played" section with up to 5 clickable shortcuts on desktop; the section is hidden when history is empty.
+
+**Mobile library overlay** renders `MobileLibraryBottomBar` (full-width search input + trailing sort dropdown) instead of the provider chip row. Mobile intentionally bypasses `providerFilters` — `ignoreProviderFilters = isMobile` in `useLibraryRoot.ts` ensures items from every enabled provider are always shown. Desktop behavior is unchanged: `FilterSidebar` provides provider chips, sort, genre, and recently-played controls.
+
+## Idle/home routing
+
+When no track is loaded, `PlayerStateRenderer` (`src/components/PlayerStateRenderer.tsx`) picks a landing view via `resolveIdleRoute(welcomeSeen, qapEnabled, hasValidSession)`:
+
+| Condition | Landing view |
+|---|---|
+| `welcomeSeen === false` | `WelcomeScreen` (supersedes all other inputs) |
+| valid `lastSession` + `qapEnabled` | `QuickAccessPanel` (with Resume hero) |
+| valid `lastSession` + `!qapEnabled` | player hydrated via `handleHydrate` (paused) |
+| no/stale session + `qapEnabled` | `QuickAccessPanel` |
+| no/stale session + `!qapEnabled` | `LibraryPage` |
+
+QAP is opt-in via the "Quick Access Panel" On/Off control in `VisualEffectsMenu`; preference persists under `vorbis-player-qap-enabled` (default `false`) via `useQapEnabled()`. Clicking "Browse Library" from QAP or Welcome flips a local `libraryOverride` flag — once engaged, the idle view stays on `LibraryPage` for the rest of the session (one-way door).
+
+**Welcome screen** — `WelcomeScreen` (`src/components/WelcomeScreen/index.tsx`) shows once for new users with a per-provider status summary and context-aware primary CTA (*Connect a provider* when `connectedProviderIds.length === 0`, *Browse your library* otherwise). The dismiss-for-good flag persists via `useWelcomeSeen` (`src/hooks/useWelcomeSeen.ts`) under the `vorbis-player-welcome-seen` localStorage key (default `false`).
+
+**Stale session cutoff** — `isSessionStale(session, now?)` from `src/services/sessionPersistence.ts` returns true when the session is absent, missing `savedAt`, or older than `STALE_SESSION_MS` (30 days). Stale sessions are treated as no session for landing routing and resume affordances.
+
+**Resume hero** — `ResumeHero` (`src/components/QuickAccessPanel/ResumeHero.tsx`) renders at the top of `QuickAccessPanel` (above `PinRing`) when a valid `lastSession` is present; clicking the Resume CTA invokes `onResume` (autoplay). The footer `ResumeCard` is suppressed inside QAP to avoid duplicate affordances; it still renders as the `footer` prop of `LibraryPage` on the idle library route.
+
+**Settings gear on idle views** — `SettingsGearButton` (`src/components/SettingsGearButton/index.tsx`) is mounted top-right by `PlayerStateRenderer` on `WelcomeScreen`, idle `LibraryPage`, and `QuickAccessPanel` via the `onOpenSettings` prop, opening the existing `VisualEffectsMenu`. Hidden during loading and error states. The active-player gear continues to live in `BottomBar` / `PlayerControlsSection`.
+
+## Hydrate without autoplay
+
+`handleHydrate(session): Promise<HydrateResult>` in `usePlayerLogic` (`src/hooks/usePlayerLogic.ts`) restores `tracks` / `originalTracks` / `mediaTracksRef` / `currentTrackIndex` / `selectedPlaylistId`, sets the seek bar to `savedPositionMs`, and calls `prepareTrack(track, { positionMs })` on the driving provider — but does NOT call `play()`. A `hydratedPendingPlayRef = { index, positionMs }` records the target so the next user-initiated `handlePlay` starts from the saved offset. Any call into `playTrack` (next/previous/new collection) clears the ref.
+
+- `HydrateResult` shape: `{ track: MediaTrack | null, skipped: boolean, totalFailure: boolean }`.
+- **prepareTrack is emit-only** — both adapters emit a `PlaybackState` event with `positionMs` + `durationMs` so the seek bar reflects the saved position before any user action. No audio actually starts.
+  - Spotify (`stageTrackPaused`): calls `ensurePlaybackReady` which transfers Spotify Connect to this device with `play: false`. Does NOT call `/me/player/play` — that API starts audio and Spotify's eventual consistency makes a subsequent `pause()` race against the just-started playback, leaking audio on fresh tabs.
+  - Dropbox: sets `audio.src` to the stream URL and seeks to `positionMs`. Does NOT call `audio.play()`.
+- **probePlayable iterator** — before calling `prepareTrack`, `handleHydrate` optionally calls `descriptor.playback.probePlayable(track): Promise<boolean>` (defined on `PlaybackProvider` in `src/types/providers.ts`). Returns `false` for known-unplayable tracks (Spotify market-restricted / 404, Dropbox file moved); throws `AuthExpiredError` for transient auth failures. If `probePlayable` returns false or throws, the iterator skips to the next track in the queue. The iterator is bounded by `queueTracks.length` to prevent infinite loops.
+- **Partial-skip toast** — when `skipped === true` (saved track was unplayable, a later track was used): `"Couldn't resume previous track — starting from next in queue."`.
+- **Total-failure path** — when no track in the queue could be prepared: `handleHydrate` calls `handleBackToLibrary` and returns `totalFailure: true`. `AudioPlayer.handleHydrateFailed` then calls `useSessionPersistence.resetLastSession()` (clears both localStorage AND the cached React `lastSession` state) and surfaces `"Couldn't resume your last session."`. `PlayerStateRenderer` on `totalFailure` flips `libraryOverride = true` so the user routes to the library immediately.
+- **Resume toast** — `ResumeToast` surfaces on normal hydrate with `"Resuming '<Track>' — press play to continue."`. Auto-dismisses on next/previous/open-library/open-queue.
+- `PlayerStateRenderer` routes to the hydrate loading card; on mount fires `onHydrate(session)` exactly once via `hydrateFiredRef`.
+- Distinct from `handleResume` (in `AudioPlayer.tsx`), which autoplays from the saved position.
+
+## Zen mode
+
+**Overlays** (`ZenClickZoneOverlay`, `ZenLikeOverlay`): hover-activated on desktop (pointer devices only), hidden when flip menu is open (`isFlipped`), with vertical dead zones (top/bottom 20% of album art ignored). Mobile zen uses touch gestures instead (`useZenTouchGestures`). BottomBar in zen mode shows via grip pill tap with tap-outside-to-dismiss backdrop.
+
+**Entry/exit orchestration** — timing constants live in `src/constants/zenAnimation.ts`; CSS transitions in `PlayerContent/styled.ts` (`ContentWrapper`, `PlayerStack`, `ZenControlsWrapper`) and `BottomBar/styled.ts`. Entry and exit sequences are asymmetric on purpose:
+
+- **Entry** (normal → zen): controls fade in place over `ZEN_CONTROLS_DURATION`; after `ZEN_ART_ENTER_DELAY` the art grows (`PlayerStack.max-width`) in parallel with the controls row collapsing (`grid-template-rows 1fr → 0fr`) over `ZEN_ART_DURATION`.
+- **Exit** (zen → normal): art shrink, `ContentWrapper.margin-bottom` growth, `CardContent.transform` shift, and controls row expansion (`grid-template-rows 0fr → 1fr`) all animate in parallel over `ZEN_ART_DURATION`. Opacity/transform on the controls and the `BottomBar` slide-up are delayed by `ZEN_EXIT_REENTRY_DELAY` (= `ZEN_ART_DURATION`) so they appear after the art has settled.
+- **`--player-controls-height` freeze during transitions** — `PlayerContent` holds a `zenTransitioningRef` that gates the `ResizeObserver` on the controls element. Without this, the row expanding `0 → 220px` on exit would push the CSS variable through every intermediate frame, moving `PlayerStack.max-width`'s target mid-transition and causing the art to chase it. The ref is raised in `handleZenModeToggle`, cleared via `setTimeout` after `ZEN_ART_DURATION + ZEN_ART_ENTER_DELAY + 50ms`.
+- `prefers-reduced-motion: reduce` short-circuits transitions on `PlayerStack`, `ZenControlsWrapper`, and `BottomBarContainer`. Per-element transition rationale is inlined in `PlayerContent/styled.ts` and `BottomBar/styled.ts`.
+
+## Background Visualizers
+
+Four animated background styles, selectable via the flip menu's Speed/Style controls. All share a `speed` prop (multiplier from `VisualEffectsContext`) and per-visualizer tuning in `src/constants/visualizerDebugConfig.ts`.
+
+| Style key | Component | Description |
+|-----------|-----------|-------------|
+| `fireflies` | `ParticleVisualizer` | Drifting particles with pulsing opacity |
+| `comet` | `TrailVisualizer` | Ships leaving fading particle trails |
+| `wave` | `WaveVisualizer` | Layered sine waves spread vertically |
+| `grid` | `GridWaveVisualizer` | Dot grid distorted by traveling waves |
+
+Type: `VisualizerStyle` in `src/types/visualizer.ts`. Components in `src/components/visualizers/`.
+
+## Responsive sizing
+
+Breakpoints and exact values are in `src/styles/theme.ts`. Sizing calculations are in `src/utils/sizingUtils.ts` and `src/hooks/usePlayerSizing.ts`.
+
+- Mobile: < 700px, Tablet: 700–1024px, Desktop: ≥ 1024px
+- Uses `usePlayerSizing` hook for viewport-aware dimensions
+
+## Common layout pitfalls
+
+- Player not centered → `ContentWrapper` must use `position: relative`
+- Elements clipped → ensure `overflow: visible` on `ContentWrapper`
+- Mobile viewport bouncing → use `100dvh` not `100vh`

--- a/docs/architecture/playback.md
+++ b/docs/architecture/playback.md
@@ -1,0 +1,57 @@
+# Playback & Queue Mutation
+
+## Playback flow
+
+User action to audio output follows this chain:
+
+1. **User triggers play/next/previous** — `usePlayerLogic` dispatches via `handlePlay` / `handleNext` / `handlePrevious`
+2. **Provider resolution** — `useProviderPlayback.playTrack(index)` resolves the provider for the track at that index: `track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback
+3. **Cross-provider handoff** — `pausePreviousProvider()` pauses the old provider if the driving provider changed, then updates `currentPlaybackProviderRef`
+4. **Adapter playback** — calls `descriptor.playback.playTrack(mediaTrack)` on the resolved `PlaybackProvider` (Spotify SDK or HTML5 Audio)
+5. **Next-track pre-warm** — after successful play, `prepareTrack()` is called on the next track's provider
+6. **State subscription** — `usePlaybackSubscription` subscribes to all registered providers, filters events by driving provider, and syncs `isPlaying`, `playbackPosition`, and `currentTrackIndex` back to React state. Uses `expectedTrackIdRef` to ignore stale provider index updates during transitions. Also listens for `visibilitychange` events — when the tab returns to foreground, it clears `expectedTrackIdRef` (stale transition guards) and calls `getState()` on the driving provider to resync track info, album art, and playback position.
+   - **`expectedTrackIdRef` ownership** — `useProviderPlayback.playTrack` is the single owner: it sets `expectedTrackIdRef.current` to the target track's id *before* calling the adapter's `playTrack` (and before the next-track pre-warm's `prepareTrack`). This covers every normal entry point — `handleNext`, `handlePrevious`, fresh `loadCollection` → `playTrack(0)`, and empty-queue append — so callers no longer set the ref themselves. Without this guard a `loadCollection` → `playTrack(0)` path is racey: the pre-warm's emitted `PlaybackState` can flip `currentTrackIndex` before the real play-state arrives, causing album art to mismatch the playing audio. **Exception**: `handleHydrate` in `usePlayerLogic` sets `expectedTrackIdRef.current` directly because the hydrate path calls `descriptor.playback.prepareTrack` (emit-only, no `playTrack` invocation), so the centralised guard in `useProviderPlayback` does not apply.
+7. **Auto-advance** — `useAutoAdvance` subscribes to all providers and detects track end via two signals: `timeRemaining <= endThreshold` (near-end) or `wasPlaying && isPaused && position === 0` (natural end). A 5-second cooldown (`PLAY_COOLDOWN_MS`) prevents false triggers during buffering
+8. **Error recovery** — `UnavailableTrackError` and generic errors trigger auto-skip to the next track when `skipOnError` is true. `AuthExpiredError` surfaces a re-auth prompt
+
+Key files: `usePlayerLogic.ts` → `useProviderPlayback.ts` → `PlaybackProvider` (interface in `types/providers.ts`) → `usePlaybackSubscription.ts` → `useAutoAdvance.ts`
+
+## Queue mutation flow
+
+Queue state lives in `TrackContext` (`tracks`, `originalTracks`, `currentTrackIndex`, `shuffleEnabled`) and is mutated through `TrackOperations` (defined in `types/trackOperations.ts`). A parallel `mediaTracksRef` keeps an imperative mirror for index-based playback without waiting for React renders.
+
+### Loading a collection (`useCollectionLoader.loadCollection`)
+
+- Resolves the target provider and collection ref
+- Fetches tracks via `catalog.listTracks(collectionRef)`
+- Calls `applyTracks()` which stores `originalTracks`, optionally shuffles, sets `tracks` + `mediaTracksRef`, resets `currentTrackIndex` to 0, then calls `playTrack(0)`
+- Unified Liked Songs path merges tracks from all connected providers sorted by `addedAt`
+
+### Adding to queue (`useQueueManagement.handleAddToQueue`)
+
+- If queue is empty, delegates to `loadCollection` (full load + autoplay)
+- Otherwise fetches tracks via `catalog.listTracks` and appends to `tracks`, `originalTracks`, and `mediaTracksRef` without resetting `currentTrackIndex`
+- Deduplicates by track ID before appending — tracks already in the queue are skipped
+
+### Removing from queue (`handleRemoveFromQueue`)
+
+- Blocks removal of the currently playing track (`index === currentTrackIndex`)
+- Removes by index from `tracks`, by ID from `originalTracks` and `mediaTracksRef`
+- Decrements `currentTrackIndex` if the removed track was before the current one
+- If only one track remains, calls `handleBackToLibrary` (full reset)
+
+### Reordering (`handleReorderQueue`)
+
+- Uses `moveItemInArray` on `tracks`, then syncs `mediaTracksRef` via `reorderMediaTracksToMatchTracks`
+- Recalculates `currentTrackIndex` by finding the playing track's ID in the new order
+- Only updates `originalTracks` when shuffle is off
+
+### Shuffle interaction (`TrackContext.handleShuffleToggle`)
+
+- Enable: shuffles `originalTracks` (excluding current track), places current track first, resets index to 0
+- Disable: restores `originalTracks`, finds current track's original index
+- Persisted via `useLocalStorage`
+
+### Queue change notification
+
+`usePlayerLogic` calls `descriptor.playback.onQueueChanged?(tracks, currentTrackIndex)` whenever `tracks` or `currentTrackIndex` change, allowing providers with native queue sync (Spotify) to stay aligned.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -1,0 +1,93 @@
+# Multi-Provider Architecture
+
+## Provider model
+
+Defined in `src/types/providers.ts` and `src/types/domain.ts`.
+
+- **Provider interfaces**: `AuthProvider`, `CatalogProvider`, `PlaybackProvider`
+- **Registration**: `src/providers/registry.ts` — singleton `providerRegistry`; providers self-register on import
+- **Dropbox** only registers when `VITE_DROPBOX_CLIENT_ID` is set
+
+**Domain types** (`src/types/domain.ts`):
+
+- `MediaTrack` — provider-agnostic track with `playbackRef`
+- `MediaCollection` — provider-agnostic collection (playlist or album)
+- `CollectionRef` — `{ provider, kind, id }`; serialized via `collectionRefToKey` / `keyToCollectionRef`
+
+**Capability-aware UI**: check `activeDescriptor.capabilities` before rendering provider-specific controls (`hasSaveTrack`, `hasExternalLink`, `hasLikedCollection`). Both Spotify and Dropbox support `hasSaveTrack` and `hasLikedCollection`.
+
+## Provider toggle (Music Sources section in settings)
+
+- Each provider row has a single on/off toggle — there is no separate Reconnect button.
+- `enabledProviderIds` — localStorage-persisted set of providers the user has opted into.
+- `connectedProviderIds` — derived set: `enabledProviderIds` ∩ authenticated providers. Used by cross-provider features (Unified Liked Songs, radio resolver).
+- Toggle-OFF: opens `ProviderDisconnectDialog` showing the provider name and count of queued tracks that will be removed. Confirming calls `logout()`, removes the provider from `enabledProviderIds`, and cleans up queue/playback state. The last enabled provider's toggle is disabled to prevent a zero-provider state.
+- Toggle-ON when already authenticated: silently adds to `enabledProviderIds`.
+- Toggle-ON when not authenticated: calls `beginLogin({ popup: true })` immediately. The provider is added to `enabledProviderIds` only after the OAuth popup reports success via `AUTH_COMPLETE_EVENT`.
+- OAuth cancel/failure: toggle reverts; a toast shows `"Couldn't connect to {provider}. Try again."`.
+- Mid-session unrecoverable 401: `logout()` is called automatically; a toast shows `"{Provider} disconnected — session expired."`.
+- Implementation: `src/components/VisualEffectsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
+
+## Unified playback across providers
+
+- Queue items are represented as provider-agnostic `MediaTrack` records and can mix Spotify + Dropbox tracks in one queue.
+- Provider model:
+  - **Active provider** = selected provider context for browsing/catalog actions.
+  - **Driving provider** = provider currently controlling audio output.
+  - These can differ in mixed queues (Unified Liked Songs, radio, cross-provider handoff).
+- Playback controls (`play`, `pause`, `next`, `previous`) route via the **driving provider**, not just the active provider.
+- Provider state subscriptions are multiplexed and filtered by the **driving provider** so visualizer/play state stays in sync.
+- Routing structure:
+  - `useProviderPlayback` resolves provider per index (`track.provider` → `drivingProviderRef` → `activeDescriptor.id` fallback).
+  - `usePlayerLogic` owns control actions and playback-state synchronization using `getDrivingProviderId()`.
+  - `useAutoAdvance` advances based on events from the current driving provider.
+- Unified liked songs can merge liked tracks from all connected providers (`connectedProviderIds`) and sort by `addedAt`.
+
+## Radio generation
+
+- Radio is a one-shot action (not a sticky toggle) that builds a playlist from the current track.
+- `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
+- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated and Spotify is in `connectedProviderIds`.
+- Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
+- **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
+
+## Provider implementation details
+
+### Dropbox folder structure
+
+```
+Dropbox root/
+└── <Artist>/<Album>/
+    ├── cover.jpg     # also: album.jpg, folder.jpg, front.jpg
+    └── 01 - Track.mp3
+```
+
+Folders containing audio files become albums; parent folder = artist. A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended.
+
+### Dropbox "All Music" card
+
+`useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. `AllMusicCard` (`src/components/PlaylistSelection/AllMusicCard.tsx`) renders the row in the **playlist grid** at the top anchor slot, alongside `LikedSongsCard`. The card uses a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph in both grid and list layouts; subtitle is `"{N} tracks • Shuffled"`. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
+
+### All Music shuffle-by-default
+
+Loading or appending the All Music aggregate always shuffles, independently of the global `shuffleEnabled` toggle. Detection uses `isAllMusicRef(collectionRef)` from `src/constants/playlist.ts`. `useCollectionLoader.applyTracks` accepts a `forceShuffle` option that ORs with `shuffleEnabled`; `loadCollection` passes `{ forceShuffle: isAllMusicRef(ref) }`. `useQueueManagement.handleAddToQueue` shuffles the fetched tracks with `shuffleArray()` before deduping and appending. The user's `shuffleEnabled` preference is not mutated — it remains whatever they set globally.
+
+### Dropbox Liked Songs
+
+Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
+
+### Dropbox preferences sync
+
+Pins (unified playlists/albums) and accent overrides/custom colors are synced to `/.vorbis/preferences.json`. Merge is last-write-wins by `updatedAt`. `dropboxPreferencesSync.ts` provides `initPreferencesSync(auth)`, `getPreferencesSync()`, `initialSync()`, and `schedulePush()` (2s debounce). PinnedItemsContext and ColorContext call `schedulePush()` after local changes; App and provider trigger `initialSync()` after Dropbox OAuth and when already authenticated.
+
+### Token refresh
+
+Both providers preserve refresh tokens during transient failures and proactively refresh before expiry. Spotify uses a 5-minute buffer; Dropbox uses a 60-second buffer. On 401/400 errors Dropbox performs full logout; on 5xx or network errors it preserves the refresh token for retry.
+
+### Spotify SDK loading
+
+The Spotify Web Playback SDK is loaded lazily by `SpotifyPlayerService.loadSDK()` — no global script tag in `index.html`. The SDK is only injected when the Spotify provider activates.
+
+### Spotify API batching
+
+`checkTrackSaved` in `src/services/spotify/tracks.ts` uses microtask-based batching — concurrent calls within the same render cycle are collected and flushed as a single `/me/tracks/contains` request (up to 50 IDs per Spotify API limit), preventing 429 rate limiting.

--- a/docs/architecture/shadcn.md
+++ b/docs/architecture/shadcn.md
@@ -1,0 +1,73 @@
+# shadcn/ui Integration
+
+vorbis-player uses a hybrid styling stack: **styled-components for bespoke surfaces, shadcn/ui (Radix primitives + Tailwind) for chrome**. Both coexist permanently.
+
+## Stack coexistence rule — pick by surface type
+
+| Surface type | Stack | Examples |
+|---|---|---|
+| Visualizers, animations, gestures | styled-components (forever) | `BackgroundVisualizer`, zen-mode orchestration in `PlayerContent/styled.ts`, swipe gestures, album-art flip menu, `BottomBar` |
+| Standard chrome (modals, sliders, popovers, switches, toasts) | shadcn primitives | `src/components/ui/*.tsx`: `dialog.tsx`, `button.tsx`, `slider.tsx`, `switch.tsx`, `accordion.tsx`, `popover.tsx`, `sonner.tsx` |
+| Whole-screen redesigns | shadcn, gated behind `?ui=v2` | future `SettingsV2`, `OnboardingV2`, command palette |
+
+## Theme bridge — `--accent-color` is player chrome ONLY
+
+The runtime `--accent-color` / `--accent-contrast-color` (injected on `document.documentElement` by `ColorContext.tsx`) belong exclusively to player chrome that intentionally retints with the playing track:
+
+- `BottomBar` (background tint, control hover states)
+- `LikeButton` (filled state)
+- `TimelineSlider` (fill + thumb gradient — wraps shadcn `slider.tsx`)
+- `VolumeSlider` (fill + thumb gradient — wraps shadcn `slider.tsx`, vertical orientation)
+- `Switch` accent variant (`controls/QuickEffectsRow.tsx` glow/visualizer/translucence toggles — uses default `variant="accent"` of `src/components/ui/switch.tsx`, retints checked-state track with `var(--accent-color)`)
+- Glow effects (`--glow-intensity`, `--glow-rate`, `--glow-opacity`)
+- Accent color overrides menu in `VisualEffectsMenu`
+
+**shadcn primitives use the neutral palette** defined in `src/styles/shadcn-tokens.css` (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, etc.). shadcn's `--accent` token is a static neutral surface and is **not** the same as the player's `--accent-color`. Never wire shadcn's `--primary` or `--accent` to `var(--accent-color)` — dialogs, popovers, and other chrome must stay neutral so they don't retint per track.
+
+## `?ui=v2` flag mechanism
+
+The `useUiV2()` hook (`src/hooks/useUiV2.ts`) returns `true` when EITHER:
+
+- `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in for staging deploys), OR
+- the URL contains `?ui=v2` (per-session opt-in for testing).
+
+It subscribes to `popstate` so SPA navigation flips the flag without a reload. SSR-safe.
+
+Convention for flagged screens:
+
+- Components consuming the flag render the **legacy** path by default.
+- The v2 branch lives under `if (uiV2) { … }`.
+- Future redesign components are colocated next to the legacy file as `<ScreenName>V2.tsx` (e.g. `Settings.tsx` + `SettingsV2.tsx`). The parent component picks one or the other via `useUiV2()`.
+
+## Current shadcn primitives
+
+| Primitive | File | Notes |
+|---|---|---|
+| `Dialog` | `dialog.tsx` | Used by `ProviderDisconnectDialog`, `ConfirmDeleteDialog`, `SaveQueueDialog`, `KeyboardShortcutsHelp`. Unflagged. |
+| `Slider` | `slider.tsx` | Wrapped by `TimelineSlider` (horizontal, accent fill/thumb gradient) and `VolumeSlider` (vertical). Per-part `trackStyle` / `thumbStyle` / `rangeStyle` escape hatches preserve accent retinting. |
+| `Switch` | `switch.tsx` | Dual variants: `accent` (default, player chrome) and `neutral` (settings toggles). |
+| `Toast` (Sonner) | `sonner.tsx` | `<Toaster />` mounted at app root in `App.tsx`. `RadioProgressContent` rendered via `toast.custom()`. |
+| `Popover` | `popover.tsx` | Used by `TrackInfoPopover` via virtual-anchor pattern (zero-size fixed div positioned at `anchorRect` coordinates) so consumer call sites stay unchanged. |
+| `Accordion` | `accordion.tsx` | Used by `AppSettingsMenu` — each section is its own `Accordion.Root` with `type="single" collapsible` to preserve independent open state. Tailwind keyframes `accordion-down` / `accordion-up` (200ms ease) defined in `tailwind.config.ts`. |
+
+**Next-wave primitives** (tracked as on-hold epics; need decomposition via `/speckit:interview`): #1265 (FilterSidebar — shadcn wave 3), #1262 (Settings v2), #1263 (Cmd-K palette), #1264 (Onboarding v2).
+
+## Canonical patterns for new shadcn primitives
+
+When adding a new primitive in `src/components/ui/`:
+
+- **Per-part style escape hatches** (from `slider.tsx` / `switch.tsx`): expose `trackStyle` / `thumbStyle` / `rangeStyle` props that pass through to the relevant Radix part. Lets player-chrome consumers retint via inline `var(--accent-color)` without polluting the primitive's neutral default. The primitive itself stays neutral; opt-in retinting happens at the call site.
+- **z-index inline override** (from `dialog.tsx`): set `style={{ zIndex: <PRIMITIVE>_Z_INDEX, ...style }}` on the Content. Tailwind `z-50` is below the player's `BottomBar` (up to `theme.zIndex.modal` = 1400), so every primitive that renders above chrome needs an explicit override.
+- **Virtual-anchor pattern** (from `popover.tsx`): when a consumer passes a DOMRect rather than wrapping `<PopoverTrigger>`, render a hidden zero-size `aria-hidden` `<PopoverAnchor asChild>` `<div style={{ position: 'fixed', left: rect.left + rect.width/2, top: rect.bottom, width: 0, height: 0, pointerEvents: 'none' }} />` and let Radix position relative to it.
+- **`onOpenChange` handles both gestures** (from `Popover` migration): when `<Popover open onOpenChange={(open) => !open && onClose()}>` is used, do NOT also wire `onPointerDownOutside={onClose}` and `onEscapeKeyDown={onClose}` — Radix invokes `onOpenChange(false)` for both, and the explicit handlers double-fire. The single `onOpenChange` path is sufficient.
+- **`motion-reduce:` Tailwind variants** on animation classes — every primitive with entry/exit or transform animations should include `motion-reduce:animate-none` (or equivalent) to respect `prefers-reduced-motion`.
+
+## z-index for shadcn primitives
+
+shadcn defaults to `z-50` (Tailwind), which is below the player's `BottomBar` (up to `theme.zIndex.modal` = 1400). Each primitive that renders above chrome overrides via inline style:
+
+| Primitive | z-index | Source |
+|---|---|---|
+| `dialog.tsx` | `1405` | `DIALOG_Z_INDEX` constant |
+| `popover.tsx` | `1500` | `POPOVER_Z_INDEX` constant (matches `theme.zIndex.popover`) |
+| `sonner.tsx` (Toast) | `1410` | inline `--z-index` CSS custom property on `<Toaster />` |

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -1,0 +1,17 @@
+# Keyboard Shortcuts
+
+Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` media queries (not viewport width) to detect device type.
+
+| Key | Desktop | Touch-only |
+|-----|---------|------------|
+| `Space` | Play/Pause | Play/Pause |
+| `←` / `→` | Prev/Next track | Prev/Next track |
+| `↑` / `Q` | Toggle queue | Volume up (↑ only) |
+| `↓` / `L` | Toggle library | Volume down (↓ only) |
+| `V` / `G` / `S` / `T` | Visualizer / Glow / Shuffle / Translucence | same |
+| `Z` | Toggle zen mode | same |
+| `O` / `K` / `M` | Effects menu / Like / Mute | same |
+| `?` / `/` | Keyboard help | same |
+| `Escape` | Close all menus | same |
+
+`Q` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,37 @@
+# Testing Guide
+
+Run with `npm run test:run`. Tests are colocated with source files in `__tests__/` subdirectories.
+
+- Verify actual behavior, not mock implementations
+- Every test should have meaningful assertions
+
+## Test utilities (`src/test/`)
+
+| File | Purpose |
+|------|---------|
+| `setup.ts` | Global test setup: mocks `localStorage`, `sessionStorage`, `window.location`, `history`, `fetch`, `crypto` (for PKCE), `btoa`/`atob`; imports `fake-indexeddb/auto` and `@testing-library/jest-dom`; clears all mocks in `afterEach` |
+| `fixtures.ts` | Factory functions for domain objects: `makeTrack()`, `makeMediaTrack()`, `makePlaylistInfo()`, `makeAlbumInfo()`, `makeProviderDescriptor()` — all accept partial overrides |
+| `testWrappers.tsx` | `TestWrapper` component that nests all app context providers (`ProviderProvider`, `PlayerSizingProvider`, `TrackProvider`, `ColorProvider`, `VisualEffectsProvider`, `PinnedItemsProvider`) for component/hook tests |
+| `providerTestUtils.tsx` | `ProviderWrapper` — lighter wrapper with only `ProviderProvider`, for hooks that only need provider context |
+
+## BDD comment convention
+
+Tests use `// #given`, `// #when`, `// #then` comments to mark the Arrange-Act-Assert phases:
+
+```ts
+it('loads volume from localStorage on init', () => {
+  // #given
+  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+    if (key === 'vorbis-player-volume') return '75';
+    return null;
+  });
+
+  // #when
+  const { result } = renderHook(() => useVolume(), { wrapper: ProviderWrapper });
+
+  // #then
+  expect(result.current.volume).toBe(75);
+});
+```
+
+Use this pattern in all new tests. The `#given` section is optional when there is no setup beyond what `beforeEach` provides.


### PR DESCRIPTION
## Summary

- Extract long-form architecture sections from CLAUDE.md (488 lines) into dedicated docs under `docs/architecture/`, plus `docs/testing.md`, `docs/keyboard.md`, and `.claude/agents/README.md`.
- CLAUDE.md (now 156 lines) keeps top-level project guidance and links to the new docs via an "Architecture docs" index table.
- Also fixes accumulated rot in CLAUDE.md: stale source-layout tree (counts off, missing `ui/` and `contexts/`), stale line-number citations, duplicated layout invariants, and an outdated "future epics" list (epics #1262–#1265 are now filed).

## New docs

| File | Source content |
|---|---|
| \`docs/architecture/layout.md\` | Layout invariants, idle routing, hydrate flow, zen mode, visualizers, responsive sizing |
| \`docs/architecture/providers.md\` | Provider model, toggle state machine, radio, Spotify/Dropbox internals |
| \`docs/architecture/playback.md\` | Playback flow + queue mutation flow |
| \`docs/architecture/shadcn.md\` | Stack rule, theme bridge, current primitives table, canonical patterns, z-index |
| \`docs/testing.md\` | Test utilities + BDD `// #given/#when/#then` convention |
| \`docs/keyboard.md\` | Keyboard shortcut table |
| \`.claude/agents/README.md\` | Multi-agent team workflows (`/spawn-team`, `/agent-team-retro`) |

## Why direct to `main` (no RC)

This is meta-tooling docs only — no app code, no user-visible behavior. Per the project's release-flow exception for `agents/skills/CLAUDE.md`-class changes, this skips the develop → RC → main path. Commit will need to be back-merged into develop after merge so develop's CLAUDE.md doesn't drift.

## Test plan

- [x] `wc -l` confirms CLAUDE.md is 156 lines (down from 488)
- [x] All cross-references in the new "Architecture docs" table resolve to existing files
- [ ] Reviewer spot-checks one extracted doc for fidelity to the original CLAUDE.md content