### PR TITLE
release: 2026-04-26

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -100,6 +100,27 @@ This applies especially to:
 - Deleting files (`controls/Switch.tsx`, `Toast.tsx`, `CollapsibleSection.tsx`-style)
 - Renaming public hook signatures consumed in multiple files
 
+## Pause-on-correction — re-read before any commit/push/PR
+
+Before any commit, push, or PR-open step, re-read the most recent lead message in full. If it contains a protocol gate (stop, hold, await reviewer, "do NOT commit"), respect it even if an earlier message implied ship-immediately. Lead corrections often arrive after you've already started executing the original instruction — racing to complete the original directive in spite of a follow-up correction is the failure mode this rule exists to prevent. The cost of one extra inbox read is far cheaper than recovering from a wrongly-shipped PR.
+
+## Shared-hook full-suite gate
+
+When a fix changes shared-hook semantics (anything in `src/hooks/` consumed by 5+ files — `useLocalStorage`, `useRecentlyPlayedCollections`, etc.), run the full `npm run test:run` BEFORE posting ship-state, even when targeted tests pass. Targeted runs hide cross-file regressions that the next reviewer or CI run will surface anyway; one extra full-suite run is cheaper than a fix-up cycle.
+
+## Branch hygiene when merging sibling work
+
+When pulling work from a sibling builder's branch, always create a new branch from the feature branch first — never merge sibling branches into your current PR branch. The wrong shape silently absorbs sibling commits into your PR's diff:
+
+```bash
+# WRONG — merges sibling into current PR branch
+git merge origin/worktree-agent-builder-2
+
+# RIGHT — create clean branch first, then merge sibling
+git checkout -b worktree-agent-<you>-phase2 origin/feature/<epic>
+git merge origin/worktree-agent-builder-2
+```
+
 ## Reviewer FAIL gates the PR
 
 If reviewer returns FAIL on a review, do NOT commit, push, or open a PR until the flagged blocker is fixed and reviewer reconfirms PASS. The order is: implement → run gates → ship-state report to lead → reviewer review → if FAIL: fix → re-review → PASS → only THEN commit/push/PR. A PR opened with a known unresolved reviewer block is process drift; recovering with a follow-up fixup commit is more expensive than gating the open. The "ship state" report deliberately does not include a commit/push step — wait for the lead's PASS-acknowledged go-ahead.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -48,6 +48,10 @@ Discovering each dependency file as the writeup demands it produces fragmented e
 
 This applies specifically to architectural-detail-mapping (per scope classification above). For verify-only tasks, stay narrow and don't speculatively read.
 
+## Cite sibling files even when unread
+
+When recon touches a component or hook, list its sibling files (`styled.ts`, `__tests__/`, adjacent `useFoo.ts`, etc.) in the per-landmark citation table even if you didn't open them. The lead and architect skim the citation table to know the full surface area exists; if a sibling file is omitted, they assume it doesn't exist and follow up with "did you check X?". A 30-second `Glob` or `LS` on the component directory and a one-line entry like `src/components/Foo/styled.ts — not read; styling tokens for Foo` prevents the round-trip.
+
 ## Full-suite verification when verifying CI failures
 
 When the recon task involves verifying a CI failure (e.g. "confirm these N tests fail / count newly broken tests / characterize the failure mode"), always run the full `npm run test:run` — not just the targeted file(s). CI runs the full suite on every push, so "any unexpected failures beyond the N expected" must be answered against the same scope. Targeted-file runs hide cross-file ordering bugs and unrelated regressions that CI will surface anyway.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -67,6 +67,10 @@ Default review pattern (in priority order):
 
 If you find yourself reading `src/components/...` via the local `Read` tool during a review, stop and switch to one of the patterns above. A finding that doesn't appear in `git diff main...<branch> -- <file>` is a working-tree artifact, not a real review concern, and must be discarded.
 
+## Missing builder gate = FAIL (not conditional pass)
+
+If any mandatory builder gate (`npx tsc -b --noEmit`, `npm run build`, `npm run test:run`) is not confirmed in the builder or tester report, the verdict is FAIL — not "conditional pass" — until the missing gate result is provided. Soft-landing a missing gate as conditional leaves ambiguity in the lead's queue and lets the PR ship on a half-verified baseline. Be crisp: gate missing → FAIL → builder must re-run and re-report before review proceeds.
+
 ## Delta-only on duplicate review of the same commit
 
 If a review request arrives for a commit you have already reviewed in this session, send only a delta — cite the prior message and address only the new criteria the lead added. Never re-issue a full review for the same commit. The correct shape is:

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -44,6 +44,10 @@ When the builder posts an interface contract for a new component / hook (props +
 When your task is blocked on a dependency (the builder has not yet landed the implementation you need to test), do NOT idle silently. Pre-read the test files and source files named in the issue spec — note current shape, existing test patterns, sibling tests' assertion style, and any surprises (e.g. test expects an interface the spec doesn't mention). Surface findings to the lead via `SendMessage` before going idle.
 
 The hard rule still holds: do not write test code before the implementation interface lands (per "Interface alignment with the builder"). But warming context costs nothing and shortens cold-start time once the dependency clears. Pre-work is a ~200-word note to the lead, not a draft test file.
