### PR TITLE
docs(library): document new route + useNewLibraryRoute flag (#1299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI assista
 
 **Vorbis Player** is a React/TypeScript music player with customizable visual effects and a pluggable provider architecture. Supports **Spotify** (streaming, Premium required) and **Dropbox** (personal files via HTML5 Audio), including cross-provider queues.
 
-Key capabilities: multi-provider auth/catalog/playback adapters, unified liked songs, cross-provider playback handoff, Last.fm-powered radio queue generation, background visualizers, album art flip menu, bottom bar, swipe gestures (queue drawer / full-screen library), keyboard shortcuts, IndexedDB caching, responsive layout.
+Key capabilities: multi-provider auth/catalog/playback adapters, unified liked songs, cross-provider playback handoff, Last.fm-powered radio queue generation, background visualizers, album art flip menu, bottom bar, swipe gestures (queue drawer / full-screen library — legacy LibraryPage and opt-in LibraryRoute behind useNewLibraryRoute), keyboard shortcuts, IndexedDB caching, responsive layout.
 
 ## Architecture docs
 
@@ -86,7 +86,7 @@ src/
 ## Terminology
 
 - **Queue** — tracks scheduled to play next (reorder/remove in `QueueDrawer` / `QueueBottomSheet`; list UI in `QueueTrackList.tsx`).
-- **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `PlaylistSelection` and loaded through `usePlaylistManager` / catalog APIs.
+- **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `PlaylistSelection` (legacy `LibraryPage`) or `LibraryRoute` (opt-in via `useNewLibraryRoute`), and loaded through `usePlaylistManager` / catalog APIs.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 #### Library drawer
 <img src="public/assets/library-drawer.png" alt="Vorbis Player - Library" width="600">
 
+> **Note:** A redesigned library route is available behind the `useNewLibraryRoute` opt-in flag (Settings → New Library Route). Screenshots above show the current default (`LibraryDrawer` / `LibraryPage`); updated imagery will land when the new route becomes default. **[NEW LIBRARY ROUTE — remove note when #1298 lands.]**
 
 ## Features
 
@@ -27,6 +28,7 @@ A music player with visualizers and multi-provider support (Spotify, Dropbox), b
 - **Zen Mode** — Distraction-free playback with hover-activated controls (desktop) or touch gestures (mobile), album art focus, and auto-hiding bottom bar
 - **Queue** — See and edit what plays next (reorder, remove, deduplicate) in the queue drawer or mobile sheet
 - **Playlists & Albums** — Browse, search, sort, filter, and pin your **library** collections (not the same as the playback queue)
+- **Library Route (opt-in)** — Redesigned library surface organized as scannable rows (Resume, Recently Played, Pinned, Liked, Playlists, Albums). Enable via Settings → New Library Route. **[NEW LIBRARY ROUTE — remove bullet when #1298 lands.]**
 - **All Music shuffle** — Dropbox users get an "All Music" card pinned to the top of the playlist grid that always plays your entire library shuffled
 - **Unified Liked Songs** — Merge liked tracks from connected providers into one queue; "Play Liked" and "Queue Liked" filter any collection to just your favorites
 - **Track Radio** — Generate a one-shot radio playlist from the current track (Last.fm-powered matching)

--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -24,15 +24,20 @@ The queue drawers (`QueueDrawer`, `QueueBottomSheet`) render `QueueSkeleton` (`s
 
 ## Full-screen library
 
-The library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered in `AudioPlayer.tsx` via `React.lazy` when `showLibrary` is true.
+Two implementations coexist behind the `useNewLibraryRoute` feature flag (`vorbis-player-new-library-route` localStorage key, default `false`):
 
-**Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
+- **Legacy library (`LibraryPage`)** — flag `false`. The library browser opens as `LibraryPage` (a full-screen view), not a drawer. `showLibrary` state in `usePlayerLogic` gates it; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryPage` is rendered via `React.lazy` from `AudioPlayer.tsx` (idle library overlay) and `PlayerStateRenderer.tsx` (idle route).
+- **New Library Route (`LibraryRoute`)** — flag `true`. A new top-level surface composed of section components (Resume hero, Recently Played, Pinned, Liked, Playlists, Albums). Mounted from the same two render sites as `LibraryPage` via the same `showLibrary` / idle-route gates, so all open/close affordances continue to work. See `src/components/LibraryRoute/`. **[NEW LIBRARY ROUTE — temporary; section is consolidated into a single description when #1298 lands.]**
 
-**Filter state** for the library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`). Opening the library from the QAP "Browse Library" button clears these keys before navigating.
+`usePlayerLogic` exposes both `state.showLibrary` (legacy boolean) and `state.currentView: 'player' | 'library'` (new). `showLibrary` is derived from `currentView` (`currentView === 'library'`); writers (`handleOpenLibrary`, `handleCloseLibrary`) drive `currentView`. Legacy readers in `PlayerContent`, `DrawerOrchestrator`, `PlayerControlsSection`, and `AudioPlayer` continue using `showLibrary` unchanged.
 
-**Recently Played history** is tracked by `useRecentlyPlayedCollections` (`src/hooks/useRecentlyPlayedCollections.ts`). It exposes `history: RecentlyPlayedEntry[]` and `record(ref, name)`. Successful collection loads via `useCollectionLoader.loadCollection` call `record` automatically. History is stored under `vorbis-player-recently-played` (localStorage), capped at 5 entries, deduped by `CollectionRef` key, newest first. `FilterSidebar` renders a "Recently Played" section with up to 5 clickable shortcuts on desktop; the section is hidden when history is empty.
+**Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer. Behavior is identical between flag states.
 
-**Mobile library overlay** renders `MobileLibraryBottomBar` (full-width search input + trailing sort dropdown) instead of the provider chip row. Mobile intentionally bypasses `providerFilters` — `ignoreProviderFilters = isMobile` in `useLibraryRoot.ts` ensures items from every enabled provider are always shown. Desktop behavior is unchanged: `FilterSidebar` provides provider chips, sort, genre, and recently-played controls.
+**Filter state** for the legacy library persists to localStorage via `useLocalStorage`. Keys are prefixed `vorbis-player-library-*` (e.g., `vorbis-player-library-search`, `vorbis-player-library-provider-filters`, `vorbis-player-library-genres`). Opening the library from the QAP "Browse Library" button clears these keys before navigating. The new route's filter persistence is described in `docs/features/library.md` once #1296 lands.
+
+**Recently Played history** is tracked by `useRecentlyPlayedCollections` (`src/hooks/useRecentlyPlayedCollections.ts`). It exposes `history: RecentlyPlayedEntry[]` and `record(ref, name)`. Successful collection loads via `useCollectionLoader.loadCollection` call `record` automatically. History is stored under `vorbis-player-recently-played` (localStorage), capped at 5 entries, deduped by `CollectionRef` key, newest first. The legacy `FilterSidebar` renders a "Recently Played" section with up to 5 clickable shortcuts on desktop (hidden when history is empty); the new route surfaces the same data via `useRecentlyPlayedSection` as a top-level row.
+
+**Mobile library overlay** (legacy): `MobileLibraryBottomBar` (full-width search input + trailing sort dropdown) instead of the provider chip row. Mobile intentionally bypasses `providerFilters` — `ignoreProviderFilters = isMobile` in `useLibraryRoot.ts` ensures items from every enabled provider are always shown. Desktop behavior is unchanged: `FilterSidebar` provides provider chips, sort, genre, and recently-played controls. The new route handles mobile/desktop layouts via its own `MobileLayout` / `DesktopLayout` styled-components in `src/components/LibraryRoute/styled.ts`.
 
 ## Idle/home routing
 
@@ -55,6 +60,8 @@ QAP is opt-in via the "Quick Access Panel" On/Off control in `VisualEffectsMenu`
 **Resume hero** — `ResumeHero` (`src/components/QuickAccessPanel/ResumeHero.tsx`) renders at the top of `QuickAccessPanel` (above `PinRing`) when a valid `lastSession` is present; clicking the Resume CTA invokes `onResume` (autoplay). The footer `ResumeCard` is suppressed inside QAP to avoid duplicate affordances; it still renders as the `footer` prop of `LibraryPage` on the idle library route.
 
 **Settings gear on idle views** — `SettingsGearButton` (`src/components/SettingsGearButton/index.tsx`) is mounted top-right by `PlayerStateRenderer` on `WelcomeScreen`, idle `LibraryPage`, and `QuickAccessPanel` via the `onOpenSettings` prop, opening the existing `VisualEffectsMenu`. Hidden during loading and error states. The active-player gear continues to live in `BottomBar` / `PlayerControlsSection`.
+
+When `useNewLibraryRoute` is enabled, the `LibraryPage` mount in the idle library route is swapped for `LibraryRoute`. Routing logic (Welcome → QAP → Hydrate → Library) is unchanged; only the leaf component differs. The `SettingsGearButton` continues to mount above the library on the idle route in both flag states. **[NEW LIBRARY ROUTE — remove paragraph when #1298 lands.]**
 
 ## Hydrate without autoplay
 

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -9,6 +9,16 @@ The library browser shows the user's music collections (playlists, albums, liked
 
 Both contexts render `LibraryPage` (default export from `src/components/PlaylistSelection/index.tsx`).
 
+## Implementations
+
+This document describes the **legacy** library implementation (`LibraryPage` + `useLibraryRoot`). A redesigned route (`LibraryRoute`) is available behind the `useNewLibraryRoute` feature flag (default off, set in Settings → New Library Route).
+
+The legacy implementation remains the default and authoritative documentation target through #1294–#1297. When #1298 retires the legacy view, this doc will be rewritten in full to cover the new route. Until then, sections describing `useLibraryRoot`, `LibraryPage`, `LibraryContext`, four-context bundling, and the `showLibrary` initialization in `PlayerStateRenderer` apply to the **flag-off path only**.
+
+For the new route's data hooks (`useResumeSection`, `useRecentlyPlayedSection`, `usePinnedSection`, `usePlaylistsSection`, `useAlbumsSection`, `useLikedSection`), see `src/components/LibraryRoute/hooks/`.
+
+**[NEW LIBRARY ROUTE — entire section removed when #1298 lands.]**
+
 ## LibraryPage
 
 **File:** `src/components/PlaylistSelection/index.tsx`
@@ -273,7 +283,7 @@ When no track is loaded (`selectedPlaylistId === null || tracks.length === 0`), 
 
 QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (default `false`), read via `useQapEnabled()` hook.
 
-`PlayerStateRenderer` initializes `showLibrary = !qapEnabled`. When the user selects a playlist from either view, `showLibrary` resets to `false` and `onPlaylistSelect` fires.
+`PlayerStateRenderer` initializes `showLibrary = !qapEnabled` (legacy path). When `useNewLibraryRoute` is enabled, the same idle-route conditions instead mount `LibraryRoute`; the gating boolean and routing inputs are identical. **[NEW LIBRARY ROUTE — sentence removed when #1298 lands.]** When the user selects a playlist from either view, `showLibrary` resets to `false` and `onPlaylistSelect` fires.
 
 ## Key Files
 
@@ -297,6 +307,9 @@ QAP preference is stored in `localStorage` key `vorbis-player-qap-enabled` (defa
 | `src/components/QuickAccessPanel/ResumeCard.tsx` | Session resume card |
 | `src/contexts/PinnedItemsContext.tsx` | Pin state and IndexedDB persistence |
 | `src/services/settings/pinnedItemsStorage.ts` | IndexedDB pin storage, MAX_PINS, events |
+| `src/components/LibraryRoute/` | New library route shell + section composition (opt-in via useNewLibraryRoute) **[NEW]** |
+| `src/components/LibraryRoute/hooks/` | Section data hooks for the new route **[NEW]** |
+| `src/hooks/useNewLibraryRoute.ts` | Feature flag for the new library route **[NEW]** |
 | `src/hooks/useLibrarySync.ts` | Collection sync engine across providers |
 | `src/hooks/useUnifiedLikedTracks.ts` | Cross-provider liked songs merge |
 | `src/hooks/useQapEnabled.ts` | QAP preference (localStorage) |

--- a/docs/features/player-controls.md
+++ b/docs/features/player-controls.md
@@ -51,6 +51,8 @@ return {
 };
 ```
 
+> The active-player Settings menu (AppSettingsMenu rendered from PlayerControlsSection) gains a "New Library Route" toggle when this branch ships; flipping it changes which library component opens via the existing affordances (BottomBar button, swipe-down, keyboard ↓ / L). **[NEW LIBRARY ROUTE — note removed when #1298 lands.]**
+
 ### Ref-based state pattern
 
 `tracksRef`, `currentTrackIndexRef`, and `expectedTrackIdRef` are `useRef` mirrors of their corresponding React state. This is intentional: the `usePlaybackSubscription` effect depends only on `activeDescriptor`, not on tracks/index. Without refs, every track change would tear down and recreate the provider subscription, triggering a `getState()` call that briefly resets `currentTrackIndex` to the old track.
@@ -333,6 +335,8 @@ qapEnabled (from useQapEnabled) ?
 ### QAP preference
 
 Stored in `localStorage` under key `vorbis-player-qap-enabled` (default `false`). Toggled via the settings panel (`VisualEffectsMenu`). The `useQapEnabled()` hook wraps `useLocalStorage`.
+
+> See also docs/features/settings.md § "New Library Route (opt-in)" for the parallel library route flag. **[NEW LIBRARY ROUTE — line removed when #1298 lands.]**
 
 ### Other states
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -136,6 +136,16 @@ export const useQapEnabled = (): [boolean, (value: boolean) => void] => {
 
 The QAP key is NOT centralized in `STORAGE_KEYS`. It is hardcoded as a string literal in `useQapEnabled.ts`. If you need to reference it elsewhere, use the hook or duplicate the string.
 
+### New Library Route (opt-in)
+
+A redesigned library surface (`LibraryRoute`) replacing the legacy `LibraryPage`. Toggle via the **New Library Route** On/Off pills in Settings. Persists to localStorage as `vorbis-player-new-library-route` (default `false`) via `useNewLibraryRoute()` hook. When enabled, both the idle library route (`PlayerStateRenderer`) and the active-player library overlay (`AudioPlayer`) render `LibraryRoute` instead of `LibraryPage`. The toggle is read in:
+
+- `src/components/AudioPlayer.tsx` — gates idle library mount
+- `src/components/PlayerStateRenderer.tsx` — gates idle library route
+- `src/components/PlayerContent/PlayerControlsSection.tsx` — wires the toggle setter into the active-player Settings menu
+
+**[NEW LIBRARY ROUTE — section removed when #1298 lands and the toggle disappears.]**
+
 ## Dropbox Preferences Sync
 
 File: `src/providers/dropbox/dropboxPreferencesSync.ts`
@@ -271,6 +281,7 @@ These are compatible because `JSON.parse('"true"')` and `'true' === 'true'` both
 | `src/constants/storage.ts` | `STORAGE_KEYS` constant object |
 | `src/hooks/useLocalStorage.ts` | Generic localStorage hook with cross-tab sync |
 | `src/hooks/useQapEnabled.ts` | QAP preference hook |
+| `src/hooks/useNewLibraryRoute.ts` | New Library Route flag (localStorage) **[NEW]** |
 | `src/contexts/VisualEffectsContext.tsx` | Visual effects state (glow, visualizer, translucence, zen) |
 | `src/providers/dropbox/dropboxPreferencesSync.ts` | Dropbox preferences sync service |
 | `src/components/PlayerContent/PlayerControlsSection.tsx` | Wires settings props from contexts to the drawer |


### PR DESCRIPTION
## Summary
- Updates docs/architecture/layout.md with new route structure, view-state model, section taxonomy
- Adds opt-in note to README.md + Library Route features bullet
- Patches CLAUDE.md capabilities + terminology
- Inserts Implementations section in docs/features/library.md (legacy doc remains authoritative until #1298)
- Adds New Library Route section to docs/features/settings.md
- Cross-references in docs/features/player-controls.md
- All edits use \`[NEW LIBRARY ROUTE — ...]\` callouts for mechanical removal in #1298

Part of #1300. Addresses #1299.

## Test plan
- [x] rg "NEW LIBRARY ROUTE" → 13 matches (9 callouts + 4 **[NEW]** table markers)
- [x] tsc clean (no code-fence breakage)
- [x] Markdown-only diff, no test impact