### PR TITLE
feat(onboarding-v2): OnboardingFlowV2 container + barrel (Phase 3)

### DIFF
--- a/src/components/OnboardingV2/OnboardingFlowV2.tsx
+++ b/src/components/OnboardingV2/OnboardingFlowV2.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from 'react';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import { useOnboardingV2 } from '@/hooks/useOnboardingV2';
+import { OnboardingNavControls } from './OnboardingNavControls';
+import { OnboardingProgressDots } from './OnboardingProgressDots';
+import { OnboardingStepSwipeQueue } from './steps/OnboardingStepSwipeQueue';
+import { OnboardingStepVisualizers } from './steps/OnboardingStepVisualizers';
+import { OnboardingStepZenMode } from './steps/OnboardingStepZenMode';
+import {
+  OnboardingContent,
+  OnboardingRoot,
+  StepContent,
+} from './styled';
+
+export interface OnboardingFlowV2Props {
+  onConnectProvider: () => void;
+  onBrowseLibrary: () => void;
+}
+
+const OnboardingFlowV2Component: React.FC<OnboardingFlowV2Props> = () => {
+  const isDesktop = useIsDesktop();
+  const totalSteps = isDesktop ? 3 : 2;
+  const { step, isFirst, isLast, next, back, complete, skipAll } =
+    useOnboardingV2(totalSteps);
+
+  const handleNext = useCallback(() => {
+    if (isLast) {
+      complete();
+    } else {
+      next();
+    }
+  }, [isLast, complete, next]);
+
+  const stepContent = (() => {
+    switch (step) {
+      case 0:
+        return <OnboardingStepSwipeQueue />;
+      case 1:
+        return <OnboardingStepVisualizers />;
+      case 2:
+        return isDesktop ? <OnboardingStepZenMode /> : null;
+      default:
+        return null;
+    }
+  })();
+
+  return (
+    <OnboardingRoot role="region" aria-label="Get started with Vorbis Player">
+      <OnboardingContent>
+        <OnboardingProgressDots total={totalSteps} current={step} />
+        <StepContent key={step}>{stepContent}</StepContent>
+        <OnboardingNavControls
+          isFirst={isFirst}
+          isLast={isLast}
+          onBack={back}
+          onNext={handleNext}
+          onSkip={skipAll}
+        />
+      </OnboardingContent>
+    </OnboardingRoot>
+  );
+};
+
+export const OnboardingFlowV2 = React.memo(OnboardingFlowV2Component);

--- a/src/components/OnboardingV2/index.tsx
+++ b/src/components/OnboardingV2/index.tsx
@@ -1,0 +1,4 @@
+export { OnboardingFlowV2 } from './OnboardingFlowV2';
+export type { OnboardingFlowV2Props } from './OnboardingFlowV2';
+import { OnboardingFlowV2 } from './OnboardingFlowV2';
+export default OnboardingFlowV2;

--- a/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  SwipeCardMock,
+} from '../styled';
+
+export const OnboardingStepSwipeQueue: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <SwipeCardMock />
+    </StepIllustration>
+    <StepTitle>Swipe to explore your queue</StepTitle>
+    <StepDescription>
+      Swipe right on the player to open your play queue. Reorder tracks, jump
+      ahead, or clear what's coming up.
+    </StepDescription>
+  </StepContent>
+);

--- a/src/components/OnboardingV2/steps/OnboardingStepVisualizers.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepVisualizers.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  BarGroup,
+  Bar,
+} from '../styled';
+
+export const OnboardingStepVisualizers: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <BarGroup>
+        <Bar $delay={0} style={{ height: '32px' }} />
+        <Bar $delay={80} style={{ height: '40px' }} />
+        <Bar $delay={160} style={{ height: '24px' }} />
+      </BarGroup>
+      <BarGroup style={{ marginLeft: '12px' }}>
+        <Bar $delay={40} style={{ height: '44px' }} />
+        <Bar $delay={120} style={{ height: '28px' }} />
+        <Bar $delay={200} style={{ height: '36px' }} />
+      </BarGroup>
+      <BarGroup style={{ marginLeft: '12px' }}>
+        <Bar $delay={20} style={{ height: '38px' }} />
+        <Bar $delay={100} style={{ height: '48px' }} />
+        <Bar $delay={180} style={{ height: '20px' }} />
+      </BarGroup>
+    </StepIllustration>
+    <StepTitle>Set the mood with visualizers</StepTitle>
+    <StepDescription>
+      Choose a background visual effect from the menu. Waveforms, particles,
+      and gradients respond to your music in real time.
+    </StepDescription>
+  </StepContent>
+);

--- a/src/components/OnboardingV2/steps/OnboardingStepZenMode.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepZenMode.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  StepContent,
+  StepIllustration,
+  StepTitle,
+  StepDescription,
+  ZenMockScreen,
+  ZenMockAlbumArt,
+  ZenKbdBadge,
+} from '../styled';
+
+export const OnboardingStepZenMode: React.FC = () => (
+  <StepContent>
+    <StepIllustration aria-hidden="true">
+      <ZenMockScreen>
+        <ZenMockAlbumArt />
+        <ZenKbdBadge>Z</ZenKbdBadge>
+      </ZenMockScreen>
+    </StepIllustration>
+    <StepTitle>Go full-screen with Zen mode</StepTitle>
+    <StepDescription>
+      Press Z or click the Zen icon to enter a distraction-free view. Perfect
+      for ambient listening.
+    </StepDescription>
+  </StepContent>
+);


### PR DESCRIPTION
## Summary
- Adds `src/components/OnboardingV2/OnboardingFlowV2.tsx` — composes `useIsDesktop` + `useOnboardingV2`, the progress dots, step components, and nav controls. Wrapped in `React.memo`. `key={step}` on `StepContent` re-triggers enter animation per step.
- Adds `src/components/OnboardingV2/index.tsx` barrel exporting `OnboardingFlowV2` (named + default) and the `OnboardingFlowV2Props` type.
- Total step count: 3 on desktop, 2 on mobile (Zen Mode hidden on non-desktop).

## Stacked on
- PR #1280 (Phase 2 step components) — merge that first; this PR's diff against the feature branch will then narrow to only the container + barrel.

## Verification
- `npx tsc -b --noEmit` → exit 0

Targets `feature/onboarding-v2-1264`.