### PR TITLE
feat(onboarding-v2): add step components (Phase 2)

### DIFF
--- a/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  SwipeCardMock,
+} from '../styled';
+
+export const OnboardingStepSwipeQueue: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <SwipeCardMock />
+    </StepIllustration>
+    <StepTitle>Swipe to explore your queue</StepTitle>
+    <StepDescription>
+      Swipe right on the player to open your play queue. Reorder tracks, jump
+      ahead, or clear what's coming up.
+    </StepDescription>
+  </StepContent>
+);

--- a/src/components/OnboardingV2/steps/OnboardingStepVisualizers.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepVisualizers.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  BarGroup,
+  Bar,
+} from '../styled';
+
+export const OnboardingStepVisualizers: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <BarGroup>
+        <Bar $delay={0} style={{ height: '32px' }} />
+        <Bar $delay={80} style={{ height: '40px' }} />
+        <Bar $delay={160} style={{ height: '24px' }} />
+      </BarGroup>
+      <BarGroup style={{ marginLeft: '12px' }}>
+        <Bar $delay={40} style={{ height: '44px' }} />
+        <Bar $delay={120} style={{ height: '28px' }} />
+        <Bar $delay={200} style={{ height: '36px' }} />
+      </BarGroup>
+      <BarGroup style={{ marginLeft: '12px' }}>
+        <Bar $delay={20} style={{ height: '38px' }} />
+        <Bar $delay={100} style={{ height: '48px' }} />
+        <Bar $delay={180} style={{ height: '20px' }} />
+      </BarGroup>
+    </StepIllustration>
+    <StepTitle>Set the mood with visualizers</StepTitle>
+    <StepDescription>
+      Choose a background visual effect from the menu. Waveforms, particles,
+      and gradients respond to your music in real time.
+    </StepDescription>
+  </StepContent>
+);

--- a/src/components/OnboardingV2/steps/OnboardingStepZenMode.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepZenMode.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  ZenMockScreen,
+  ZenMockAlbumArt,
+  ZenKbdBadge,
+} from '../styled';
+
+export const OnboardingStepZenMode: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <ZenMockScreen>
+        <ZenMockAlbumArt />
+        <ZenKbdBadge>Z</ZenKbdBadge>
+      </ZenMockScreen>
+    </StepIllustration>
+    <StepTitle>Go full-screen with Zen mode</StepTitle>
+    <StepDescription>
+      Press Z or click the Zen icon to enter a distraction-free view. Perfect
+      for ambient listening.
+    </StepDescription>
+  </StepContent>
+);


### PR DESCRIPTION
## Summary
Phase 2 of onboarding v2: three pure presentational step components composed of styled primitives from `../styled`. Each step renders a decorative illustration (aria-hidden) with a title and description.

- `OnboardingStepSwipeQueue` — uses `SwipeCardMock`.
- `OnboardingStepVisualizers` — three `BarGroup`s with staggered `Bar` delays for a pulsing waveform mock.
- `OnboardingStepZenMode` — `ZenMockScreen` with album art and the `Z` keyboard badge.

Builds on the styled primitives from #1273 (Phase 1B).

## Verification
- \`npx tsc -b --noEmit\` clean.
- \`npm run test:run\`: 1285 passing; 3 pre-existing failures (missing `@testing-library/user-event` import in switch/toast tests, unrelated).

## Test plan
- [ ] Tester to add unit tests in Phase 6 (per task #6).