### PR TITLE
fix(hooks): broadcast useLocalStorage updates within the same tab

### DIFF
--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -126,6 +126,38 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('original');
   });
 
+  it('syncs state across two same-tab hook instances sharing a key', () => {
+    // #given
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => {});
+    const { result: instanceA } = renderHook(() => useLocalStorage('shared-key', 'initial'));
+    const { result: instanceB } = renderHook(() => useLocalStorage('shared-key', 'initial'));
+
+    // #when
+    act(() => {
+      instanceA.current[1]('updated-by-a');
+    });
+
+    // #then
+    expect(instanceA.current[0]).toBe('updated-by-a');
+    expect(instanceB.current[0]).toBe('updated-by-a');
+  });
+
+  it('does not sync same-tab updates for unrelated keys', () => {
+    // #given
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => {});
+    const { result: instanceA } = renderHook(() => useLocalStorage('key-a', 'a-initial'));
+    const { result: instanceB } = renderHook(() => useLocalStorage('key-b', 'b-initial'));
+
+    // #when
+    act(() => {
+      instanceA.current[1]('a-updated');
+    });
+
+    // #then
+    expect(instanceA.current[0]).toBe('a-updated');
+    expect(instanceB.current[0]).toBe('b-initial');
+  });
+
   it('removes the storage event listener when the hook unmounts', () => {
     // #given
     const removeListenerSpy = vi.spyOn(window, 'removeEventListener');
@@ -136,6 +168,7 @@ describe('useLocalStorage', () => {
 
     // #then
     expect(removeListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    expect(removeListenerSpy).toHaveBeenCalledWith('vorbis-player:localStorage', expect.any(Function));
 
     removeListenerSpy.mockRestore();
   });

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,5 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 
+const SAME_TAB_STORAGE_EVENT = 'vorbis-player:localStorage';
+
+interface SameTabStorageDetail {
+  key: string;
+  newValue: string;
+}
+
 export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] => {
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
@@ -16,11 +23,23 @@ export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T 
 
   const setValue = useCallback(
     (value: T | ((val: T) => T)) => {
+      // Dispatch lives inside the updater so callers can batch many setValue
+      // calls in one render (e.g. a `for` loop in `act`) and have each one
+      // observe the previously-queued value via `prevStoredValue`. Other
+      // instances' listeners receive the synchronous dispatch and call
+      // `setStoredValue` on themselves; React 18 absorbs that nested update
+      // into the same batch.
       setStoredValue((prevStoredValue) => {
         const valueToStore = value instanceof Function ? value(prevStoredValue) : value;
+        const serialized = JSON.stringify(valueToStore);
 
         try {
-          window.localStorage.setItem(key, JSON.stringify(valueToStore));
+          window.localStorage.setItem(key, serialized);
+          window.dispatchEvent(
+            new CustomEvent<SameTabStorageDetail>(SAME_TAB_STORAGE_EVENT, {
+              detail: { key, newValue: serialized },
+            }),
+          );
         } catch (error) {
           console.warn(`Failed to write "${key}" to localStorage:`, error);
         }
@@ -42,9 +61,21 @@ export const useLocalStorage = <T>(key: string, initialValue: T): [T, (value: T 
       }
     };
 
+    const handleSameTabChange = (e: Event) => {
+      const detail = (e as CustomEvent<SameTabStorageDetail>).detail;
+      if (!detail || detail.key !== key) return;
+      try {
+        setStoredValue(JSON.parse(detail.newValue));
+      } catch (error) {
+        console.warn(`Failed to parse "${key}" from same-tab storage event:`, error);
+      }
+    };
+
     window.addEventListener('storage', handleStorageChange);
+    window.addEventListener(SAME_TAB_STORAGE_EVENT, handleSameTabChange);
     return () => {
       window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(SAME_TAB_STORAGE_EVENT, handleSameTabChange);
     };
   }, [key]);
 


### PR DESCRIPTION
Part of #1264.

## Summary
- Native `storage` events don't fire same-tab. Two `useLocalStorage` instances sharing a key inside one tab never saw each other's writes — surfaced as v2 onboarding's "Get started" button looping back to step 0 (useOnboardingV2 set welcomeSeen=true but AudioPlayer's sibling instance held stale `false`).
- Fix dispatches a same-tab `vorbis-player:localStorage` CustomEvent after every write; each instance listens for it alongside the existing cross-tab `storage` handler.
- Updater pattern preserved (dispatch fires inside `setStoredValue` callback) so callers that batch many `setValue` calls in one render keep observing prior queued values via `prevStoredValue`. React 18 absorbs the nested same-tab `setStoredValue` calls into the same batch.

## Tests
- `useLocalStorage.test.ts` adds two cases: same-tab cross-instance sync; same-tab unrelated-key isolation.
- Existing unmount test now also asserts removal of the `vorbis-player:localStorage` listener.

## Verification
- `npx tsc -b --noEmit` → 0
- `npm run test:run` → 1336 passed; 0 net-new failures (3 pre-existing accordion/popover/switch file-load failures unchanged)
- `npm run build` → clean