### PR TITLE
feat(library): library search (#1296)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "debug": "^4.4.3",
         "html2canvas": "^1.4.1",
         "lucide-react": "^1.11.0",
@@ -4531,6 +4532,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "debug": "^4.4.3",
     "html2canvas": "^1.4.1",
     "lucide-react": "^1.11.0",

--- a/src/components/LibraryRoute/MiniPlayer/MiniPlayer.styled.ts
+++ b/src/components/LibraryRoute/MiniPlayer/MiniPlayer.styled.ts
@@ -1,8 +1,10 @@
 import styled, { css, keyframes } from 'styled-components';
 import { theme } from '@/styles/theme';
 
-const HEIGHT_MOBILE = 64;
-const HEIGHT_DESKTOP = 72;
+export const MINI_PLAYER_HEIGHT_MOBILE = 64;
+export const MINI_PLAYER_HEIGHT_DESKTOP = 72;
+const HEIGHT_MOBILE = MINI_PLAYER_HEIGHT_MOBILE;
+const HEIGHT_DESKTOP = MINI_PLAYER_HEIGHT_DESKTOP;
 
 export const MiniPlayerRoot = styled.div`
   position: sticky;

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -7,9 +7,14 @@ import { toAlbumPlaylistId } from '@/constants/playlist';
 import { LibraryRouteRoot, MobileLayout, DesktopLayout } from './styled';
 import HomeView from './views/HomeView';
 import SeeAllView from './views/SeeAllView';
+import SearchResultsView from './views/SearchResultsView';
 import { fetchLikedForProvider } from './hooks';
 import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from './types';
 import MiniPlayer from './MiniPlayer/MiniPlayer';
+import SearchBar from './search/SearchBar';
+import CommandPalette from './search/CommandPalette';
+import { useLibrarySearch } from './search/useLibrarySearch';
+import { useCommandPaletteShortcut } from './search/useCommandPaletteShortcut';
 
 // LibraryRoute assumes upstream guards have already filtered out cold-start cases:
 // - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
@@ -58,25 +63,25 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   const { isMobile } = usePlayerSizingContext();
   const [view, setView] = useState<LibraryRouteView>('home');
   const { unifiedTracks, isUnifiedLikedActive } = useUnifiedLikedTracks();
+  const search = useLibrarySearch();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  useCommandPaletteShortcut(() => setPaletteOpen(true), !isMobile);
 
   const handleSelectCollection = useCallback(
     (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => {
+      if (search.isSearching) search.setQuery('');
       if (kind === 'album') {
         onPlaylistSelect(toAlbumPlaylistId(id), name, provider);
         return;
       }
-      // playlist or recently-played-as-playlist: pass id through
       onPlaylistSelect(id, name, provider);
     },
-    [onPlaylistSelect],
+    [onPlaylistSelect, search],
   );
 
   const handleSelectLiked = useCallback(
     async (provider?: ProviderId) => {
       if (!onPlayLikedTracks) return;
-      // Why: when unified-liked is active and no provider was specified, the in-memory
-      // unifiedTracks list is the source. For a per-provider liked tile the unified list
-      // may not be authoritative for that single provider, so fetch it directly.
       let tracks: MediaTrack[];
       let collectionId: string;
       let providerArg: ProviderId | undefined;
@@ -89,7 +94,6 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         collectionId = 'liked-unified';
         providerArg = undefined;
       } else {
-        // single-provider, non-unified path — fall back to the active provider's liked
         const inferred: ProviderId = unifiedTracks[0]?.provider ?? 'spotify';
         tracks = await fetchLikedForProvider(inferred);
         collectionId = `liked-${inferred}`;
@@ -102,8 +106,6 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   );
 
   const handleContextMenuRequest = useCallback((req: ContextMenuRequest) => {
-    // #1297 will mount the context menu portal. For #1294 the request is logged in dev
-    // so click affordances are visible during integration without forcing menu shape now.
     if (import.meta.env.DEV) {
       console.debug('[LibraryRoute] context menu requested', req);
     }
@@ -113,38 +115,46 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   const Layout = isMobile ? MobileLayout : DesktopLayout;
   const layoutTestId = isMobile ? 'library-route-mobile' : 'library-route-desktop';
 
+  const effectiveView: LibraryRouteView = search.isSearching ? 'search' : view;
+
+  let body: React.ReactNode;
+  if (effectiveView === 'search') {
+    body = (
+      <SearchResultsView
+        search={search}
+        onSelectCollection={handleSelectCollection}
+        onContextMenuRequest={handleContextMenuRequest}
+      />
+    );
+  } else if (effectiveView === 'home' || effectiveView === 'liked') {
+    body = (
+      <HomeView
+        layout={layout}
+        lastSession={lastSession ?? null}
+        onResume={onResume}
+        onSelectCollection={handleSelectCollection}
+        onSelectLiked={handleSelectLiked}
+        onNavigate={setView}
+        onContextMenuRequest={handleContextMenuRequest}
+      />
+    );
+  } else {
+    body = (
+      <SeeAllView
+        view={effectiveView as Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>}
+        onBack={() => setView('home')}
+        onSelectCollection={handleSelectCollection}
+        onContextMenuRequest={handleContextMenuRequest}
+      />
+    );
+  }
+
   return (
     <LibraryRouteRoot>
       <Layout data-testid={layoutTestId}>
-        {view === 'home' ? (
-          <HomeView
-            layout={layout}
-            lastSession={lastSession ?? null}
-            onResume={onResume}
-            onSelectCollection={handleSelectCollection}
-            onSelectLiked={handleSelectLiked}
-            onNavigate={setView}
-            onContextMenuRequest={handleContextMenuRequest}
-          />
-        ) : view === 'liked' ? (
-          // Liked has no SeeAll page — fall back to home defensively if navigated here.
-          <HomeView
-            layout={layout}
-            lastSession={lastSession ?? null}
-            onResume={onResume}
-            onSelectCollection={handleSelectCollection}
-            onSelectLiked={handleSelectLiked}
-            onNavigate={setView}
-            onContextMenuRequest={handleContextMenuRequest}
-          />
-        ) : (
-          <SeeAllView
-            view={view}
-            onBack={() => setView('home')}
-            onSelectCollection={handleSelectCollection}
-            onContextMenuRequest={handleContextMenuRequest}
-          />
-        )}
+        {!isMobile && <SearchBar variant="desktop" search={search} />}
+        {body}
+        {isMobile && <SearchBar variant="mobile" search={search} />}
       </Layout>
       <MiniPlayer
         isPlaying={isPlaying}
@@ -157,6 +167,13 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         onExpand={onMiniExpand}
         onStartRadio={onMiniStartRadio}
       />
+      {!isMobile && (
+        <CommandPalette
+          open={paletteOpen}
+          onClose={() => setPaletteOpen(false)}
+          onSelectCollection={handleSelectCollection}
+        />
+      )}
     </LibraryRouteRoot>
   );
 };

--- a/src/components/LibraryRoute/search/CommandPalette.tsx
+++ b/src/components/LibraryRoute/search/CommandPalette.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { usePinnedSection, usePlaylistsSection, useAlbumsSection } from '../hooks';
+import { toAlbumPlaylistId } from '@/constants/playlist';
+import type { ProviderId } from '@/types/domain';
+import type { LibraryItemKind } from '../types';
+
+export interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectCollection: (
+    kind: LibraryItemKind,
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+}
+
+const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, onSelectCollection }) => {
+  const pinned = usePinnedSection();
+  const { items: playlists } = usePlaylistsSection({ excludePinned: true });
+  const { items: albums } = useAlbumsSection({ excludePinned: true });
+
+  const pinnedItems = pinned.combined;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) onClose();
+  };
+
+  const groups = useMemo(
+    () => ({ pinnedItems, playlists, albums }),
+    [pinnedItems, playlists, albums],
+  );
+
+  return (
+    <CommandDialog open={open} onOpenChange={handleOpenChange}>
+      <CommandInput placeholder="Search collections..." data-testid="library-palette-input" />
+      <CommandList>
+        <CommandEmpty>No results.</CommandEmpty>
+        {groups.pinnedItems.length > 0 && (
+          <CommandGroup heading="Pinned">
+            {groups.pinnedItems.map((item) => (
+              <CommandItem
+                key={`pinned-${item.kind}-${item.provider ?? 'spotify'}-${item.id}`}
+                value={`pinned ${item.name}`}
+                onSelect={() => {
+                  if (item.kind === 'album') {
+                    onSelectCollection('album', toAlbumPlaylistId(item.id), item.name, item.provider);
+                  } else {
+                    onSelectCollection('playlist', item.id, item.name, item.provider);
+                  }
+                  onClose();
+                }}
+              >
+                {item.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        {groups.playlists.length > 0 && (
+          <CommandGroup heading="Playlists">
+            {groups.playlists.map((p) => (
+              <CommandItem
+                key={`playlist-${p.provider ?? 'spotify'}-${p.id}`}
+                value={`playlist ${p.name}`}
+                onSelect={() => {
+                  onSelectCollection('playlist', p.id, p.name, p.provider);
+                  onClose();
+                }}
+              >
+                {p.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        {groups.albums.length > 0 && (
+          <CommandGroup heading="Albums">
+            {groups.albums.map((a) => (
+              <CommandItem
+                key={`album-${a.provider ?? 'spotify'}-${a.id}`}
+                value={`album ${a.name} ${a.artists}`}
+                onSelect={() => {
+                  onSelectCollection('album', toAlbumPlaylistId(a.id), a.name, a.provider);
+                  onClose();
+                }}
+              >
+                {a.name} — {a.artists}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+};
+
+CommandPalette.displayName = 'CommandPalette';
+export default CommandPalette;

--- a/src/components/LibraryRoute/search/FilterSheet.styled.ts
+++ b/src/components/LibraryRoute/search/FilterSheet.styled.ts
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const FilterBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.lg};
+  padding-top: ${theme.spacing.md};
+`;
+
+export const Group = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.sm};
+`;
+
+export const GroupLabel = styled.div`
+  color: ${theme.colors.muted.foreground};
+  font-size: ${theme.fontSize.xs};
+  font-weight: ${theme.fontWeight.medium};
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+export const CheckboxRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  cursor: pointer;
+  color: ${theme.colors.foreground};
+  font-size: ${theme.fontSize.sm};
+  text-transform: capitalize;
+`;
+
+export const SortSelect = styled.select`
+  appearance: none;
+  background: ${theme.colors.control.background};
+  color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.borderSubtle};
+  border-radius: ${theme.borderRadius.md};
+  padding: ${theme.spacing.sm};
+  font-size: ${theme.fontSize.sm};
+  cursor: pointer;
+`;
+
+export const ClearAllButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: 1px solid ${theme.colors.borderSubtle};
+  color: ${theme.colors.foreground};
+  padding: ${theme.spacing.sm};
+  border-radius: ${theme.borderRadius.md};
+  cursor: pointer;
+  font-size: ${theme.fontSize.sm};
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:not(:disabled):hover {
+    background: ${theme.colors.control.background};
+  }
+`;

