### PR TITLE
fix(onboarding-v2): match Next button label to spec ('Next →')

### DIFF
--- a/src/components/OnboardingV2/OnboardingNavControls.tsx
+++ b/src/components/OnboardingV2/OnboardingNavControls.tsx
@@ -34,7 +34,7 @@ export const OnboardingNavControls: React.FC<OnboardingNavControlsProps> = ({
       Skip
     </SkipButton>
     <NextButton type="button" onClick={onNext}>
-      {isLast ? 'Get started' : 'Next'}
+      {isLast ? 'Get started' : 'Next →'}
     </NextButton>
   </NavRow>
 );


### PR DESCRIPTION
## Summary
Architect spec specifies the intermediate-step Next button label as `Next →` (with trailing arrow). Initial implementation used plain `Next`. One-character patch.

## Verification
- \`npx tsc -b --noEmit\` clean.

## Test plan
- [ ] Tester to update matching test in their PR before it merges.