### PR TITLE
feat(library): mini-player (#1295)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -488,6 +488,15 @@ const AudioPlayerComponent = () => {
                 onOpenSettings={handleOpenSettings}
                 onResume={handleResume}
                 lastSession={lastSession}
+                isPlaying={state.isPlaying}
+                isRadioAvailable={radio.isRadioAvailable}
+                isRadioGenerating={radio.radioState?.isGenerating}
+                onMiniPlay={playbackHandlers.onPlay}
+                onMiniPause={playbackHandlers.onPause}
+                onMiniNext={playbackHandlers.onNext}
+                onMiniPrevious={playbackHandlers.onPrevious}
+                onMiniExpand={handlers.handleCloseLibrary}
+                onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
               />
             ) : (
               <LibraryPage

--- a/src/components/LibraryRoute/MiniPlayer/MiniArt.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniArt.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ArtFrame, ArtImage, PulseDot } from './MiniPlayer.styled';
+
+export interface MiniArtProps {
+  imageUrl?: string;
+  alt: string;
+  isPlaying: boolean;
+}
+
+const MiniArt: React.FC<MiniArtProps> = ({ imageUrl, alt, isPlaying }) => (
+  <ArtFrame>
+    {imageUrl ? <ArtImage src={imageUrl} alt={alt} loading="lazy" /> : null}
+    <PulseDot
+      data-testid="mini-pulse-dot"
+      data-playing={isPlaying ? 'true' : 'false'}
+      $playing={isPlaying}
+      aria-hidden="true"
+    />
+  </ArtFrame>
+);
+
+MiniArt.displayName = 'MiniArt';
+export default MiniArt;

