### PR TITLE
test(library): wave-2 edge cases for #1295

### DIFF
--- a/src/components/LibraryRoute/MiniPlayer/__tests__/MiniPlayer.edges.test.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/__tests__/MiniPlayer.edges.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * Edge-case tests for MiniPlayer beyond the baseline coverage in MiniPlayer.test.tsx.
+ *
+ * Covers:
+ *  - Re-render swap when currentTrack changes mid-mount
+ *  - Missing track.image → no <img>, placeholder ArtFrame still mounts
+ *  - Missing / empty track.artists → graceful empty subtitle, no crash
+ *  - Semantic <button> tap-target + control buttons (keyboard-activatable)
+ *  - isRadioGenerating disabled→enabled transition + click after re-enable
+ */
+
+import React, { useState } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockCurrentTrack } = vi.hoisted(() => ({
+  mockCurrentTrack: vi.fn<[], { currentTrack: MediaTrack | null }>(),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: () => mockCurrentTrack(),
+}));
+
+import MiniPlayer, { type MiniPlayerProps } from '../MiniPlayer';
+
+function makeTrack(overrides: Partial<MediaTrack> = {}): MediaTrack {
+  return {
+    id: 't1',
+    name: 'Track A',
+    artists: 'Artist A',
+    duration_ms: 1000,
+    image: 'https://example.com/a.png',
+    provider: 'spotify',
+    uri: 'spotify:track:t1',
+    ...overrides,
+  } as MediaTrack;
+}
+
+function defaultProps(overrides: Partial<MiniPlayerProps> = {}): MiniPlayerProps {
+  return {
+    isPlaying: false,
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    onNext: vi.fn(),
+    onPrevious: vi.fn(),
+    onExpand: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderMP(propsOverrides: Partial<MiniPlayerProps> = {}) {
+  const props = defaultProps(propsOverrides);
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <MiniPlayer {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('MiniPlayer edges', () => {
+  beforeEach(() => {
+    mockCurrentTrack.mockReset();
+  });
+
+  describe('currentTrack re-render', () => {
+    it('swaps title / artist / image when currentTrack changes', () => {
+      // #given — track A mounted
+      const trackA = makeTrack({
+        id: 'a',
+        name: 'Track A',
+        artists: 'Artist A',
+        image: 'https://example.com/a.png',
+      });
+      const trackB = makeTrack({
+        id: 'b',
+        name: 'Track B',
+        artists: 'Artist B',
+        image: 'https://example.com/b.png',
+      });
+
+      // Drive re-render via a parent with a counter, so memoized MiniPlayer still
+      // re-evaluates the mocked context call (mock isn't a real React context).
+      function Harness() {
+        const [, force] = useState(0);
+        // expose force via window for the test
+        (Harness as unknown as { rerender?: () => void }).rerender = () =>
+          force((n) => n + 1);
+        return <MiniPlayer {...defaultProps()} />;
+      }
+
+      mockCurrentTrack.mockReturnValue({ currentTrack: trackA });
+      render(
+        <ThemeProvider theme={theme}>
+          <Harness />
+        </ThemeProvider>,
+      );
+
+      // #then — track A visible
+      expect(screen.getByText('Track A')).toBeInTheDocument();
+      expect(screen.getByText('Artist A')).toBeInTheDocument();
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        'https://example.com/a.png',
+      );
+
+      // #when — context now returns track B; force re-render
+      mockCurrentTrack.mockReturnValue({ currentTrack: trackB });
+      act(() => {
+        (Harness as unknown as { rerender: () => void }).rerender();
+      });
+
+      // #then — track B replaces track A in same mount
+      expect(screen.getByText('Track B')).toBeInTheDocument();
+      expect(screen.getByText('Artist B')).toBeInTheDocument();
+      expect(screen.queryByText('Track A')).toBeNull();
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        'https://example.com/b.png',
+      );
+    });
+  });
+
+  describe('missing fields', () => {
+    it('renders no <img> when track.image is missing', () => {
+      // #given — track with no image
+      mockCurrentTrack.mockReturnValue({
+        currentTrack: makeTrack({ image: undefined as unknown as string }),
+      });
+
+      // #when
+      renderMP();
+
+      // #then — root + pulse dot present, but no <img> tag rendered
+      expect(screen.getByTestId('library-mini-player')).toBeInTheDocument();
+      expect(screen.getByTestId('mini-pulse-dot')).toBeInTheDocument();
+      expect(screen.queryByRole('img')).toBeNull();
+    });
+
+    it('renders no <img> when track.image is empty string', () => {
+      // #given
+      mockCurrentTrack.mockReturnValue({
+        currentTrack: makeTrack({ image: '' }),
+      });
+
+      // #when
+      renderMP();
+
+      // #then — falsy image short-circuits to undefined → MiniArt skips <img>
+      expect(screen.queryByRole('img')).toBeNull();
+    });
+
+    it('renders empty Artist subtitle when track.artists is missing', () => {
+      // #given
+      mockCurrentTrack.mockReturnValue({
+        currentTrack: makeTrack({
+          name: 'Solo Track',
+          artists: undefined as unknown as string,
+        }),
+      });
+
+      // #when
+      renderMP();
+
+      // #then — title renders, no crash; artists fallback to ''
+      expect(screen.getByText('Solo Track')).toBeInTheDocument();
+      const root = screen.getByTestId('library-mini-player');
+      expect(root.textContent).toContain('Solo Track');
+      // Artist node should be empty (no artist text leaks through)
+      expect(screen.queryByText('Artist A')).toBeNull();
+    });
+
+    it('renders empty Title when track.name is missing', () => {
+      // #given — name missing, artist present
+      mockCurrentTrack.mockReturnValue({
+        currentTrack: makeTrack({
+          name: undefined as unknown as string,
+          artists: 'Lone Artist',
+        }),
+      });
+
+      // #when
+      renderMP();
+
+      // #then — no crash; artist renders; aria-label falls back to 'Now playing' image alt
+      expect(screen.getByText('Lone Artist')).toBeInTheDocument();
+      const expandBtn = screen.getByTestId('mini-expand');
+      expect(expandBtn.getAttribute('aria-label')).toBe('Expand player — ');
+    });
+  });
+
+  describe('semantic markup (keyboard a11y baseline)', () => {
+    it('tap-target is a real <button>', () => {
+      // #given
+      mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+      // #when
+      renderMP();
+
+      // #then — semantic <button> means browsers natively activate on Enter / Space
+      // (jsdom does not synthesize this, so we lock the structural guarantee.)
+      const expandBtn = screen.getByTestId('mini-expand');
+      expect(expandBtn.tagName).toBe('BUTTON');
+      expect(expandBtn.getAttribute('type')).toBe('button');
+    });
+
+    it('all control buttons are real <button> elements', () => {
+      // #given
+      mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+
+      // #when
+      renderMP({
+        isRadioAvailable: true,
+        onStartRadio: vi.fn(),
+      });
+
+      // #then — every control is a <button> (so Tab / Enter / Space work natively)
+      for (const tid of ['mini-prev', 'mini-play-pause', 'mini-next', 'mini-radio']) {
+        const el = screen.getByTestId(tid);
+        expect(el.tagName).toBe('BUTTON');
+        expect(el.getAttribute('type')).toBe('button');
+      }
+    });
+
+    it('clicking the tap-target button fires onExpand (keyboard activation simulated by click)', () => {
+      // #given — when a button is focused and Enter is pressed, browsers synthesize a
+      // click event. jsdom doesn't, so we assert via fireEvent.click which IS what
+      // the browser dispatches in response to Enter / Space on a focused <button>.
+      mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+      const onExpand = vi.fn();
+
+      // #when
+      renderMP({ onExpand });
+      const btn = screen.getByTestId('mini-expand');
+      btn.focus();
+      fireEvent.click(btn);
+
+      // #then
+      expect(onExpand).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(btn);
+    });
+  });
+
+  describe('isRadioGenerating transition', () => {
+    it('disables radio button while generating, then re-enables and fires on click', () => {
+      // #given — radio available, currently generating
+      mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+      const onStartRadio = vi.fn();
+
+      const baseProps: MiniPlayerProps = defaultProps({
+        isRadioAvailable: true,
+        isRadioGenerating: true,
+        onStartRadio,
+      });
+
+      const { rerender } = render(
+        <ThemeProvider theme={theme}>
+          <MiniPlayer {...baseProps} />
+        </ThemeProvider>,
+      );
+
+      const btn = screen.getByTestId('mini-radio') as HTMLButtonElement;
+
+      // #then — disabled while generating
+      expect(btn.disabled).toBe(true);
+
+      // #when — click while disabled has no effect (browser blocks; jsdom blocks too)
+      fireEvent.click(btn);
+      expect(onStartRadio).not.toHaveBeenCalled();
+
+      // #when — generating flips to false
+      rerender(
+        <ThemeProvider theme={theme}>
+          <MiniPlayer {...baseProps} isRadioGenerating={false} />
+        </ThemeProvider>,
+      );
+
+      // #then — button re-enabled
+      const reEnabled = screen.getByTestId('mini-radio') as HTMLButtonElement;
+      expect(reEnabled.disabled).toBe(false);
+
+      // #when — click after re-enable
+      fireEvent.click(reEnabled);
+
+      // #then — handler fires exactly once for the post-enable click
+      expect(onStartRadio).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates aria-label as isRadioGenerating flips', () => {
+      // #given
+      mockCurrentTrack.mockReturnValue({ currentTrack: makeTrack() });
+      const baseProps: MiniPlayerProps = defaultProps({
+        isRadioAvailable: true,
+        isRadioGenerating: true,
+        onStartRadio: vi.fn(),
+      });
+
+      const { rerender } = render(
+        <ThemeProvider theme={theme}>
+          <MiniPlayer {...baseProps} />
+        </ThemeProvider>,
+      );
+
+      // #then — generating label
+      expect(
+        screen.getByLabelText('Generating radio playlist'),
+      ).toBeInTheDocument();
+
+      // #when — flip to not generating
+      rerender(
+        <ThemeProvider theme={theme}>
+          <MiniPlayer {...baseProps} isRadioGenerating={false} />
+        </ThemeProvider>,
+      );
+
+      // #then — idle label
+      expect(
+        screen.getByLabelText('Start radio from current track'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
@@ -11,6 +11,13 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
   usePlayerSizingContext: vi.fn(),
 }));
 
+// LibraryRoute mounts MiniPlayer (added by #1295), which calls useCurrentTrackContext.
+// Stub the context so navigation tests don't need a full TrackProvider tree.
+// Default returns null → MiniPlayer renders null and stays out of the way.
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: () => ({ currentTrack: null }),
+}));
+
 vi.mock('@/contexts/ProviderContext', () => ({
   useProviderContext: vi.fn(() => ({
     hasMultipleProviders: false,

--- a/src/components/PlayerContent/__tests__/PlayerControlsSection.bottomBarHide.test.tsx
+++ b/src/components/PlayerContent/__tests__/PlayerControlsSection.bottomBarHide.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * Truth-table tests for BottomBar conservative-hide behavior.
+ *
+ * `bottomBarActions.hidden = showLibrary && (isMobile || newLibraryRouteEnabled)`
+ *
+ *  showLibrary | isMobile | newLibraryRouteEnabled | hidden
+ *  ----------- | -------- | ---------------------- | ------
+ *      true    |  false   |         true           |  true     (mini-player owns bottom)
+ *      true    |  true    |         false          |  true     (mobile-legacy)
+ *      true    |  false   |         false          |  false    (desktop-legacy — REGRESSION GUARD)
+ *      false   |   any    |          any           |  false
+ *
+ * Captured via a mocked BottomBarActionsProvider that records its `value` prop.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { MediaTrack } from '@/types/domain';
+import type { BottomBarActionsValue } from '@/contexts/BottomBarActionsContext';
+
+// ---- capture spy: mocked BottomBarActionsProvider records its value ------- //
+
+const captured: { value: BottomBarActionsValue | null } = { value: null };
+
+vi.mock('@/contexts/BottomBarActionsContext', () => ({
+  BottomBarActionsProvider: ({
+    value,
+    children,
+  }: {
+    value: BottomBarActionsValue;
+    children: React.ReactNode;
+  }) => {
+    captured.value = value;
+    return <>{children}</>;
+  },
+  useBottomBarActions: () => captured.value,
+}));
+
+// ---- light no-op mocks for every PlayerControlsSection dependency --------- //
+
+const { mockUseSizing, mockUseNewLibraryRoute, mockUseQapEnabled } = vi.hoisted(() => ({
+  mockUseSizing: vi.fn(),
+  mockUseNewLibraryRoute: vi.fn(),
+  mockUseQapEnabled: vi.fn(),
+}));
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: () => mockUseSizing(),
+}));
+
+vi.mock('@/hooks/useNewLibraryRoute', () => ({
+  useNewLibraryRoute: () => mockUseNewLibraryRoute(),
+}));
+
+vi.mock('@/hooks/useQapEnabled', () => ({
+  useQapEnabled: () => mockUseQapEnabled(),
+}));
+
+vi.mock('@/contexts/ColorContext', () => ({
+  useColorContext: () => ({ accentColor: '#fff' }),
+}));
+
+vi.mock('@/hooks/useVisualEffectsState', () => ({
+  useVisualEffectsState: () => ({
+    effectiveGlow: { intensity: 0, rate: 0 },
+    restoreGlowSettings: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/visualEffects', () => ({
+  useTranslucence: () => ({ setTranslucenceEnabled: vi.fn() }),
+  useVisualEffectsToggle: () => ({
+    visualEffectsEnabled: false,
+    setVisualEffectsEnabled: vi.fn(),
+    showVisualEffects: false,
+    setShowVisualEffects: vi.fn(),
+  }),
+  useVisualizer: () => ({
+    backgroundVisualizerStyle: 'fireflies',
+    setBackgroundVisualizerStyle: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  useProfilingContext: () => ({ enabled: false, toggle: vi.fn() }),
+}));
+
+vi.mock('@/contexts/VisualizerDebugContext', () => ({
+  useVisualizerDebug: () => null,
+}));
+
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
+vi.mock('@/hooks/useVolume', () => ({
+  useVolume: () => ({
+    handleMuteToggle: vi.fn(),
+    volume: 50,
+    setVolumeLevel: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: () => ({ tracks: [], handleShuffleToggle: vi.fn() }),
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  clearCacheWithOptions: vi.fn(),
+}));
+
+vi.mock('@/services/settings/pinnedItemsStorage', () => ({
+  clearAllPins: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTransitionWillChange', () => ({
+  useTransitionWillChange: vi.fn(),
+}));
+
+vi.mock('@/components/BottomBar', () => ({
+  default: () => <div data-testid="bottom-bar" />,
+}));
+
+vi.mock('@/components/SpotifyPlayerControls', () => ({
+  default: () => <div data-testid="spotify-controls" />,
+}));
+
+vi.mock('@/components/ProfiledComponent', () => ({
+  ProfiledComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// LoadingCard / ZenControls* are styled components from local sibling — pass-through.
+vi.mock('../styled', () => ({
+  LoadingCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ZenControlsWrapper: React.forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+    ({ children }, ref) => <div ref={ref}>{children}</div>,
+  ),
+  ZenControlsInner: React.forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+    ({ children }, ref) => <div ref={ref}>{children}</div>,
+  ),
+}));
+
+// -------------------------------------------------------------------------- //
+
+import { PlayerControlsSection } from '../PlayerControlsSection';
+
+function makeTrack(): MediaTrack {
+  return {
+    id: 't1',
+    name: 'Track',
+    artists: 'Artist',
+    duration_ms: 1000,
+    image: 'https://example.com/art.png',
+    provider: 'spotify',
+    uri: 'spotify:track:t1',
+  } as MediaTrack;
+}
+
+interface Scenario {
+  showLibrary: boolean;
+  isMobile: boolean;
+  newLibraryRouteEnabled: boolean;
+}
+
+function renderWith(scenario: Scenario) {
+  mockUseSizing.mockReturnValue({
+    isMobile: scenario.isMobile,
+    isTablet: false,
+    isDesktop: !scenario.isMobile,
+    isTouchDevice: false,
+    hasPointerInput: true,
+    viewport: { width: 1024, height: 768, ratio: 1024 / 768 },
+    dimensions: { width: 600, height: 600 },
+  });
+  mockUseNewLibraryRoute.mockReturnValue([scenario.newLibraryRouteEnabled, vi.fn()]);
+  mockUseQapEnabled.mockReturnValue([false, vi.fn()]);
+
+  const controlsRef = React.createRef<HTMLDivElement>();
+  return render(
+    <ThemeProvider theme={theme}>
+      <PlayerControlsSection
+        currentTrack={makeTrack()}
+        currentTrackProvider="spotify"
+        isPlaying={false}
+        zenModeEnabled={false}
+        hasPointerInput={true}
+        showLibrary={scenario.showLibrary}
+        showQueue={false}
+        controlsRef={controlsRef}
+        onPlay={vi.fn()}
+        onPause={vi.fn()}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        onArtistBrowse={vi.fn()}
+        onAlbumPlay={vi.fn()}
+        onShowQueue={vi.fn()}
+        onCloseQueue={vi.fn()}
+        onOpenLibrary={vi.fn()}
+        onCloseLibrary={vi.fn()}
+        onZenModeToggle={vi.fn()}
+        isLiked={false}
+        isLikePending={false}
+        onLikeToggle={vi.fn()}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('PlayerControlsSection — BottomBar conservative-hide truth table', () => {
+  beforeEach(() => {
+    captured.value = null;
+    mockUseSizing.mockReset();
+    mockUseNewLibraryRoute.mockReset();
+    mockUseQapEnabled.mockReset();
+  });
+
+  it('hidden=true when showLibrary + newLibraryRouteEnabled (desktop)', () => {
+    // #given showLibrary=true, isMobile=false, newLibraryRouteEnabled=true
+    // #when
+    renderWith({ showLibrary: true, isMobile: false, newLibraryRouteEnabled: true });
+
+    // #then — mini-player owns bottom strip; BottomBar hides
+    expect(captured.value?.hidden).toBe(true);
+  });
+
+  it('hidden=true when showLibrary + isMobile (legacy mobile behavior preserved)', () => {
+    // #given showLibrary=true, isMobile=true, newLibraryRouteEnabled=false
+    // #when
+    renderWith({ showLibrary: true, isMobile: true, newLibraryRouteEnabled: false });
+
+    // #then
+    expect(captured.value?.hidden).toBe(true);
+  });
+
+  it('hidden=false when showLibrary on legacy desktop (REGRESSION GUARD)', () => {
+    // #given showLibrary=true, isMobile=false, newLibraryRouteEnabled=false
+    // #when
+    renderWith({ showLibrary: true, isMobile: false, newLibraryRouteEnabled: false });
+
+    // #then — legacy desktop path MUST keep BottomBar visible
+    expect(captured.value?.hidden).toBe(false);
+  });
+
+  it('hidden=false when showLibrary=false regardless of flag (mobile + NLR on)', () => {
+    // #given showLibrary=false, isMobile=true, newLibraryRouteEnabled=true
+    // #when
+    renderWith({ showLibrary: false, isMobile: true, newLibraryRouteEnabled: true });
+
+    // #then
+    expect(captured.value?.hidden).toBe(false);
+  });
+
+  it('hidden=false when showLibrary=false on plain desktop', () => {
+    // #given showLibrary=false, isMobile=false, newLibraryRouteEnabled=false
+    // #when
+    renderWith({ showLibrary: false, isMobile: false, newLibraryRouteEnabled: false });
+
+    // #then
+    expect(captured.value?.hidden).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #1300. Edge cases for mini-player (track A→B transitions, missing image / artists / name fields, semantic <button> a11y baseline, isRadioGenerating disabled→enabled transition + aria-label flip) plus a 5-row truth table for the `PlayerControlsSection` BottomBar conservative-hide behavior — including an explicit regression guard for legacy desktop (`showLibrary=true + isMobile=false + newLibraryRouteEnabled=false → hidden=false`).

Also folds in a fix for a cross-PR regression discovered during the cold sweep: `LibraryRoute.nav.test.tsx` (landed in PR #1307) was broken once #1295 merged, because `LibraryRoute` now mounts `MiniPlayer` which calls `useCurrentTrackContext` — but the nav test didn't stub the context. Fix mirrors the pattern from sibling `LibraryRoute.test.tsx`.

## Test files
- `src/components/LibraryRoute/MiniPlayer/__tests__/MiniPlayer.edges.test.tsx` (10 new tests)
- `src/components/PlayerContent/__tests__/PlayerControlsSection.bottomBarHide.test.tsx` (5 new tests)
- `src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx` (7 tests restored to green)

22 tests touched, all green cold + warm. tsc clean. Full sweep: 1497/1497 passing aside from the 3 pre-existing baseline failures (`accordion`, `popover`, `switch` — missing `@testing-library/user-event`).