+## Pause-on-correction — re-read before any commit/push/PR
+
+Before any commit, push, or PR-open step, re-read the most recent lead message in full. If it contains a protocol gate (stop, hold, await reviewer, "do NOT commit"), respect it even if an earlier message implied ship-immediately. Lead corrections often arrive after you've already started executing the original instruction — racing to complete the original directive in spite of a follow-up correction is the failure mode this rule exists to prevent.
+
 ## Worktree pre-flight
 
 You are spawned with `isolation: "worktree"` by default (see spawn-team skill). Your worktree does not inherit `node_modules` or `.env.local` from the main workspace. Before running any tests or installing dependencies, execute:

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -136,7 +136,7 @@ For each specialist not already alive, spawn via `Agent` in a single message wit
 | Role | `subagent_type` | `name` | `model` (override) |
 |---|---|---|---|
 | explorer | `explorer` | `explorer` | (default) |
-| architect | `architect` | `architect` | `sonnet` |
+| architect | `architect` | `architect` | `opus[1m]` |
 | builder (singleton, count=1) | `builder` | `builder` | `opus` |
 | builder (multi, count>1) | `builder` | `builder-1`, `builder-2`, … `builder-N` | `opus` |
 | reviewer | `reviewer` | `reviewer` | `sonnet` |
@@ -174,7 +174,16 @@ Set `team_name: vorbis-crew` and `name: {name}` on every Agent call so the spawn
 
 1. Wait for each spawned agent's first message (acknowledgment) — they should send via `SendMessage` per their role definition's exit gate. Each builder instance acks independently.
 2. If any agent goes silent for two turns (no ack), warn the user — likely a `SendMessage` provisioning gap (the architect/reviewer fallback caveat) or a spawn-flake. Name the silent agent(s) explicitly so the user can decide whether to respawn.
-3. Report final state with builder count broken out: e.g. `"Team ready: explorer, architect, builder-1, builder-2, reviewer, tester (6 specialists, 2 builders)"`. List any failed acks separately.
+3. **Verify architect toolset on ack.** Architect's blueprint quality depends on `Glob`, `Grep`, `LS`, and `BashOutput` for path discovery and pattern verification. After architect's first ack, send a one-line check: *"Confirm your toolset includes Glob, Grep, LS, BashOutput in addition to Read/SendMessage."* If architect reports any missing, the spawn fell back to a stripped subagent type — respawn with the project-local `architect` `subagent_type` or warn the user to investigate. Architect without `Glob` burns round-trips path-guessing through `Read` failures.
+4. Report final state with builder count broken out: e.g. `"Team ready: explorer, architect, builder-1, builder-2, reviewer, tester (6 specialists, 2 builders)"`. List any failed acks separately.
+
+## PR body convention for sub-PRs targeting a feature branch
+
+When the team's epic uses a long-lived feature branch (e.g. `feature/onboarding-v2-1264`) and builders open sub-PRs against it, the lead's dispatch must instruct builders to use **"Part of #EPIC"** (not "Closes #EPIC") in PR bodies. GitHub's auto-close fires only on default-branch merges, so "Closes" on a feature-branch-targeted PR never closes the issue and leaves stale tracking. The final PR (feature → develop/main) is the one merge that should include "Closes #EPIC".
+
+Lead's dispatch boilerplate when assigning a builder to open a sub-PR:
+
+> *"Open the PR with base `feature/<epic-branch>` and body containing `Part of #<EPIC>` (not Closes — only the final epic merge to develop closes the epic)."*
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Apply approved 2026-04-26 retro findings to the team's agent definitions and the spawn-team skill — operating-rule additions for builder, tester, reviewer, and explorer; architect spawn upgrades to opus[1m] with a toolset-verification step; and a documented "Part of #N" PR-body convention for sub-PRs targeting a feature branch.

## Release summary

**Built from**: `rc/2026-04-26.1`

### Changes

**other**
- chore(agents): apply 2026-04-26 retro findings (#1290)