### PR TITLE
feat(library): sections UI (#1294)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -487,7 +487,7 @@ const AudioPlayerComponent = () => {
                 onQueueLikedTracks={handleQueueLikedTracks}
                 onOpenSettings={handleOpenSettings}
                 onResume={handleResume}
-                hasResumableSession={!!lastSession?.queueTracks?.length}
+                lastSession={lastSession}
               />
             ) : (
               <LibraryPage

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -7,12 +7,49 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
   usePlayerSizingContext: vi.fn(),
 }));
 
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    hasMultipleProviders: false,
+    enabledProviderIds: ['spotify'],
+  })),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(() => ({
+    unifiedTracks: [],
+    isUnifiedLikedActive: false,
+    totalCount: 0,
+    isLoading: false,
+  })),
+}));
+
+vi.mock('../hooks', () => ({
+  useResumeSection: vi.fn(() => ({ session: null, hasResumable: false })),
+  useRecentlyPlayedSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  usePinnedSection: vi.fn(() => ({
+    pinnedPlaylists: [],
+    pinnedAlbums: [],
+    combined: [],
+    isLoading: false,
+    isEmpty: true,
+  })),
+  usePlaylistsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useAlbumsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useLikedSection: vi.fn(() => ({
+    totalCount: 0,
+    perProvider: [],
+    isUnified: false,
+    isLoading: false,
+  })),
+  fetchLikedForProvider: vi.fn(async () => []),
+}));
+
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const baseProps = {
   onPlaylistSelect: vi.fn(),
   onOpenSettings: vi.fn(),
-  hasResumableSession: false,
+  lastSession: null,
 };
 
 describe('LibraryRoute', () => {
@@ -20,83 +57,38 @@ describe('LibraryRoute', () => {
     vi.clearAllMocks();
   });
 
-  describe('layout selection', () => {
-    it('renders mobile shell when isMobile is true', () => {
-      // #given
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
+  it('renders mobile layout testid when isMobile is true', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
 
-      // #when
-      render(<LibraryRoute {...baseProps} />);
+    // #when
+    render(<LibraryRoute {...baseProps} />);
 
-      // #then
-      expect(screen.getByTestId('library-route-mobile')).toBeInTheDocument();
-      expect(screen.queryByTestId('library-route-desktop')).not.toBeInTheDocument();
-    });
-
-    it('renders desktop shell when isMobile is false', () => {
-      // #given
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
-
-      // #when
-      render(<LibraryRoute {...baseProps} />);
-
-      // #then
-      expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
-      expect(screen.queryByTestId('library-route-mobile')).not.toBeInTheDocument();
-    });
+    // #then
+    expect(screen.getByTestId('library-route-mobile')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-route-desktop')).not.toBeInTheDocument();
   });
 
-  describe('session props', () => {
-    it('renders with hasResumableSession true and callable onResume', () => {
-      // #given
-      const onResume = vi.fn();
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+  it('renders desktop layout testid when isMobile is false', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
 
-      // #when
-      render(<LibraryRoute {...baseProps} hasResumableSession={true} onResume={onResume} />);
+    // #when
+    render(<LibraryRoute {...baseProps} />);
 
-      // #then
-      expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
-    });
-
-    it('renders with hasResumableSession false without onResume', () => {
-      // #given
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
-
-      // #when
-      render(<LibraryRoute {...baseProps} hasResumableSession={false} />);
-
-      // #then
-      expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
-    });
+    // #then
+    expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-route-mobile')).not.toBeInTheDocument();
   });
 
-  describe('optional callback props', () => {
-    it('accepts onAddToQueue as optional', () => {
-      // #given
-      const onAddToQueue = vi.fn().mockResolvedValue(null);
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+  it('renders HomeView at home view by default', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
 
-      // #when / #then — no error on render
-      expect(() => render(<LibraryRoute {...baseProps} onAddToQueue={onAddToQueue} />)).not.toThrow();
-    });
+    // #when
+    render(<LibraryRoute {...baseProps} />);
 
-    it('accepts onPlayLikedTracks as optional', () => {
-      // #given
-      const onPlayLikedTracks = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
-
-      // #when / #then — no error on render
-      expect(() => render(<LibraryRoute {...baseProps} onPlayLikedTracks={onPlayLikedTracks} />)).not.toThrow();
-    });
-
-    it('accepts onQueueLikedTracks as optional', () => {
-      // #given
-      const onQueueLikedTracks = vi.fn();
-      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
-
-      // #when / #then — no error on render
-      expect(() => render(<LibraryRoute {...baseProps} onQueueLikedTracks={onQueueLikedTracks} />)).not.toThrow();
-    });
+    // #then
+    expect(screen.getByTestId('library-home')).toBeInTheDocument();
   });
 });

--- a/src/components/LibraryRoute/card/LibraryCard.styled.ts
+++ b/src/components/LibraryRoute/card/LibraryCard.styled.ts
@@ -1,0 +1,95 @@
+import styled, { css } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const CardButton = styled.button<{ $variant: 'row' | 'grid' }>`
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.sm};
+  color: inherit;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+
+  ${({ $variant }) =>
+    $variant === 'row'
+      ? css`
+          width: 144px;
+          flex: 0 0 auto;
+          scroll-snap-align: start;
+        `
+      : css`
+          width: 100%;
+        `}
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+    border-radius: ${theme.borderRadius.lg};
+  }
+`;
+
+export const ArtWrap = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: ${theme.borderRadius.lg};
+  overflow: hidden;
+  background: ${theme.colors.muted.background};
+`;
+
+export const ArtImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+`;
+
+export const ArtPlaceholder = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: ${theme.fontSize.lg};
+  color: ${theme.colors.muted.foreground};
+`;
+
+export const ProviderBadge = styled.span`
+  position: absolute;
+  top: ${theme.spacing.xs};
+  right: ${theme.spacing.xs};
+  padding: 0 ${theme.spacing.xs};
+  border-radius: ${theme.borderRadius.sm};
+  background: rgba(0, 0, 0, 0.6);
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.xs};
+  text-transform: capitalize;
+`;
+
+export const Title = styled.div`
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.medium};
+  line-height: 1.2;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+export const Subtitle = styled.div`
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.xs};
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/components/LibraryRoute/card/LibraryCard.tsx
+++ b/src/components/LibraryRoute/card/LibraryCard.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback } from 'react';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import type { ProviderId } from '@/types/domain';
+import { useLongPress } from './useLongPress';
+import {
+  CardButton,
+  ArtWrap,
+  ArtImage,
+  ArtPlaceholder,
+  ProviderBadge,
+  Title,
+  Subtitle,
+} from './LibraryCard.styled';
+
+export interface LibraryCardProps {
+  kind: LibraryItemKind;
+  id: string;
+  provider?: ProviderId;
+  name: string;
+  subtitle?: string;
+  imageUrl?: string;
+  showProviderBadge?: boolean;
+  variant: 'row' | 'grid';
+  onSelect: () => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const placeholderGlyphForKind = (kind: LibraryItemKind): string => {
+  switch (kind) {
+    case 'album':
+      return '💿';
+    case 'liked':
+      return '♥';
+    case 'recently-played':
+      return '⏱';
+    default:
+      return '♪';
+  }
+};
+
+const LibraryCard: React.FC<LibraryCardProps> = ({
+  kind,
+  id,
+  provider,
+  name,
+  subtitle,
+  imageUrl,
+  showProviderBadge,
+  variant,
+  onSelect,
+  onContextMenuRequest,
+}) => {
+  const longPressEnabled = !!onContextMenuRequest;
+
+  const fireContextMenu = useCallback(
+    (anchorRect: DOMRect) => {
+      onContextMenuRequest?.({ kind, id, provider, name, anchorRect });
+    },
+    [onContextMenuRequest, kind, id, provider, name],
+  );
+
+  const longPressHandlers = useLongPress({
+    onLongPress: fireContextMenu,
+    onTap: longPressEnabled ? onSelect : undefined,
+    enabled: longPressEnabled,
+  });
+
+  const handleClick = useCallback(() => {
+    if (longPressEnabled) return;
+    onSelect();
+  }, [longPressEnabled, onSelect]);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      if (!onContextMenuRequest) return;
+      e.preventDefault();
+      const anchor = new DOMRect(e.clientX, e.clientY, 0, 0);
+      fireContextMenu(anchor);
+    },
+    [onContextMenuRequest, fireContextMenu],
+  );
+
+  return (
+    <CardButton
+      type="button"
+      $variant={variant}
+      data-testid={`library-card-${kind}-${id}`}
+      onClick={handleClick}
+      onContextMenu={handleContextMenu}
+      {...longPressHandlers}
+      aria-label={subtitle ? `${name}, ${subtitle}` : name}
+    >
+      <ArtWrap>
+        {imageUrl ? (
+          <ArtImage src={imageUrl} alt="" loading="lazy" />
+        ) : (
+          <ArtPlaceholder>{placeholderGlyphForKind(kind)}</ArtPlaceholder>
+        )}
+        {showProviderBadge && provider && <ProviderBadge>{provider}</ProviderBadge>}
+      </ArtWrap>
+      <Title>{name}</Title>
+      {subtitle && <Subtitle>{subtitle}</Subtitle>}
+    </CardButton>
+  );
+};
+
+LibraryCard.displayName = 'LibraryCard';
+export default LibraryCard;

--- a/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
+++ b/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LibraryCard from '../LibraryCard';
+
+const baseProps = {
+  kind: 'playlist' as const,
+  id: 'p1',
+  name: 'Sample Playlist',
+  variant: 'row' as const,
+  onSelect: vi.fn(),
+};
+
+describe('LibraryCard', () => {
+  it('renders artwork image when imageUrl provided', () => {
+    // #given
+    render(<LibraryCard {...baseProps} imageUrl="https://example.com/x.png" />);
+
+    // #then
+    const img = document.querySelector('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/x.png');
+  });
+
+  it('renders placeholder glyph when no imageUrl', () => {
+    // #given
+    render(<LibraryCard {...baseProps} />);
+
+    // #then
+    expect(screen.getByText('♪')).toBeInTheDocument();
+  });
+
+  it('shows provider badge only when showProviderBadge is true', () => {
+    // #given
+    const { rerender } = render(<LibraryCard {...baseProps} provider="spotify" />);
+    expect(screen.queryByText('spotify')).not.toBeInTheDocument();
+
+    // #when
+    rerender(<LibraryCard {...baseProps} provider="spotify" showProviderBadge />);
+
+    // #then
+    expect(screen.getByText('spotify')).toBeInTheDocument();
+  });
+
+  it('fires onSelect on click when no onContextMenuRequest', () => {
+    // #given
+    const onSelect = vi.fn();
+    render(<LibraryCard {...baseProps} onSelect={onSelect} />);
+
+    // #when
+    fireEvent.click(screen.getByTestId('library-card-playlist-p1'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onContextMenuRequest with click coords on right-click', () => {
+    // #given
+    const onContextMenuRequest = vi.fn();
+    render(<LibraryCard {...baseProps} onContextMenuRequest={onContextMenuRequest} />);
+
+    // #when
+    fireEvent.contextMenu(screen.getByTestId('library-card-playlist-p1'), { clientX: 50, clientY: 75 });
+
+    // #then
+    expect(onContextMenuRequest).toHaveBeenCalledTimes(1);
+    const req = onContextMenuRequest.mock.calls[0][0];
+    expect(req.kind).toBe('playlist');
+    expect(req.id).toBe('p1');
+    expect(req.anchorRect.x).toBe(50);
+    expect(req.anchorRect.y).toBe(75);
+  });
+
+  it('uses correct testid for different kinds', () => {
+    // #given
+    render(<LibraryCard {...baseProps} kind="album" id="a1" />);
+
+    // #then
+    expect(screen.getByTestId('library-card-album-a1')).toBeInTheDocument();
+  });
+});

--- a/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
+++ b/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPress } from '../useLongPress';
+
+function makeEvent(overrides: Partial<{ clientX: number; clientY: number }> = {}): React.PointerEvent<HTMLElement> {
+  const target = document.createElement('div');
+  return {
+    clientX: overrides.clientX ?? 0,
+    clientY: overrides.clientY ?? 0,
+    currentTarget: target,
+  } as unknown as React.PointerEvent<HTMLElement>;
+}
+
+describe('useLongPress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires onLongPress after 500ms hold without movement', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ clientX: 10, clientY: 10 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // #then
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels long-press when pointer moves more than 8px', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ clientX: 0, clientY: 0 }));
+      result.current.onPointerMove(makeEvent({ clientX: 20, clientY: 0 }));
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('fires onTap when pointer up before timer without long-press', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ clientX: 0, clientY: 0 }));
+      result.current.onPointerUp(makeEvent());
+    });
+
+    // #then
+    expect(onTap).toHaveBeenCalledTimes(1);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('suppresses onTap when long-press has fired', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ clientX: 0, clientY: 0 }));
+      vi.advanceTimersByTime(500);
+      result.current.onPointerUp(makeEvent());
+    });
+
+    // #then
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when disabled', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap, enabled: false }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ clientX: 0, clientY: 0 }));
+      vi.advanceTimersByTime(500);
+      result.current.onPointerUp(makeEvent());
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('cancels long-press on pointer cancel', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent());
+      result.current.onPointerCancel(makeEvent());
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LibraryRoute/card/useLongPress.ts
+++ b/src/components/LibraryRoute/card/useLongPress.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const LONG_PRESS_MS = 500;
+const MOVE_TOLERANCE_PX = 8;
+
+export interface UseLongPressOptions {
+  onLongPress: (anchor: DOMRect) => void;
+  onTap?: () => void;
+  enabled?: boolean;
+}
+
+interface PointerState {
+  startX: number;
+  startY: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  triggered: boolean;
+  active: boolean;
+}
+
+export interface UseLongPressHandlers {
+  onPointerDown: (e: React.PointerEvent<HTMLElement>) => void;
+  onPointerMove: (e: React.PointerEvent<HTMLElement>) => void;
+  onPointerUp: (e: React.PointerEvent<HTMLElement>) => void;
+  onPointerCancel: (e: React.PointerEvent<HTMLElement>) => void;
+  onPointerLeave: (e: React.PointerEvent<HTMLElement>) => void;
+}
+
+export function useLongPress({ onLongPress, onTap, enabled = true }: UseLongPressOptions): UseLongPressHandlers {
+  const stateRef = useRef<PointerState>({
+    startX: 0,
+    startY: 0,
+    timer: null,
+    triggered: false,
+    active: false,
+  });
+
+  const clearTimer = useCallback(() => {
+    if (stateRef.current.timer !== null) {
+      clearTimeout(stateRef.current.timer);
+      stateRef.current.timer = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const state = stateRef.current;
+      state.startX = e.clientX;
+      state.startY = e.clientY;
+      state.triggered = false;
+      state.active = true;
+      const target = e.currentTarget as HTMLElement;
+      state.timer = setTimeout(() => {
+        if (!state.active) return;
+        state.triggered = true;
+        const rect = target.getBoundingClientRect();
+        const anchor = new DOMRect(state.startX, state.startY, 0, 0);
+        onLongPress(rect.width > 0 ? anchor : rect);
+      }, LONG_PRESS_MS);
+    },
+    [enabled, onLongPress],
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    const state = stateRef.current;
+    if (!state.active) return;
+    const dx = e.clientX - state.startX;
+    const dy = e.clientY - state.startY;
+    if (Math.hypot(dx, dy) > MOVE_TOLERANCE_PX) {
+      clearTimer();
+      state.active = false;
+    }
+  }, [clearTimer]);
+
+  const onPointerUp = useCallback(() => {
+    const state = stateRef.current;
+    const wasTriggered = state.triggered;
+    const wasActive = state.active;
+    clearTimer();
+    state.active = false;
+    state.triggered = false;
+    if (wasActive && !wasTriggered) {
+      onTap?.();
+    }
+  }, [clearTimer, onTap]);
+
+  const onPointerCancel = useCallback(() => {
+    clearTimer();
+    stateRef.current.active = false;
+    stateRef.current.triggered = false;
+  }, [clearTimer]);
+
+  const onPointerLeave = useCallback(() => {
+    clearTimer();
+    stateRef.current.active = false;
+  }, [clearTimer]);
+
+  return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onPointerLeave };
+}

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import type { ProviderId, AddToQueueResult, MediaTrack } from '@/types/domain';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { toAlbumPlaylistId } from '@/constants/playlist';
 import { LibraryRouteRoot, MobileLayout, DesktopLayout } from './styled';
+import HomeView from './views/HomeView';
+import SeeAllView from './views/SeeAllView';
+import { fetchLikedForProvider } from './hooks';
+import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from './types';
 
 // LibraryRoute assumes upstream guards have already filtered out cold-start cases:
 // - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
@@ -11,26 +18,115 @@ import { LibraryRouteRoot, MobileLayout, DesktopLayout } from './styled';
 export interface LibraryRouteProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue?: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
-  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
+  onPlayLikedTracks?: (
+    tracks: MediaTrack[],
+    collectionId: string,
+    collectionName: string,
+    provider?: ProviderId,
+  ) => Promise<void>;
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   onOpenSettings: () => void;
   onResume?: () => void;
-  hasResumableSession: boolean;
+  lastSession?: SessionSnapshot | null;
 }
 
-const LibraryRoute: React.FC<LibraryRouteProps> = () => {
+const LibraryRoute: React.FC<LibraryRouteProps> = ({
+  onPlaylistSelect,
+  onPlayLikedTracks,
+  onResume,
+  lastSession,
+}) => {
   const { isMobile } = usePlayerSizingContext();
+  const [view, setView] = useState<LibraryRouteView>('home');
+  const { unifiedTracks, isUnifiedLikedActive } = useUnifiedLikedTracks();
+
+  const handleSelectCollection = useCallback(
+    (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => {
+      if (kind === 'album') {
+        onPlaylistSelect(toAlbumPlaylistId(id), name, provider);
+        return;
+      }
+      // playlist or recently-played-as-playlist: pass id through
+      onPlaylistSelect(id, name, provider);
+    },
+    [onPlaylistSelect],
+  );
+
+  const handleSelectLiked = useCallback(
+    async (provider?: ProviderId) => {
+      if (!onPlayLikedTracks) return;
+      // Why: when unified-liked is active and no provider was specified, the in-memory
+      // unifiedTracks list is the source. For a per-provider liked tile the unified list
+      // may not be authoritative for that single provider, so fetch it directly.
+      let tracks: MediaTrack[];
+      let collectionId: string;
+      let providerArg: ProviderId | undefined;
+      if (provider) {
+        tracks = await fetchLikedForProvider(provider);
+        collectionId = `liked-${provider}`;
+        providerArg = provider;
+      } else if (isUnifiedLikedActive) {
+        tracks = unifiedTracks;
+        collectionId = 'liked-unified';
+        providerArg = undefined;
+      } else {
+        // single-provider, non-unified path — fall back to the active provider's liked
+        const inferred: ProviderId = unifiedTracks[0]?.provider ?? 'spotify';
+        tracks = await fetchLikedForProvider(inferred);
+        collectionId = `liked-${inferred}`;
+        providerArg = inferred;
+      }
+      if (tracks.length === 0) return;
+      await onPlayLikedTracks(tracks, collectionId, 'Liked Songs', providerArg);
+    },
+    [onPlayLikedTracks, isUnifiedLikedActive, unifiedTracks],
+  );
+
+  const handleContextMenuRequest = useCallback((req: ContextMenuRequest) => {
+    // #1297 will mount the context menu portal. For #1294 the request is logged in dev
+    // so click affordances are visible during integration without forcing menu shape now.
+    if (import.meta.env.DEV) {
+      console.debug('[LibraryRoute] context menu requested', req);
+    }
+  }, []);
+
+  const layout: 'row' | 'grid' = isMobile ? 'row' : 'grid';
+  const Layout = isMobile ? MobileLayout : DesktopLayout;
+  const layoutTestId = isMobile ? 'library-route-mobile' : 'library-route-desktop';
+
   return (
     <LibraryRouteRoot>
-      {isMobile ? (
-        <MobileLayout data-testid="library-route-mobile">
-          <div>New Library Route — mobile shell (placeholder)</div>
-        </MobileLayout>
-      ) : (
-        <DesktopLayout data-testid="library-route-desktop">
-          <div>New Library Route — desktop shell (placeholder)</div>
-        </DesktopLayout>
-      )}
+      <Layout data-testid={layoutTestId}>
+        {view === 'home' ? (
+          <HomeView
+            layout={layout}
+            lastSession={lastSession ?? null}
+            onResume={onResume}
+            onSelectCollection={handleSelectCollection}
+            onSelectLiked={handleSelectLiked}
+            onNavigate={setView}
+            onContextMenuRequest={handleContextMenuRequest}
+          />
+        ) : view === 'liked' ? (
+          // Liked has no SeeAll page — fall back to home defensively if navigated here.
+          <HomeView
+            layout={layout}
+            lastSession={lastSession ?? null}
+            onResume={onResume}
+            onSelectCollection={handleSelectCollection}
+            onSelectLiked={handleSelectLiked}
+            onNavigate={setView}
+            onContextMenuRequest={handleContextMenuRequest}
+          />
+        ) : (
+          <SeeAllView
+            view={view}
+            onBack={() => setView('home')}
+            onSelectCollection={handleSelectCollection}
+            onContextMenuRequest={handleContextMenuRequest}
+          />
+        )}
+      </Layout>
     </LibraryRouteRoot>
   );
 };

--- a/src/components/LibraryRoute/sections/AlbumsSection.tsx
+++ b/src/components/LibraryRoute/sections/AlbumsSection.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { useAlbumsSection } from '../hooks';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import Section from './Section';
+import SectionSkeleton from './SectionSkeleton';
+import LibraryCard from '../card/LibraryCard';
+
+const SEE_ALL_THRESHOLD = 8;
+
+export interface AlbumsSectionProps {
+  layout: 'row' | 'grid';
+  excludePinned?: boolean;
+  showProviderBadges?: boolean;
+  onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
+  onSeeAll?: () => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const AlbumsSection: React.FC<AlbumsSectionProps> = ({
+  layout,
+  excludePinned = true,
+  showProviderBadges,
+  onSelect,
+  onSeeAll,
+  onContextMenuRequest,
+}) => {
+  const { items, isLoading, isEmpty } = useAlbumsSection({ excludePinned });
+  if (!isLoading && isEmpty) return null;
+
+  const showSeeAll = layout === 'row' && items.length > SEE_ALL_THRESHOLD;
+
+  return (
+    <Section
+      title="Albums"
+      id="albums"
+      layout={layout}
+      onSeeAll={showSeeAll ? onSeeAll : undefined}
+    >
+      {isLoading && items.length === 0 ? (
+        <SectionSkeleton variant={layout} />
+      ) : (
+        items.map((a) => (
+          <LibraryCard
+            key={`${a.provider ?? 'spotify'}-${a.id}`}
+            kind="album"
+            id={a.id}
+            provider={a.provider}
+            name={a.name}
+            subtitle={a.artists}
+            imageUrl={a.images?.[0]?.url}
+            showProviderBadge={showProviderBadges}
+            variant={layout === 'row' ? 'row' : 'grid'}
+            onSelect={() => onSelect('album', a.id, a.name, a.provider)}
+            onContextMenuRequest={onContextMenuRequest}
+          />
+        ))
+      )}
+    </Section>
+  );
+};
+
+AlbumsSection.displayName = 'AlbumsSection';
+export default AlbumsSection;

--- a/src/components/LibraryRoute/sections/LikedSection.tsx
+++ b/src/components/LibraryRoute/sections/LikedSection.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { useLikedSection } from '../hooks';
+import type { ContextMenuRequest } from '../types';
+import Section from './Section';
+import SectionSkeleton from './SectionSkeleton';
+import LibraryCard from '../card/LibraryCard';
+
+export interface LikedSectionProps {
+  layout: 'row' | 'grid';
+  showProviderBadges?: boolean;
+  onSelectLiked: (provider?: ProviderId) => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const formatCount = (n: number): string => `${n} song${n === 1 ? '' : 's'}`;
+
+const LikedSection: React.FC<LikedSectionProps> = ({
+  layout,
+  showProviderBadges,
+  onSelectLiked,
+  onContextMenuRequest,
+}) => {
+  const { totalCount, perProvider, isUnified, isLoading } = useLikedSection();
+  const isEmpty = totalCount === 0;
+  if (!isLoading && isEmpty) return null;
+
+  const showPerProvider = !isUnified && showProviderBadges && perProvider.length > 1;
+
+  return (
+    <Section title="Liked Songs" id="liked" layout={layout}>
+      {isLoading && isEmpty ? (
+        <SectionSkeleton variant={layout} count={1} />
+      ) : showPerProvider ? (
+        perProvider.map(({ provider, count }) => (
+          <LibraryCard
+            key={`liked-${provider}`}
+            kind="liked"
+            id={`liked-${provider}`}
+            provider={provider}
+            name="Liked Songs"
+            subtitle={formatCount(count)}
+            showProviderBadge
+            variant={layout === 'row' ? 'row' : 'grid'}
+            onSelect={() => onSelectLiked(provider)}
+            onContextMenuRequest={onContextMenuRequest}
+          />
+        ))
+      ) : (
+        <LibraryCard
+          kind="liked"
+          id="liked"
+          name="Liked Songs"
+          subtitle={formatCount(totalCount)}
+          variant={layout === 'row' ? 'row' : 'grid'}
+          onSelect={() => onSelectLiked()}
+          onContextMenuRequest={onContextMenuRequest}
+        />
+      )}
+    </Section>
+  );
+};
+
+LikedSection.displayName = 'LikedSection';
+export default LikedSection;

--- a/src/components/LibraryRoute/sections/PinnedSection.tsx
+++ b/src/components/LibraryRoute/sections/PinnedSection.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { usePinnedSection } from '../hooks';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import Section from './Section';
+import SectionSkeleton from './SectionSkeleton';
+import LibraryCard from '../card/LibraryCard';
+
+const SEE_ALL_THRESHOLD = 6;
+
+export interface PinnedSectionProps {
+  layout: 'row' | 'grid';
+  showProviderBadges?: boolean;
+  onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
+  onSeeAll?: () => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const PinnedSection: React.FC<PinnedSectionProps> = ({
+  layout,
+  showProviderBadges,
+  onSelect,
+  onSeeAll,
+  onContextMenuRequest,
+}) => {
+  const { combined, isLoading, isEmpty } = usePinnedSection();
+  if (!isLoading && isEmpty) return null;
+
+  const showSeeAll = layout === 'row' && combined.length > SEE_ALL_THRESHOLD;
+
+  return (
+    <Section
+      title="Pinned"
+      id="pinned"
+      layout={layout}
+      onSeeAll={showSeeAll ? onSeeAll : undefined}
+    >
+      {isLoading && combined.length === 0 ? (
+        <SectionSkeleton variant={layout} />
+      ) : (
+        combined.map((item) => (
+          <LibraryCard
+            key={`${item.kind}-${item.provider ?? 'default'}-${item.id}`}
+            kind={item.kind}
+            id={item.id}
+            provider={item.provider}
+            name={item.name}
+            imageUrl={item.imageUrl}
+            showProviderBadge={showProviderBadges}
+            variant={layout === 'row' ? 'row' : 'grid'}
+            onSelect={() => onSelect(item.kind, item.id, item.name, item.provider)}
+            onContextMenuRequest={onContextMenuRequest}
+          />
+        ))
+      )}
+    </Section>
+  );
+};
+
+PinnedSection.displayName = 'PinnedSection';
+export default PinnedSection;

--- a/src/components/LibraryRoute/sections/PlaylistsSection.tsx
+++ b/src/components/LibraryRoute/sections/PlaylistsSection.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { usePlaylistsSection } from '../hooks';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import Section from './Section';
+import SectionSkeleton from './SectionSkeleton';
+import LibraryCard from '../card/LibraryCard';
+
+const SEE_ALL_THRESHOLD = 8;
+
+export interface PlaylistsSectionProps {
+  layout: 'row' | 'grid';
+  excludePinned?: boolean;
+  showProviderBadges?: boolean;
+  onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
+  onSeeAll?: () => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const PlaylistsSection: React.FC<PlaylistsSectionProps> = ({
+  layout,
+  excludePinned = true,
+  showProviderBadges,
+  onSelect,
+  onSeeAll,
+  onContextMenuRequest,
+}) => {
+  const { items, isLoading, isEmpty } = usePlaylistsSection({ excludePinned });
+  if (!isLoading && isEmpty) return null;
+
+  const showSeeAll = layout === 'row' && items.length > SEE_ALL_THRESHOLD;
+
+  return (
+    <Section
+      title="Playlists"
+      id="playlists"
+      layout={layout}
+      onSeeAll={showSeeAll ? onSeeAll : undefined}
+    >
+      {isLoading && items.length === 0 ? (
+        <SectionSkeleton variant={layout} />
+      ) : (
+        items.map((p) => (
+          <LibraryCard
+            key={`${p.provider ?? 'spotify'}-${p.id}`}
+            kind="playlist"
+            id={p.id}
+            provider={p.provider}
+            name={p.name}
+            imageUrl={p.images?.[0]?.url}
+            showProviderBadge={showProviderBadges}
+            variant={layout === 'row' ? 'row' : 'grid'}
+            onSelect={() => onSelect('playlist', p.id, p.name, p.provider)}
+            onContextMenuRequest={onContextMenuRequest}
+          />
+        ))
+      )}
+    </Section>
+  );
+};
+
+PlaylistsSection.displayName = 'PlaylistsSection';
+export default PlaylistsSection;

--- a/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
+++ b/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { useRecentlyPlayedSection } from '../hooks';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import Section from './Section';
+import SectionSkeleton from './SectionSkeleton';
+import LibraryCard from '../card/LibraryCard';
+
+const SEE_ALL_THRESHOLD = 4;
+
+export interface RecentlyPlayedSectionProps {
+  layout: 'row' | 'grid';
+  showProviderBadges?: boolean;
+  onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
+  onSeeAll?: () => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const RecentlyPlayedSection: React.FC<RecentlyPlayedSectionProps> = ({
+  layout,
+  showProviderBadges,
+  onSelect,
+  onSeeAll,
+  onContextMenuRequest,
+}) => {
+  const { items, isLoading, isEmpty } = useRecentlyPlayedSection();
+  if (!isLoading && isEmpty) return null;
+
+  const showSeeAll = layout === 'row' && items.length > SEE_ALL_THRESHOLD;
+
+  return (
+    <Section
+      title="Recently Played"
+      id="recently-played"
+      layout={layout}
+      onSeeAll={showSeeAll ? onSeeAll : undefined}
+    >
+      {isLoading && items.length === 0 ? (
+        <SectionSkeleton variant={layout} />
+      ) : (
+        items.map((entry) => {
+          const { ref, name, imageUrl } = entry;
+          let cardKind: LibraryItemKind;
+          let cardId: string;
+          if (ref.kind === 'liked') {
+            cardKind = 'liked';
+            cardId = 'liked';
+          } else if (ref.kind === 'album') {
+            cardKind = 'album';
+            cardId = ref.id;
+          } else {
+            cardKind = 'playlist';
+            cardId = ref.id;
+          }
+          return (
+            <LibraryCard
+              key={`${ref.provider}-${ref.kind}-${cardId}`}
+              kind={cardKind}
+              id={cardId}
+              provider={ref.provider}
+              name={name}
+              imageUrl={imageUrl ?? undefined}
+              showProviderBadge={showProviderBadges}
+              variant={layout === 'row' ? 'row' : 'grid'}
+              onSelect={() => onSelect(cardKind, cardId, name, ref.provider)}
+              onContextMenuRequest={onContextMenuRequest}
+            />
+          );
+        })
+      )}
+    </Section>
+  );
+};
+
+RecentlyPlayedSection.displayName = 'RecentlyPlayedSection';
+export default RecentlyPlayedSection;

--- a/src/components/LibraryRoute/sections/ResumeHero.styled.ts
+++ b/src/components/LibraryRoute/sections/ResumeHero.styled.ts
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const Root = styled.section`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.md};
+  padding: ${theme.spacing.md};
+  margin: 0 ${theme.spacing.md};
+  border-radius: ${theme.borderRadius.lg};
+  background: ${theme.colors.muted.background};
+  border: 1px solid ${theme.colors.borderSubtle};
+`;
+
+export const Art = styled.div`
+  width: 120px;
+  height: 120px;
+  border-radius: ${theme.borderRadius.md};
+  overflow: hidden;
+  background: ${theme.colors.muted.background};
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+export const TextStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xs};
+  flex: 1;
+  min-width: 0;
+`;
+
+export const TrackName = styled.div`
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.lg};
+  font-weight: ${theme.fontWeight.semibold};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ArtistName = styled.div`
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.sm};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const CollectionName = styled.div`
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.xs};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ResumeButton = styled.button`
+  appearance: none;
+  background: ${theme.colors.primary};
+  color: ${theme.colors.white};
+  border: none;
+  padding: ${theme.spacing.sm} ${theme.spacing.lg};
+  border-radius: ${theme.borderRadius.full};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.medium};
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:hover {
+    background: ${theme.colors.primaryHover};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.white};
+    outline-offset: 2px;
+  }
+`;