--- a/src/components/LibraryRoute/MiniPlayer/MiniControls.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniControls.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback } from 'react';
+import { ControlButton, ControlButtonRow } from './MiniPlayer.styled';
+
+export interface MiniControlsProps {
+  isPlaying: boolean;
+  isRadioAvailable?: boolean;
+  isRadioGenerating?: boolean;
+  onPlay: () => void;
+  onPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onStartRadio?: () => void;
+}
+
+// SVG path data sourced from src/components/controls/PlaybackControls.tsx
+// (kept inline so MiniControls renders without coupling to PlaybackControls' ControlButton styling).
+
+const MiniControls: React.FC<MiniControlsProps> = ({
+  isPlaying,
+  isRadioAvailable,
+  isRadioGenerating,
+  onPlay,
+  onPause,
+  onNext,
+  onPrevious,
+  onStartRadio,
+}) => {
+  const stop = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  const handlePlayPause = useCallback(
+    (e: React.MouseEvent) => {
+      stop(e);
+      if (isPlaying) onPause();
+      else onPlay();
+    },
+    [stop, isPlaying, onPlay, onPause],
+  );
+
+  const handlePrev = useCallback(
+    (e: React.MouseEvent) => {
+      stop(e);
+      onPrevious();
+    },
+    [stop, onPrevious],
+  );
+
+  const handleNext = useCallback(
+    (e: React.MouseEvent) => {
+      stop(e);
+      onNext();
+    },
+    [stop, onNext],
+  );
+
+  const handleRadio = useCallback(
+    (e: React.MouseEvent) => {
+      stop(e);
+      onStartRadio?.();
+    },
+    [stop, onStartRadio],
+  );
+
+  return (
+    <ControlButtonRow onClick={stop}>
+      <ControlButton
+        type="button"
+        data-testid="mini-prev"
+        aria-label="Previous track"
+        onClick={handlePrev}
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
+        </svg>
+      </ControlButton>
+      <ControlButton
+        type="button"
+        data-testid="mini-play-pause"
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+        aria-pressed={isPlaying}
+        onClick={handlePlayPause}
+      >
+        {isPlaying ? (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+      </ControlButton>
+      <ControlButton
+        type="button"
+        data-testid="mini-next"
+        aria-label="Next track"
+        onClick={handleNext}
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+        </svg>
+      </ControlButton>
+      {isRadioAvailable && onStartRadio ? (
+        <ControlButton
+          type="button"
+          data-testid="mini-radio"
+          aria-label={isRadioGenerating ? 'Generating radio playlist' : 'Start radio from current track'}
+          title={isRadioGenerating ? 'Generating radio playlist...' : 'Start radio from current track'}
+          disabled={isRadioGenerating}
+          onClick={handleRadio}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H8.3l8.26-3.34L15.88 1 3.24 6.15zM7 20c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm13-8h-2v-2h-2v2H4V8h16v4z" />
+          </svg>
+        </ControlButton>
+      ) : null}
+    </ControlButtonRow>
+  );
+};
+
+MiniControls.displayName = 'MiniControls';
+export default MiniControls;

--- a/src/components/LibraryRoute/MiniPlayer/MiniPlayer.styled.ts
+++ b/src/components/LibraryRoute/MiniPlayer/MiniPlayer.styled.ts
@@ -1,0 +1,162 @@
+import styled, { css, keyframes } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+const HEIGHT_MOBILE = 64;
+const HEIGHT_DESKTOP = 72;
+
+export const MiniPlayerRoot = styled.div`
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  height: ${HEIGHT_MOBILE}px;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  padding-bottom: calc(${theme.spacing.sm} + env(safe-area-inset-bottom, 0px));
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-top: 1px solid ${theme.colors.borderSubtle};
+
+  @media (min-width: ${theme.breakpoints.md}) {
+    height: ${HEIGHT_DESKTOP}px;
+  }
+`;
+
+export const TapTarget = styled.button`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color, ${theme.colors.accent});
+    outline-offset: 2px;
+    border-radius: ${theme.borderRadius.md};
+  }
+`;
+
+export const TextStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+`;
+
+export const Title = styled.span`
+  font-size: ${theme.fontSize?.sm ?? '0.875rem'};
+  font-weight: 600;
+  color: ${theme.colors.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const Artist = styled.span`
+  font-size: ${theme.fontSize?.xs ?? '0.75rem'};
+  color: ${theme.colors.muted.foreground};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ControlButtonRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.xs};
+  flex-shrink: 0;
+`;
+
+export const ControlButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: ${theme.borderRadius.full};
+  background: transparent;
+  border: none;
+  color: ${theme.colors.foreground};
+  cursor: pointer;
+  transition: background 120ms ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &:active {
+    background: rgba(255, 255, 255, 0.14);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color, ${theme.colors.accent});
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+    fill: currentColor;
+  }
+`;
+
+export const ArtFrame = styled.div`
+  position: relative;
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: ${theme.borderRadius.md};
+  overflow: hidden;
+  background: ${theme.colors.muted.background};
+`;
+
+export const ArtImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+`;
+
+const pulse = keyframes`
+  0%, 100% { transform: scale(0.85); opacity: 0.7; }
+  50%      { transform: scale(1);    opacity: 1; }
+`;
+
+export const PulseDot = styled.span<{ $playing: boolean }>`
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: ${theme.borderRadius.full};
+  background: var(--accent-color, ${theme.colors.accent});
+  opacity: ${({ $playing }) => ($playing ? 1 : 0)};
+  transform-origin: center;
+
+  ${({ $playing }) =>
+    $playing &&
+    css`
+      animation: ${pulse} 1200ms ease-in-out infinite;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+        transform: scale(1);
+        opacity: 1;
+      }
+    `}
+`;

--- a/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
@@ -1,0 +1,77 @@
+import React, { memo, useCallback } from 'react';
+import { useCurrentTrackContext } from '@/contexts/TrackContext';
+import MiniArt from './MiniArt';
+import MiniControls from './MiniControls';
+import {
+  Artist,
+  MiniPlayerRoot,
+  TapTarget,
+  TextStack,
+  Title,
+} from './MiniPlayer.styled';
+
+export interface MiniPlayerProps {
+  isPlaying: boolean;
+  isRadioAvailable?: boolean;
+  isRadioGenerating?: boolean;
+  onPlay: () => void;
+  onPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onExpand: () => void;
+  onStartRadio?: () => void;
+}
+
+const MiniPlayer: React.FC<MiniPlayerProps> = ({
+  isPlaying,
+  isRadioAvailable,
+  isRadioGenerating,
+  onPlay,
+  onPause,
+  onNext,
+  onPrevious,
+  onExpand,
+  onStartRadio,
+}) => {
+  const { currentTrack } = useCurrentTrackContext();
+
+  const handleExpand = useCallback(() => {
+    onExpand();
+  }, [onExpand]);
+
+  if (!currentTrack) return null;
+
+  const trackName = currentTrack.name ?? '';
+  const artistName = currentTrack.artists ?? '';
+  const artUrl = currentTrack.image || undefined;
+
+  return (
+    <MiniPlayerRoot data-testid="library-mini-player">
+      <TapTarget
+        type="button"
+        aria-label={`Expand player — ${trackName}`}
+        data-testid="mini-expand"
+        onClick={handleExpand}
+      >
+        <MiniArt imageUrl={artUrl} alt={trackName || 'Now playing'} isPlaying={isPlaying} />
+        <TextStack>
+          <Title>{trackName}</Title>
+          <Artist>{artistName}</Artist>
+        </TextStack>
+      </TapTarget>
+      <MiniControls
+        isPlaying={isPlaying}
+        isRadioAvailable={isRadioAvailable}
+        isRadioGenerating={isRadioGenerating}
+        onPlay={onPlay}
+        onPause={onPause}
+        onNext={onNext}
+        onPrevious={onPrevious}
+        onStartRadio={onStartRadio}
+      />
+    </MiniPlayerRoot>
+  );
+};
+
+MiniPlayer.displayName = 'MiniPlayer';
+export default memo(MiniPlayer);

--- a/src/components/LibraryRoute/MiniPlayer/__tests__/MiniPlayer.test.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/__tests__/MiniPlayer.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockCurrentTrack } = vi.hoisted(() => ({
+  mockCurrentTrack: vi.fn<[], { currentTrack: MediaTrack | null }>(),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: () => mockCurrentTrack(),
+}));
+
+import MiniPlayer, { type MiniPlayerProps } from '../MiniPlayer';
+
+function makeTrack(overrides: Partial<MediaTrack> = {}): MediaTrack {
+  return {
+    id: 't1',
+    name: 'Test Song',
+    artists: 'Test Artist',
+    duration_ms: 1000,
+    image: 'https://example.com/art.png',
+    provider: 'spotify',
+    uri: 'spotify:track:t1',
+    ...overrides,
+  } as MediaTrack;
+}
+
+function renderMP(propsOverrides: Partial<MiniPlayerProps> = {}) {
+  const props: MiniPlayerProps = {
+    isPlaying: false,
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    onNext: vi.fn(),
+    onPrevious: vi.fn(),
+    onExpand: vi.fn(),
+    ...propsOverrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <MiniPlayer {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('MiniPlayer', () => {
+  beforeEach(() => {
+    mockCurrentTrack.mockReset();
+  });
+
+  it('renders nothing when currentTrack is null', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: null });
+
+    // #when
+    renderMP();
+
+    // #then
+    expect(screen.queryByTestId('library-mini-player')).toBeNull();
+  });
+
+  it('renders track name and artist', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when
+    renderMP();
+
+    // #then
+    expect(screen.getByText('Test Song')).toBeInTheDocument();
+    expect(screen.getByText('Test Artist')).toBeInTheDocument();
+  });
+
+  it('shows pause icon and Pause label when isPlaying', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when
+    renderMP({ isPlaying: true });
+
+    // #then
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+  });
+
+  it('shows play label when not playing', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when
+    renderMP({ isPlaying: false });
+
+    // #then
+    expect(screen.getByLabelText('Play')).toBeInTheDocument();
+  });
+
+  it('fires onPause when play-pause clicked while playing', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onPause = vi.fn();
+    const onPlay = vi.fn();
+
+    // #when
+    renderMP({ isPlaying: true, onPause, onPlay });
+    fireEvent.click(screen.getByTestId('mini-play-pause'));
+
+    // #then
+    expect(onPause).toHaveBeenCalledTimes(1);
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+
+  it('fires onPlay when play-pause clicked while paused', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onPause = vi.fn();
+    const onPlay = vi.fn();
+
+    // #when
+    renderMP({ isPlaying: false, onPause, onPlay });
+    fireEvent.click(screen.getByTestId('mini-play-pause'));
+
+    // #then
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPause).not.toHaveBeenCalled();
+  });
+
+  it('fires onNext / onPrevious from their buttons', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onNext = vi.fn();
+    const onPrevious = vi.fn();
+
+    // #when
+    renderMP({ onNext, onPrevious });
+    fireEvent.click(screen.getByTestId('mini-next'));
+    fireEvent.click(screen.getByTestId('mini-prev'));
+
+    // #then
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onExpand when art / title region clicked', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onExpand = vi.fn();
+
+    // #when
+    renderMP({ onExpand });
+    fireEvent.click(screen.getByTestId('mini-expand'));
+
+    // #then
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire onExpand when control buttons clicked (stopPropagation)', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onExpand = vi.fn();
+
+    // #when
+    renderMP({ onExpand });
+    fireEvent.click(screen.getByTestId('mini-play-pause'));
+    fireEvent.click(screen.getByTestId('mini-next'));
+    fireEvent.click(screen.getByTestId('mini-prev'));
+
+    // #then
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it('renders radio button only when isRadioAvailable && onStartRadio provided', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when (no radio)
+    const { rerender } = renderMP();
+
+    // #then
+    expect(screen.queryByTestId('mini-radio')).toBeNull();
+
+    // #when (radio available + handler)
+    rerender(
+      <ThemeProvider theme={theme}>
+        <MiniPlayer
+          isPlaying={false}
+          isRadioAvailable
+          onPlay={() => {}}
+          onPause={() => {}}
+          onNext={() => {}}
+          onPrevious={() => {}}
+          onExpand={() => {}}
+          onStartRadio={() => {}}
+        />
+      </ThemeProvider>,
+    );
+
+    // #then
+    expect(screen.getByTestId('mini-radio')).toBeInTheDocument();
+  });
+
+  it('disables radio button while isRadioGenerating', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onStartRadio = vi.fn();
+
+    // #when
+    renderMP({ isRadioAvailable: true, isRadioGenerating: true, onStartRadio });
+    const btn = screen.getByTestId('mini-radio') as HTMLButtonElement;
+
+    // #then
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('fires onStartRadio when radio button clicked (not generating)', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+    const onStartRadio = vi.fn();
+    const onExpand = vi.fn();
+
+    // #when
+    renderMP({ isRadioAvailable: true, onStartRadio, onExpand });
+    fireEvent.click(screen.getByTestId('mini-radio'));
+
+    // #then
+    expect(onStartRadio).toHaveBeenCalledTimes(1);
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it('marks pulse dot as playing when isPlaying', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when
+    renderMP({ isPlaying: true });
+
+    // #then
+    expect(screen.getByTestId('mini-pulse-dot').dataset.playing).toBe('true');
+  });
+
+  it('marks pulse dot as not playing when paused', () => {
+    // #given
+    mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+    // #when
+    renderMP({ isPlaying: false });
+
+    // #then
+    expect(screen.getByTestId('mini-pulse-dot').dataset.playing).toBe('false');
+  });
+});

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
 import LibraryRoute from '../index';
