### PR TITLE
release: 2026-04-25 (#2)

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -44,3 +44,13 @@ When the builder posts an interface contract for a new component / hook (props +
 When your task is blocked on a dependency (the builder has not yet landed the implementation you need to test), do NOT idle silently. Pre-read the test files and source files named in the issue spec — note current shape, existing test patterns, sibling tests' assertion style, and any surprises (e.g. test expects an interface the spec doesn't mention). Surface findings to the lead via `SendMessage` before going idle.
 
 The hard rule still holds: do not write test code before the implementation interface lands (per "Interface alignment with the builder"). But warming context costs nothing and shortens cold-start time once the dependency clears. Pre-work is a ~200-word note to the lead, not a draft test file.
+## Worktree pre-flight
+
+You are spawned with `isolation: "worktree"` by default (see spawn-team skill). Your worktree does not inherit `node_modules` or `.env.local` from the main workspace. Before running any tests or installing dependencies, execute:
+
+```bash
+npm install
+cp ../../.env.local .env.local 2>/dev/null || true
+```
+
+Verify the setup with `npm run test:run` on a known-passing file before touching task files.

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -45,6 +45,12 @@ The user may override the count explicitly: *"spawn the team with 3 builders"*, 
 
 **`BUILDER_COUNT == 1`** can stay in shared workspace (no parallel conflict possible). But for any wave with parallel builders, set `isolation: "worktree"` on the spawn `Agent` call.
 
+**Default for tester: spawn with `isolation: "worktree"` whenever the lead operates in the main workspace** (which is essentially always — the lead cannot easily move). The tester runs `git checkout`, `git commit`, and `npm run test:run` operations that swap branch context; when both lead and tester share `/Users/roman/src/vorbis-player`, the tester's branch operations land under the lead's open session and corrupt the lead's commit graph. Worktree isolation eliminates this class of contamination at the same ~30s `npm install` cost paid by builders:
+
+- Lead's branch context stays stable for the entire session
+- Tester's `git commit` / `npm run test:run` operations are fully sandboxed
+- Test PRs from the tester carry clean diffs with no accidental lead-session commits absorbed
+
 When using worktrees, the spawn prompt should include the pre-flight setup instructions:
 
 ```

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -20,20 +20,40 @@ const SaveQueueDialog = lazy(() => import('@/components/SaveQueueDialog'));
 const QueueDrawer = lazy(() => import('@/components/QueueDrawer'));
 const QueueBottomSheet = lazy(() => import('@/components/QueueBottomSheet'));
 
-function QueueLoadingFallback(): React.ReactElement {
+function QueueLoadingFallback({ isMobile }: { isMobile: boolean }): React.ReactElement {
   const theme = useTheme();
+  const sharedStyle: React.CSSProperties = {
+    position: 'fixed',
+    background: theme.colors.overlay.panel,
+    padding: theme.spacing.md,
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    zIndex: theme.zIndex.modal,
+  };
+  if (isMobile) {
+    return (
+      <div style={{
+        ...sharedStyle,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: '66dvh',
+        maxHeight: '66dvh',
+        borderTopLeftRadius: theme.borderRadius['2xl'],
+        borderTopRightRadius: theme.borderRadius['2xl'],
+      }}>
+        <QueueSkeleton />
+      </div>
+    );
+  }
   return (
     <div style={{
-      position: 'fixed',
+      ...sharedStyle,
       top: 0,
       right: 0,
       bottom: 0,
       width: theme.drawer.widths.tablet,
-      background: theme.colors.overlay.panel,
-      padding: theme.spacing.md,
-      boxSizing: 'border-box',
-      display: 'flex',
-      flexDirection: 'column',
     }}>
       <QueueSkeleton />
     </div>
@@ -174,7 +194,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
 
   return (
     <>
-      <Suspense fallback={showQueue ? <QueueLoadingFallback /> : null}>
+      <Suspense fallback={showQueue ? <QueueLoadingFallback isMobile={isMobile} /> : null}>
         {isMobile ? (
           <ProfiledComponent id="QueueBottomSheet">
             <QueueBottomSheet


### PR DESCRIPTION
## Summary

Mobile QueueLoadingFallback now respects viewport (no more desktop sidebar chrome on small screens), and the multi-agent tester role defaults to worktree isolation to prevent branch-context contamination of the lead workspace.

## Release summary

**Built from**: `rc/2026-04-25.5`

### Changes

**other**
- fix(player): make QueueLoadingFallback viewport-aware on mobile (#1267)
- chore(agents): default tester to worktree isolation (#1270)

Closes #1220
Closes #1261