--- a/src/components/LibraryRoute/sections/ResumeHero.tsx
+++ b/src/components/LibraryRoute/sections/ResumeHero.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { Root, Art, TextStack, TrackName, ArtistName, CollectionName, ResumeButton } from './ResumeHero.styled';
+
+export interface ResumeHeroProps {
+  session: SessionSnapshot;
+  onResume: () => void;
+}
+
+const ResumeHero: React.FC<ResumeHeroProps> = ({ session, onResume }) => {
+  const title = session.trackTitle ?? session.collectionName;
+  return (
+    <Root data-testid="library-section-resume" aria-label={`Resume ${title}`}>
+      <Art>
+        {session.trackImage ? (
+          <img src={session.trackImage} alt="" loading="lazy" />
+        ) : (
+          <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>♪</span>
+        )}
+      </Art>
+      <TextStack>
+        <TrackName>{title}</TrackName>
+        {session.trackArtist && <ArtistName>{session.trackArtist}</ArtistName>}
+        <CollectionName>{session.collectionName}</CollectionName>
+      </TextStack>
+      <ResumeButton type="button" onClick={onResume} data-testid="library-resume-button">
+        Resume
+      </ResumeButton>
+    </Root>
+  );
+};
+
+ResumeHero.displayName = 'ResumeHero';
+export default ResumeHero;

