### PR TITLE
fix(onboarding-v2): correct SwipeQueue gesture copy + restrict to mobile

### DIFF
--- a/src/components/OnboardingV2/OnboardingFlowV2.tsx
+++ b/src/components/OnboardingV2/OnboardingFlowV2.tsx
@@ -19,7 +19,10 @@ export interface OnboardingFlowV2Props {
 
 const OnboardingFlowV2Component: React.FC<OnboardingFlowV2Props> = () => {
   const isDesktop = useIsDesktop();
-  const totalSteps = isDesktop ? 3 : 2;
+  const steps = isDesktop
+    ? [<OnboardingStepVisualizers />, <OnboardingStepZenMode />]
+    : [<OnboardingStepSwipeQueue />, <OnboardingStepVisualizers />];
+  const totalSteps = steps.length;
   const { step, isFirst, isLast, next, back, complete, skipAll } =
     useOnboardingV2(totalSteps);
 
@@ -31,18 +34,7 @@ const OnboardingFlowV2Component: React.FC<OnboardingFlowV2Props> = () => {
     }
   }, [isLast, complete, next]);
 
-  const stepContent = (() => {
-    switch (step) {
-      case 0:
-        return <OnboardingStepSwipeQueue />;
-      case 1:
-        return <OnboardingStepVisualizers />;
-      case 2:
-        return isDesktop ? <OnboardingStepZenMode /> : null;
-      default:
-        return null;
-    }
-  })();
+  const stepContent = steps[step] ?? null;
 
   return (
     <OnboardingRoot role="region" aria-label="Get started with Vorbis Player">

--- a/src/components/OnboardingV2/__tests__/OnboardingFlowV2.test.tsx
+++ b/src/components/OnboardingV2/__tests__/OnboardingFlowV2.test.tsx
@@ -79,7 +79,7 @@ describe('OnboardingFlowV2', () => {
   });
 
   describe('desktop layout (useIsDesktop → true)', () => {
-    it('renders 3 progress dots', () => {
+    it('renders 2 progress dots', () => {
       // #given
       mockIsDesktop = true;
       mockStep = 0;
@@ -88,26 +88,13 @@ describe('OnboardingFlowV2', () => {
       renderFlow();
 
       // #then
-      expect(screen.getAllByRole('tab')).toHaveLength(3);
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
     });
 
-    it('shows SwipeQueue step on step 0', () => {
+    it('shows Visualizers step on step 0', () => {
       // #given
       mockIsDesktop = true;
       mockStep = 0;
-
-      // #when
-      renderFlow();
-
-      // #then
-      expect(screen.getByTestId('step-swipe-queue')).toBeInTheDocument();
-    });
-
-    it('shows Visualizers step on step 1', () => {
-      // #given
-      mockIsDesktop = true;
-      mockStep = 1;
-      mockIsFirst = false;
 
       // #when
       renderFlow();
@@ -116,10 +103,10 @@ describe('OnboardingFlowV2', () => {
       expect(screen.getByTestId('step-visualizers')).toBeInTheDocument();
     });
 
-    it('shows ZenMode step on step 2 (desktop only)', () => {
+    it('shows ZenMode step on step 1 (desktop only)', () => {
       // #given
       mockIsDesktop = true;
-      mockStep = 2;
+      mockStep = 1;
       mockIsFirst = false;
       mockIsLast = true;
 
@@ -128,6 +115,18 @@ describe('OnboardingFlowV2', () => {
 
       // #then
       expect(screen.getByTestId('step-zen-mode')).toBeInTheDocument();
+    });
+
+    it('does NOT render SwipeQueue step on desktop', () => {
+      // #given — desktop flow is [Visualizers, ZenMode]; SwipeQueue is mobile-only
+      mockIsDesktop = true;
+      mockStep = 0;
+
+      // #when
+      renderFlow();
+
+      // #then
+      expect(screen.queryByTestId('step-swipe-queue')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
+++ b/src/components/OnboardingV2/steps/OnboardingStepSwipeQueue.tsx
@@ -14,7 +14,7 @@ export const OnboardingStepSwipeQueue: React.FC = () => (
     </StepIllustration>
     <StepTitle>Swipe to explore your queue</StepTitle>
     <StepDescription>
-      Swipe right on the player to open your play queue. Reorder tracks, jump
+      Swipe up on the album art to open your queue. Reorder tracks, jump
       ahead, or clear what's coming up.
     </StepDescription>
   </StepContent>


### PR DESCRIPTION
## Summary
Fixes two bugs surfaced during manual visual test of PR #1285:

- **Copy fix:** Description now reads "Swipe up on the album art…" — matches the actual gesture wired in `AlbumArtSection` via `useVerticalSwipeGesture`. The previous "swipe right on the player" was incorrect.
- **Platform routing:** SwipeQueue now renders on mobile only. Desktop has no touch swipe gesture for opening the queue, so showing this step there was misleading. Switched `OnboardingFlowV2` to a step-array model so the platform skip is explicit:
  - mobile = `[SwipeQueue, Visualizers]`
  - desktop = `[Visualizers, ZenMode]`
  Both platforms now have 2 steps.

Tests in `OnboardingFlowV2.test.tsx` updated for the new desktop layout (2 dots, step 0 Visualizers, step 1 ZenMode) plus a new assertion that SwipeQueue does not render on desktop.

Part of #1264

## Verification
- `npx tsc -b --noEmit` clean.
- `npm run build` clean.
- `npm run test:run`: 1334 passing; same 3 pre-existing baseline failures, no regressions.

## Test plan
- [ ] On mobile (`?ui=v2` + viewport <700px): step 0 = SwipeQueue ("Swipe up…"), step 1 = Visualizers (last).
- [ ] On desktop (`?ui=v2` + viewport ≥700px): step 0 = Visualizers, step 1 = ZenMode (last). No SwipeQueue.