+import type { MediaTrack } from '@/types/domain';
 
 vi.mock('@/contexts/PlayerSizingContext', () => ({
   usePlayerSizingContext: vi.fn(),
@@ -44,17 +47,40 @@ vi.mock('../hooks', () => ({
   fetchLikedForProvider: vi.fn(async () => []),
 }));
 
+const { mockCurrentTrack } = vi.hoisted(() => ({
+  mockCurrentTrack: vi.fn<[], { currentTrack: MediaTrack | null }>(),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: () => mockCurrentTrack(),
+}));
+
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const baseProps = {
   onPlaylistSelect: vi.fn(),
   onOpenSettings: vi.fn(),
   lastSession: null,
+  isPlaying: false,
+  onMiniPlay: vi.fn(),
+  onMiniPause: vi.fn(),
+  onMiniNext: vi.fn(),
+  onMiniPrevious: vi.fn(),
+  onMiniExpand: vi.fn(),
 };
+
+function renderRoute(propsOverrides: Partial<React.ComponentProps<typeof LibraryRoute>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <LibraryRoute {...baseProps} {...propsOverrides} />
+    </ThemeProvider>,
+  );
+}
 
 describe('LibraryRoute', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCurrentTrack.mockReturnValue({ currentTrack: null });
   });
 
   it('renders mobile layout testid when isMobile is true', () => {
@@ -62,7 +88,7 @@ describe('LibraryRoute', () => {
     vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
 
     // #when
-    render(<LibraryRoute {...baseProps} />);
+    renderRoute();
 
     // #then
     expect(screen.getByTestId('library-route-mobile')).toBeInTheDocument();
@@ -74,7 +100,7 @@ describe('LibraryRoute', () => {
     vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
 
     // #when
-    render(<LibraryRoute {...baseProps} />);
+    renderRoute();
 
     // #then
     expect(screen.getByTestId('library-route-desktop')).toBeInTheDocument();
@@ -86,9 +112,56 @@ describe('LibraryRoute', () => {
     vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
 
     // #when
-    render(<LibraryRoute {...baseProps} />);
+    renderRoute();
 
     // #then
     expect(screen.getByTestId('library-home')).toBeInTheDocument();
+  });
+
+  it('does not mount mini-player when no current track', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+    mockCurrentTrack.mockReturnValue({ currentTrack: null });
+
+    // #when
+    renderRoute();
+
+    // #then
+    expect(screen.queryByTestId('library-mini-player')).toBeNull();
+  });
+
+  it('mounts mini-player when a current track is loaded', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
+    mockCurrentTrack.mockReturnValue({
+      currentTrack: {
+        id: 't1',
+        name: 'Song',
+        artists: 'Artist',
+      } as MediaTrack,
+    });
+
+    // #when
+    renderRoute();
+
+    // #then
+    expect(screen.getByTestId('library-mini-player')).toBeInTheDocument();
+    expect(screen.getByText('Song')).toBeInTheDocument();
+  });
+
+  it('forwards onMiniExpand from the mini-player tap region', () => {
+    // #given
+    vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: true } as ReturnType<typeof usePlayerSizingContext>);
+    mockCurrentTrack.mockReturnValue({
+      currentTrack: { id: 't1', name: 'Song', artists: 'Artist' } as MediaTrack,
+    });
+    const onMiniExpand = vi.fn();
+
+    // #when
+    renderRoute({ onMiniExpand });
+    fireEvent.click(screen.getByTestId('mini-expand'));
+
+    // #then
+    expect(onMiniExpand).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -9,6 +9,7 @@ import HomeView from './views/HomeView';
 import SeeAllView from './views/SeeAllView';
 import { fetchLikedForProvider } from './hooks';
 import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from './types';
+import MiniPlayer from './MiniPlayer/MiniPlayer';
 
 // LibraryRoute assumes upstream guards have already filtered out cold-start cases:
 // - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
@@ -28,6 +29,15 @@ export interface LibraryRouteProps {
   onOpenSettings: () => void;
   onResume?: () => void;
   lastSession?: SessionSnapshot | null;
+  isPlaying: boolean;
+  isRadioAvailable?: boolean;
+  isRadioGenerating?: boolean;
+  onMiniPlay: () => void;
+  onMiniPause: () => void;
+  onMiniNext: () => void;
+  onMiniPrevious: () => void;
+  onMiniExpand: () => void;
+  onMiniStartRadio?: () => void;
 }
 
 const LibraryRoute: React.FC<LibraryRouteProps> = ({
@@ -35,6 +45,15 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onPlayLikedTracks,
   onResume,
   lastSession,
+  isPlaying,
+  isRadioAvailable,
+  isRadioGenerating,
+  onMiniPlay,
+  onMiniPause,
+  onMiniNext,
+  onMiniPrevious,
+  onMiniExpand,
+  onMiniStartRadio,
 }) => {
   const { isMobile } = usePlayerSizingContext();
   const [view, setView] = useState<LibraryRouteView>('home');
@@ -127,6 +146,17 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
           />
         )}
       </Layout>
+      <MiniPlayer
+        isPlaying={isPlaying}
+        isRadioAvailable={isRadioAvailable}
+        isRadioGenerating={isRadioGenerating}
+        onPlay={onMiniPlay}
+        onPause={onMiniPause}
+        onNext={onMiniNext}
+        onPrevious={onMiniPrevious}
+        onExpand={onMiniExpand}
+        onStartRadio={onMiniStartRadio}
+      />
     </LibraryRouteRoot>
   );
 };

--- a/src/components/LibraryRoute/styled.ts
+++ b/src/components/LibraryRoute/styled.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export const LibraryRouteRoot = styled.div`
   display: flex;
+  flex-direction: column;
   flex: 1;
   width: 100%;
   height: 100%;
@@ -23,7 +24,6 @@ export const DesktopLayout = styled.div`
   flex-direction: column;
   flex: 1;
   width: 100%;
-  height: 100%;
   min-height: 0;
   overflow-y: auto;
 `;

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -286,7 +286,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   }, [volume, setVolumeLevel]);
 
   const bottomBarActions = useMemo<BottomBarActionsValue>(() => ({
-    hidden: showLibrary && isMobile,
+    hidden: showLibrary && (isMobile || newLibraryRouteEnabled),
     showSettings: handleShowVisualEffects,
     showQueue: onShowQueue,
     openLibrary: onOpenLibrary,
@@ -297,6 +297,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   }), [
     showLibrary,
     isMobile,
+    newLibraryRouteEnabled,
     handleShowVisualEffects,
     onShowQueue,
     onOpenLibrary,

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -347,6 +347,12 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
               onOpenSettings={onOpenSettings}
               onResume={onResume}
               lastSession={lastSession}
+              isPlaying={false}
+              onMiniPlay={() => {}}
+              onMiniPause={() => {}}
+              onMiniNext={() => {}}
+              onMiniPrevious={() => {}}
+              onMiniExpand={() => {}}
             />
           ) : (
             <LibraryPage


### PR DESCRIPTION
## Summary
- New `src/components/LibraryRoute/MiniPlayer/` with sticky-bottom strip (art + title/artist + prev/play/next + radio + tap-to-expand)
- Pulse animation gated by isPlaying; respects prefers-reduced-motion
- Reads currentTrack via useCurrentTrackContext; returns null when no track loaded
- Wires from AudioPlayer (active player) and PlayerStateRenderer (idle, safe defaults)
- BottomBar hide extended: `showLibrary && (isMobile || newLibraryRouteEnabled)` — conservative, only affects flag-on path
- Coexists cleanly with #1294 (only LibraryRouteRoot got flex-direction:column added; index.tsx props extended for mini-player handlers)

Part of #1300. Addresses #1295.

## Test plan
- [x] tsc clean
- [x] LibraryRoute scope: 10 files, 53/53 tests pass
- [x] Full sweep: 1338 passed (+23 from baseline 1315); same 3 baseline failures unchanged
- [x] lint clean on new files
- [x] build clean