--- a/src/components/LibraryRoute/sections/ResumeSection.tsx
+++ b/src/components/LibraryRoute/sections/ResumeSection.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { useResumeSection } from '../hooks';
+import ResumeHero from './ResumeHero';
+
+export interface ResumeSectionProps {
+  lastSession: SessionSnapshot | null;
+  onResume?: () => void;
+}
+
+const ResumeSection: React.FC<ResumeSectionProps> = ({ lastSession, onResume }) => {
+  const { session, hasResumable } = useResumeSection({ lastSession });
+  if (!hasResumable || !session || !onResume) return null;
+  return <ResumeHero session={session} onResume={onResume} />;
+};
+
+ResumeSection.displayName = 'ResumeSection';
+export default ResumeSection;

--- a/src/components/LibraryRoute/sections/Section.styled.ts
+++ b/src/components/LibraryRoute/sections/Section.styled.ts
@@ -1,0 +1,68 @@
+import styled, { css } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const SectionRoot = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.md};
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: ${theme.spacing.md};
+  padding: 0 ${theme.spacing.md};
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.lg};
+  font-weight: ${theme.fontWeight.semibold};
+`;
+
+export const SeeAllButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+  padding: ${theme.spacing.xs} ${theme.spacing.sm};
+  border-radius: ${theme.borderRadius.md};
+
+  &:hover {
+    color: ${theme.colors.white};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const Body = styled.div<{ $layout: 'row' | 'grid' }>`
+  ${({ $layout }) =>
+    $layout === 'row'
+      ? css`
+          display: flex;
+          flex-direction: row;
+          gap: ${theme.spacing.md};
+          padding: 0 ${theme.spacing.md};
+          overflow-x: auto;
+          overflow-y: hidden;
+          scroll-snap-type: x proximity;
+          -webkit-overflow-scrolling: touch;
+          scrollbar-width: none;
+          &::-webkit-scrollbar {
+            display: none;
+          }
+        `
+      : css`
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+          gap: ${theme.spacing.md};
+          padding: 0 ${theme.spacing.md};
+        `}
+`;

--- a/src/components/LibraryRoute/sections/Section.tsx
+++ b/src/components/LibraryRoute/sections/Section.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { SectionRoot, Header, Title, SeeAllButton, Body } from './Section.styled';
+
+export interface SectionProps {
+  title: string;
+  onSeeAll?: () => void;
+  hidden?: boolean;
+  layout: 'row' | 'grid';
+  children: React.ReactNode;
+  id: string;
+}
+
+const Section: React.FC<SectionProps> = ({ title, onSeeAll, hidden, layout, children, id }) => {
+  if (hidden) return null;
+  return (
+    <SectionRoot data-testid={`library-section-${id}`} aria-label={title}>
+      <Header>
+        <Title>{title}</Title>
+        {onSeeAll && (
+          <SeeAllButton type="button" onClick={onSeeAll} data-testid={`library-section-${id}-see-all`}>
+            See all
+          </SeeAllButton>
+        )}
+      </Header>
+      <Body $layout={layout}>{children}</Body>
+    </SectionRoot>
+  );
+};
+
+Section.displayName = 'Section';
+export default Section;

--- a/src/components/LibraryRoute/sections/SectionSkeleton.tsx
+++ b/src/components/LibraryRoute/sections/SectionSkeleton.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+const shimmer = keyframes`
+  0% { opacity: 0.4; }
+  50% { opacity: 0.7; }
+  100% { opacity: 0.4; }
+`;
+
+const Wrap = styled.div<{ $variant: 'row' | 'grid' }>`
+  display: ${({ $variant }) => ($variant === 'row' ? 'flex' : 'grid')};
+  ${({ $variant }) =>
+    $variant === 'row'
+      ? `flex-direction: row; gap: ${theme.spacing.md}; padding: 0 ${theme.spacing.md};`
+      : `grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); gap: ${theme.spacing.md}; padding: 0 ${theme.spacing.md};`}
+`;
+
+const Card = styled.div<{ $variant: 'row' | 'grid' }>`
+  ${({ $variant }) => ($variant === 'row' ? 'width: 144px; flex: 0 0 auto;' : 'width: 100%;')}
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.sm};
+`;
+
+const Art = styled.div`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: ${theme.borderRadius.lg};
+  background: ${theme.colors.muted.background};
+  animation: ${shimmer} 1.6s ease-in-out infinite;
+`;
+
+const Line = styled.div`
+  height: 0.875rem;
+  border-radius: ${theme.borderRadius.sm};
+  background: ${theme.colors.muted.background};
+  animation: ${shimmer} 1.6s ease-in-out infinite;
+`;
+
+interface SectionSkeletonProps {
+  count?: number;
+  variant: 'row' | 'grid';
+}
+
+const SectionSkeleton: React.FC<SectionSkeletonProps> = ({ count = 4, variant }) => (
+  <Wrap $variant={variant} data-testid="library-section-skeleton">
+    {Array.from({ length: count }).map((_, i) => (
+      <Card key={i} $variant={variant}>
+        <Art />
+        <Line />
+      </Card>
+    ))}
+  </Wrap>
+);
+
+SectionSkeleton.displayName = 'SectionSkeleton';
+export default SectionSkeleton;

--- a/src/components/LibraryRoute/sections/index.ts
+++ b/src/components/LibraryRoute/sections/index.ts
@@ -1,0 +1,16 @@
+export { default as Section } from './Section';
+export type { SectionProps } from './Section';
+export { default as SectionSkeleton } from './SectionSkeleton';
+export { default as ResumeSection } from './ResumeSection';
+export type { ResumeSectionProps } from './ResumeSection';
+export { default as ResumeHero } from './ResumeHero';
+export { default as RecentlyPlayedSection } from './RecentlyPlayedSection';
+export type { RecentlyPlayedSectionProps } from './RecentlyPlayedSection';
+export { default as PinnedSection } from './PinnedSection';
+export type { PinnedSectionProps } from './PinnedSection';
+export { default as PlaylistsSection } from './PlaylistsSection';
+export type { PlaylistsSectionProps } from './PlaylistsSection';
+export { default as AlbumsSection } from './AlbumsSection';
+export type { AlbumsSectionProps } from './AlbumsSection';
+export { default as LikedSection } from './LikedSection';
+export type { LikedSectionProps } from './LikedSection';

--- a/src/components/LibraryRoute/styled.ts
+++ b/src/components/LibraryRoute/styled.ts
@@ -13,16 +13,17 @@ export const MobileLayout = styled.div`
   flex-direction: column;
   flex: 1;
   width: 100%;
