### PR TITLE
fix(onboarding-v2): swipe-up hint animation moves vertically not horizontally

### DIFF
--- a/src/components/OnboardingV2/styled.ts
+++ b/src/components/OnboardingV2/styled.ts
@@ -25,10 +25,10 @@ export const stepEnter = keyframes`
 
 export const swipeHint = keyframes`
   0%, 100% {
-    transform: translateX(0);
+    transform: translateY(0);
   }
   50% {
-    transform: translateX(18px);
+    transform: translateY(-18px);
   }
 `;
 


### PR DESCRIPTION
## Summary
The `swipeHint` keyframes animated `translateX`, hinting a horizontal gesture, but the actual queue gesture is swipe up on the album art. Switched to `translateY` with a negative magnitude so the `SwipeCardMock` demonstrates the correct upward motion.

Part of #1264

## Verification
- `npx tsc -b --noEmit` clean.
- `npm run build` clean.
- `npm run test:run`: 1339 passing; same 3 pre-existing baseline failures, no regressions.

## Test plan
- [ ] On `?ui=v2` mobile: SwipeCardMock visibly bobs upward (bottom-to-top hint), not side-to-side.