--- a/src/components/LibraryRoute/search/FilterSheet.tsx
+++ b/src/components/LibraryRoute/search/FilterSheet.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import type { ProviderId } from '@/types/domain';
+import type { LibraryKindFilter, LibrarySearchState, LibrarySort } from './useLibrarySearch';
+import {
+  FilterBody,
+  Group,
+  GroupLabel,
+  CheckboxRow,
+  SortSelect,
+  ClearAllButton,
+} from './FilterSheet.styled';
+
+export interface FilterSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  search: LibrarySearchState;
+  side?: 'right' | 'bottom';
+}
+
+const KIND_OPTIONS: LibraryKindFilter[] = ['playlist', 'album'];
+const SORT_OPTIONS: Array<{ value: LibrarySort; label: string }> = [
+  { value: 'recent', label: 'Recently Added' },
+  { value: 'name-asc', label: 'A → Z' },
+  { value: 'name-desc', label: 'Z → A' },
+];
+
+const FilterSheet: React.FC<FilterSheetProps> = ({ open, onOpenChange, search, side = 'right' }) => {
+  const { enabledProviderIds } = useProviderContext();
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side={side} data-testid="library-filter-sheet">
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+        </SheetHeader>
+        <FilterBody>
+          {enabledProviderIds.length > 1 && (
+            <Group>
+              <GroupLabel>Source</GroupLabel>
+              {enabledProviderIds.map((id: ProviderId) => (
+                <CheckboxRow key={id}>
+                  <input
+                    type="checkbox"
+                    checked={search.providerFilter.includes(id)}
+                    onChange={() => search.toggleProvider(id)}
+                    data-testid={`library-filter-provider-${id}`}
+                  />
+                  {id}
+                </CheckboxRow>
+              ))}
+            </Group>
+          )}
+          <Group>
+            <GroupLabel>Type</GroupLabel>
+            {KIND_OPTIONS.map((kind) => (
+              <CheckboxRow key={kind}>
+                <input
+                  type="checkbox"
+                  checked={search.kindFilter.includes(kind)}
+                  onChange={() => search.toggleKind(kind)}
+                  data-testid={`library-filter-kind-${kind}`}
+                />
+                {kind}s
+              </CheckboxRow>
+            ))}
+          </Group>
+          <Group>
+            <GroupLabel>Sort</GroupLabel>
+            <SortSelect
+              value={search.sort}
+              onChange={(e) => search.setSort(e.target.value as LibrarySort)}
+              data-testid="library-filter-sort"
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </SortSelect>
+          </Group>
+          <ClearAllButton
+            type="button"
+            disabled={!search.hasActiveFilters && !search.isSearching}
+            onClick={search.clearAll}
+            data-testid="library-filter-clear"
+          >
+            Clear all
+          </ClearAllButton>
+        </FilterBody>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+FilterSheet.displayName = 'FilterSheet';
+export default FilterSheet;

--- a/src/components/LibraryRoute/search/SearchBar.styled.ts
+++ b/src/components/LibraryRoute/search/SearchBar.styled.ts
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import { MINI_PLAYER_HEIGHT_MOBILE } from '../MiniPlayer/MiniPlayer.styled';
+
+export const SearchBarRoot = styled.div<{ $variant: 'mobile' | 'desktop' }>`
+  position: sticky;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  background: ${theme.colors.muted.background};
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+
+  ${({ $variant }) =>
+    $variant === 'mobile'
+      ? `bottom: ${MINI_PLAYER_HEIGHT_MOBILE}px; border-top: 1px solid ${theme.colors.borderSubtle};`
+      : `top: 0; border-bottom: 1px solid ${theme.colors.borderSubtle};`}
+`;
+
+export const InputWrap = styled.div`
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+
+  & > input {
+    background: ${theme.colors.control.background};
+    color: ${theme.colors.white};
+    border: 1px solid ${theme.colors.borderSubtle};
+  }
+
+  & > input::placeholder {
+    color: ${theme.colors.muted.foreground};
+  }
+`;
+
+export const ClearButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: ${theme.colors.muted.foreground};
+  cursor: pointer;
+  position: absolute;
+  right: ${theme.spacing.sm};
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: ${theme.borderRadius.full};
+
+  &:hover {
+    color: ${theme.colors.white};
+    background: ${theme.colors.control.background};
+  }
+`;
+
+export const FilterButton = styled.button<{ $hasActive?: boolean }>`
+  appearance: none;
+  background: transparent;
+  border: 1px solid ${theme.colors.borderSubtle};
+  color: ${theme.colors.white};
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: ${theme.borderRadius.md};
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: ${theme.colors.control.background};
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: ${theme.colors.primary};
+    display: ${({ $hasActive }) => ($hasActive ? 'block' : 'none')};
+  }
+`;

--- a/src/components/LibraryRoute/search/SearchBar.tsx
+++ b/src/components/LibraryRoute/search/SearchBar.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Filter, Search as SearchIcon, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import type { LibrarySearchState } from './useLibrarySearch';
+import FilterSheet from './FilterSheet';
+import { SearchBarRoot, InputWrap, ClearButton, FilterButton } from './SearchBar.styled';
+
+export interface SearchBarProps {
+  variant: 'mobile' | 'desktop';
+  search: LibrarySearchState;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ variant, search }) => {
+  const [filterOpen, setFilterOpen] = useState(false);
+  return (
+    <SearchBarRoot $variant={variant} data-testid={`library-search-bar-${variant}`}>
+      <InputWrap>
+        <SearchIcon
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 12,
+            width: 16,
+            height: 16,
+            color: 'rgba(255,255,255,0.5)',
+            pointerEvents: 'none',
+          }}
+        />
+        <Input
+          type="search"
+          aria-label="Search library"
+          placeholder="Search your library"
+          value={search.query}
+          onChange={(e) => search.setQuery(e.target.value)}
+          style={{ paddingLeft: 36, paddingRight: search.query ? 32 : 12 }}
+          data-testid={`library-search-input-${variant}`}
+        />
+        {search.query && (
+          <ClearButton
+            type="button"
+            aria-label="Clear search"
+            onClick={() => search.setQuery('')}
+            data-testid={`library-search-clear-${variant}`}
+          >
+            <X width={14} height={14} aria-hidden="true" />
+          </ClearButton>
+        )}
+      </InputWrap>
+      <FilterButton
+        type="button"
+        aria-label="Filters"
+        $hasActive={search.hasActiveFilters}
+        onClick={() => setFilterOpen(true)}
+        data-testid={`library-search-filter-${variant}`}
+      >
+        <Filter width={16} height={16} aria-hidden="true" />
+      </FilterButton>
+      <FilterSheet
+        open={filterOpen}
+        onOpenChange={setFilterOpen}
+        search={search}
+        side={variant === 'mobile' ? 'bottom' : 'right'}
+      />
+    </SearchBarRoot>
+  );
+};
+
+SearchBar.displayName = 'SearchBar';
+export default SearchBar;

--- a/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeQuery, matchesQuery, passesProviderFilter, sortItems } from '../searchMatch';
+
+describe('normalizeQuery', () => {
+  it('trims and lowercases', () => {
+    expect(normalizeQuery('  Rock  ')).toBe('rock');
+  });
+
+  it('returns empty for whitespace', () => {
+    expect(normalizeQuery('   ')).toBe('');
+  });
+});
+
+describe('matchesQuery', () => {
+  it('matches case-insensitive substring', () => {
+    expect(matchesQuery({ name: 'Classic Rock' }, 'rock')).toBe(true);
+    expect(matchesQuery({ name: 'classic rock' }, 'CLASSIC')).toBe(false);
+  });
+
+  it('returns true for empty query', () => {
+    expect(matchesQuery({ name: 'anything' }, '')).toBe(true);
+  });
+
+  it('returns false on no match', () => {
+    expect(matchesQuery({ name: 'Jazz' }, 'rock')).toBe(false);
+  });
+});
+
+describe('passesProviderFilter', () => {
+  it('passes everything when filter is empty', () => {
+    expect(passesProviderFilter({ provider: 'spotify' }, [])).toBe(true);
+    expect(passesProviderFilter({}, [])).toBe(true);
+  });
+
+  it('passes only items in filter list', () => {
+    expect(passesProviderFilter({ provider: 'spotify' }, ['spotify'])).toBe(true);
+    expect(passesProviderFilter({ provider: 'dropbox' }, ['spotify'])).toBe(false);
+  });
+
+  it('treats missing provider as spotify', () => {
+    expect(passesProviderFilter({}, ['spotify'])).toBe(true);
+    expect(passesProviderFilter({}, ['dropbox'])).toBe(false);
+  });
+});
+
+describe('sortItems', () => {
+  const items = [
+    { name: 'Charlie' },
+    { name: 'alpha' },
+    { name: 'Bravo' },
+  ];
+
+  it('returns items unchanged for recent sort', () => {
+    expect(sortItems(items, 'recent')).toBe(items);
+  });
+
+  it('sorts ascending by name (case-insensitive via localeCompare)', () => {
+    expect(sortItems(items, 'name-asc').map((i) => i.name)).toEqual(['alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('sorts descending by name', () => {
+    expect(sortItems(items, 'name-desc').map((i) => i.name)).toEqual(['Charlie', 'Bravo', 'alpha']);
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
@@ -3,41 +3,71 @@ import { normalizeQuery, matchesQuery, passesProviderFilter, sortItems } from '.
 
 describe('normalizeQuery', () => {
   it('trims and lowercases', () => {
-    expect(normalizeQuery('  Rock  ')).toBe('rock');
+    // #when
+    const result = normalizeQuery('  Rock  ');
+
+    // #then
+    expect(result).toBe('rock');
   });
 
   it('returns empty for whitespace', () => {
-    expect(normalizeQuery('   ')).toBe('');
+    // #when
+    const result = normalizeQuery('   ');
+
+    // #then
+    expect(result).toBe('');
   });
 });
 
 describe('matchesQuery', () => {
   it('matches case-insensitive substring', () => {
-    expect(matchesQuery({ name: 'Classic Rock' }, 'rock')).toBe(true);
-    expect(matchesQuery({ name: 'classic rock' }, 'CLASSIC')).toBe(false);
+    // #given
+    const item = { name: 'Classic Rock' };
+
+    // #when / #then
+    expect(matchesQuery(item, 'rock')).toBe(true);
+  });
+
+  it('does not match when needle has different casing than haystack but normalized form differs', () => {
+    // #given — caller is responsible for normalizing the query before passing it in
+    const item = { name: 'classic rock' };
+
+    // #when / #then — passing un-normalized 'CLASSIC' must NOT match (lowercase haystack only)
+    expect(matchesQuery(item, 'CLASSIC')).toBe(false);
   });
 
   it('returns true for empty query', () => {
-    expect(matchesQuery({ name: 'anything' }, '')).toBe(true);
+    // #given
+    const item = { name: 'anything' };
+
+    // #when / #then
+    expect(matchesQuery(item, '')).toBe(true);
   });
 
   it('returns false on no match', () => {
-    expect(matchesQuery({ name: 'Jazz' }, 'rock')).toBe(false);
+    // #given
+    const item = { name: 'Jazz' };
+
+    // #when / #then
+    expect(matchesQuery(item, 'rock')).toBe(false);
   });
 });
 
 describe('passesProviderFilter', () => {
   it('passes everything when filter is empty', () => {
+    // #when / #then
     expect(passesProviderFilter({ provider: 'spotify' }, [])).toBe(true);
     expect(passesProviderFilter({}, [])).toBe(true);
   });
 
   it('passes only items in filter list', () => {
+    // #when / #then
     expect(passesProviderFilter({ provider: 'spotify' }, ['spotify'])).toBe(true);
     expect(passesProviderFilter({ provider: 'dropbox' }, ['spotify'])).toBe(false);
   });
 
   it('treats missing provider as spotify', () => {
+    // #when / #then
     expect(passesProviderFilter({}, ['spotify'])).toBe(true);
     expect(passesProviderFilter({}, ['dropbox'])).toBe(false);
   });
@@ -51,14 +81,26 @@ describe('sortItems', () => {
   ];
 
   it('returns items unchanged for recent sort', () => {
-    expect(sortItems(items, 'recent')).toBe(items);
+    // #when
+    const result = sortItems(items, 'recent');
+
+    // #then — same reference (caller-supplied order = "recent")
+    expect(result).toBe(items);
   });
 
   it('sorts ascending by name (case-insensitive via localeCompare)', () => {
-    expect(sortItems(items, 'name-asc').map((i) => i.name)).toEqual(['alpha', 'Bravo', 'Charlie']);
+    // #when
+    const result = sortItems(items, 'name-asc');
+
+    // #then
+    expect(result.map((i) => i.name)).toEqual(['alpha', 'Bravo', 'Charlie']);
   });
 
   it('sorts descending by name', () => {
-    expect(sortItems(items, 'name-desc').map((i) => i.name)).toEqual(['Charlie', 'Bravo', 'alpha']);
+    // #when
+    const result = sortItems(items, 'name-desc');
+
+    // #then
+    expect(result.map((i) => i.name)).toEqual(['Charlie', 'Bravo', 'alpha']);
   });
 });

--- a/src/components/LibraryRoute/search/__tests__/useCommandPaletteShortcut.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/useCommandPaletteShortcut.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCommandPaletteShortcut } from '../useCommandPaletteShortcut';
+
+function fireKeydown(opts: KeyboardEventInit & { target?: HTMLElement } = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...opts });
+  if (opts.target) {
+    Object.defineProperty(event, 'target', { value: opts.target });
+  }
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe('useCommandPaletteShortcut', () => {
+  afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  });
+
+  it('fires onOpen on Cmd+K', () => {
+    // #given
+    const onOpen = vi.fn();
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true });
+
+    // #then
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onOpen on Ctrl+K', () => {
+    // #given
+    const onOpen = vi.fn();
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', ctrlKey: true });
+
+    // #then
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire on plain K', () => {
+    // #given
+    const onOpen = vi.fn();
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k' });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('skips when active element is an input', () => {
+    // #given
+    const onOpen = vi.fn();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true, target: input });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled=false', () => {
+    // #given
+    const onOpen = vi.fn();
+    renderHook(() => useCommandPaletteShortcut(onOpen, false));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/useLibrarySearch.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/useLibrarySearch.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLibrarySearch } from '../useLibrarySearch';
+
+describe('useLibrarySearch', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  it('defaults to empty query and inactive search', () => {
+    // #when
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #then
+    expect(result.current.query).toBe('');
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.hasActiveFilters).toBe(false);
+    expect(result.current.providerFilter).toEqual([]);
+    expect(result.current.kindFilter).toEqual([]);
+    expect(result.current.sort).toBe('recent');
+  });
+
+  it('marks isSearching true when query has non-whitespace', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.setQuery('rock');
+    });
+
+    // #then
+    expect(result.current.isSearching).toBe(true);
+  });
+
+  it('whitespace-only query is not searching', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.setQuery('   ');
+    });
+
+    // #then
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it('toggleProvider adds and removes provider', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.toggleProvider('spotify');
+    });
+    expect(result.current.providerFilter).toEqual(['spotify']);
+
+    act(() => {
+      result.current.toggleProvider('spotify');
+    });
+
+    // #then
+    expect(result.current.providerFilter).toEqual([]);
+  });
+
+  it('toggleKind adds and removes kind', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.toggleKind('album');
+    });
+
+    // #then
+    expect(result.current.kindFilter).toEqual(['album']);
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it('hasActiveFilters reflects sort change', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.setSort('name-asc');
+    });
+
+    // #then
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it('clearAll resets query, filters, and sort', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+    act(() => {
+      result.current.setQuery('test');
+      result.current.toggleProvider('spotify');
+      result.current.toggleKind('album');
+      result.current.setSort('name-asc');
+    });
+
+    // #when
+    act(() => {
+      result.current.clearAll();
+    });
+
+    // #then
+    expect(result.current.query).toBe('');
+    expect(result.current.providerFilter).toEqual([]);
+    expect(result.current.kindFilter).toEqual([]);
+    expect(result.current.sort).toBe('recent');
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+
+  it('persists provider filter to localStorage', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.toggleProvider('dropbox');
+    });
+
+    // #then
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'vorbis-player-library-route-provider-filter',
+      JSON.stringify(['dropbox']),
+    );
+  });
+
+  it('does not persist query to localStorage', () => {
+    // #given
+    const { result } = renderHook(() => useLibrarySearch());
+
+    // #when
+    act(() => {
+      result.current.setQuery('jazz');
+    });
+
+    // #then
+    const setItemCalls = vi.mocked(window.localStorage.setItem).mock.calls;
+    const queryWrite = setItemCalls.find(([key]) => String(key).includes('search'));
+    expect(queryWrite).toBeUndefined();
+  });
+});

--- a/src/components/LibraryRoute/search/searchMatch.ts
+++ b/src/components/LibraryRoute/search/searchMatch.ts
@@ -1,0 +1,31 @@
+import type { ProviderId } from '@/types/domain';
+import type { LibrarySort } from './useLibrarySearch';
+
+export function normalizeQuery(q: string): string {
+  return q.trim().toLowerCase();
+}
+
+export function matchesQuery(item: { name: string }, normalizedQuery: string): boolean {
+  if (!normalizedQuery) return true;
+  return item.name.toLowerCase().includes(normalizedQuery);
+}
+
+export function passesProviderFilter(
+  item: { provider?: ProviderId },
+  providerFilter: ProviderId[],
+): boolean {
+  if (providerFilter.length === 0) return true;
+  const provider = item.provider ?? 'spotify';
+  return providerFilter.includes(provider);
+}
+
+export function sortItems<T extends { name: string; added_at?: string }>(
+  items: T[],
+  sort: LibrarySort,
+): T[] {
+  if (sort === 'recent') return items;
+  const copy = [...items];
+  copy.sort((a, b) => a.name.localeCompare(b.name));
+  if (sort === 'name-desc') copy.reverse();
+  return copy;
+}

--- a/src/components/LibraryRoute/search/useCommandPaletteShortcut.ts
+++ b/src/components/LibraryRoute/search/useCommandPaletteShortcut.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+function isEditableTarget(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return el.isContentEditable;
+}
+
+export function useCommandPaletteShortcut(onOpen: () => void, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'k' && e.key !== 'K') return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (isEditableTarget(e.target)) return;
+      e.preventDefault();
+      onOpen();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onOpen, enabled]);
+}

--- a/src/components/LibraryRoute/search/useLibrarySearch.ts
+++ b/src/components/LibraryRoute/search/useLibrarySearch.ts
@@ -1,0 +1,95 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import type { ProviderId } from '@/types/domain';
+
+export type LibraryKindFilter = 'playlist' | 'album';
+export type LibrarySort = 'recent' | 'name-asc' | 'name-desc';
+
+const STORAGE_KEYS = {
+  providerFilter: 'vorbis-player-library-route-provider-filter',
+  kindFilter: 'vorbis-player-library-route-kind-filter',
+  sort: 'vorbis-player-library-route-sort',
+} as const;
+
+const DEFAULT_KIND_FILTER: LibraryKindFilter[] = [];
+const DEFAULT_PROVIDER_FILTER: ProviderId[] = [];
+const DEFAULT_SORT: LibrarySort = 'recent';
+
+export interface LibrarySearchState {
+  query: string;
+  setQuery: (q: string) => void;
+  providerFilter: ProviderId[];
+  setProviderFilter: (next: ProviderId[]) => void;
+  toggleProvider: (id: ProviderId) => void;
+  kindFilter: LibraryKindFilter[];
+  setKindFilter: (next: LibraryKindFilter[]) => void;
+  toggleKind: (kind: LibraryKindFilter) => void;
+  sort: LibrarySort;
+  setSort: (s: LibrarySort) => void;
+  isSearching: boolean;
+  hasActiveFilters: boolean;
+  clearAll: () => void;
+}
+
+export function useLibrarySearch(): LibrarySearchState {
+  const [query, setQuery] = useState('');
+  const [providerFilter, setProviderFilter] = useLocalStorage<ProviderId[]>(
+    STORAGE_KEYS.providerFilter,
+    DEFAULT_PROVIDER_FILTER,
+  );
+  const [kindFilter, setKindFilter] = useLocalStorage<LibraryKindFilter[]>(
+    STORAGE_KEYS.kindFilter,
+    DEFAULT_KIND_FILTER,
+  );
+  const [sort, setSort] = useLocalStorage<LibrarySort>(STORAGE_KEYS.sort, DEFAULT_SORT);
+
+  const toggleProvider = useCallback(
+    (id: ProviderId) => {
+      setProviderFilter(
+        providerFilter.includes(id)
+          ? providerFilter.filter((p) => p !== id)
+          : [...providerFilter, id],
+      );
+    },
+    [providerFilter, setProviderFilter],
+  );
+
+  const toggleKind = useCallback(
+    (kind: LibraryKindFilter) => {
+      setKindFilter(
+        kindFilter.includes(kind) ? kindFilter.filter((k) => k !== kind) : [...kindFilter, kind],
+      );
+    },
+    [kindFilter, setKindFilter],
+  );
+
+  const isSearching = query.trim().length > 0;
+  const hasActiveFilters = useMemo(
+    () =>
+      providerFilter.length > 0 || kindFilter.length > 0 || sort !== DEFAULT_SORT,
+    [providerFilter, kindFilter, sort],
+  );
+
+  const clearAll = useCallback(() => {
+    setQuery('');
+    setProviderFilter(DEFAULT_PROVIDER_FILTER);
+    setKindFilter(DEFAULT_KIND_FILTER);
+    setSort(DEFAULT_SORT);
+  }, [setProviderFilter, setKindFilter, setSort]);
+
+  return {
+    query,
+    setQuery,
+    providerFilter,
+    setProviderFilter,
+    toggleProvider,
+    kindFilter,
+    setKindFilter,
+    toggleKind,
+    sort,
+    setSort,
+    isSearching,
+    hasActiveFilters,
+    clearAll,
+  };
+}

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -17,7 +17,14 @@ export interface LikedSummary {
   isLoading: boolean;
 }
 
-export type LibraryRouteView = 'home' | 'recently-played' | 'pinned' | 'playlists' | 'albums' | 'liked';
+export type LibraryRouteView =
+  | 'home'
+  | 'recently-played'
+  | 'pinned'
+  | 'playlists'
+  | 'albums'
+  | 'liked'
+  | 'search';
 
 export type LibraryItemKind = 'playlist' | 'album' | 'liked' | 'recently-played';
 

--- a/src/components/LibraryRoute/views/SearchResultsView.tsx
+++ b/src/components/LibraryRoute/views/SearchResultsView.tsx
@@ -1,0 +1,191 @@
+import React, { useMemo } from 'react';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import {
+  usePinnedSection,
+  useRecentlyPlayedSection,
+  usePlaylistsSection,
+  useAlbumsSection,
+} from '../hooks';
+import LibraryCard from '../card/LibraryCard';
+import Section from '../sections/Section';
+import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import type { ProviderId } from '@/types/domain';
+import type { LibrarySearchState } from '../search/useLibrarySearch';
+import { matchesQuery, normalizeQuery, passesProviderFilter, sortItems } from '../search/searchMatch';
+import { SeeAllRoot } from './views.styled';
+
+export interface SearchResultsViewProps {
+  search: LibrarySearchState;
+  onSelectCollection: (
+    kind: LibraryItemKind,
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+}
+
+const SearchResultsView: React.FC<SearchResultsViewProps> = ({
+  search,
+  onSelectCollection,
+  onContextMenuRequest,
+}) => {
+  const { hasMultipleProviders } = useProviderContext();
+  const showProviderBadges = hasMultipleProviders;
+
+  const { combined: pinned } = usePinnedSection();
+  const { items: recently } = useRecentlyPlayedSection();
+  const { items: playlists } = usePlaylistsSection({ excludePinned: true });
+  const { items: albums } = useAlbumsSection({ excludePinned: true });
+
+  const q = normalizeQuery(search.query);
+
+  const showPlaylists = search.kindFilter.length === 0 || search.kindFilter.includes('playlist');
+  const showAlbums = search.kindFilter.length === 0 || search.kindFilter.includes('album');
+
+  const pinnedFiltered = useMemo(
+    () =>
+      pinned
+        .filter((p) => matchesQuery({ name: p.name }, q))
+        .filter((p) => passesProviderFilter({ provider: p.provider }, search.providerFilter))
+        .filter((p) => (p.kind === 'album' ? showAlbums : showPlaylists)),
+    [pinned, q, search.providerFilter, showAlbums, showPlaylists],
+  );
+
+  const recentlyFiltered = useMemo(
+    () =>
+      recently.filter((entry) => {
+        if (entry.ref.kind === 'album' && !showAlbums) return false;
+        if (entry.ref.kind === 'playlist' && !showPlaylists) return false;
+        if (entry.ref.kind === 'liked') return false;
+        if (!matchesQuery({ name: entry.name }, q)) return false;
+        if (!passesProviderFilter({ provider: entry.ref.provider }, search.providerFilter)) return false;
+        return true;
+      }),
+    [recently, q, search.providerFilter, showAlbums, showPlaylists],
+  );
+
+  const playlistsFiltered = useMemo(
+    () =>
+      showPlaylists
+        ? sortItems(
+            playlists
+              .filter((p) => matchesQuery({ name: p.name }, q))
+              .filter((p) => passesProviderFilter({ provider: p.provider }, search.providerFilter)),
+            search.sort,
+          )
+        : [],
+    [playlists, q, search.providerFilter, search.sort, showPlaylists],
+  );
+
+  const albumsFiltered = useMemo(
+    () =>
+      showAlbums
+        ? sortItems(
+            albums
+              .filter((a) => matchesQuery({ name: a.name }, q))
+              .filter((a) => passesProviderFilter({ provider: a.provider }, search.providerFilter)),
+            search.sort,
+          )
+        : [],
+    [albums, q, search.providerFilter, search.sort, showAlbums],
+  );
+
+  const totalResults =
+    pinnedFiltered.length + recentlyFiltered.length + playlistsFiltered.length + albumsFiltered.length;
+
+  if (totalResults === 0) {
+    return (
+      <SeeAllRoot data-testid="library-search-results">
+        <div style={{ padding: '2rem 1rem', textAlign: 'center', color: 'rgba(255,255,255,0.6)' }}>
+          No results for &ldquo;{search.query.trim()}&rdquo;.
+        </div>
+      </SeeAllRoot>
+    );
+  }
+
+  return (
+    <SeeAllRoot data-testid="library-search-results">
+      {pinnedFiltered.length > 0 && (
+        <Section title="Pinned" id="search-pinned" layout="grid">
+          {pinnedFiltered.map((item) => (
+            <LibraryCard
+              key={`${item.kind}-${item.provider ?? 'default'}-${item.id}`}
+              kind={item.kind}
+              id={item.id}
+              provider={item.provider}
+              name={item.name}
+              imageUrl={item.imageUrl}
+              showProviderBadge={showProviderBadges}
+              variant="grid"
+              onSelect={() => onSelectCollection(item.kind, item.id, item.name, item.provider)}
+              onContextMenuRequest={onContextMenuRequest}
+            />
+          ))}
+        </Section>
+      )}
+      {recentlyFiltered.length > 0 && (
+        <Section title="Recently Played" id="search-recent" layout="grid">
+          {recentlyFiltered.map((entry) => {
+            const cardKind: LibraryItemKind = entry.ref.kind === 'album' ? 'album' : 'playlist';
+            const id = entry.ref.kind === 'liked' ? 'liked' : entry.ref.id;
+            return (
+              <LibraryCard
+                key={`${entry.ref.provider}-${entry.ref.kind}-${id}`}
+                kind={cardKind}
+                id={id}
+                provider={entry.ref.provider}
+                name={entry.name}
+                imageUrl={entry.imageUrl ?? undefined}
+                showProviderBadge={showProviderBadges}
+                variant="grid"
+                onSelect={() => onSelectCollection(cardKind, id, entry.name, entry.ref.provider)}
+                onContextMenuRequest={onContextMenuRequest}
+              />
+            );
+          })}
+        </Section>
+      )}
+      {playlistsFiltered.length > 0 && (
+        <Section title="Playlists" id="search-playlists" layout="grid">
+          {playlistsFiltered.map((p) => (
+            <LibraryCard
+              key={`${p.provider ?? 'spotify'}-${p.id}`}
+              kind="playlist"
+              id={p.id}
+              provider={p.provider}
+              name={p.name}
+              imageUrl={p.images?.[0]?.url}
+              showProviderBadge={showProviderBadges}
+              variant="grid"
+              onSelect={() => onSelectCollection('playlist', p.id, p.name, p.provider)}
+              onContextMenuRequest={onContextMenuRequest}
+            />
+          ))}
+        </Section>
+      )}
+      {albumsFiltered.length > 0 && (
+        <Section title="Albums" id="search-albums" layout="grid">
+          {albumsFiltered.map((a) => (
+            <LibraryCard
+              key={`${a.provider ?? 'spotify'}-${a.id}`}
+              kind="album"
+              id={a.id}
+              provider={a.provider}
+              name={a.name}
+              subtitle={a.artists}
+              imageUrl={a.images?.[0]?.url}
+              showProviderBadge={showProviderBadges}
+              variant="grid"
+              onSelect={() => onSelectCollection('album', a.id, a.name, a.provider)}
+              onContextMenuRequest={onContextMenuRequest}
+            />
+          ))}
+        </Section>
+      )}
+    </SeeAllRoot>
+  );
+};
+
+SearchResultsView.displayName = 'SearchResultsView';
+export default SearchResultsView;

--- a/src/components/LibraryRoute/views/SeeAllView.tsx
+++ b/src/components/LibraryRoute/views/SeeAllView.tsx
@@ -11,7 +11,7 @@ import { BackToLibraryIcon } from '@/components/icons/QuickActionIcons';
 import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from '../types';
 import { SeeAllRoot, BackBar, BackButton, BackTitle } from './views.styled';
 
-const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked'>, string> = {
+const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>, string> = {
   'recently-played': 'Recently Played',
   pinned: 'Pinned',
   playlists: 'Playlists',
@@ -19,7 +19,7 @@ const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked'>, string> = {
 };
 
 export interface SeeAllViewProps {
-  view: Exclude<LibraryRouteView, 'home' | 'liked'>;
+  view: Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>;
   onBack: () => void;
   onSelectCollection: (
     kind: LibraryItemKind,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -20,7 +20,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends React.ComponentProps<typeof Dialog> {}
+type CommandDialogProps = React.ComponentProps<typeof Dialog>
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => (
   <Dialog {...props}>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,111 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { Search } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className,
+    )}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+interface CommandDialogProps extends React.ComponentProps<typeof Dialog> {}
+
+const CommandDialog = ({ children, ...props }: CommandDialogProps) => (
+  <Dialog {...props}>
+    <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+      {children}
+    </Command>
+    </DialogContent>
+  </Dialog>
+)
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+))
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+))
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+))
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+))
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+))
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Sheet is a Radix Dialog rendered as a side panel.
+ * Z-index forced to 1410 (above BottomBar 1350 and base Dialog 1405) so a
+ * filter sheet opened from inside a Dialog still wins.
+ */
+const SHEET_Z_INDEX = 1410
+
+const Sheet = DialogPrimitive.Root
+const SheetTrigger = DialogPrimitive.Trigger
+const SheetClose = DialogPrimitive.Close
+const SheetPortal = DialogPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, style, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    data-testid="sheet-overlay"
+    className={cn(
+      "fixed inset-0 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    style={{ zIndex: SHEET_Z_INDEX, ...style }}
+    {...props}
+  />
+))
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: { side: "right" },
+  },
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, style, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      style={{ zIndex: SHEET_Z_INDEX, ...style }}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = DialogPrimitive.Content.displayName
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = DialogPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## Summary
- shadcn primitives lifted: `Input`, `Sheet` (z-index 1410), `Command` (cmdk dep)
- `useLibrarySearch` hook (query non-persisted, filters/sort persisted to `vorbis-player-library-route-*`)
- Mobile bottom-sticky SearchBar above mini-player; desktop top-sticky + Cmd/Ctrl-K palette
- FilterSheet (provider + kind checkboxes, sort dropdown, clear-all) — Sheet side: bottom on mobile, right on desktop
- SearchResultsView replaces HomeView when query non-empty; flat results grouped by section
- `useCommandPaletteShortcut` document-level keydown listener (skips when input/textarea active)
- `MINI_PLAYER_HEIGHT_MOBILE`/`_DESKTOP` exported from MiniPlayer.styled.ts to remove magic-number duplication

Sort modes: `'recent' | 'name-asc' | 'name-desc'` (new-route-only naming, distinct from legacy 'recently-added').

Did NOT touch `handleContextMenuRequest` (still dev-debug from #1294 — #1297 owns the swap).

Part of #1300. Addresses #1296.

## Test plan
- [x] tsc clean
- [x] Search scope: 25/25 tests pass in isolation
- [x] LibraryRoute scope: 6/6 pass
- [x] Full sweep: 1500/1507 (3 baseline + 1 known wave-2 nav-test issue fixed in PR #1308)
- [x] lint clean on new files
- [x] build clean

## Notes for reviewer
- Sort naming: new route uses `'recent'` etc. rather than legacy `'recently-added'` — flag if literal parity preferred.
- iOS soft-keyboard sticky-bottom quirk: deferred per blueprint.
- LibraryRoute.nav.test.tsx baseline failure (TrackProvider missing post-#1295) is unrelated to this PR — already fixed in PR #1308.