-  padding: 1rem;
-  gap: 1rem;
+  height: 100%;
+  min-height: 0;
   overflow-y: auto;
 `;
 
 export const DesktopLayout = styled.div`
-  display: grid;
-  grid-template-columns: 280px 1fr;
+  display: flex;
+  flex-direction: column;
   flex: 1;
   width: 100%;
   height: 100%;
   min-height: 0;
+  overflow-y: auto;
 `;

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -17,6 +17,18 @@ export interface LikedSummary {
   isLoading: boolean;
 }
 
+export type LibraryRouteView = 'home' | 'recently-played' | 'pinned' | 'playlists' | 'albums' | 'liked';
+
+export type LibraryItemKind = 'playlist' | 'album' | 'liked' | 'recently-played';
+
+export interface ContextMenuRequest {
+  kind: LibraryItemKind;
+  id: string;
+  provider?: ProviderId;
+  name: string;
+  anchorRect: DOMRect;
+}
+
 export type {
   CachedPlaylistInfo,
   AlbumInfo,

--- a/src/components/LibraryRoute/views/HomeView.tsx
+++ b/src/components/LibraryRoute/views/HomeView.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import {
+  ResumeSection,
+  RecentlyPlayedSection,
+  PinnedSection,
+  LikedSection,
+  PlaylistsSection,
+  AlbumsSection,
+} from '../sections';
+import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from '../types';
+import { HomeStack } from './views.styled';
+
+export interface HomeViewProps {
+  layout: 'row' | 'grid';
+  lastSession: SessionSnapshot | null;
+  onResume?: () => void;
+  onSelectCollection: (
+    kind: LibraryItemKind,
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onSelectLiked: (provider?: ProviderId) => void;
+  onNavigate: (view: LibraryRouteView) => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const HomeView: React.FC<HomeViewProps> = ({
+  layout,
+  lastSession,
+  onResume,
+  onSelectCollection,
+  onSelectLiked,
+  onNavigate,
+  onContextMenuRequest,
+}) => {
+  const { hasMultipleProviders } = useProviderContext();
+  const showProviderBadges = hasMultipleProviders;
+
+  return (
+    <HomeStack data-testid="library-home">
+      <ResumeSection lastSession={lastSession} onResume={onResume} />
+      <RecentlyPlayedSection
+        layout={layout}
+        showProviderBadges={showProviderBadges}
+        onSelect={onSelectCollection}
+        onSeeAll={() => onNavigate('recently-played')}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+      <PinnedSection
+        layout={layout}
+        showProviderBadges={showProviderBadges}
+        onSelect={onSelectCollection}
+        onSeeAll={() => onNavigate('pinned')}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+      <LikedSection
+        layout={layout}
+        showProviderBadges={showProviderBadges}
+        onSelectLiked={onSelectLiked}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+      <PlaylistsSection
+        layout={layout}
+        showProviderBadges={showProviderBadges}
+        onSelect={onSelectCollection}
+        onSeeAll={() => onNavigate('playlists')}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+      <AlbumsSection
+        layout={layout}
+        showProviderBadges={showProviderBadges}
+        onSelect={onSelectCollection}
+        onSeeAll={() => onNavigate('albums')}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+    </HomeStack>
+  );
+};
+
+HomeView.displayName = 'HomeView';
+export default HomeView;

--- a/src/components/LibraryRoute/views/SeeAllView.tsx
+++ b/src/components/LibraryRoute/views/SeeAllView.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { ProviderId } from '@/types/domain';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import {
+  RecentlyPlayedSection,
+  PinnedSection,
+  PlaylistsSection,
+  AlbumsSection,
+} from '../sections';
+import { BackToLibraryIcon } from '@/components/icons/QuickActionIcons';
+import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from '../types';
+import { SeeAllRoot, BackBar, BackButton, BackTitle } from './views.styled';
+
+const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked'>, string> = {
+  'recently-played': 'Recently Played',
+  pinned: 'Pinned',
+  playlists: 'Playlists',
+  albums: 'Albums',
+};
+
+export interface SeeAllViewProps {
+  view: Exclude<LibraryRouteView, 'home' | 'liked'>;
+  onBack: () => void;
+  onSelectCollection: (
+    kind: LibraryItemKind,
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const SeeAllView: React.FC<SeeAllViewProps> = ({
+  view,
+  onBack,
+  onSelectCollection,
+  onContextMenuRequest,
+}) => {
+  const { hasMultipleProviders } = useProviderContext();
+  const showProviderBadges = hasMultipleProviders;
+
+  const sectionProps = {
+    layout: 'grid' as const,
+    showProviderBadges,
+    onSelect: onSelectCollection,
+    onContextMenuRequest,
+  };
+
+  return (
+    <SeeAllRoot data-testid={`library-see-all-${view}`}>
+      <BackBar>
+        <BackButton type="button" onClick={onBack} aria-label="Back to library home" data-testid="library-see-all-back">
+          <BackToLibraryIcon />
+        </BackButton>
+        <BackTitle>{TITLES[view]}</BackTitle>
+      </BackBar>
+      {view === 'recently-played' && <RecentlyPlayedSection {...sectionProps} />}
+      {view === 'pinned' && <PinnedSection {...sectionProps} />}
+      {view === 'playlists' && <PlaylistsSection {...sectionProps} excludePinned={false} />}
+      {view === 'albums' && <AlbumsSection {...sectionProps} excludePinned={false} />}
+    </SeeAllRoot>
+  );
+};
+
+SeeAllView.displayName = 'SeeAllView';
+export default SeeAllView;

--- a/src/components/LibraryRoute/views/views.styled.ts
+++ b/src/components/LibraryRoute/views/views.styled.ts
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const HomeStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xl};
+  padding-top: ${theme.spacing.lg};
+  padding-bottom: ${theme.spacing.xl};
+  width: 100%;
+  min-height: 0;
+`;
+
+export const SeeAllRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.lg};
+  width: 100%;
+  padding-bottom: ${theme.spacing.xl};
+`;
+
+export const BackBar = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.md};
+  padding: ${theme.spacing.md};
+  background: ${theme.colors.muted.background};
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+`;
+
+export const BackButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: ${theme.colors.white};
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: ${theme.borderRadius.full};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  & > svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  &:hover {
+    background: ${theme.colors.control.background};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const BackTitle = styled.h1`
+  margin: 0;
+  color: ${theme.colors.white};
+  font-size: ${theme.fontSize.xl};
+  font-weight: ${theme.fontWeight.semibold};
+`;

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -346,7 +346,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
               onQueueLikedTracks={onQueueLikedTracks}
               onOpenSettings={onOpenSettings}
               onResume={onResume}
-              hasResumableSession={!!lastSession?.queueTracks?.length}
+              lastSession={lastSession}
             />
           ) : (
             <LibraryPage


### PR DESCRIPTION
## Summary
- Adds 6 sections under `src/components/LibraryRoute/sections/` (Resume hero, Recently Played, Pinned, Liked, Playlists, Albums) + shared `Section` chrome + `SectionSkeleton`
- Adds polymorphic `LibraryCard` + `useLongPress` (500ms, 8px tolerance) — fires `onContextMenuRequest` for #1297 to wire the menu
- Adds `HomeView` + `SeeAllView` with local sub-route state in LibraryRoute
- Native overflow-x w/ scroll-snap on mobile (not Radix ScrollArea — preserves iOS momentum)
- LibraryRoute drops `hasResumableSession` prop, adds `lastSession` (caller updates in AudioPlayer + PlayerStateRenderer)
- Album-id encoding via toAlbumPlaylistId; liked routing via useUnifiedLikedTracks + fetchLikedForProvider
- BackBar uses BackToLibraryIcon from QuickActionIcons (existing back-affordance icon)

Part of #1300. Addresses #1294.

## Test plan
- [x] tsc clean
- [x] LibraryRoute scope: 10/10 files, 45/45 tests pass in isolation
- [x] Full sweep: 1334/1334 tests pass; 3 baseline file failures unchanged
- [x] lint clean on new files
- [x] build clean