### PR TITLE
feat(onboarding-v2): add useIsDesktop and useOnboardingV2 hooks (Phase 1A)

### DIFF
--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+const DESKTOP_QUERY = '(min-width: 700px)';
+
+/**
+ * Returns `true` when the viewport matches the desktop breakpoint
+ * (>= 700px). Subscribes to `matchMedia` `change` events so the value
+ * stays in sync as the viewport resizes.
+ *
+ * SSR-safe: returns `false` during a render where `window` is undefined.
+ */
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState<boolean>(() =>
+    typeof window === 'undefined' ? false : window.matchMedia(DESKTOP_QUERY).matches
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const handleChange = (event: MediaQueryListEvent): void => {
+      setIsDesktop(event.matches);
+    };
+
+    mql.addEventListener('change', handleChange);
+    return () => {
+      mql.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return isDesktop;
+}

--- a/src/hooks/useOnboardingV2.ts
+++ b/src/hooks/useOnboardingV2.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
+
+export const ONBOARDING_V2_STEP_KEY = 'vorbis-player-onboarding-v2-step';
+
+export interface UseOnboardingV2Result {
+  step: number;
+  isFirst: boolean;
+  isLast: boolean;
+  next: () => void;
+  back: () => void;
+  complete: () => void;
+  skipAll: () => void;
+}
+
+export function useOnboardingV2(totalSteps: number): UseOnboardingV2Result {
+  const [persistedStep, setPersistedStep] = useLocalStorage<number>(ONBOARDING_V2_STEP_KEY, 0);
+  const [, setWelcomeSeen] = useWelcomeSeen();
+
+  const maxIndex = Math.max(totalSteps - 1, 0);
+  const step = Math.min(Math.max(persistedStep, 0), maxIndex);
+
+  const next = useCallback(() => {
+    setPersistedStep((s) => Math.min(s + 1, maxIndex));
+  }, [setPersistedStep, maxIndex]);
+
+  const back = useCallback(() => {
+    setPersistedStep((s) => Math.max(s - 1, 0));
+  }, [setPersistedStep]);
+
+  const complete = useCallback(() => {
+    setWelcomeSeen(true);
+    setPersistedStep(0);
+  }, [setWelcomeSeen, setPersistedStep]);
+
+  const skipAll = useCallback(() => {
+    setWelcomeSeen(true);
+    setPersistedStep(0);
+  }, [setWelcomeSeen, setPersistedStep]);
+
+  return {
+    step,
+    isFirst: step === 0,
+    isLast: step === maxIndex,
+    next,
+    back,
+    complete,
+    skipAll,
+  };
+}


### PR DESCRIPTION
## Summary
Phase 1A of onboarding v2: introduce two hooks that the upcoming flow container will compose.

- `useIsDesktop` — tracks `(min-width: 700px)` via `matchMedia`, SSR-safe (matches `useUiV2.ts` pattern).
- `useOnboardingV2(totalSteps)` — persists step under `vorbis-player-onboarding-v2-step`, clamps stale values when `totalSteps` shrinks (mobile resize), exposes `next` / `back` and semantically distinct `complete` / `skipAll` (both flip `welcome-seen` + reset step; kept separate for future analytics).

## Verification
- \`npx tsc -b --noEmit\` clean.

## Test plan
- [ ] Tester to add unit tests in Phase 6 (per task #6).