### PR TITLE
feat(library): section data hooks (#1293)

### DIFF
--- a/src/components/LibraryRoute/hooks/__tests__/likedAccessors.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/likedAccessors.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import { fetchLikedForProvider } from '../likedAccessors';
+
+describe('fetchLikedForProvider', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns [] when no descriptor is registered for the provider', async () => {
+    // #given
+    mockGet.mockReturnValue(undefined);
+
+    // #when
+    const tracks = await fetchLikedForProvider('spotify');
+
+    // #then
+    expect(tracks).toEqual([]);
+  });
+
+  it('returns [] when descriptor lacks a catalog', async () => {
+    // #given
+    mockGet.mockReturnValue({});
+
+    // #when
+    const tracks = await fetchLikedForProvider('spotify');
+
+    // #then
+    expect(tracks).toEqual([]);
+  });
+
+  it('delegates to catalog.listTracks with a liked CollectionRef', async () => {
+    // #given
+    const fakeTracks: MediaTrack[] = [{ id: 't1' } as MediaTrack];
+    const listTracks = vi.fn().mockResolvedValue(fakeTracks);
+    mockGet.mockReturnValue({ catalog: { listTracks } });
+
+    // #when
+    const tracks = await fetchLikedForProvider('spotify');
+
+    // #then
+    expect(listTracks).toHaveBeenCalledWith(
+      { provider: 'spotify', kind: 'liked' },
+      undefined,
+    );
+    expect(tracks).toBe(fakeTracks);
+  });
+
+  it('propagates the AbortSignal to listTracks', async () => {
+    // #given
+    const listTracks = vi.fn().mockResolvedValue([]);
+    mockGet.mockReturnValue({ catalog: { listTracks } });
+    const ac = new AbortController();
+
+    // #when
+    await fetchLikedForProvider('dropbox', ac.signal);
+
+    // #then
+    expect(listTracks).toHaveBeenCalledWith(
+      { provider: 'dropbox', kind: 'liked' },
+      ac.signal,
+    );
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/useAlbumsSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/useAlbumsSection.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { AlbumInfo } from '@/services/spotify';
+import type { ProviderId } from '@/types/domain';
+
+const { mockPinned, mockLibrarySync } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: () => mockLibrarySync(),
+}));
+
+import { useAlbumsSection } from '../useAlbumsSection';
+
+function makeAlbum(id: string, provider: ProviderId = 'spotify'): AlbumInfo {
+  return {
+    id,
+    name: `Album ${id}`,
+    artists: 'Test',
+    images: [],
+    release_date: '2024-01-01',
+    total_tracks: 1,
+    uri: `spotify:album:${id}`,
+    provider,
+  };
+}
+
+describe('useAlbumsSection', () => {
+  beforeEach(() => {
+    mockPinned.mockReset();
+    mockLibrarySync.mockReset();
+    mockPinned.mockReturnValue({ pinnedAlbumIds: [] });
+  });
+
+  it('returns full album list when no filter or pinning', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      albums: [makeAlbum('a1'), makeAlbum('a2')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => useAlbumsSection({ excludePinned: false }));
+
+    // #then
+    expect(result.current.items.map((a) => a.id)).toEqual(['a1', 'a2']);
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('excludes pinned albums when excludePinned is true (default)', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedAlbumIds: ['a1'] });
+    mockLibrarySync.mockReturnValue({
+      albums: [makeAlbum('a1'), makeAlbum('a2')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => useAlbumsSection());
+
+    // #then
+    expect(result.current.items.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('filters by providerFilter', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      albums: [makeAlbum('a1', 'spotify'), makeAlbum('a2', 'dropbox')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useAlbumsSection({ providerFilter: ['dropbox'], excludePinned: false }),
+    );
+
+    // #then
+    expect(result.current.items.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('treats empty providerFilter array as no filter', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      albums: [makeAlbum('a1', 'spotify'), makeAlbum('a2', 'dropbox')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useAlbumsSection({ providerFilter: [], excludePinned: false }),
+    );
+
+    // #then
+    expect(result.current.items.map((a) => a.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('reports isLoading until initial load completes', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      albums: [],
+      isInitialLoadComplete: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => useAlbumsSection());
+
+    // #then
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isEmpty).toBe(true);
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/useLikedSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/useLikedSection.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { mockUnified, mockLibrarySync } = vi.hoisted(() => ({
+  mockUnified: vi.fn(),
+  mockLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: () => mockUnified(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: () => mockLibrarySync(),
+}));
+
+import { useLikedSection } from '../useLikedSection';
+
+describe('useLikedSection', () => {
+  beforeEach(() => {
+    mockUnified.mockReset();
+    mockLibrarySync.mockReset();
+  });
+
+  it('uses single-provider count when unified mode is inactive', () => {
+    // #given
+    mockUnified.mockReturnValue({ isUnifiedLikedActive: false, totalCount: 0, isLoading: false });
+    mockLibrarySync.mockReturnValue({
+      likedSongsCount: 42,
+      likedSongsPerProvider: [{ provider: 'spotify', count: 42 }],
+      isLikedSongsSyncing: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => useLikedSection());
+
+    // #then
+    expect(result.current.totalCount).toBe(42);
+    expect(result.current.isUnified).toBe(false);
+  });
+
+  it('uses unified totalCount when unified mode is active', () => {
+    // #given
+    mockUnified.mockReturnValue({ isUnifiedLikedActive: true, totalCount: 100, isLoading: false });
+    mockLibrarySync.mockReturnValue({
+      likedSongsCount: 42,
+      likedSongsPerProvider: [
+        { provider: 'spotify', count: 42 },
+        { provider: 'dropbox', count: 58 },
+      ],
+      isLikedSongsSyncing: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => useLikedSection());
+
+    // #then
+    expect(result.current.totalCount).toBe(100);
+    expect(result.current.isUnified).toBe(true);
+  });
+
+  it('switches isLoading source between unified loading and library syncing', () => {
+    // #given
+    mockUnified.mockReturnValue({ isUnifiedLikedActive: true, totalCount: 0, isLoading: true });
+    mockLibrarySync.mockReturnValue({
+      likedSongsCount: 0,
+      likedSongsPerProvider: [],
+      isLikedSongsSyncing: false,
+    });
+
+    // #when
+    const { result: unifiedResult } = renderHook(() => useLikedSection());
+
+    // #then
+    expect(unifiedResult.current.isLoading).toBe(true);
+
+    // #given (single-provider mode)
+    mockUnified.mockReturnValue({ isUnifiedLikedActive: false, totalCount: 0, isLoading: true });
+    mockLibrarySync.mockReturnValue({
+      likedSongsCount: 0,
+      likedSongsPerProvider: [],
+      isLikedSongsSyncing: true,
+    });
+
+    // #when
+    const { result: singleResult } = renderHook(() => useLikedSection());
+
+    // #then
+    expect(singleResult.current.isLoading).toBe(true);
+  });
+
+  it('passes through perProvider counts unchanged', () => {
+    // #given
+    const perProvider = [
+      { provider: 'spotify' as const, count: 10 },
+      { provider: 'dropbox' as const, count: 20 },
+    ];
+    mockUnified.mockReturnValue({ isUnifiedLikedActive: false, totalCount: 0, isLoading: false });
+    mockLibrarySync.mockReturnValue({
+      likedSongsCount: 30,
+      likedSongsPerProvider: perProvider,
+      isLikedSongsSyncing: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => useLikedSection());
+
+    // #then
+    expect(result.current.perProvider).toBe(perProvider);
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/usePinnedSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/usePinnedSection.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { AlbumInfo, SpotifyImage } from '@/services/spotify';
+
+const { mockPinned, mockLibrarySync } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: () => mockLibrarySync(),
+}));
+
+import { usePinnedSection } from '../usePinnedSection';
+
+function makePlaylist(id: string, imageUrl: string | null = null): CachedPlaylistInfo {
+  const images: SpotifyImage[] = imageUrl ? [{ url: imageUrl, height: null, width: null }] : [];
+  return {
+    id,
+    name: `Playlist ${id}`,
+    description: null,
+    images,
+    tracks: { total: 0 },
+    owner: null,
+    provider: 'spotify',
+  };
+}
+
+function makeAlbum(id: string, imageUrl: string | null = null): AlbumInfo {
+  const images: SpotifyImage[] = imageUrl ? [{ url: imageUrl, height: null, width: null }] : [];
+  return {
+    id,
+    name: `Album ${id}`,
+    artists: 'Test',
+    images,
+    release_date: '2024-01-01',
+    total_tracks: 1,
+    uri: `spotify:album:${id}`,
+    provider: 'spotify',
+  };
+}
+
+describe('usePinnedSection', () => {
+  beforeEach(() => {
+    mockPinned.mockReset();
+    mockLibrarySync.mockReset();
+  });
+
+  it('returns empty when nothing pinned', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: [], pinnedAlbumIds: [] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1')],
+      albums: [makeAlbum('a1')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePinnedSection());
+
+    // #then
+    expect(result.current.combined).toEqual([]);
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports isLoading when library has not finished initial load', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: [], pinnedAlbumIds: [] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [],
+      albums: [],
+      isInitialLoadComplete: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePinnedSection());
+
+    // #then
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('filters playlists and albums to only the pinned ids', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: ['p1'], pinnedAlbumIds: ['a2'] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1', 'p1.png'), makePlaylist('p2', 'p2.png')],
+      albums: [makeAlbum('a1', 'a1.png'), makeAlbum('a2', 'a2.png')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePinnedSection());
+
+    // #then
+    expect(result.current.pinnedPlaylists.map((p) => p.id)).toEqual(['p1']);
+    expect(result.current.pinnedAlbums.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  it('orders combined list with playlists first then albums', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: ['p1'], pinnedAlbumIds: ['a1'] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1', 'p1.png')],
+      albums: [makeAlbum('a1', 'a1.png')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePinnedSection());
+
+    // #then
+    expect(result.current.combined.map((c) => `${c.kind}:${c.id}`)).toEqual([
+      'playlist:p1',
+      'album:a1',
+    ]);
+    expect(result.current.combined[0].imageUrl).toBe('p1.png');
+    expect(result.current.combined[1].imageUrl).toBe('a1.png');
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/usePlaylistsSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/usePlaylistsSection.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { ProviderId } from '@/types/domain';
+
+const { mockPinned, mockLibrarySync } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: () => mockLibrarySync(),
+}));
+
+import { usePlaylistsSection } from '../usePlaylistsSection';
+
+function makePlaylist(id: string, provider: ProviderId = 'spotify'): CachedPlaylistInfo {
+  return {
+    id,
+    name: `Playlist ${id}`,
+    description: null,
+    images: [],
+    tracks: { total: 0 },
+    owner: null,
+    provider,
+  };
+}
+
+describe('usePlaylistsSection', () => {
+  beforeEach(() => {
+    mockPinned.mockReset();
+    mockLibrarySync.mockReset();
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: [] });
+  });
+
+  it('returns full playlist list when no filter or pinning', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1'), makePlaylist('p2')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePlaylistsSection({ excludePinned: false }));
+
+    // #then
+    expect(result.current.items.map((p) => p.id)).toEqual(['p1', 'p2']);
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('excludes pinned playlists when excludePinned is true (default)', () => {
+    // #given
+    mockPinned.mockReturnValue({ pinnedPlaylistIds: ['p1'] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1'), makePlaylist('p2')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePlaylistsSection());
+
+    // #then
+    expect(result.current.items.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('filters by providerFilter', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      playlists: [
+        makePlaylist('p1', 'spotify'),
+        makePlaylist('p2', 'dropbox'),
+        makePlaylist('p3', 'spotify'),
+      ],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      usePlaylistsSection({ providerFilter: ['dropbox'], excludePinned: false }),
+    );
+
+    // #then
+    expect(result.current.items.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('treats empty providerFilter array as no filter', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1', 'spotify'), makePlaylist('p2', 'dropbox')],
+      isInitialLoadComplete: true,
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      usePlaylistsSection({ providerFilter: [], excludePinned: false }),
+    );
+
+    // #then
+    expect(result.current.items.map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('reports isLoading until initial load completes', () => {
+    // #given
+    mockLibrarySync.mockReturnValue({
+      playlists: [],
+      isInitialLoadComplete: false,
+    });
+
+    // #when
+    const { result } = renderHook(() => usePlaylistsSection());
+
+    // #then
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isEmpty).toBe(true);
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/useRecentlyPlayedSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/useRecentlyPlayedSection.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { AlbumInfo, SpotifyImage } from '@/services/spotify';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
+
+const { mockRecentlyPlayed, mockLibrarySync } = vi.hoisted(() => ({
+  mockRecentlyPlayed: vi.fn(),
+  mockLibrarySync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockRecentlyPlayed(),
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  useLibrarySync: () => mockLibrarySync(),
+}));
+
+import { useRecentlyPlayedSection } from '../useRecentlyPlayedSection';
+
+function makePlaylist(id: string, imageUrl: string | null = null, provider = 'spotify'): CachedPlaylistInfo {
+  const images: SpotifyImage[] = imageUrl ? [{ url: imageUrl, height: null, width: null }] : [];
+  return {
+    id,
+    name: `Playlist ${id}`,
+    description: null,
+    images,
+    tracks: { total: 0 },
+    owner: null,
+    provider: provider as CachedPlaylistInfo['provider'],
+  };
+}
+
+function makeAlbum(id: string, imageUrl: string | null = null, provider = 'spotify'): AlbumInfo {
+  const images: SpotifyImage[] = imageUrl ? [{ url: imageUrl, height: null, width: null }] : [];
+  return {
+    id,
+    name: `Album ${id}`,
+    artists: 'Test',
+    images,
+    release_date: '2024-01-01',
+    total_tracks: 1,
+    uri: `spotify:album:${id}`,
+    provider: provider as AlbumInfo['provider'],
+  };
+}
+
+describe('useRecentlyPlayedSection', () => {
+  beforeEach(() => {
+    mockRecentlyPlayed.mockReset();
+    mockLibrarySync.mockReset();
+    mockLibrarySync.mockReturnValue({ playlists: [], albums: [] });
+  });
+
+  it('returns empty when history is empty', () => {
+    // #given
+    mockRecentlyPlayed.mockReturnValue({ history: [] });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedSection());
+
+    // #then
+    expect(result.current.items).toEqual([]);
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('preserves entry imageUrl when already present', () => {
+    // #given
+    const entry: RecentlyPlayedEntry = {
+      ref: { provider: 'spotify', kind: 'playlist', id: 'p1' },
+      name: 'Already has art',
+      imageUrl: 'https://existing.example/art.png',
+    };
+    mockRecentlyPlayed.mockReturnValue({ history: [entry] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1', 'https://different.example/art.png')],
+      albums: [],
+    });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedSection());
+
+    // #then
+    expect(result.current.items[0].imageUrl).toBe('https://existing.example/art.png');
+  });
+
+  it('hydrates playlist imageUrl from useLibrarySync match by provider+id', () => {
+    // #given
+    const entry: RecentlyPlayedEntry = {
+      ref: { provider: 'spotify', kind: 'playlist', id: 'p1' },
+      name: 'No art',
+    };
+    mockRecentlyPlayed.mockReturnValue({ history: [entry] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [makePlaylist('p1', 'https://hydrated.example/art.png')],
+      albums: [],
+    });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedSection());
+
+    // #then
+    expect(result.current.items[0].imageUrl).toBe('https://hydrated.example/art.png');
+  });
+
+  it('hydrates album imageUrl from useLibrarySync match by provider+id', () => {
+    // #given
+    const entry: RecentlyPlayedEntry = {
+      ref: { provider: 'spotify', kind: 'album', id: 'a1' },
+      name: 'Album',
+    };
+    mockRecentlyPlayed.mockReturnValue({ history: [entry] });
+    mockLibrarySync.mockReturnValue({
+      playlists: [],
+      albums: [makeAlbum('a1', 'https://album.example/art.png')],
+    });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedSection());
+
+    // #then
+    expect(result.current.items[0].imageUrl).toBe('https://album.example/art.png');
+  });
+
+  it('passes through entry unchanged when no match in library', () => {
+    // #given
+    const entry: RecentlyPlayedEntry = {
+      ref: { provider: 'spotify', kind: 'playlist', id: 'missing' },
+      name: 'Orphan',
+    };
+    mockRecentlyPlayed.mockReturnValue({ history: [entry] });
+
+    // #when
+    const { result } = renderHook(() => useRecentlyPlayedSection());
+
+    // #then
+    expect(result.current.items[0]).toBe(entry);
+    expect(result.current.items[0].imageUrl).toBeUndefined();
+  });
+});

--- a/src/components/LibraryRoute/hooks/__tests__/useResumeSection.test.ts
+++ b/src/components/LibraryRoute/hooks/__tests__/useResumeSection.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useResumeSection } from '../useResumeSection';
+import { STALE_SESSION_MS, type SessionSnapshot } from '@/services/sessionPersistence';
+
+function makeSession(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
+  return {
+    collectionId: 'playlist-1',
+    collectionName: 'My Playlist',
+    trackIndex: 0,
+    savedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('useResumeSection', () => {
+  it('returns no resumable when lastSession is null', () => {
+    // #when
+    const { result } = renderHook(() => useResumeSection({ lastSession: null }));
+
+    // #then
+    expect(result.current.session).toBeNull();
+    expect(result.current.hasResumable).toBe(false);
+  });
+
+  it('returns no resumable when session is stale', () => {
+    // #given
+    const stale = makeSession({ savedAt: Date.now() - STALE_SESSION_MS - 1000 });
+
+    // #when
+    const { result } = renderHook(() => useResumeSection({ lastSession: stale }));
+
+    // #then
+    expect(result.current.session).toBeNull();
+    expect(result.current.hasResumable).toBe(false);
+  });
+
+  it('surfaces session when fresh', () => {
+    // #given
+    const fresh = makeSession();
+
+    // #when
+    const { result } = renderHook(() => useResumeSection({ lastSession: fresh }));
+
+    // #then
+    expect(result.current.session).toBe(fresh);
+    expect(result.current.hasResumable).toBe(true);
+  });
+});

--- a/src/components/LibraryRoute/hooks/index.ts
+++ b/src/components/LibraryRoute/hooks/index.ts
@@ -1,0 +1,19 @@
+export { useResumeSection } from './useResumeSection';
+export type { UseResumeSectionParams, ResumeSectionState } from './useResumeSection';
+
+export { useRecentlyPlayedSection } from './useRecentlyPlayedSection';
+
+export { usePinnedSection } from './usePinnedSection';
+export type { PinnedItem, PinnedSectionState } from './usePinnedSection';
+
+export { usePlaylistsSection } from './usePlaylistsSection';
+export type { UsePlaylistsSectionParams } from './usePlaylistsSection';
+
+export { useAlbumsSection } from './useAlbumsSection';
+export type { UseAlbumsSectionParams } from './useAlbumsSection';
+
+export { useLikedSection } from './useLikedSection';
+
+export { fetchLikedForProvider } from './likedAccessors';
+
+export type { SectionState, LikedSummary } from '../types';

--- a/src/components/LibraryRoute/hooks/likedAccessors.ts
+++ b/src/components/LibraryRoute/hooks/likedAccessors.ts
@@ -1,0 +1,11 @@
+import { providerRegistry } from '@/providers/registry';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+
+export async function fetchLikedForProvider(
+  provider: ProviderId,
+  signal?: AbortSignal,
+): Promise<MediaTrack[]> {
+  const catalog = providerRegistry.get(provider)?.catalog;
+  if (!catalog) return [];
+  return catalog.listTracks({ provider, kind: 'liked' }, signal);
+}

--- a/src/components/LibraryRoute/hooks/useAlbumsSection.ts
+++ b/src/components/LibraryRoute/hooks/useAlbumsSection.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import type { AlbumInfo } from '@/services/spotify';
+import type { ProviderId } from '@/types/domain';
+import type { SectionState } from '../types';
+
+export interface UseAlbumsSectionParams {
+  providerFilter?: ProviderId[];
+  excludePinned?: boolean;
+}
+
+export function useAlbumsSection(
+  { providerFilter, excludePinned = true }: UseAlbumsSectionParams = {},
+): SectionState<AlbumInfo> {
+  const { albums, isInitialLoadComplete } = useLibrarySync();
+  const { pinnedAlbumIds } = usePinnedItems();
+
+  const items = useMemo(() => {
+    let result = albums;
+    if (providerFilter && providerFilter.length > 0) {
+      const allowed = new Set(providerFilter);
+      result = result.filter((a) => allowed.has((a.provider ?? 'spotify') as ProviderId));
+    }
+    if (excludePinned) {
+      result = result.filter((a) => !pinnedAlbumIds.includes(a.id));
+    }
+    return result;
+  }, [albums, providerFilter, excludePinned, pinnedAlbumIds]);
+
+  return {
+    items,
+    isLoading: !isInitialLoadComplete,
+    isEmpty: items.length === 0,
+  };
+}

--- a/src/components/LibraryRoute/hooks/useLikedSection.ts
+++ b/src/components/LibraryRoute/hooks/useLikedSection.ts
@@ -1,0 +1,19 @@
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
+import type { LikedSummary } from '../types';
+
+export function useLikedSection(): LikedSummary {
+  const {
+    isUnifiedLikedActive,
+    totalCount: unifiedCount,
+    isLoading: unifiedLoading,
+  } = useUnifiedLikedTracks();
+  const { likedSongsCount, likedSongsPerProvider, isLikedSongsSyncing } = useLibrarySync();
+
+  return {
+    totalCount: isUnifiedLikedActive ? unifiedCount : likedSongsCount,
+    perProvider: likedSongsPerProvider,
+    isUnified: isUnifiedLikedActive,
+    isLoading: isUnifiedLikedActive ? unifiedLoading : isLikedSongsSyncing,
+  };
+}

--- a/src/components/LibraryRoute/hooks/usePinnedSection.ts
+++ b/src/components/LibraryRoute/hooks/usePinnedSection.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { ProviderId } from '@/types/domain';
+
+export interface PinnedItem {
+  kind: 'playlist' | 'album';
+  id: string;
+  provider?: ProviderId;
+  name: string;
+  imageUrl?: string;
+}
+
+export interface PinnedSectionState {
+  pinnedPlaylists: CachedPlaylistInfo[];
+  pinnedAlbums: AlbumInfo[];
+  combined: PinnedItem[];
+  isLoading: boolean;
+  isEmpty: boolean;
+}
+
+export function usePinnedSection(): PinnedSectionState {
+  const { pinnedPlaylistIds, pinnedAlbumIds } = usePinnedItems();
+  const { playlists, albums, isInitialLoadComplete } = useLibrarySync();
+
+  const pinnedPlaylists = useMemo(
+    () => playlists.filter((p) => pinnedPlaylistIds.includes(p.id)),
+    [playlists, pinnedPlaylistIds],
+  );
+
+  const pinnedAlbums = useMemo(
+    () => albums.filter((a) => pinnedAlbumIds.includes(a.id)),
+    [albums, pinnedAlbumIds],
+  );
+
+  const combined = useMemo<PinnedItem[]>(
+    () => [
+      ...pinnedPlaylists.map((p) => ({
+        kind: 'playlist' as const,
+        id: p.id,
+        provider: p.provider,
+        name: p.name,
+        imageUrl: p.images?.[0]?.url,
+      })),
+      ...pinnedAlbums.map((a) => ({
+        kind: 'album' as const,
+        id: a.id,
+        provider: a.provider,
+        name: a.name,
+        imageUrl: a.images?.[0]?.url,
+      })),
+    ],
+    [pinnedPlaylists, pinnedAlbums],
+  );
+
+  return {
+    pinnedPlaylists,
+    pinnedAlbums,
+    combined,
+    isLoading: !isInitialLoadComplete,
+    isEmpty: combined.length === 0,
+  };
+}

--- a/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
+++ b/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { ProviderId } from '@/types/domain';
+import type { SectionState } from '../types';
+
+export interface UsePlaylistsSectionParams {
+  providerFilter?: ProviderId[];
+  excludePinned?: boolean;
+}
+
+export function usePlaylistsSection(
+  { providerFilter, excludePinned = true }: UsePlaylistsSectionParams = {},
+): SectionState<CachedPlaylistInfo> {
+  const { playlists, isInitialLoadComplete } = useLibrarySync();
+  const { pinnedPlaylistIds } = usePinnedItems();
+
+  const items = useMemo(() => {
+    let result = playlists;
+    if (providerFilter && providerFilter.length > 0) {
+      const allowed = new Set(providerFilter);
+      result = result.filter((p) => allowed.has((p.provider ?? 'spotify') as ProviderId));
+    }
+    if (excludePinned) {
+      result = result.filter((p) => !pinnedPlaylistIds.includes(p.id));
+    }
+    return result;
+  }, [playlists, providerFilter, excludePinned, pinnedPlaylistIds]);
+
+  return {
+    items,
+    isLoading: !isInitialLoadComplete,
+    isEmpty: items.length === 0,
+  };
+}

--- a/src/components/LibraryRoute/hooks/useRecentlyPlayedSection.ts
+++ b/src/components/LibraryRoute/hooks/useRecentlyPlayedSection.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useLibrarySync } from '@/hooks/useLibrarySync';
+import {
+  useRecentlyPlayedCollections,
+  type RecentlyPlayedEntry,
+} from '@/hooks/useRecentlyPlayedCollections';
+import type { SectionState } from '../types';
+
+export function useRecentlyPlayedSection(): SectionState<RecentlyPlayedEntry> {
+  const { history } = useRecentlyPlayedCollections();
+  const { playlists, albums } = useLibrarySync();
+
+  const items = useMemo<RecentlyPlayedEntry[]>(() => {
+    return history.map((entry) => {
+      if (entry.imageUrl) return entry;
+      const { ref } = entry;
+      if (ref.kind === 'playlist') {
+        const match = playlists.find(
+          (p) => p.id === ref.id && (p.provider ?? 'spotify') === ref.provider,
+        );
+        const imageUrl = match?.images?.[0]?.url;
+        return imageUrl ? { ...entry, imageUrl } : entry;
+      }
+      if (ref.kind === 'album') {
+        const match = albums.find(
+          (a) => a.id === ref.id && (a.provider ?? 'spotify') === ref.provider,
+        );
+        const imageUrl = match?.images?.[0]?.url;
+        return imageUrl ? { ...entry, imageUrl } : entry;
+      }
+      return entry;
+    });
+  }, [history, playlists, albums]);
+
+  return { items, isLoading: false, isEmpty: items.length === 0 };
+}

--- a/src/components/LibraryRoute/hooks/useResumeSection.ts
+++ b/src/components/LibraryRoute/hooks/useResumeSection.ts
@@ -1,0 +1,18 @@
+import { isSessionStale, type SessionSnapshot } from '@/services/sessionPersistence';
+
+export interface UseResumeSectionParams {
+  lastSession: SessionSnapshot | null;
+}
+
+export interface ResumeSectionState {
+  session: SessionSnapshot | null;
+  hasResumable: boolean;
+}
+
+export function useResumeSection({ lastSession }: UseResumeSectionParams): ResumeSectionState {
+  const hasResumable = !!lastSession && !isSessionStale(lastSession);
+  return {
+    session: hasResumable ? lastSession : null,
+    hasResumable,
+  };
+}

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -1,0 +1,27 @@
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+
+export interface SectionState<T> {
+  items: T[];
+  isLoading: boolean;
+  isEmpty: boolean;
+}
+
+export interface LikedSummary {
+  totalCount: number;
+  perProvider: Array<{ provider: ProviderId; count: number }>;
+  isUnified: boolean;
+  isLoading: boolean;
+}
+
+export type {
+  CachedPlaylistInfo,
+  AlbumInfo,
+  MediaTrack,
+  ProviderId,
+  RecentlyPlayedEntry,
+  SessionSnapshot,
+};


### PR DESCRIPTION
## Summary
- Adds 5 section data hooks under `src/components/LibraryRoute/hooks/`: useResumeSection, useRecentlyPlayedSection, usePinnedSection, usePlaylistsSection, useAlbumsSection
- Adds useLikedSection (count summary) + fetchLikedForProvider (per-provider accessor for #1297 context menus)
- Common types module at `src/components/LibraryRoute/types.ts`
- Hooks delegate to existing data sources (useLibrarySync, usePinnedItems, useUnifiedLikedTracks, useRecentlyPlayedCollections); legacy useLibraryRoot left intact for LibraryPage

Part of #1300. Addresses #1293.

## Test plan
- [ ] All hook tests pass under LibraryRoute/hooks/__tests__/
- [ ] tsc + lint + build clean
- [ ] No circular imports / missing exports (smoke imported all hooks in scratch and removed)