### PR TITLE
feat(library): route shell + useNewLibraryRoute flag (#1292)

### DIFF
--- a/src/components/AppSettingsMenu/index.tsx
+++ b/src/components/AppSettingsMenu/index.tsx
@@ -54,6 +54,8 @@ interface AppSettingsMenuProps {
   onVisualizerDebugToggle: () => void;
   qapEnabled: boolean;
   onQapToggle: () => void;
+  newLibraryRouteEnabled: boolean;
+  onNewLibraryRouteToggle: () => void;
 }
 
 const arePropsEqual = (
@@ -64,7 +66,8 @@ const arePropsEqual = (
     prevProps.isOpen !== nextProps.isOpen ||
     prevProps.profilerEnabled !== nextProps.profilerEnabled ||
     prevProps.visualizerDebugEnabled !== nextProps.visualizerDebugEnabled ||
-    prevProps.qapEnabled !== nextProps.qapEnabled
+    prevProps.qapEnabled !== nextProps.qapEnabled ||
+    prevProps.newLibraryRouteEnabled !== nextProps.newLibraryRouteEnabled
   ) {
     return false;
   }
@@ -82,6 +85,8 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
   onVisualizerDebugToggle,
   qapEnabled,
   onQapToggle,
+  newLibraryRouteEnabled,
+  onNewLibraryRouteToggle,
 }) => {
   const { viewport, isMobile, isTablet, transitionDuration, transitionEasing } = usePlayerSizingContext();
   const { enabledProviderIds, registry } = useProviderContext();
@@ -156,6 +161,24 @@ const AppSettingsMenu: React.FC<AppSettingsMenuProps> = memo(({
               <OptionButton
                 $isActive={!qapEnabled}
                 onClick={onQapToggle}
+              >
+                Off
+              </OptionButton>
+            </OptionButtonGroup>
+          </ControlGroup>
+
+          <ControlGroup>
+            <ControlLabel>New Library Route</ControlLabel>
+            <OptionButtonGroup>
+              <OptionButton
+                $isActive={newLibraryRouteEnabled}
+                onClick={onNewLibraryRouteToggle}
+              >
+                On
+              </OptionButton>
+              <OptionButton
+                $isActive={!newLibraryRouteEnabled}
+                onClick={onNewLibraryRouteToggle}
               >
                 Off
               </OptionButton>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -28,9 +28,11 @@ import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/AppSettingsMenu';
 import { useSessionPersistence } from '@/hooks/useSessionPersistence';
 import QuickAccessPanel from './QuickAccessPanel';
+import { useNewLibraryRoute } from '@/hooks/useNewLibraryRoute';
 
 const VisualEffectsMenu = lazy(() => import('./AppSettingsMenu/index'));
 const LibraryPage = lazy(() => import('./PlaylistSelection'));
+const LibraryRoute = lazy(() => import('./LibraryRoute'));
 
 const RESUME_TOAST_ID = 'resume-toast';
 const FALLTHROUGH_TOAST_ID = 'fallthrough-toast';
@@ -73,6 +75,7 @@ const AudioPlayerComponent = () => {
   } = useVisualizer();
   const { accentColorBackgroundEnabled } = useAccentColorBackground();
   const { showVisualEffects, setShowVisualEffects } = useVisualEffectsToggle();
+  const [newLibraryRouteEnabled, setNewLibraryRouteEnabled] = useNewLibraryRoute();
   const { tracks, selectedPlaylistId, setTracks, setOriginalTracks, setSelectedPlaylistId } = useTrackListContext();
   const { currentTrack, currentTrackIndex, setCurrentTrackIndex, showQueue, setShowQueue } = useCurrentTrackContext();
 
@@ -467,22 +470,38 @@ const AudioPlayerComponent = () => {
               onVisualizerDebugToggle={() => {}}
               qapEnabled={false}
               onQapToggle={() => {}}
+              newLibraryRouteEnabled={newLibraryRouteEnabled}
+              onNewLibraryRouteToggle={() => setNewLibraryRouteEnabled(!newLibraryRouteEnabled)}
             />
           </Suspense>
         )}
         {needsSetup && state.showLibrary && (
           <Suspense fallback={null}>
-            <LibraryPage
-              onPlaylistSelect={(id, name, provider) => {
-                handlers.handleCloseLibrary();
-                handlePlaylistSelect(id, name, provider);
-              }}
-              onPlayLikedTracks={handlePlayLikedTracks}
-              onQueueLikedTracks={handleQueueLikedTracks}
-              footer={lastSession && handleResume ? (
-                <ResumeCard session={lastSession} onResume={handleResume} />
-              ) : undefined}
-            />
+            {newLibraryRouteEnabled ? (
+              <LibraryRoute
+                onPlaylistSelect={(id, name, provider) => {
+                  handlers.handleCloseLibrary();
+                  handlePlaylistSelect(id, name ?? '', provider);
+                }}
+                onPlayLikedTracks={handlePlayLikedTracks}
+                onQueueLikedTracks={handleQueueLikedTracks}
+                onOpenSettings={handleOpenSettings}
+                onResume={handleResume}
+                hasResumableSession={!!lastSession?.queueTracks?.length}
+              />
+            ) : (
+              <LibraryPage
+                onPlaylistSelect={(id, name, provider) => {
+                  handlers.handleCloseLibrary();
+                  handlePlaylistSelect(id, name, provider);
+                }}
+                onPlayLikedTracks={handlePlayLikedTracks}
+                onQueueLikedTracks={handleQueueLikedTracks}
+                footer={lastSession && handleResume ? (
+                  <ResumeCard session={lastSession} onResume={handleResume} />
+                ) : undefined}
+              />
+            )}
           </Suspense>
         )}
       </Container>

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LibraryRoute from '../index';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: vi.fn(),
+}));
+
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+
+const baseProps = {
+  onPlaylistSelect: vi.fn(),
+  onOpenSettings: vi.fn(),
+  hasResumableSession: false,
+};
+
+describe('LibraryRoute', () => {
+  it('renders mobile shell when isMobile is true', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
+
+    // #when
+    render(<LibraryRoute {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-route-mobile')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-route-desktop')).not.toBeInTheDocument();
+  });
+
+  it('renders desktop shell when isMobile is false', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+
+    // #when
+    render(<LibraryRoute {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-route-mobile')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import type { ProviderId, AddToQueueResult, MediaTrack } from '@/types/domain';
+import { LibraryRouteRoot, MobileLayout, DesktopLayout } from './styled';
+
+// LibraryRoute assumes upstream guards have already filtered out cold-start cases:
+// - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
+// - PlayerStateRenderer.tsx routes to WelcomeScreen when !welcomeSeen
+// If this component renders, at least one provider is connected AND welcome has been dismissed.
+
+export interface LibraryRouteProps {
+  onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
+  onAddToQueue?: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  onOpenSettings: () => void;
+  onResume?: () => void;
+  hasResumableSession: boolean;
+}
+
+const LibraryRoute: React.FC<LibraryRouteProps> = () => {
+  const { isMobile } = usePlayerSizingContext();
+  return (
+    <LibraryRouteRoot>
+      {isMobile ? (
+        <MobileLayout data-testid="library-route-mobile">
+          <div>New Library Route — mobile shell (placeholder)</div>
+        </MobileLayout>
+      ) : (
+        <DesktopLayout data-testid="library-route-desktop">
+          <div>New Library Route — desktop shell (placeholder)</div>
+        </DesktopLayout>
+      )}
+    </LibraryRouteRoot>
+  );
+};
+
+LibraryRoute.displayName = 'LibraryRoute';
+export default LibraryRoute;

--- a/src/components/LibraryRoute/styled.ts
+++ b/src/components/LibraryRoute/styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const LibraryRouteRoot = styled.div`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+`;
+
+export const MobileLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  padding: 1rem;
+  gap: 1rem;
+  overflow-y: auto;
+`;
+
+export const DesktopLayout = styled.div`
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+`;

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -23,6 +23,7 @@ import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/AppSettingsMenu';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useNewLibraryRoute } from '@/hooks/useNewLibraryRoute';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useTransitionWillChange } from '@/hooks/useTransitionWillChange';
 import {
@@ -156,6 +157,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
   const [qapEnabled, setQapEnabled] = useQapEnabled();
+  const [newLibraryRouteEnabled, setNewLibraryRouteEnabled] = useNewLibraryRoute();
 
   const settingsHasBeenOpenedRef = useRef(false);
   if (showVisualEffects) settingsHasBeenOpenedRef.current = true;
@@ -387,6 +389,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
             onVisualizerDebugToggle={handleVisualizerDebugToggle}
             qapEnabled={qapEnabled}
             onQapToggle={() => setQapEnabled(!qapEnabled)}
+            newLibraryRouteEnabled={newLibraryRouteEnabled}
+            onNewLibraryRouteToggle={() => setNewLibraryRouteEnabled(!newLibraryRouteEnabled)}
           />
         </Suspense>
       )}

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -10,6 +10,7 @@ import { flexColumn, cardBase } from '../styles/utils';
 import { theme } from '@/styles/theme';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useNewLibraryRoute } from '@/hooks/useNewLibraryRoute';
 import { useWelcomeSeen } from '@/hooks/useWelcomeSeen';
 import QuickAccessPanel from './QuickAccessPanel';
 import ResumeCard from './QuickAccessPanel/ResumeCard';
@@ -17,6 +18,7 @@ import SettingsGearButton from './SettingsGearButton';
 import WelcomeScreen from './WelcomeScreen';
 
 const LibraryPage = React.lazy(() => import('./PlaylistSelection'));
+const LibraryRouteLazy = React.lazy(() => import('./LibraryRoute'));
 
 const pulseWave = keyframes`
   0%, 100% {
@@ -219,6 +221,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
   const { activeDescriptor } = useProviderContext();
   const providerName = activeDescriptor?.name ?? 'Music Service';
   const [qapEnabled] = useQapEnabled();
+  const [newLibraryRouteEnabled] = useNewLibraryRoute();
   const [welcomeSeen] = useWelcomeSeen();
   const hasValidSession = !isSessionStale(lastSession);
   const route = resolveIdleRoute(welcomeSeen, qapEnabled, hasValidSession);
@@ -336,14 +339,25 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
             </LoadingContainer>
           </LoadingCard>
         }>
-          <LibraryPage
-            onPlaylistSelect={handlePlaylistSelectWrapped}
-            onPlayLikedTracks={onPlayLikedTracks}
-            onQueueLikedTracks={onQueueLikedTracks}
-            footer={lastSession && onResume ? (
-              <ResumeCard session={lastSession} onResume={onResume} />
-            ) : undefined}
-          />
+          {newLibraryRouteEnabled ? (
+            <LibraryRouteLazy
+              onPlaylistSelect={(id, name, provider) => handlePlaylistSelectWrapped(id, name ?? '', provider)}
+              onPlayLikedTracks={onPlayLikedTracks}
+              onQueueLikedTracks={onQueueLikedTracks}
+              onOpenSettings={onOpenSettings}
+              onResume={onResume}
+              hasResumableSession={!!lastSession?.queueTracks?.length}
+            />
+          ) : (
+            <LibraryPage
+              onPlaylistSelect={handlePlaylistSelectWrapped}
+              onPlayLikedTracks={onPlayLikedTracks}
+              onQueueLikedTracks={onQueueLikedTracks}
+              footer={lastSession && onResume ? (
+                <ResumeCard session={lastSession} onResume={onResume} />
+              ) : undefined}
+            />
+          )}
         </Suspense>
       </>
     );

--- a/src/components/__tests__/AppSettingsMenu.test.tsx
+++ b/src/components/__tests__/AppSettingsMenu.test.tsx
@@ -85,6 +85,8 @@ describe('AppSettingsMenu', () => {
     onVisualizerDebugToggle: vi.fn(),
     qapEnabled: false,
     onQapToggle: vi.fn(),
+    newLibraryRouteEnabled: false,
+    onNewLibraryRouteToggle: vi.fn(),
   };
 
   beforeEach(() => {
@@ -185,7 +187,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[1]);
+      fireEvent.click(onButtons[2]);
 
       // #then
       expect(onProfilerToggle).toHaveBeenCalled();
@@ -203,7 +205,7 @@ describe('AppSettingsMenu', () => {
       // #when
       fireEvent.click(screen.getByText('Advanced'));
       const onButtons = screen.getAllByText('On');
-      fireEvent.click(onButtons[2]);
+      fireEvent.click(onButtons[3]);
 
       // #then
       expect(onVisualizerDebugToggle).toHaveBeenCalled();

--- a/src/hooks/__tests__/useNewLibraryRoute.test.ts
+++ b/src/hooks/__tests__/useNewLibraryRoute.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNewLibraryRoute } from '../useNewLibraryRoute';
+
+describe('useNewLibraryRoute', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('defaults to false when localStorage is empty', () => {
+    // #when
+    const { result } = renderHook(() => useNewLibraryRoute());
+
+    // #then
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('can be set to true', () => {
+    // #given
+    const { result } = renderHook(() => useNewLibraryRoute());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('persists to localStorage under the correct key', () => {
+    // #given
+    const { result } = renderHook(() => useNewLibraryRoute());
+
+    // #when
+    act(() => {
+      result.current[1](true);
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'vorbis-player-new-library-route',
+      'true'
+    );
+  });
+
+  it('reads initial value from localStorage', () => {
+    // #given
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === 'vorbis-player-new-library-route') return 'true';
+      return null;
+    });
+
+    // #when
+    const { result } = renderHook(() => useNewLibraryRoute());
+
+    // #then
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/src/hooks/useNewLibraryRoute.ts
+++ b/src/hooks/useNewLibraryRoute.ts
@@ -1,0 +1,5 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export const useNewLibraryRoute = (): [boolean, (value: boolean) => void] => {
+  return useLocalStorage<boolean>('vorbis-player-new-library-route', false);
+};

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -100,7 +100,10 @@ export function usePlayerLogic() {
   const [authExpired, setAuthExpired] = useState<ProviderId | null>(null);
 
   // Library full-screen visibility (local UI state)
-  const [showLibrary, setShowLibrary] = useState(false);
+  // currentView is the forward-looking compat slice; showLibrary is derived for legacy consumers.
+  type PlayerView = 'player' | 'library';
+  const [currentView, setCurrentView] = useState<PlayerView>('player');
+  const showLibrary = currentView === 'library';
 
   // Radio generation progress panel state
   const [radioProgress, setRadioProgress] = useState<RadioProgress | null>(null);
@@ -284,13 +287,13 @@ export function usePlayerLogic() {
   }, [getDrivingProviderId, getDrivingProviderDescriptor]);
 
   const handleOpenLibrary = useCallback(() => {
-    setShowLibrary(true);
+    setCurrentView('library');
     setShowQueue(false);
     setShowVisualEffects(false);
   }, [setShowQueue, setShowVisualEffects]);
 
   const handleCloseLibrary = useCallback(() => {
-    setShowLibrary(false);
+    setCurrentView('player');
   }, []);
 
   // Initialize radio session (before handleBackToLibrary, which needs stopRadio)
@@ -472,6 +475,7 @@ export function usePlayerLogic() {
       handleRemoveFromQueue,
       handleReorderQueue,
       handleHydrate,
+      setCurrentView,
     }),
     [
       loadCollection,
@@ -490,6 +494,7 @@ export function usePlayerLogic() {
       handleRemoveFromQueue,
       handleReorderQueue,
       handleHydrate,
+      setCurrentView,
     ]
   );
 
@@ -500,6 +505,7 @@ export function usePlayerLogic() {
       selectedPlaylistId,
       tracks,
       showLibrary,
+      currentView,
       isPlaying,
       playbackPosition,
     },


### PR DESCRIPTION
## Summary
- Adds `useNewLibraryRoute` feature flag (localStorage key `vorbis-player-new-library-route`, default off)
- New `LibraryRoute` placeholder shell with mobile/desktop layouts (real sections in #1294)
- `usePlayerLogic` gains `state.currentView: 'player' | 'library'`; `state.showLibrary` derived for legacy readers
- `AppSettingsMenu` toggle pill mirroring QAP pattern; wired into both AudioPlayer (idle) and PlayerControlsSection (active) menus
- AudioPlayer + PlayerStateRenderer conditionally swap LibraryPage ↔ LibraryRoute based on flag

Part of #1300. Addresses #1292.

## Test plan
- [ ] Hook tests pass (useNewLibraryRoute, usePlayerLogic.currentView)
- [ ] Component tests pass (LibraryRoute, AppSettingsMenu toggle)
- [ ] Render-swap tests pass (AudioPlayer, PlayerStateRenderer flag-on/off)
- [ ] Manual: flag-off renders LibraryPage as before
- [ ] Manual: flag-on renders LibraryRoute placeholder shell