### PR TITLE
fix(onboarding-v2): show v2 onboarding before provider setup when welcome unseen

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -8,6 +8,10 @@ import BackgroundVisualizer from './BackgroundVisualizer';
 import AccentColorBackground from './AccentColorBackground';
 import DebugOverlay, { useDebugActivator } from './DebugOverlay';
 import ProviderSetupScreen from './ProviderSetupScreen';
+import SettingsGearButton from './SettingsGearButton';
+import OnboardingFlowV2 from './OnboardingV2';
+import { useUiV2 } from '@/hooks/useUiV2';
+import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
 import { toast } from 'sonner';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
 import { ProfilingProvider } from '@/contexts/ProfilingContext';
@@ -270,6 +274,9 @@ const AudioPlayerComponent = () => {
     ? connectedProviderIds.length === 0
     : !activeDescriptor?.auth.isAuthenticated() && connectedProviderIds.length === 0;
 
+  const isUiV2 = useUiV2();
+  const [welcomeSeen] = useWelcomeSeen();
+
   const autoSelectFired = useRef(false);
   useEffect(() => {
     if (needsSetup || autoSelectFired.current || selectedPlaylistId !== null) return;
@@ -335,6 +342,18 @@ const AudioPlayerComponent = () => {
   }, []);
 
   const renderContent = () => {
+    if (isUiV2 && !welcomeSeen) {
+      return (
+        <>
+          <SettingsGearButton onClick={handleOpenSettings} />
+          <OnboardingFlowV2
+            onConnectProvider={() => {}}
+            onBrowseLibrary={() => {}}
+          />
+        </>
+      );
+    }
+
     if (needsSetup) {
       return (
         <ProviderSetupScreen


### PR DESCRIPTION
## Summary
`renderContent` in `AudioPlayer.tsx` short-circuited to `ProviderSetupScreen` whenever `needsSetup` was true, bypassing `PlayerStateRenderer` entirely. That meant a fresh user (no auth, `welcomeSeen=false`, `?ui=v2`) never saw the v2 onboarding — they landed on `ProviderSetupScreen` instead.

This PR gates `OnboardingFlowV2` ahead of the `needsSetup` branch so v2 users get the onboarding first; once `welcomeSeen` flips to true (via `complete` or `skipAll`), the existing fall-through to `ProviderSetupScreen` takes over naturally.

- `useUiV2()` and `useWelcomeSeen()` hoisted to component scope (above `renderContent`).
- `onConnectProvider` / `onBrowseLibrary` are no-ops for now — `OnboardingFlowV2` doesn't consume them yet; future iteration can wire them to provider auth.
- The `PlayerStateRenderer` welcome route remains intact — that's the post-auth path. This new gate is the pre-auth path. Both reach `OnboardingFlowV2` by different routes.

Part of #1264

## Verification
- `npx tsc -b --noEmit` clean.
- `npm run build` clean.
- `npm run test:run`: 1334 passing; 3 pre-existing failures (missing `@testing-library/user-event` import in switch/toast tests, unrelated).

## Test plan
- [ ] `?ui=v2` + `localStorage.removeItem('vorbis-player-welcome-seen')` + no provider → OnboardingFlowV2 (was: ProviderSetupScreen).
- [ ] After complete/skip → `welcomeSeen=true` → ProviderSetupScreen.
- [ ] `welcomeSeen=true` already + `?ui=v2` + no auth → ProviderSetupScreen (existing behavior preserved).
- [ ] `?ui=v2` removed → v1 path unchanged.