### PR TITLE
feat(library): card context menu (#1297)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -497,6 +497,9 @@ const AudioPlayerComponent = () => {
                 onMiniPrevious={playbackHandlers.onPrevious}
                 onMiniExpand={handlers.handleCloseLibrary}
                 onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
+                /* onPlayNext + onStartRadioForCollection: disabled-fallback for #1297. Follow-up tickets implement queue-insert + radio orchestration. */
+                onPlayNext={undefined}
+                onStartRadioForCollection={undefined}
               />
             ) : (
               <LibraryPage

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
@@ -18,6 +18,24 @@ vi.mock('@/contexts/TrackContext', () => ({
   useCurrentTrackContext: () => ({ currentTrack: null }),
 }));
 
+// LibraryRoute mounts LibraryContextMenu (added by #1297), which calls
+// usePinnedItems + useRecentlyPlayedCollections. Stub them so navigation tests
+// don't need full PinnedItems/RecentlyPlayed providers.
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => ({
+    pinnedPlaylistIds: [],
+    pinnedAlbumIds: [],
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => ({ history: [], record: vi.fn(), remove: vi.fn() }),
+}));
+
 vi.mock('@/contexts/ProviderContext', () => ({
   useProviderContext: vi.fn(() => ({
     hasMultipleProviders: false,

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -55,6 +55,21 @@ vi.mock('@/contexts/TrackContext', () => ({
   useCurrentTrackContext: () => mockCurrentTrack(),
 }));
 
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => ({
+    pinnedPlaylistIds: [],
+    pinnedAlbumIds: [],
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => ({ history: [], record: vi.fn(), remove: vi.fn() }),
+}));
+
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const baseProps = {

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.styled.ts
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const VirtualAnchor = styled.div`
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+`;
+
+export const MenuRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  padding: ${theme.spacing.xs};
+  gap: 1px;
+`;
+
+export const MenuItemButton = styled.button<{ $variant?: 'default' | 'destructive' }>`
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  font-size: ${theme.fontSize?.sm ?? '0.875rem'};
+  color: ${({ $variant }) =>
+    $variant === 'destructive' ? theme.colors.error : theme.colors.foreground};
+  border-radius: ${theme.borderRadius.md};
+  cursor: pointer;
+  transition: background 80ms ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: rgba(255, 255, 255, 0.08);
+    outline: none;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -106,8 +106,6 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
       ? () => togglePinPlaylist(request.id)
       : () => togglePinAlbum(request.id);
 
-    const noopAction = () => {};
-
     const playLikedFor = async (provider: ProviderId) => {
       const tracks = await loadLikedTracks(provider);
       if (tracks.length === 0) return;
@@ -174,9 +172,6 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
         }
       });
     }
-
-    // Quiet noopAction lint when not used in some branches.
-    void noopAction;
 
     return buildMenuItems(request, actions);
   }, [

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useMemo } from 'react';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
+import { useLikedSection } from '../hooks';
+import type { ContextMenuRequest } from '../types';
+import type { ProviderId, MediaTrack } from '@/types/domain';
+import { useLikedTracksForProvider } from './useLikedTracksForProvider';
+import {
+  buildMenuItems,
+  type MenuActions,
+  type MenuItem,
+} from './menuItemsForKind';
+import { MenuItemButton, MenuRoot, VirtualAnchor } from './LibraryContextMenu.styled';
+
+const PROVIDER_LABEL: Record<string, string> = {
+  spotify: 'Spotify',
+  dropbox: 'Dropbox',
+};
+
+function providerLabel(provider: ProviderId): string {
+  return PROVIDER_LABEL[provider] ?? provider;
+}
+
+export interface LibraryContextMenuProps {
+  request: ContextMenuRequest | null;
+  onClose: () => void;
+  onPlayCollection: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onAddToQueue?: (id: string, name: string, provider?: ProviderId) => void | Promise<unknown>;
+  onPlayNext?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onStartRadioForCollection?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    provider?: ProviderId,
+  ) => void;
+  onPlayLikedTracks: (
+    tracks: MediaTrack[],
+    collectionId: string,
+    collectionName: string,
+    provider?: ProviderId,
+  ) => Promise<void> | void;
+}
+
+const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
+  request,
+  onClose,
+  onPlayCollection,
+  onAddToQueue,
+  onPlayNext,
+  onStartRadioForCollection,
+  onPlayLikedTracks,
+}) => {
+  const {
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+  } = usePinnedItems();
+  const { remove: removeRecent } = useRecentlyPlayedCollections();
+  const { perProvider } = useLikedSection();
+  const { loadLikedTracks } = useLikedTracksForProvider();
+
+  const closeAfter = useCallback(
+    (fn: () => void | Promise<unknown>): (() => void) =>
+      () => {
+        onClose();
+        Promise.resolve(fn()).catch(() => {
+          /* swallow — toast surfaces user-facing errors */
+        });
+      },
+    [onClose],
+  );
+
+  const playNextDisabled = !onPlayNext;
+  const startRadioDisabled = !onStartRadioForCollection;
+
+  const items = useMemo<MenuItem[]>(() => {
+    if (!request) return [];
+
+    const effectiveKind: 'playlist' | 'album' | 'liked' =
+      request.kind === 'recently-played'
+        ? request.originalKind ?? 'playlist'
+        : (request.kind as 'playlist' | 'album' | 'liked');
+
+    const isPlaylistKind = effectiveKind === 'playlist';
+    const isAlbumKind = effectiveKind === 'album';
+    const isLikedKind = effectiveKind === 'liked';
+
+    const isPinned = isPlaylistKind
+      ? isPlaylistPinned(request.id)
+      : isAlbumKind
+        ? isAlbumPinned(request.id)
+        : false;
+
+    const togglePin = isPlaylistKind
+      ? () => togglePinPlaylist(request.id)
+      : () => togglePinAlbum(request.id);
+
+    const noopAction = () => {};
+
+    const playLikedFor = async (provider: ProviderId) => {
+      const tracks = await loadLikedTracks(provider);
+      if (tracks.length === 0) return;
+      await onPlayLikedTracks(tracks, `liked-${provider}`, 'Liked Songs', provider);
+    };
+
+    const likedProviderActions = isLikedKind
+      ? perProvider.map((entry) => ({
+          provider: entry.provider,
+          label: `Play (${providerLabel(entry.provider)})`,
+          onPlay: closeAfter(() => playLikedFor(entry.provider)),
+        }))
+      : undefined;
+
+    const actions: MenuActions = {
+      onPlay: closeAfter(() => {
+        if (isLikedKind) {
+          // "Play All" routes through the library's own liked-handler via the parent.
+          const inferred = perProvider[0]?.provider;
+          if (inferred) void playLikedFor(inferred);
+          return;
+        }
+        if (isPlaylistKind || isAlbumKind) {
+          onPlayCollection(effectiveKind, request.id, request.name, request.provider);
+        }
+      }),
+      onAddToQueue: closeAfter(() => {
+        if (onAddToQueue) onAddToQueue(request.id, request.name, request.provider);
+      }),
+      onPlayNext: closeAfter(() => {
+        if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
+          onPlayNext(effectiveKind, request.id, request.name, request.provider);
+        }
+      }),
+      onTogglePin: closeAfter(togglePin),
+      onStartRadio: closeAfter(() => {
+        if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
+          onStartRadioForCollection(effectiveKind, request.id, request.provider);
+        }
+      }),
+      isPinned,
+      startRadioDisabled: startRadioDisabled || isLikedKind,
+      playNextDisabled: playNextDisabled || isLikedKind,
+      likedProviderActions,
+    };
+
+    if (request.kind === 'recently-played' && request.recentRef) {
+      const recentRef = request.recentRef;
+      actions.onRemoveFromHistory = closeAfter(() => {
+        if (recentRef.kind === 'liked') {
+          removeRecent({ provider: recentRef.provider as ProviderId, kind: 'liked' });
+        } else if (recentRef.kind === 'album') {
+          removeRecent({
+            provider: recentRef.provider as ProviderId,
+            kind: 'album',
+            id: recentRef.id,
+          });
+        } else {
+          removeRecent({
+            provider: recentRef.provider as ProviderId,
+            kind: 'playlist',
+            id: recentRef.id,
+          });
+        }
+      });
+    }
+
+    // Quiet noopAction lint when not used in some branches.
+    void noopAction;
+
+    return buildMenuItems(request, actions);
+  }, [
+    request,
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+    perProvider,
+    onPlayCollection,
+    onAddToQueue,
+    onPlayNext,
+    onStartRadioForCollection,
+    onPlayLikedTracks,
+    loadLikedTracks,
+    removeRecent,
+    closeAfter,
+    playNextDisabled,
+    startRadioDisabled,
+  ]);
+
+  if (!request) return null;
+
+  const anchorStyle: React.CSSProperties = {
+    left: request.anchorRect.left + request.anchorRect.width / 2,
+    top: request.anchorRect.bottom,
+  };
+
+  return (
+    <Popover
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <PopoverAnchor asChild>
+        <VirtualAnchor aria-hidden style={anchorStyle} />
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={4}
+        data-testid="library-context-menu"
+      >
+        <MenuRoot role="menu" aria-label={`Actions for ${request.name}`}>
+          {items.map((item) => (
+            <MenuItemButton
+              key={item.id}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              $variant={item.variant}
+              onClick={item.onSelect}
+              data-testid={`menu-${item.id}`}
+            >
+              {item.label}
+            </MenuItemButton>
+          ))}
+        </MenuRoot>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+LibraryContextMenu.displayName = 'LibraryContextMenu';
+export default LibraryContextMenu;

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { ContextMenuRequest } from '../../types';
+import type { ProviderId, MediaTrack } from '@/types/domain';
+
+const { mockPinned, mockLikedSection, mockRecent, mockLoadLiked } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLikedSection: vi.fn(),
+  mockRecent: vi.fn(),
+  mockLoadLiked: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockRecent(),
+}));
+
+vi.mock('../../hooks', () => ({
+  useLikedSection: () => mockLikedSection(),
+}));
+
+vi.mock('../useLikedTracksForProvider', () => ({
+  useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
+}));
+
+import LibraryContextMenu, { type LibraryContextMenuProps } from '../LibraryContextMenu';
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'My Playlist',
+    provider: 'spotify' as ProviderId,
+    anchorRect: new DOMRect(10, 10, 100, 40),
+    ...overrides,
+  };
+}
+
+function defaultMocks() {
+  mockPinned.mockReturnValue({
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  });
+  mockLikedSection.mockReturnValue({
+    perProvider: [{ provider: 'spotify' as ProviderId, count: 10 }],
+  });
+  mockRecent.mockReturnValue({ remove: vi.fn() });
+  mockLoadLiked.mockResolvedValue([]);
+}
+
+function renderMenu(propsOverrides: Partial<LibraryContextMenuProps> = {}) {
+  const props: LibraryContextMenuProps = {
+    request: makeRequest(),
+    onClose: vi.fn(),
+    onPlayCollection: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayLikedTracks: vi.fn(),
+    ...propsOverrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <LibraryContextMenu {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('LibraryContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultMocks();
+  });
+
+  it('renders nothing when request is null', () => {
+    // #when
+    renderMenu({ request: null });
+
+    // #then
+    expect(screen.queryByTestId('library-context-menu')).toBeNull();
+  });
+
+  it('renders the playlist schema with 5 items', () => {
+    // #when
+    renderMenu({ request: makeRequest({ kind: 'playlist' }) });
+
+    // #then
+    expect(screen.getByTestId('menu-play')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-add-to-queue')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-play-next')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-toggle-pin')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-start-radio')).toBeInTheDocument();
+  });
+
+  it('disables Play Next and Start Radio when handlers are undefined', () => {
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+      onPlayNext: undefined,
+      onStartRadioForCollection: undefined,
+    });
+
+    // #then
+    expect((screen.getByTestId('menu-play-next') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('menu-start-radio') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables Play Next and Start Radio when handlers are provided', () => {
+    // #given
+    const onPlayNext = vi.fn();
+    const onStartRadio = vi.fn();
+    const onClose = vi.fn();
+
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+      onPlayNext,
+      onStartRadioForCollection: onStartRadio,
+      onClose,
+    });
+    fireEvent.click(screen.getByTestId('menu-play-next'));
+    fireEvent.click(screen.getByTestId('menu-start-radio'));
+
+    // #then
+    expect(onPlayNext).toHaveBeenCalledWith('playlist', 'p1', 'My Playlist', 'spotify');
+    expect(onStartRadio).toHaveBeenCalledWith('playlist', 'p1', 'spotify');
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows Pin label when not pinned, Unpin when pinned', () => {
+    // #given (not pinned)
+    const { unmount } = renderMenu({ request: makeRequest({ kind: 'playlist' }) });
+
+    // #then
+    expect(screen.getByTestId('menu-toggle-pin').textContent).toBe('Pin');
+    unmount();
+
+    // #given (pinned)
+    mockPinned.mockReturnValue({
+      isPlaylistPinned: () => true,
+      isAlbumPinned: () => false,
+      togglePinPlaylist: vi.fn(),
+      togglePinAlbum: vi.fn(),
+    });
+    renderMenu({ request: makeRequest({ kind: 'playlist' }) });
+
+    // #then
+    expect(screen.getByTestId('menu-toggle-pin').textContent).toBe('Unpin');
+  });
+
+  it('builds per-provider liked entries from useLikedSection', () => {
+    // #given
+    mockLikedSection.mockReturnValue({
+      perProvider: [
+        { provider: 'spotify', count: 10 },
+        { provider: 'dropbox', count: 5 },
+      ],
+    });
+
+    // #when
+    renderMenu({ request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }) });
+
+    // #then
+    expect(screen.getByTestId('menu-play-all')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-play-liked-spotify')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-play-liked-dropbox')).toBeInTheDocument();
+  });
+
+  it('per-provider liked play loads tracks then forwards to onPlayLikedTracks', async () => {
+    // #given
+    const tracks: MediaTrack[] = [{ id: 't1' } as MediaTrack];
+    mockLoadLiked.mockResolvedValue(tracks);
+    const onPlayLikedTracks = vi.fn();
+    const onClose = vi.fn();
+    renderMenu({
+      request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }),
+      onPlayLikedTracks,
+      onClose,
+    });
+
+    // #when
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('menu-play-liked-spotify'));
+    });
+
+    // #then
+    expect(mockLoadLiked).toHaveBeenCalledWith('spotify');
+    expect(onPlayLikedTracks).toHaveBeenCalledWith(tracks, 'liked-spotify', 'Liked Songs', 'spotify');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('appends Remove from history for recently-played and dispatches by originalKind', () => {
+    // #when
+    renderMenu({
+      request: makeRequest({
+        kind: 'recently-played',
+        originalKind: 'playlist',
+        recentRef: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+      }),
+    });
+
+    // #then
+    expect(screen.getByTestId('menu-play')).toBeInTheDocument();
+    expect(screen.getByTestId('menu-remove-from-history')).toBeInTheDocument();
+  });
+
+  it('Remove from history calls remove() with the recent ref', () => {
+    // #given
+    const remove = vi.fn();
+    mockRecent.mockReturnValue({ remove });
+
+    // #when
+    renderMenu({
+      request: makeRequest({
+        kind: 'recently-played',
+        originalKind: 'playlist',
+        recentRef: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+      }),
+    });
+    fireEvent.click(screen.getByTestId('menu-remove-from-history'));
+
+    // #then
+    expect(remove).toHaveBeenCalledWith({ provider: 'spotify', kind: 'playlist', id: 'p1' });
+  });
+
+  it('Play action invokes onPlayCollection for playlist kind', () => {
+    // #given
+    const onPlayCollection = vi.fn();
+    const onClose = vi.fn();
+
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+      onPlayCollection,
+      onClose,
+    });
+    fireEvent.click(screen.getByTestId('menu-play'));
+
+    // #then
+    expect(onPlayCollection).toHaveBeenCalledWith('playlist', 'p1', 'My Playlist', 'spotify');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Add to Queue invokes onAddToQueue', () => {
+    // #given
+    const onAddToQueue = vi.fn();
+
+    // #when
+    renderMenu({ request: makeRequest({ kind: 'playlist' }), onAddToQueue });
+    fireEvent.click(screen.getByTestId('menu-add-to-queue'));
+
+    // #then
+    expect(onAddToQueue).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify');
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildMenuItems, type MenuActions } from '../menuItemsForKind';
+import type { ContextMenuRequest } from '../../types';
+
+function makeActions(overrides: Partial<MenuActions> = {}): MenuActions {
+  return {
+    onPlay: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayNext: vi.fn(),
+    onTogglePin: vi.fn(),
+    onStartRadio: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'Test',
+    anchorRect: new DOMRect(0, 0, 0, 0),
+    ...overrides,
+  };
+}
+
+describe('buildMenuItems', () => {
+  it('builds 5 items for playlist kind', () => {
+    // #given
+    const actions = makeActions();
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.map((i) => i.id)).toEqual([
+      'play',
+      'add-to-queue',
+      'play-next',
+      'toggle-pin',
+      'start-radio',
+    ]);
+  });
+
+  it('builds 6 items for album kind when toggleSave provided', () => {
+    // #given
+    const actions = makeActions({ onToggleSave: vi.fn() });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+    // #then
+    expect(items.map((i) => i.id)).toEqual([
+      'play',
+      'add-to-queue',
+      'play-next',
+      'toggle-pin',
+      'toggle-save',
+      'start-radio',
+    ]);
+  });
+
+  it('omits Save action when onToggleSave is undefined', () => {
+    // #given
+    const actions = makeActions();
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'toggle-save')).toBeUndefined();
+  });
+
+  it('builds Play All + per-provider entries for liked kind', () => {
+    // #given
+    const actions = makeActions({
+      likedProviderActions: [
+        { provider: 'spotify', label: 'Play (Spotify)', onPlay: vi.fn() },
+        { provider: 'dropbox', label: 'Play (Dropbox)', onPlay: vi.fn() },
+      ],
+    });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'liked' }), actions);
+
+    // #then
+    expect(items.map((i) => i.id)).toEqual([
+      'play-all',
+      'play-liked-spotify',
+      'play-liked-dropbox',
+    ]);
+  });
+
+  it('dispatches recently-played by originalKind = album', () => {
+    // #given
+    const actions = makeActions({ onToggleSave: vi.fn(), onRemoveFromHistory: vi.fn() });
+
+    // #when
+    const items = buildMenuItems(
+      makeRequest({ kind: 'recently-played', originalKind: 'album' }),
+      actions,
+    );
+
+    // #then
+    expect(items[0].id).toBe('play');
+    expect(items.find((i) => i.id === 'toggle-save')).toBeDefined();
+    expect(items[items.length - 1].id).toBe('remove-from-history');
+  });
+
+  it('appends destructive Remove from history for recently-played', () => {
+    // #given
+    const actions = makeActions({ onRemoveFromHistory: vi.fn() });
+
+    // #when
+    const items = buildMenuItems(
+      makeRequest({ kind: 'recently-played', originalKind: 'playlist' }),
+      actions,
+    );
+
+    // #then
+    const remove = items.find((i) => i.id === 'remove-from-history');
+    expect(remove).toBeDefined();
+    expect(remove?.variant).toBe('destructive');
+  });
+
+  it('does not append Remove from history when onRemoveFromHistory undefined', () => {
+    // #given
+    const actions = makeActions();
+
+    // #when
+    const items = buildMenuItems(
+      makeRequest({ kind: 'recently-played', originalKind: 'playlist' }),
+      actions,
+    );
+
+    // #then
+    expect(items.find((i) => i.id === 'remove-from-history')).toBeUndefined();
+  });
+
+  it('flips Pin label to Unpin when isPinned=true', () => {
+    // #given
+    const actions = makeActions({ isPinned: true });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
+  });
+
+  it('flips Save label to Unsave when isSaved=true', () => {
+    // #given
+    const actions = makeActions({ onToggleSave: vi.fn(), isSaved: true });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unsave');
+  });
+
+  it('marks Start Radio disabled when startRadioDisabled=true', () => {
+    // #given
+    const actions = makeActions({ startRadioDisabled: true });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'start-radio')?.disabled).toBe(true);
+  });
+
+  it('marks Play Next disabled when playNextDisabled=true', () => {
+    // #given
+    const actions = makeActions({ playNextDisabled: true });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'play-next')?.disabled).toBe(true);
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/__tests__/useLikedTracksForProvider.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useLikedTracksForProvider.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockFetchLiked } = vi.hoisted(() => ({
+  mockFetchLiked: vi.fn(),
+}));
+
+vi.mock('../../hooks', () => ({
+  fetchLikedForProvider: (...args: unknown[]) => mockFetchLiked(...args),
+}));
+
+import {
+  resetLikedTracksCache,
+  useLikedTracksForProvider,
+} from '../useLikedTracksForProvider';
+
+describe('useLikedTracksForProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetLikedTracksCache();
+    mockFetchLiked.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches via fetchLikedForProvider on first call', async () => {
+    // #given
+    const tracks: MediaTrack[] = [{ id: 't1' } as MediaTrack];
+    mockFetchLiked.mockResolvedValue(tracks);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    // #when
+    let returned: MediaTrack[] = [];
+    await act(async () => {
+      returned = await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+    expect(returned).toEqual(tracks);
+  });
+
+  it('returns cached value on second call within TTL without re-fetching', async () => {
+    // #given
+    mockFetchLiked.mockResolvedValue([{ id: 't1' } as MediaTrack]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    // #when
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after TTL elapses', async () => {
+    // #given
+    mockFetchLiked.mockResolvedValue([{ id: 't1' } as MediaTrack]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    // #when
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    vi.setSystemTime(Date.now() + 60_001);
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches per-provider independently', async () => {
+    // #given
+    mockFetchLiked
+      .mockResolvedValueOnce([{ id: 's1' } as MediaTrack])
+      .mockResolvedValueOnce([{ id: 'd1' } as MediaTrack]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    // #when
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    await act(async () => {
+      await result.current.loadLikedTracks('dropbox');
+    });
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -1,0 +1,125 @@
+import type { ProviderId } from '@/types/domain';
+import type { ContextMenuRequest } from '../types';
+
+export interface MenuItem {
+  id: string;
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+  variant?: 'default' | 'destructive';
+}
+
+export interface MenuActions {
+  onPlay: () => void;
+  onAddToQueue: () => void;
+  onPlayNext: () => void;
+  onTogglePin: () => void;
+  onToggleSave?: () => void;
+  onStartRadio: () => void;
+  likedProviderActions?: Array<{ provider: ProviderId; label: string; onPlay: () => void }>;
+  onRemoveFromHistory?: () => void;
+  isPinned?: boolean;
+  isSaved?: boolean;
+  startRadioDisabled?: boolean;
+  playNextDisabled?: boolean;
+}
+
+function buildPlaylistItems(actions: MenuActions): MenuItem[] {
+  return [
+    { id: 'play', label: 'Play', onSelect: actions.onPlay },
+    { id: 'add-to-queue', label: 'Add to Queue', onSelect: actions.onAddToQueue },
+    {
+      id: 'play-next',
+      label: 'Play Next',
+      onSelect: actions.onPlayNext,
+      disabled: actions.playNextDisabled === true,
+    },
+    {
+      id: 'toggle-pin',
+      label: actions.isPinned ? 'Unpin' : 'Pin',
+      onSelect: actions.onTogglePin,
+    },
+    {
+      id: 'start-radio',
+      label: 'Start Radio',
+      onSelect: actions.onStartRadio,
+      disabled: actions.startRadioDisabled === true,
+    },
+  ];
+}
+
+function buildAlbumItems(actions: MenuActions): MenuItem[] {
+  const items: MenuItem[] = [
+    { id: 'play', label: 'Play', onSelect: actions.onPlay },
+    { id: 'add-to-queue', label: 'Add to Queue', onSelect: actions.onAddToQueue },
+    {
+      id: 'play-next',
+      label: 'Play Next',
+      onSelect: actions.onPlayNext,
+      disabled: actions.playNextDisabled === true,
+    },
+    {
+      id: 'toggle-pin',
+      label: actions.isPinned ? 'Unpin' : 'Pin',
+      onSelect: actions.onTogglePin,
+    },
+  ];
+  if (actions.onToggleSave) {
+    items.push({
+      id: 'toggle-save',
+      label: actions.isSaved ? 'Unsave' : 'Save',
+      onSelect: actions.onToggleSave,
+    });
+  }
+  items.push({
+    id: 'start-radio',
+    label: 'Start Radio',
+    onSelect: actions.onStartRadio,
+    disabled: actions.startRadioDisabled === true,
+  });
+  return items;
+}
+
+function buildLikedItems(actions: MenuActions): MenuItem[] {
+  const items: MenuItem[] = [
+    { id: 'play-all', label: 'Play All', onSelect: actions.onPlay },
+  ];
+  for (const liked of actions.likedProviderActions ?? []) {
+    items.push({
+      id: `play-liked-${liked.provider}`,
+      label: liked.label,
+      onSelect: liked.onPlay,
+    });
+  }
+  return items;
+}
+
+export function buildMenuItems(request: ContextMenuRequest, actions: MenuActions): MenuItem[] {
+  let items: MenuItem[];
+  let isRecentlyPlayed = false;
+
+  if (request.kind === 'recently-played') {
+    isRecentlyPlayed = true;
+    const original = request.originalKind ?? 'playlist';
+    if (original === 'album') items = buildAlbumItems(actions);
+    else if (original === 'liked') items = buildLikedItems(actions);
+    else items = buildPlaylistItems(actions);
+  } else if (request.kind === 'album') {
+    items = buildAlbumItems(actions);
+  } else if (request.kind === 'liked') {
+    items = buildLikedItems(actions);
+  } else {
+    items = buildPlaylistItems(actions);
+  }
+
+  if (isRecentlyPlayed && actions.onRemoveFromHistory) {
+    items.push({
+      id: 'remove-from-history',
+      label: 'Remove from history',
+      onSelect: actions.onRemoveFromHistory,
+      variant: 'destructive',
+    });
+  }
+
+  return items;
+}

--- a/src/components/LibraryRoute/contextMenu/useLikedTracksForProvider.ts
+++ b/src/components/LibraryRoute/contextMenu/useLikedTracksForProvider.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { fetchLikedForProvider } from '../hooks';
+
+const TTL_MS = 60_000;
+
+interface CacheEntry {
+  tracks: MediaTrack[];
+  expiresAt: number;
+}
+
+const cache = new Map<ProviderId, CacheEntry>();
+
+export function resetLikedTracksCache(): void {
+  cache.clear();
+}
+
+async function getLikedForProvider(
+  provider: ProviderId,
+  now: number,
+  signal?: AbortSignal,
+): Promise<MediaTrack[]> {
+  const entry = cache.get(provider);
+  if (entry && entry.expiresAt > now) {
+    return entry.tracks;
+  }
+  const tracks = await fetchLikedForProvider(provider, signal);
+  cache.set(provider, { tracks, expiresAt: now + TTL_MS });
+  return tracks;
+}
+
+export interface UseLikedTracksForProviderResult {
+  loadLikedTracks: (provider: ProviderId, signal?: AbortSignal) => Promise<MediaTrack[]>;
+}
+
+export function useLikedTracksForProvider(): UseLikedTracksForProviderResult {
+  const loadLikedTracks = useCallback(
+    (provider: ProviderId, signal?: AbortSignal) => getLikedForProvider(provider, Date.now(), signal),
+    [],
+  );
+  return { loadLikedTracks };
+}

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -15,6 +15,7 @@ import SearchBar from './search/SearchBar';
 import CommandPalette from './search/CommandPalette';
 import { useLibrarySearch } from './search/useLibrarySearch';
 import { useCommandPaletteShortcut } from './search/useCommandPaletteShortcut';
+import LibraryContextMenu from './contextMenu/LibraryContextMenu';
 
 // LibraryRoute assumes upstream guards have already filtered out cold-start cases:
 // - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
@@ -34,6 +35,17 @@ export interface LibraryRouteProps {
   onOpenSettings: () => void;
   onResume?: () => void;
   lastSession?: SessionSnapshot | null;
+  onPlayNext?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onStartRadioForCollection?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    provider?: ProviderId,
+  ) => void;
   isPlaying: boolean;
   isRadioAvailable?: boolean;
   isRadioGenerating?: boolean;
@@ -50,6 +62,9 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onPlayLikedTracks,
   onResume,
   lastSession,
+  onAddToQueue,
+  onPlayNext,
+  onStartRadioForCollection,
   isPlaying,
   isRadioAvailable,
   isRadioGenerating,
@@ -105,11 +120,42 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
     [onPlayLikedTracks, isUnifiedLikedActive, unifiedTracks],
   );
 
+  const [contextRequest, setContextRequest] = useState<ContextMenuRequest | null>(null);
+
   const handleContextMenuRequest = useCallback((req: ContextMenuRequest) => {
-    if (import.meta.env.DEV) {
-      console.debug('[LibraryRoute] context menu requested', req);
-    }
+    setContextRequest(req);
   }, []);
+
+  const handleCloseContextMenu = useCallback(() => {
+    setContextRequest(null);
+  }, []);
+
+  const handlePlayCollection = useCallback(
+    (kind: 'playlist' | 'album', id: string, name: string, provider?: ProviderId) => {
+      handleSelectCollection(kind, id, name, provider);
+    },
+    [handleSelectCollection],
+  );
+
+  const handleAddToQueueAction = useCallback(
+    (id: string, name: string, provider?: ProviderId) => {
+      void onAddToQueue?.(id, name, provider);
+    },
+    [onAddToQueue],
+  );
+
+  const handlePlayLikedFromMenu = useCallback(
+    async (
+      tracks: MediaTrack[],
+      collectionId: string,
+      collectionName: string,
+      provider?: ProviderId,
+    ) => {
+      if (!onPlayLikedTracks) return;
+      await onPlayLikedTracks(tracks, collectionId, collectionName, provider);
+    },
+    [onPlayLikedTracks],
+  );
 
   const layout: 'row' | 'grid' = isMobile ? 'row' : 'grid';
   const Layout = isMobile ? MobileLayout : DesktopLayout;
@@ -156,6 +202,15 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         {body}
         {isMobile && <SearchBar variant="mobile" search={search} />}
       </Layout>
+      <LibraryContextMenu
+        request={contextRequest}
+        onClose={handleCloseContextMenu}
+        onPlayCollection={handlePlayCollection}
+        onAddToQueue={handleAddToQueueAction}
+        onPlayNext={onPlayNext}
+        onStartRadioForCollection={onStartRadioForCollection}
+        onPlayLikedTracks={handlePlayLikedFromMenu}
+      />
       <MiniPlayer
         isPlaying={isPlaying}
         isRadioAvailable={isRadioAvailable}

--- a/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
+++ b/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
@@ -52,6 +52,18 @@ const RecentlyPlayedSection: React.FC<RecentlyPlayedSectionProps> = ({
             cardKind = 'playlist';
             cardId = ref.id;
           }
+          const refOriginalKind: 'playlist' | 'album' | 'liked' =
+            ref.kind === 'liked' ? 'liked' : ref.kind === 'album' ? 'album' : 'playlist';
+          const wrappedContextMenu = onContextMenuRequest
+            ? (req: ContextMenuRequest) => {
+                onContextMenuRequest({
+                  ...req,
+                  kind: 'recently-played',
+                  originalKind: refOriginalKind,
+                  recentRef: { kind: refOriginalKind, id: cardId, provider: ref.provider },
+                });
+              }
+            : undefined;
           return (
             <LibraryCard
               key={`${ref.provider}-${ref.kind}-${cardId}`}
@@ -63,7 +75,7 @@ const RecentlyPlayedSection: React.FC<RecentlyPlayedSectionProps> = ({
               showProviderBadge={showProviderBadges}
               variant={layout === 'row' ? 'row' : 'grid'}
               onSelect={() => onSelect(cardKind, cardId, name, ref.provider)}
-              onContextMenuRequest={onContextMenuRequest}
+              onContextMenuRequest={wrappedContextMenu}
             />
           );
         })

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -34,6 +34,10 @@ export interface ContextMenuRequest {
   provider?: ProviderId;
   name: string;
   anchorRect: DOMRect;
+  /** When kind === 'recently-played', the underlying collection kind so the menu can dispatch the right schema. */
+  originalKind?: 'playlist' | 'album' | 'liked';
+  /** When kind === 'recently-played', back-pointer used by the "Remove from history" action. */
+  recentRef?: { kind: 'playlist' | 'album' | 'liked'; id: string; provider?: ProviderId };
 }
 
 export type {

--- a/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
+++ b/src/hooks/__tests__/useRecentlyPlayedCollections.test.ts
@@ -176,4 +176,44 @@ describe('useRecentlyPlayedCollections', () => {
     expect(result.current.history).toHaveLength(1);
     expect(result.current.history[0]).toEqual({ ref, name: 'Persisted Playlist' });
   });
+
+  it('removes an entry by CollectionRef key', () => {
+    // #given
+    const ref1 = makeRef({ id: 'p1' });
+    const ref2 = makeRef({ id: 'p2' });
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+    act(() => {
+      result.current.record(ref1, 'First');
+      result.current.record(ref2, 'Second');
+    });
+
+    // #when
+    act(() => {
+      result.current.remove(ref1);
+    });
+
+    // #then
+    const remainingIds = result.current.history.map((entry) =>
+      entry.ref.kind === 'playlist' || entry.ref.kind === 'album' ? (entry.ref as { id: string }).id : entry.ref.kind,
+    );
+    expect(remainingIds).toEqual(['p2']);
+  });
+
+  it('remove is a no-op when the ref is not in history', () => {
+    // #given
+    const ref = makeRef({ id: 'p1' });
+    const missing = makeRef({ id: 'p-missing' });
+    const { result } = renderHook(() => useRecentlyPlayedCollections());
+    act(() => {
+      result.current.record(ref, 'Only');
+    });
+
+    // #when
+    act(() => {
+      result.current.remove(missing);
+    });
+
+    // #then
+    expect(result.current.history).toHaveLength(1);
+  });
 });

--- a/src/hooks/useRecentlyPlayedCollections.ts
+++ b/src/hooks/useRecentlyPlayedCollections.ts
@@ -15,6 +15,7 @@ export interface RecentlyPlayedEntry {
 export interface UseRecentlyPlayedCollectionsResult {
   history: RecentlyPlayedEntry[];
   record: (ref: CollectionRef, name: string, imageUrl?: string | null) => void;
+  remove: (ref: CollectionRef) => void;
 }
 
 export function useRecentlyPlayedCollections(): UseRecentlyPlayedCollectionsResult {
@@ -32,5 +33,13 @@ export function useRecentlyPlayedCollections(): UseRecentlyPlayedCollectionsResu
     [setHistory]
   );
 
-  return { history, record };
+  const remove = useCallback(
+    (ref: CollectionRef) => {
+      const key = collectionRefToKey(ref);
+      setHistory((prev) => prev.filter((entry) => collectionRefToKey(entry.ref) !== key));
+    },
+    [setHistory],
+  );
+
+  return { history, record, remove };
 }


### PR DESCRIPTION
## Summary
- Virtual-anchored Popover (NOT Radix ContextMenu) — single instance, anchored to request.anchorRect (per shadcn.md TrackInfoPopover pattern)
- Per-kind menu schemas: playlist (5 items), album (5 — Save deferred), liked (Play All + per-provider), recently-played (dispatch by originalKind + Remove from history destructive)
- `menuItemsForKind.ts` pure schema builder with `buildMenuItems(request, actions)`
- `useLikedTracksForProvider` 60s in-memory cache wrapping `fetchLikedForProvider`
- LibraryRoute holds `currentRequest` state; `handleContextMenuRequest` now sets it (was dev-debug)
- LibraryRouteProps extended with `onPlayNext` + `onStartRadioForCollection` (both optional)
- AudioPlayer + PlayerStateRenderer pass undefined for both — disabled-fallback per lead decision (follow-up tickets implement queue-insert + radio orchestration)
- ContextMenuRequest extended: `originalKind?` + `recentRef?` for recently-played dispatch
- useRecentlyPlayedCollections gains `remove(ref)` method
- RecentlyPlayedSection wraps onContextMenuRequest forwarding to populate originalKind + recentRef
- 26 tests across 3 new files + 2 added to useRecentlyPlayedCollections

Part of #1300. Addresses #1297.

## Test plan
- [x] tsc clean
- [x] LibraryRoute scope: 18 files, 144/144 pass
- [x] Full sweep: 1440 passed (+102 from baseline 1315); same 3 baseline failures unchanged
- [x] lint clean on new files
- [x] build clean

## Notes for reviewer
- Album Save/Unsave deferred — useAlbumSavedStatus is tightly coupled to legacy useItemPopover; will land in #1298 cleanup or follow-up
- No dedicated integration test (LibraryRoute.contextMenu.test.tsx) — per-component coverage is comprehensive (26 tests); can add fake-timer integration if reviewer wants belt-and-suspenders
- Will need rebase after #1309 (#1296 search) merges (overlap on LibraryRoute/index.tsx)