### PR TITLE
test(library): wave-2 coverage for sections UI (#1294)

### DIFF
--- a/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for LibraryRoute — sub-route navigation, liked fallback, album encoding (#1294).
+ * Supplements the existing LibraryRoute.test.tsx (layout shell tests).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: vi.fn(),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    hasMultipleProviders: false,
+    enabledProviderIds: ['spotify'],
+  })),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(() => ({
+    unifiedTracks: [],
+    isUnifiedLikedActive: false,
+    totalCount: 0,
+    isLoading: false,
+  })),
+}));
+
+vi.mock('../hooks', () => ({
+  useResumeSection: vi.fn(() => ({ session: null, hasResumable: false })),
+  useRecentlyPlayedSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  usePinnedSection: vi.fn(() => ({ combined: [], pinnedPlaylists: [], pinnedAlbums: [], isLoading: false, isEmpty: true })),
+  usePlaylistsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useAlbumsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useLikedSection: vi.fn(() => ({ totalCount: 0, perProvider: [], isUnified: false, isLoading: false })),
+  fetchLikedForProvider: vi.fn(async () => []),
+}));
+
+// Stub views so we can control navigation triggers without rendering the full section tree
+vi.mock('../views/HomeView', () => ({
+  default: ({
+    onNavigate,
+    onSelectCollection,
+  }: {
+    onNavigate: (view: string) => void;
+    onSelectCollection: (kind: string, id: string, name: string, provider?: string) => void;
+  }) => (
+    <div data-testid="home-view">
+      <button onClick={() => onNavigate('playlists')}>go-playlists</button>
+      <button onClick={() => onNavigate('albums')}>go-albums</button>
+      <button onClick={() => onNavigate('liked')}>go-liked</button>
+      <button onClick={() => onSelectCollection('album', 'a1', 'Dark Side', 'spotify')}>select-album</button>
+      <button onClick={() => onSelectCollection('playlist', 'p1', 'Chill', 'spotify')}>select-playlist</button>
+    </div>
+  ),
+}));
+
+vi.mock('../views/SeeAllView', () => ({
+  default: ({ view, onBack }: { view: string; onBack: () => void }) => (
+    <div data-testid={`see-all-view-${view}`}>
+      <button onClick={onBack}>back</button>
+    </div>
+  ),
+}));
+
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import LibraryRoute from '../index';
+
+const mockUsePlayerSizingContext = vi.mocked(usePlayerSizingContext);
+
+const baseProps = {
+  onPlaylistSelect: vi.fn(),
+  onOpenSettings: vi.fn(),
+  lastSession: null,
+};
+
+describe('LibraryRoute — navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePlayerSizingContext.mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+  });
+
+  it('starts at HomeView by default', () => {
+    // #given + #when
+    render(<LibraryRoute {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('home-view')).toBeInTheDocument();
+    expect(screen.queryByTestId(/see-all-view/)).not.toBeInTheDocument();
+  });
+
+  it('navigates to SeeAllView when onNavigate("playlists") fires', () => {
+    // #given
+    render(<LibraryRoute {...baseProps} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'go-playlists' }));
+
+    // #then
+    expect(screen.getByTestId('see-all-view-playlists')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-view')).not.toBeInTheDocument();
+  });
+
+  it('navigates to SeeAllView for albums', () => {
+    // #given
+    render(<LibraryRoute {...baseProps} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'go-albums' }));
+
+    // #then
+    expect(screen.getByTestId('see-all-view-albums')).toBeInTheDocument();
+  });
+
+  it('falls back to HomeView when navigating to "liked" (no SeeAll page)', () => {
+    // #given
+    render(<LibraryRoute {...baseProps} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'go-liked' }));
+
+    // #then — "liked" has no SeeAll; LibraryRoute renders HomeView defensively
+    expect(screen.getByTestId('home-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('see-all-view-liked')).not.toBeInTheDocument();
+  });
+
+  it('navigates back to HomeView from SeeAllView when onBack fires', () => {
+    // #given
+    render(<LibraryRoute {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'go-playlists' }));
+    expect(screen.getByTestId('see-all-view-playlists')).toBeInTheDocument();
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'back' }));
+
+    // #then
+    expect(screen.getByTestId('home-view')).toBeInTheDocument();
+    expect(screen.queryByTestId(/see-all-view/)).not.toBeInTheDocument();
+  });
+
+  it('calls onPlaylistSelect with toAlbumPlaylistId encoding for album selection', () => {
+    // #given
+    const onPlaylistSelect = vi.fn();
+    render(<LibraryRoute {...baseProps} onPlaylistSelect={onPlaylistSelect} />);
+
+    // #when — select an album
+    fireEvent.click(screen.getByRole('button', { name: 'select-album' }));
+
+    // #then — album id must be encoded via toAlbumPlaylistId
+    expect(onPlaylistSelect).toHaveBeenCalledTimes(1);
+    const [playlistId, name, provider] = onPlaylistSelect.mock.calls[0];
+    expect(playlistId).toMatch(/album/i); // toAlbumPlaylistId wraps with "album:" prefix
+    expect(name).toBe('Dark Side');
+    expect(provider).toBe('spotify');
+  });
+
+  it('calls onPlaylistSelect with plain id for playlist selection', () => {
+    // #given
+    const onPlaylistSelect = vi.fn();
+    render(<LibraryRoute {...baseProps} onPlaylistSelect={onPlaylistSelect} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'select-playlist' }));
+
+    // #then
+    expect(onPlaylistSelect).toHaveBeenCalledWith('p1', 'Chill', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/card/__tests__/LibraryCard.extra.test.tsx
+++ b/src/components/LibraryRoute/card/__tests__/LibraryCard.extra.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Extra tests for LibraryCard — preventDefault on right-click and long-press (#1294).
+ * Supplements card/__tests__/LibraryCard.test.tsx written by the builder.
+ */
+
+import React from 'react';
+import { render, screen, createEvent, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import LibraryCard from '../LibraryCard';
+
+const baseProps = {
+  kind: 'playlist' as const,
+  id: 'p1',
+  name: 'Sample Playlist',
+  variant: 'row' as const,
+  onSelect: vi.fn(),
+};
+
+describe('LibraryCard (extra)', () => {
+  it('calls preventDefault on context-menu event to suppress native browser menu', () => {
+    // #given
+    const onContextMenuRequest = vi.fn();
+    render(<LibraryCard {...baseProps} onContextMenuRequest={onContextMenuRequest} />);
+    const card = screen.getByTestId('library-card-playlist-p1');
+    const contextMenuEvent = createEvent.contextMenu(card, { clientX: 30, clientY: 40 });
+    const preventDefaultSpy = vi.spyOn(contextMenuEvent, 'preventDefault');
+
+    // #when
+    fireEvent(card, contextMenuEvent);
+
+    // #then
+    expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('long-press', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('fires onContextMenuRequest after 500ms hold', () => {
+      // #given
+      const onContextMenuRequest = vi.fn();
+      render(<LibraryCard {...baseProps} onContextMenuRequest={onContextMenuRequest} />);
+      const card = screen.getByTestId('library-card-playlist-p1');
+
+      // #when — simulate pointer down and wait 500ms
+      act(() => {
+        fireEvent.pointerDown(card, { clientX: 10, clientY: 10 });
+      });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // #then
+      expect(onContextMenuRequest).toHaveBeenCalledTimes(1);
+      const req = onContextMenuRequest.mock.calls[0][0];
+      expect(req.kind).toBe('playlist');
+      expect(req.id).toBe('p1');
+    });
+
+    it('fires onContextMenuRequest exactly once — does not double-fire on pointerUp after long-press', () => {
+      // #given
+      const onContextMenuRequest = vi.fn();
+      render(<LibraryCard {...baseProps} onContextMenuRequest={onContextMenuRequest} />);
+      const card = screen.getByTestId('library-card-playlist-p1');
+
+      // #when — long-press fires, then pointer released
+      act(() => { fireEvent.pointerDown(card, { clientX: 5, clientY: 5 }); });
+      act(() => { vi.advanceTimersByTime(500); });
+      act(() => { fireEvent.pointerUp(card); });
+
+      // #then — triggered exactly once (onTap suppressed after long-press)
+      expect(onContextMenuRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not activate long-press when onContextMenuRequest is undefined', () => {
+      // #given — no context menu handler, so useLongPress disabled
+      const onSelect = vi.fn();
+      render(<LibraryCard {...baseProps} onSelect={onSelect} />);
+      const card = screen.getByTestId('library-card-playlist-p1');
+
+      // #when
+      act(() => {
+        fireEvent.pointerDown(card, { clientX: 0, clientY: 0 });
+        vi.advanceTimersByTime(500);
+        fireEvent.pointerUp(card);
+      });
+
+      // #then — click fires onSelect via normal click handler (not long-press path)
+      fireEvent.click(card);
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/AlbumsSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/AlbumsSection.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for AlbumsSection — renders album cards with artist subtitle (#1294).
+ * Threshold: 8 (same as PlaylistsSection).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../hooks', () => ({
+  useAlbumsSection: vi.fn(),
+}));
+
+vi.mock('../Section', () => ({
+  default: ({
+    children,
+    onSeeAll,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    onSeeAll?: () => void;
+  }) => (
+    <div data-testid="section-albums">
+      {onSeeAll && <button onClick={onSeeAll}>See all</button>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../SectionSkeleton', () => ({
+  default: () => <div data-testid="section-skeleton" />,
+}));
+
+vi.mock('../../card/LibraryCard', () => ({
+  default: ({
+    kind,
+    id,
+    name,
+    subtitle,
+    onSelect,
+  }: {
+    kind: string;
+    id: string;
+    name: string;
+    subtitle?: string;
+    onSelect: () => void;
+  }) => (
+    <button data-testid={`library-card-${kind}-${id}`} data-subtitle={subtitle} onClick={onSelect}>
+      {name}
+    </button>
+  ),
+}));
+
+import { useAlbumsSection } from '../../hooks';
+import AlbumsSection from '../AlbumsSection';
+
+const mockUseAlbumsSection = vi.mocked(useAlbumsSection);
+
+const baseProps = {
+  layout: 'row' as const,
+  onSelect: vi.fn(),
+  onSeeAll: vi.fn(),
+};
+
+describe('AlbumsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when isEmpty and not loading', () => {
+    // #given
+    mockUseAlbumsSection.mockReturnValue({ items: [], isLoading: false, isEmpty: true });
+
+    // #when
+    const { container } = render(<AlbumsSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders skeleton when loading with no items', () => {
+    // #given
+    mockUseAlbumsSection.mockReturnValue({ items: [], isLoading: true, isEmpty: true });
+
+    // #when
+    render(<AlbumsSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('section-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a card for each album with artist subtitle', () => {
+    // #given
+    mockUseAlbumsSection.mockReturnValue({
+      items: [
+        { id: 'a1', name: 'Dark Side', artists: 'Pink Floyd', provider: 'spotify' as const, images: [] },
+      ],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<AlbumsSection {...baseProps} />);
+
+    // #then
+    const card = screen.getByTestId('library-card-album-a1');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('data-subtitle', 'Pink Floyd');
+  });
+
+  it('shows See all when layout is row and items exceed 8', () => {
+    // #given
+    mockUseAlbumsSection.mockReturnValue({
+      items: Array.from({ length: 9 }, (_, i) => ({
+        id: `a${i}`,
+        name: `Album ${i}`,
+        artists: 'Artist',
+        provider: 'spotify' as const,
+        images: [],
+      })),
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<AlbumsSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.getByRole('button', { name: 'See all' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect with album kind, id, name, provider on card click', () => {
+    // #given
+    const onSelect = vi.fn();
+    mockUseAlbumsSection.mockReturnValue({
+      items: [{ id: 'a1', name: 'OK Computer', artists: 'Radiohead', provider: 'spotify' as const, images: [] }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<AlbumsSection {...baseProps} onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('library-card-album-a1'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith('album', 'a1', 'OK Computer', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/LikedSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/LikedSection.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for LikedSection — single-card liked-songs section with unified/per-provider modes (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../hooks', () => ({
+  useLikedSection: vi.fn(),
+}));
+
+vi.mock('../Section', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="section-liked">{children}</div>
+  ),
+}));
+
+vi.mock('../SectionSkeleton', () => ({
+  default: () => <div data-testid="section-skeleton" />,
+}));
+
+vi.mock('../../card/LibraryCard', () => ({
+  default: ({
+    kind,
+    id,
+    subtitle,
+    provider,
+    onSelect,
+  }: {
+    kind: string;
+    id: string;
+    subtitle?: string;
+    provider?: string;
+    onSelect: () => void;
+  }) => (
+    <button
+      data-testid={`library-card-${kind}-${id}`}
+      data-subtitle={subtitle}
+      data-provider={provider}
+      onClick={onSelect}
+    >
+      liked
+    </button>
+  ),
+}));
+
+import { useLikedSection } from '../../hooks';
+import LikedSection from '../LikedSection';
+
+const mockUseLikedSection = vi.mocked(useLikedSection);
+
+const baseProps = {
+  layout: 'row' as const,
+  onSelectLiked: vi.fn(),
+};
+
+describe('LikedSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when totalCount is 0 and not loading', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 0,
+      perProvider: [],
+      isUnified: false,
+      isLoading: false,
+    });
+
+    // #when
+    const { container } = render(<LikedSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders skeleton when loading with no items', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 0,
+      perProvider: [],
+      isUnified: false,
+      isLoading: true,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('section-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a single unified card with song count subtitle', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 42,
+      perProvider: [{ provider: 'spotify', count: 42 }],
+      isUnified: true,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-liked-liked')).toHaveAttribute('data-subtitle', '42 songs');
+  });
+
+  it('uses singular "song" when totalCount is 1', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 1,
+      perProvider: [{ provider: 'spotify', count: 1 }],
+      isUnified: true,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-liked-liked')).toHaveAttribute('data-subtitle', '1 song');
+  });
+
+  it('renders per-provider cards when !isUnified + showProviderBadges + multiple providers', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 80,
+      perProvider: [
+        { provider: 'spotify', count: 50 },
+        { provider: 'dropbox', count: 30 },
+      ],
+      isUnified: false,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} showProviderBadges />);
+
+    // #then
+    expect(screen.getByTestId('library-card-liked-liked-spotify')).toBeInTheDocument();
+    expect(screen.getByTestId('library-card-liked-liked-dropbox')).toBeInTheDocument();
+  });
+
+  it('calls onSelectLiked without provider when unified card clicked', () => {
+    // #given
+    const onSelectLiked = vi.fn();
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 10,
+      perProvider: [{ provider: 'spotify', count: 10 }],
+      isUnified: true,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} onSelectLiked={onSelectLiked} />);
+    fireEvent.click(screen.getByTestId('library-card-liked-liked'));
+
+    // #then — called with no provider argument
+    expect(onSelectLiked).toHaveBeenCalledTimes(1);
+    expect(onSelectLiked.mock.calls[0]).toEqual([]);
+  });
+
+  it('calls onSelectLiked with provider when per-provider card clicked', () => {
+    // #given
+    const onSelectLiked = vi.fn();
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 80,
+      perProvider: [
+        { provider: 'spotify', count: 50 },
+        { provider: 'dropbox', count: 30 },
+      ],
+      isUnified: false,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} showProviderBadges onSelectLiked={onSelectLiked} />);
+    fireEvent.click(screen.getByTestId('library-card-liked-liked-spotify'));
+
+    // #then
+    expect(onSelectLiked).toHaveBeenCalledWith('spotify');
+  });
+
+  it('renders single card when !isUnified but only one provider (no badge needed)', () => {
+    // #given
+    mockUseLikedSection.mockReturnValue({
+      totalCount: 20,
+      perProvider: [{ provider: 'spotify', count: 20 }],
+      isUnified: false,
+      isLoading: false,
+    });
+
+    // #when
+    render(<LikedSection {...baseProps} showProviderBadges />);
+
+    // #then
+    expect(screen.getByTestId('library-card-liked-liked')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-card-liked-liked-spotify')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/PinnedSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/PinnedSection.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for PinnedSection — renders pinned playlists + albums as library cards (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../hooks', () => ({
+  usePinnedSection: vi.fn(),
+}));
+
+vi.mock('../Section', () => ({
+  default: ({
+    title,
+    children,
+    onSeeAll,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    onSeeAll?: () => void;
+  }) => (
+    <div data-testid={`section-${title.toLowerCase()}`}>
+      {onSeeAll && <button onClick={onSeeAll}>See all</button>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../SectionSkeleton', () => ({
+  default: () => <div data-testid="section-skeleton" />,
+}));
+
+vi.mock('../../card/LibraryCard', () => ({
+  default: ({
+    kind,
+    id,
+    name,
+    provider,
+    onSelect,
+  }: {
+    kind: string;
+    id: string;
+    name: string;
+    provider?: string;
+    onSelect: () => void;
+  }) => (
+    <button
+      data-testid={`library-card-${kind}-${id}`}
+      data-provider={provider}
+      onClick={onSelect}
+    >
+      {name}
+    </button>
+  ),
+}));
+
+import { usePinnedSection } from '../../hooks';
+import PinnedSection from '../PinnedSection';
+
+const mockUsePinnedSection = vi.mocked(usePinnedSection);
+
+const baseProps = {
+  layout: 'row' as const,
+  onSelect: vi.fn(),
+  onSeeAll: vi.fn(),
+};
+
+describe('PinnedSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when isEmpty and not loading', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: [],
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: true,
+    });
+
+    // #when
+    const { container } = render(<PinnedSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders skeleton when loading with no items', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: [],
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: true,
+      isEmpty: true,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('section-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders cards for each combined item', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: [
+        { kind: 'playlist', id: 'p1', name: 'Alpha', provider: 'spotify' },
+        { kind: 'album', id: 'a1', name: 'Beta', provider: 'spotify' },
+      ],
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-playlist-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('library-card-album-a1')).toBeInTheDocument();
+  });
+
+  it('shows See all when layout is row and items exceed 6', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: Array.from({ length: 7 }, (_, i) => ({
+        kind: 'playlist' as const,
+        id: `p${i}`,
+        name: `Playlist ${i}`,
+      })),
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.getByRole('button', { name: 'See all' })).toBeInTheDocument();
+  });
+
+  it('does not show See all when layout is row and items are at or below 6', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: Array.from({ length: 6 }, (_, i) => ({
+        kind: 'playlist' as const,
+        id: `p${i}`,
+        name: `Playlist ${i}`,
+      })),
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.queryByRole('button', { name: 'See all' })).not.toBeInTheDocument();
+  });
+
+  it('does not show See all when layout is grid even with many items', () => {
+    // #given
+    mockUsePinnedSection.mockReturnValue({
+      combined: Array.from({ length: 10 }, (_, i) => ({
+        kind: 'playlist' as const,
+        id: `p${i}`,
+        name: `Playlist ${i}`,
+      })),
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} layout="grid" />);
+
+    // #then
+    expect(screen.queryByRole('button', { name: 'See all' })).not.toBeInTheDocument();
+  });
+
+  it('calls onSelect with kind, id, name, provider when a card is clicked', () => {
+    // #given
+    const onSelect = vi.fn();
+    mockUsePinnedSection.mockReturnValue({
+      combined: [{ kind: 'album', id: 'a1', name: 'Dark Side', provider: 'spotify' as const }],
+      pinnedPlaylists: [],
+      pinnedAlbums: [],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PinnedSection {...baseProps} onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('library-card-album-a1'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith('album', 'a1', 'Dark Side', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/PlaylistsSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/PlaylistsSection.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for PlaylistsSection — renders playlist cards, skeleton, and See-all (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../hooks', () => ({
+  usePlaylistsSection: vi.fn(),
+}));
+
+vi.mock('../Section', () => ({
+  default: ({
+    children,
+    onSeeAll,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    onSeeAll?: () => void;
+  }) => (
+    <div data-testid="section-playlists">
+      {onSeeAll && <button onClick={onSeeAll}>See all</button>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../SectionSkeleton', () => ({
+  default: () => <div data-testid="section-skeleton" />,
+}));
+
+vi.mock('../../card/LibraryCard', () => ({
+  default: ({
+    kind,
+    id,
+    name,
+    onSelect,
+  }: {
+    kind: string;
+    id: string;
+    name: string;
+    onSelect: () => void;
+  }) => (
+    <button data-testid={`library-card-${kind}-${id}`} onClick={onSelect}>
+      {name}
+    </button>
+  ),
+}));
+
+import { usePlaylistsSection } from '../../hooks';
+import PlaylistsSection from '../PlaylistsSection';
+
+const mockUsePlaylistsSection = vi.mocked(usePlaylistsSection);
+
+const baseProps = {
+  layout: 'row' as const,
+  onSelect: vi.fn(),
+  onSeeAll: vi.fn(),
+};
+
+describe('PlaylistsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when isEmpty and not loading', () => {
+    // #given
+    mockUsePlaylistsSection.mockReturnValue({ items: [], isLoading: false, isEmpty: true });
+
+    // #when
+    const { container } = render(<PlaylistsSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders skeleton when loading with no items', () => {
+    // #given
+    mockUsePlaylistsSection.mockReturnValue({ items: [], isLoading: true, isEmpty: true });
+
+    // #when
+    render(<PlaylistsSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('section-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a card for each playlist item', () => {
+    // #given
+    mockUsePlaylistsSection.mockReturnValue({
+      items: [
+        { id: 'p1', name: 'Chill Vibes', provider: 'spotify' as const, images: [] },
+        { id: 'p2', name: 'Workout Mix', provider: 'spotify' as const, images: [] },
+      ],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PlaylistsSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-playlist-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('library-card-playlist-p2')).toBeInTheDocument();
+  });
+
+  it('shows See all when layout is row and items exceed 8', () => {
+    // #given
+    mockUsePlaylistsSection.mockReturnValue({
+      items: Array.from({ length: 9 }, (_, i) => ({
+        id: `p${i}`,
+        name: `Playlist ${i}`,
+        provider: 'spotify' as const,
+        images: [],
+      })),
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PlaylistsSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.getByRole('button', { name: 'See all' })).toBeInTheDocument();
+  });
+
+  it('does not show See all when items are at or below 8', () => {
+    // #given
+    mockUsePlaylistsSection.mockReturnValue({
+      items: Array.from({ length: 8 }, (_, i) => ({
+        id: `p${i}`,
+        name: `Playlist ${i}`,
+        provider: 'spotify' as const,
+        images: [],
+      })),
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PlaylistsSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.queryByRole('button', { name: 'See all' })).not.toBeInTheDocument();
+  });
+
+  it('calls onSelect with playlist kind, id, name, provider on card click', () => {
+    // #given
+    const onSelect = vi.fn();
+    mockUsePlaylistsSection.mockReturnValue({
+      items: [{ id: 'p1', name: 'My Mix', provider: 'spotify' as const, images: [] }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<PlaylistsSection {...baseProps} onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('library-card-playlist-p1'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith('playlist', 'p1', 'My Mix', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/RecentlyPlayedSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/RecentlyPlayedSection.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for RecentlyPlayedSection — renders recently-played collection cards (#1294).
+ * onSelect receives (kind, id, name, provider) derived from each entry's CollectionRef.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../hooks', () => ({
+  useRecentlyPlayedSection: vi.fn(),
+}));
+
+vi.mock('../Section', () => ({
+  default: ({
+    children,
+    onSeeAll,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    onSeeAll?: () => void;
+  }) => (
+    <div data-testid="section-recently-played">
+      {onSeeAll && <button onClick={onSeeAll}>See all</button>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../SectionSkeleton', () => ({
+  default: () => <div data-testid="section-skeleton" />,
+}));
+
+vi.mock('../../card/LibraryCard', () => ({
+  default: ({
+    kind,
+    id,
+    name,
+    onSelect,
+  }: {
+    kind: string;
+    id: string;
+    name: string;
+    onSelect: () => void;
+  }) => (
+    <button data-testid={`library-card-${kind}-${id}`} onClick={onSelect}>
+      {name}
+    </button>
+  ),
+}));
+
+import { useRecentlyPlayedSection } from '../../hooks';
+import RecentlyPlayedSection from '../RecentlyPlayedSection';
+
+const mockUseRecentlyPlayedSection = vi.mocked(useRecentlyPlayedSection);
+
+const baseProps = {
+  layout: 'row' as const,
+  onSelect: vi.fn(),
+  onSeeAll: vi.fn(),
+};
+
+describe('RecentlyPlayedSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when isEmpty and not loading', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({ items: [], isLoading: false, isEmpty: true });
+
+    // #when
+    const { container } = render(<RecentlyPlayedSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders skeleton when loading with no items', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({ items: [], isLoading: true, isEmpty: true });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('section-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a card for a playlist entry using ref.id as card id', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({
+      items: [{ ref: { kind: 'playlist', id: 'p1', provider: 'spotify' as const }, name: 'Chill Mix' }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-playlist-p1')).toBeInTheDocument();
+  });
+
+  it('renders a card for an album entry using ref.id as card id', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({
+      items: [{ ref: { kind: 'album', id: 'a1', provider: 'spotify' as const }, name: 'Dark Side' }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-album-a1')).toBeInTheDocument();
+  });
+
+  it('renders a liked entry with kind=liked and id=liked', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({
+      items: [{ ref: { kind: 'liked', provider: 'spotify' as const }, name: 'Liked Songs' }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-card-liked-liked')).toBeInTheDocument();
+  });
+
+  it('shows See all when layout is row and items exceed 4', () => {
+    // #given
+    mockUseRecentlyPlayedSection.mockReturnValue({
+      items: Array.from({ length: 5 }, (_, i) => ({
+        ref: { kind: 'playlist' as const, id: `p${i}`, provider: 'spotify' as const },
+        name: `Mix ${i}`,
+      })),
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} layout="row" />);
+
+    // #then
+    expect(screen.getByRole('button', { name: 'See all' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect with derived kind, id, name, provider when a card is clicked', () => {
+    // #given
+    const onSelect = vi.fn();
+    mockUseRecentlyPlayedSection.mockReturnValue({
+      items: [{ ref: { kind: 'album', id: 'a1', provider: 'spotify' as const }, name: 'Revolver' }],
+      isLoading: false,
+      isEmpty: false,
+    });
+
+    // #when
+    render(<RecentlyPlayedSection {...baseProps} onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('library-card-album-a1'));
+
+    // #then
+    expect(onSelect).toHaveBeenCalledWith('album', 'a1', 'Revolver', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/ResumeSection.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/ResumeSection.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for ResumeSection — renders the ResumeHero card when a resumable session exists (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+
+vi.mock('../../hooks', () => ({
+  useResumeSection: vi.fn(),
+}));
+
+import { useResumeSection } from '../../hooks';
+import ResumeSection from '../ResumeSection';
+
+const mockUseResumeSection = vi.mocked(useResumeSection);
+
+const makeSession = (overrides: Partial<SessionSnapshot> = {}): SessionSnapshot => ({
+  collectionId: 'pl1',
+  collectionName: 'My Playlist',
+  trackIndex: 0,
+  trackTitle: 'Song Title',
+  trackArtist: 'The Artist',
+  trackImage: 'https://example.com/art.jpg',
+  savedAt: Date.now(),
+  ...overrides,
+});
+
+const baseProps = {
+  lastSession: makeSession(),
+  onResume: vi.fn(),
+};
+
+describe('ResumeSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when hasResumable is false', () => {
+    // #given
+    mockUseResumeSection.mockReturnValue({ session: null, hasResumable: false });
+
+    // #when
+    const { container } = render(<ResumeSection {...baseProps} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when onResume is not provided', () => {
+    // #given
+    const session = makeSession();
+    mockUseResumeSection.mockReturnValue({ session, hasResumable: true });
+
+    // #when
+    const { container } = render(<ResumeSection lastSession={session} />);
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders ResumeHero when hasResumable is true', () => {
+    // #given
+    const session = makeSession({ trackTitle: 'Bohemian Rhapsody' });
+    mockUseResumeSection.mockReturnValue({ session, hasResumable: true });
+
+    // #when
+    render(<ResumeSection {...baseProps} lastSession={session} />);
+
+    // #then
+    expect(screen.getByTestId('library-section-resume')).toBeInTheDocument();
+  });
+
+  it('displays the session track title in ResumeHero', () => {
+    // #given
+    const session = makeSession({ trackTitle: 'Hotel California' });
+    mockUseResumeSection.mockReturnValue({ session, hasResumable: true });
+
+    // #when
+    render(<ResumeSection {...baseProps} lastSession={session} />);
+
+    // #then
+    expect(screen.getByText('Hotel California')).toBeInTheDocument();
+  });
+
+  it('calls onResume when the Resume button is clicked', () => {
+    // #given
+    const onResume = vi.fn();
+    const session = makeSession();
+    mockUseResumeSection.mockReturnValue({ session, hasResumable: true });
+
+    // #when
+    render(<ResumeSection lastSession={session} onResume={onResume} />);
+    fireEvent.click(screen.getByTestId('library-resume-button'));
+
+    // #then
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/LibraryRoute/sections/__tests__/Section.test.tsx
+++ b/src/components/LibraryRoute/sections/__tests__/Section.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for Section — the shared shell component for every library section.
+ * Section is a pure rendering component (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Section from '../Section';
+
+describe('Section', () => {
+  it('returns null when hidden', () => {
+    // #given + #when
+    const { container } = render(
+      <Section id="pinned" title="Pinned" layout="row" hidden>
+        <div>content</div>
+      </Section>
+    );
+
+    // #then
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders with correct data-testid', () => {
+    // #given + #when
+    render(
+      <Section id="playlists" title="Playlists" layout="row">
+        <div />
+      </Section>
+    );
+
+    // #then
+    expect(screen.getByTestId('library-section-playlists')).toBeInTheDocument();
+  });
+
+  it('renders section title', () => {
+    // #given + #when
+    render(
+      <Section id="albums" title="Albums" layout="row">
+        <div />
+      </Section>
+    );
+
+    // #then
+    expect(screen.getByText('Albums')).toBeInTheDocument();
+  });
+
+  it('renders See all button when onSeeAll is provided', () => {
+    // #given + #when
+    render(
+      <Section id="pinned" title="Pinned" layout="row" onSeeAll={vi.fn()}>
+        <div />
+      </Section>
+    );
+
+    // #then
+    expect(screen.getByRole('button', { name: 'See all' })).toBeInTheDocument();
+  });
+
+  it('does not render See all button when onSeeAll is absent', () => {
+    // #given + #when
+    render(
+      <Section id="pinned" title="Pinned" layout="row">
+        <div />
+      </Section>
+    );
+
+    // #then
+    expect(screen.queryByRole('button', { name: 'See all' })).not.toBeInTheDocument();
+  });
+
+  it('fires onSeeAll when See all button is clicked', () => {
+    // #given
+    const onSeeAll = vi.fn();
+    render(
+      <Section id="pinned" title="Pinned" layout="row" onSeeAll={onSeeAll}>
+        <div />
+      </Section>
+    );
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'See all' }));
+
+    // #then
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children', () => {
+    // #given + #when
+    render(
+      <Section id="test" title="Test" layout="row">
+        <div data-testid="test-child" />
+      </Section>
+    );
+
+    // #then
+    expect(screen.getByTestId('test-child')).toBeInTheDocument();
+  });
+});

--- a/src/components/LibraryRoute/views/__tests__/HomeView.test.tsx
+++ b/src/components/LibraryRoute/views/__tests__/HomeView.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Tests for HomeView — renders 6 library sections and wires onNavigate (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({ hasMultipleProviders: false })),
+}));
+
+vi.mock('../../sections', () => ({
+  ResumeSection: () => <div data-testid="stub-resume" />,
+  RecentlyPlayedSection: ({ onSeeAll }: { onSeeAll?: () => void }) => (
+    <div data-testid="stub-recently-played">
+      {onSeeAll && <button onClick={onSeeAll}>see-all-rp</button>}
+    </div>
+  ),
+  PinnedSection: ({ onSeeAll }: { onSeeAll?: () => void }) => (
+    <div data-testid="stub-pinned">
+      {onSeeAll && <button onClick={onSeeAll}>see-all-pinned</button>}
+    </div>
+  ),
+  LikedSection: () => <div data-testid="stub-liked" />,
+  PlaylistsSection: ({ onSeeAll }: { onSeeAll?: () => void }) => (
+    <div data-testid="stub-playlists">
+      {onSeeAll && <button onClick={onSeeAll}>see-all-playlists</button>}
+    </div>
+  ),
+  AlbumsSection: ({ onSeeAll }: { onSeeAll?: () => void }) => (
+    <div data-testid="stub-albums">
+      {onSeeAll && <button onClick={onSeeAll}>see-all-albums</button>}
+    </div>
+  ),
+}));
+
+import HomeView from '../HomeView';
+
+const baseProps = {
+  layout: 'row' as const,
+  lastSession: null,
+  onSelectCollection: vi.fn(),
+  onSelectLiked: vi.fn(),
+  onNavigate: vi.fn(),
+};
+
+describe('HomeView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with data-testid="library-home"', () => {
+    // #given + #when
+    render(<HomeView {...baseProps} />);
+
+    // #then
+    expect(screen.getByTestId('library-home')).toBeInTheDocument();
+  });
+
+  it('renders all 6 section stubs', () => {
+    // #given + #when
+    render(<HomeView {...baseProps} />);
+
+    // #then — all 6 sections appear
+    expect(screen.getByTestId('stub-resume')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-recently-played')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-pinned')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-liked')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-playlists')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-albums')).toBeInTheDocument();
+  });
+
+  it('calls onNavigate with "recently-played" when RecentlyPlayedSection fires onSeeAll', () => {
+    // #given
+    const onNavigate = vi.fn();
+    render(<HomeView {...baseProps} onNavigate={onNavigate} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'see-all-rp' }));
+
+    // #then
+    expect(onNavigate).toHaveBeenCalledWith('recently-played');
+  });
+
+  it('calls onNavigate with "pinned" when PinnedSection fires onSeeAll', () => {
+    // #given
+    const onNavigate = vi.fn();
+    render(<HomeView {...baseProps} onNavigate={onNavigate} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'see-all-pinned' }));
+
+    // #then
+    expect(onNavigate).toHaveBeenCalledWith('pinned');
+  });
+
+  it('calls onNavigate with "playlists" when PlaylistsSection fires onSeeAll', () => {
+    // #given
+    const onNavigate = vi.fn();
+    render(<HomeView {...baseProps} onNavigate={onNavigate} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'see-all-playlists' }));
+
+    // #then
+    expect(onNavigate).toHaveBeenCalledWith('playlists');
+  });
+
+  it('calls onNavigate with "albums" when AlbumsSection fires onSeeAll', () => {
+    // #given
+    const onNavigate = vi.fn();
+    render(<HomeView {...baseProps} onNavigate={onNavigate} />);
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'see-all-albums' }));
+
+    // #then
+    expect(onNavigate).toHaveBeenCalledWith('albums');
+  });
+});

--- a/src/components/LibraryRoute/views/__tests__/SeeAllView.test.tsx
+++ b/src/components/LibraryRoute/views/__tests__/SeeAllView.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for SeeAllView — full-grid view for a single section with a back button (#1294).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({ hasMultipleProviders: false })),
+}));
+
+vi.mock('../../sections', () => ({
+  RecentlyPlayedSection: () => <div data-testid="stub-recently-played-section" />,
+  PinnedSection: () => <div data-testid="stub-pinned-section" />,
+  PlaylistsSection: () => <div data-testid="stub-playlists-section" />,
+  AlbumsSection: () => <div data-testid="stub-albums-section" />,
+}));
+
+vi.mock('@/components/icons/QuickActionIcons', () => ({
+  BackToLibraryIcon: () => <span>←</span>,
+}));
+
+import SeeAllView from '../SeeAllView';
+
+const baseProps = {
+  view: 'playlists' as const,
+  onBack: vi.fn(),
+  onSelectCollection: vi.fn(),
+};
+
+describe('SeeAllView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with data-testid matching the view', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} view="playlists" />);
+
+    // #then
+    expect(screen.getByTestId('library-see-all-playlists')).toBeInTheDocument();
+  });
+
+  it('renders the back button with correct aria-label', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} />);
+
+    // #then
+    expect(screen.getByRole('button', { name: 'Back to library home' })).toBeInTheDocument();
+  });
+
+  it('calls onBack when the back button is clicked', () => {
+    // #given
+    const onBack = vi.fn();
+    render(<SeeAllView {...baseProps} onBack={onBack} />);
+
+    // #when
+    fireEvent.click(screen.getByTestId('library-see-all-back'));
+
+    // #then
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders PlaylistsSection for view="playlists"', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} view="playlists" />);
+
+    // #then
+    expect(screen.getByTestId('stub-playlists-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-albums-section')).not.toBeInTheDocument();
+  });
+
+  it('renders AlbumsSection for view="albums"', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} view="albums" />);
+
+    // #then
+    expect(screen.getByTestId('stub-albums-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-playlists-section')).not.toBeInTheDocument();
+  });
+
+  it('renders RecentlyPlayedSection for view="recently-played"', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} view="recently-played" />);
+
+    // #then
+    expect(screen.getByTestId('stub-recently-played-section')).toBeInTheDocument();
+  });
+
+  it('renders PinnedSection for view="pinned"', () => {
+    // #given + #when
+    render(<SeeAllView {...baseProps} view="pinned" />);
+
+    // #then
+    expect(screen.getByTestId('stub-pinned-section')).toBeInTheDocument();
+  });
+
+  it('displays the correct title for each view', () => {
+    const TITLES = {
+      playlists: 'Playlists',
+      albums: 'Albums',
+      'recently-played': 'Recently Played',
+      pinned: 'Pinned',
+    } as const;
+
+    for (const [view, title] of Object.entries(TITLES) as [keyof typeof TITLES, string][]) {
+      const { unmount } = render(<SeeAllView {...baseProps} view={view} />);
+      expect(screen.getByText(title)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Wave-2 test coverage for #1294 (Library sections UI). 11 new test files completing the section + view layer.

Part of #1300.

## New test files (11)
| File | Tests | What it covers |
|---|---|---|
| `sections/__tests__/Section.test.tsx` | 7 | hidden→null, testid, See-all gating, title, children |
| `sections/__tests__/PinnedSection.test.tsx` | 7 | null/skeleton/cards, See-all threshold (6), onSelect shape |
| `sections/__tests__/PlaylistsSection.test.tsx` | 6 | null/skeleton/cards, threshold (8), onSelect |
| `sections/__tests__/AlbumsSection.test.tsx` | 5 | null/skeleton/cards, artist subtitle, threshold (8) |
| `sections/__tests__/RecentlyPlayedSection.test.tsx` | 7 | playlist/album/liked ref→kind mapping, threshold (4), onSelect |
| `sections/__tests__/LikedSection.test.tsx` | 8 | null/skeleton, unified card, plural/singular, per-provider mode, onSelectLiked |
| `sections/__tests__/ResumeSection.test.tsx` | 5 | null when !hasResumable, null when no onResume, ResumeHero, resume button |
| `views/__tests__/HomeView.test.tsx` | 6 | library-home testid, 6 sections present, 4 onNavigate targets |
| `views/__tests__/SeeAllView.test.tsx` | 8 | testid per view, back button, title per view, correct section per view |
| `__tests__/LibraryRoute.nav.test.tsx` | 7 | home→SeeAll→home nav, liked→home fallback, album toAlbumPlaylistId encoding, playlist plain-id |
| `card/__tests__/LibraryCard.extra.test.tsx` | 4 | preventDefault on right-click, long-press fires req, no double-fire, disabled when no handler |

## Test plan
- [x] All 11 new files green in isolation
- [x] Full sweep: 26 LibraryRoute-related files, 182 tests green
- [x] 3 pre-existing failures in `ui/__tests__/{accordion,popover,switch}` confirmed unrelated (import transform error from before this branch)
- [x] Rebased on `feature/library-redesign-1300` at `3665639` (includes #1294 impl)