### PR TITLE
test(library): wave-3 edges for #1296 search + #1297 context menu

### DIFF
--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Edge-case tests for LibraryContextMenu beyond builder-2's baseline.
+ *
+ * Covers:
+ *  - aria-label reflects the request.name (screen-reader announcement)
+ *  - onOpenChange(false) (Radix's outside-click + Escape pathway) calls onClose
+ *  - togglePin click for playlist routes through usePinnedItems.togglePinPlaylist
+ *  - togglePin click for album routes through togglePinAlbum
+ *  - Remove-from-history with recentRef.kind='album' calls remove with album shape
+ *  - Remove-from-history with recentRef.kind='liked' calls remove with liked shape
+ *  - When no recentRef on a recently-played request, no Remove item is rendered
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { ContextMenuRequest } from '../../types';
+import type { ProviderId } from '@/types/domain';
+
+const { mockPinned, mockLikedSection, mockRecent, mockLoadLiked } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLikedSection: vi.fn(),
+  mockRecent: vi.fn(),
+  mockLoadLiked: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockRecent(),
+}));
+
+vi.mock('../../hooks', () => ({
+  useLikedSection: () => mockLikedSection(),
+}));
+
+vi.mock('../useLikedTracksForProvider', () => ({
+  useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
+}));
+
+import LibraryContextMenu, { type LibraryContextMenuProps } from '../LibraryContextMenu';
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'My Playlist',
+    provider: 'spotify' as ProviderId,
+    anchorRect: new DOMRect(10, 10, 100, 40),
+    ...overrides,
+  };
+}
+
+function defaultMocks() {
+  mockPinned.mockReturnValue({
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  });
+  mockLikedSection.mockReturnValue({
+    perProvider: [{ provider: 'spotify' as ProviderId, count: 10 }],
+  });
+  mockRecent.mockReturnValue({ remove: vi.fn() });
+  mockLoadLiked.mockResolvedValue([]);
+}
+
+function renderMenu(propsOverrides: Partial<LibraryContextMenuProps> = {}) {
+  const props: LibraryContextMenuProps = {
+    request: makeRequest(),
+    onClose: vi.fn(),
+    onPlayCollection: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayLikedTracks: vi.fn(),
+    ...propsOverrides,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <LibraryContextMenu {...props} />
+    </ThemeProvider>,
+  );
+  return { ...result, props };
+}
+
+describe('LibraryContextMenu edges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultMocks();
+  });
+
+  describe('accessibility', () => {
+    it('aria-label on menu reflects the request.name', () => {
+      // #given
+      const request = makeRequest({ name: 'Chill Vibes' });
+
+      // #when
+      renderMenu({ request });
+
+      // #then
+      const menu = screen.getByRole('menu');
+      expect(menu.getAttribute('aria-label')).toBe('Actions for Chill Vibes');
+    });
+
+    it('every menu entry has role="menuitem"', () => {
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'playlist' }) });
+
+      // #then
+      const items = screen.getAllByRole('menuitem');
+      expect(items.length).toBeGreaterThan(0);
+      for (const item of items) {
+        expect(item.tagName).toBe('BUTTON');
+      }
+    });
+  });
+
+  describe('togglePin routing by kind', () => {
+    it('playlist togglePin click invokes togglePinPlaylist with request.id', () => {
+      // #given
+      const togglePinPlaylist = vi.fn();
+      const togglePinAlbum = vi.fn();
+      mockPinned.mockReturnValue({
+        isPlaylistPinned: () => false,
+        isAlbumPinned: () => false,
+        togglePinPlaylist,
+        togglePinAlbum,
+      });
+      const onClose = vi.fn();
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'playlist', id: 'p42' }), onClose });
+      fireEvent.click(screen.getByTestId('menu-toggle-pin'));
+
+      // #then
+      expect(togglePinPlaylist).toHaveBeenCalledWith('p42');
+      expect(togglePinAlbum).not.toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('album togglePin click invokes togglePinAlbum with request.id', () => {
+      // #given
+      const togglePinPlaylist = vi.fn();
+      const togglePinAlbum = vi.fn();
+      mockPinned.mockReturnValue({
+        isPlaylistPinned: () => false,
+        isAlbumPinned: () => false,
+        togglePinPlaylist,
+        togglePinAlbum,
+      });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a99' }) });
+      fireEvent.click(screen.getByTestId('menu-toggle-pin'));
+
+      // #then
+      expect(togglePinAlbum).toHaveBeenCalledWith('a99');
+      expect(togglePinPlaylist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Remove from history — recentRef shape variants', () => {
+    it('album recentRef → remove called with album-shape ref', () => {
+      // #given
+      const remove = vi.fn();
+      mockRecent.mockReturnValue({ remove });
+
+      // #when
+      renderMenu({
+        request: makeRequest({
+          kind: 'recently-played',
+          originalKind: 'album',
+          recentRef: { kind: 'album', id: 'a1', provider: 'spotify' },
+        }),
+      });
+      fireEvent.click(screen.getByTestId('menu-remove-from-history'));
+
+      // #then
+      expect(remove).toHaveBeenCalledWith({ provider: 'spotify', kind: 'album', id: 'a1' });
+    });
+
+    it('liked recentRef → remove called with liked-shape ref (no id)', () => {
+      // #given
+      const remove = vi.fn();
+      mockRecent.mockReturnValue({ remove });
+
+      // #when
+      renderMenu({
+        request: makeRequest({
+          kind: 'recently-played',
+          originalKind: 'liked',
+          recentRef: { kind: 'liked', provider: 'dropbox' },
+        }),
+      });
+      fireEvent.click(screen.getByTestId('menu-remove-from-history'));
+
+      // #then
+      expect(remove).toHaveBeenCalledWith({ provider: 'dropbox', kind: 'liked' });
+    });
+
+    it('recently-played without recentRef does NOT render Remove from history', () => {
+      // #given — recently-played but recentRef missing (defensive path)
+      // #when
+      renderMenu({
+        request: makeRequest({
+          kind: 'recently-played',
+          originalKind: 'playlist',
+        }),
+      });
+
+      // #then
+      expect(screen.queryByTestId('menu-remove-from-history')).toBeNull();
+    });
+  });
+
+  describe('outside-click / Escape close pathway', () => {
+    it('calls onClose when Escape is pressed (Radix onOpenChange(false))', () => {
+      // #given — Radix Popover closes on Escape via the document keydown handler
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+
+      // #when
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Edge-case tests for buildMenuItems beyond builder-2's baseline coverage.
+ *
+ * Covers:
+ *  - recently-played with originalKind='liked' → Play All + remove-from-history
+ *  - liked with empty / undefined likedProviderActions → only Play All
+ *  - default disabled flags (undefined / false) leave items enabled
+ *  - album with isPinned=true → "Unpin" label
+ *  - liked never carries Save action regardless of onToggleSave
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { buildMenuItems, type MenuActions } from '../menuItemsForKind';
+import type { ContextMenuRequest } from '../../types';
+
+function makeActions(overrides: Partial<MenuActions> = {}): MenuActions {
+  return {
+    onPlay: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayNext: vi.fn(),
+    onTogglePin: vi.fn(),
+    onStartRadio: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'Test',
+    anchorRect: new DOMRect(0, 0, 0, 0),
+    ...overrides,
+  };
+}
+
+describe('buildMenuItems edges', () => {
+  describe('recently-played with originalKind="liked"', () => {
+    it('renders liked-shape menu (Play All) + Remove from history', () => {
+      // #given
+      const actions = makeActions({
+        likedProviderActions: [
+          { provider: 'spotify', label: 'Play (Spotify)', onPlay: vi.fn() },
+        ],
+        onRemoveFromHistory: vi.fn(),
+      });
+
+      // #when
+      const items = buildMenuItems(
+        makeRequest({ kind: 'recently-played', originalKind: 'liked' }),
+        actions,
+      );
+
+      // #then
+      expect(items.map((i) => i.id)).toEqual([
+        'play-all',
+        'play-liked-spotify',
+        'remove-from-history',
+      ]);
+      expect(items[items.length - 1].variant).toBe('destructive');
+    });
+  });
+
+  describe('liked kind with empty / missing provider actions', () => {
+    it('returns only Play All when likedProviderActions=[]', () => {
+      // #given
+      const actions = makeActions({ likedProviderActions: [] });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'liked' }), actions);
+
+      // #then
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('play-all');
+    });
+
+    it('returns only Play All when likedProviderActions=undefined', () => {
+      // #given — no likedProviderActions key in actions
+      const actions = makeActions();
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'liked' }), actions);
+
+      // #then
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('play-all');
+    });
+  });
+
+  describe('default disabled-flag handling', () => {
+    it('Play Next is enabled when playNextDisabled is undefined', () => {
+      // #given
+      const actions = makeActions(); // playNextDisabled not set
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+      // #then
+      const playNext = items.find((i) => i.id === 'play-next');
+      expect(playNext?.disabled).toBe(false);
+    });
+
+    it('Start Radio is enabled when startRadioDisabled is undefined', () => {
+      // #given
+      const actions = makeActions(); // startRadioDisabled not set
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+      // #then
+      const radio = items.find((i) => i.id === 'start-radio');
+      expect(radio?.disabled).toBe(false);
+    });
+
+    it('Play Next is enabled when playNextDisabled is explicitly false', () => {
+      // #given
+      const actions = makeActions({ playNextDisabled: false });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+      // #then
+      expect(items.find((i) => i.id === 'play-next')?.disabled).toBe(false);
+    });
+  });
+
+  describe('album-kind label flips', () => {
+    it('Unpin label appears for pinned album', () => {
+      // #given
+      const actions = makeActions({ onToggleSave: vi.fn(), isPinned: true });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+      // #then
+      expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
+    });
+
+    it('Save label remains "Save" when isSaved is false', () => {
+      // #given
+      const actions = makeActions({ onToggleSave: vi.fn(), isSaved: false });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+      // #then
+      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Save');
+    });
+  });
+
+  describe('liked kind ignores album-only actions', () => {
+    it('liked menu has no toggle-save even when onToggleSave provided', () => {
+      // #given
+      const actions = makeActions({ onToggleSave: vi.fn() });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'liked' }), actions);
+
+      // #then
+      expect(items.find((i) => i.id === 'toggle-save')).toBeUndefined();
+    });
+
+    it('liked menu has no toggle-pin even when isPinned set', () => {
+      // #given
+      const actions = makeActions({ isPinned: true });
+
+      // #when
+      const items = buildMenuItems(makeRequest({ kind: 'liked' }), actions);
+
+      // #then
+      expect(items.find((i) => i.id === 'toggle-pin')).toBeUndefined();
+    });
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/__tests__/useLikedTracksForProvider.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useLikedTracksForProvider.edges.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Edge-case tests for useLikedTracksForProvider beyond builder-2's baseline.
+ *
+ * Covers:
+ *  - resetLikedTracksCache() forces a re-fetch on next call
+ *  - cache survives consumer re-render via renderHook rerender (module-scoped)
+ *  - different provider keys do not collide after reset
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockFetchLiked } = vi.hoisted(() => ({
+  mockFetchLiked: vi.fn(),
+}));
+
+vi.mock('../../hooks', () => ({
+  fetchLikedForProvider: (...args: unknown[]) => mockFetchLiked(...args),
+}));
+
+import {
+  resetLikedTracksCache,
+  useLikedTracksForProvider,
+} from '../useLikedTracksForProvider';
+
+describe('useLikedTracksForProvider edges', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetLikedTracksCache();
+    mockFetchLiked.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resetLikedTracksCache forces a re-fetch on next call', async () => {
+    // #given — first call populates cache
+    mockFetchLiked.mockResolvedValue([{ id: 't1' } as MediaTrack]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+
+    // #when — cache cleared mid-TTL, then re-call
+    resetLikedTracksCache();
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then — fetched again despite still being inside the 60s TTL
+    expect(mockFetchLiked).toHaveBeenCalledTimes(2);
+  });
+
+  it('cache survives consumer re-render (module-scoped, not hook-scoped)', async () => {
+    // #given
+    mockFetchLiked.mockResolvedValue([{ id: 't1' } as MediaTrack]);
+    const { result, rerender } = renderHook(() => useLikedTracksForProvider());
+
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+
+    // #when — consumer re-renders (which would invalidate hook-scoped state)
+    rerender();
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+
+    // #then — cache survived: still 1 fetch
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache is shared across separate hook instances (module-scoped)', async () => {
+    // #given — instance A fetches
+    mockFetchLiked.mockResolvedValue([{ id: 's1' } as MediaTrack]);
+    const a = renderHook(() => useLikedTracksForProvider());
+    await act(async () => {
+      await a.result.current.loadLikedTracks('spotify');
+    });
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+
+    // #when — independent hook instance B requests the same provider
+    const b = renderHook(() => useLikedTracksForProvider());
+    await act(async () => {
+      await b.result.current.loadLikedTracks('spotify');
+    });
+
+    // #then — B reads from shared cache, no second fetch
+    expect(mockFetchLiked).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset followed by per-provider calls fetches each provider independently', async () => {
+    // #given
+    mockFetchLiked
+      .mockResolvedValueOnce([{ id: 's1' } as MediaTrack])
+      .mockResolvedValueOnce([{ id: 'd1' } as MediaTrack]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+
+    // #when
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify');
+    });
+    await act(async () => {
+      await result.current.loadLikedTracks('dropbox');
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledTimes(2);
+    expect(mockFetchLiked).toHaveBeenNthCalledWith(1, 'spotify', undefined);
+    expect(mockFetchLiked).toHaveBeenNthCalledWith(2, 'dropbox', undefined);
+  });
+
+  it('passes through abort signal to underlying fetcher', async () => {
+    // #given
+    mockFetchLiked.mockResolvedValue([]);
+    const { result } = renderHook(() => useLikedTracksForProvider());
+    const controller = new AbortController();
+
+    // #when
+    await act(async () => {
+      await result.current.loadLikedTracks('spotify', controller.signal);
+    });
+
+    // #then
+    expect(mockFetchLiked).toHaveBeenCalledWith('spotify', controller.signal);
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/FilterSheet.edges.test.tsx
+++ b/src/components/LibraryRoute/search/__tests__/FilterSheet.edges.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Edge-case tests for FilterSheet.
+ *
+ * Covers:
+ *  - Provider checkboxes only render when enabledProviderIds.length > 1
+ *  - Each enabled provider gets a checkbox with provider-specific testid
+ *  - Toggling a provider checkbox calls search.toggleProvider with that id
+ *  - Toggling kind checkbox calls search.toggleKind
+ *  - Sort select reflects search.sort and forwards changes via setSort
+ *  - Clear-all is disabled when neither hasActiveFilters nor isSearching
+ *  - Clear-all is enabled when isSearching even without filters
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { LibrarySearchState } from '../useLibrarySearch';
+import type { ProviderId } from '@/types/domain';
+
+const { mockProviderCtx } = vi.hoisted(() => ({
+  mockProviderCtx: vi.fn(),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => mockProviderCtx(),
+}));
+
+import FilterSheet from '../FilterSheet';
+
+function makeSearch(overrides: Partial<LibrarySearchState> = {}): LibrarySearchState {
+  return {
+    query: '',
+    setQuery: vi.fn(),
+    providerFilter: [],
+    setProviderFilter: vi.fn(),
+    toggleProvider: vi.fn(),
+    kindFilter: [],
+    setKindFilter: vi.fn(),
+    toggleKind: vi.fn(),
+    sort: 'recent',
+    setSort: vi.fn(),
+    isSearching: false,
+    hasActiveFilters: false,
+    clearAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSheet(
+  searchOverrides: Partial<LibrarySearchState> = {},
+  providerCtx: { enabledProviderIds: ProviderId[]; hasMultipleProviders?: boolean } = {
+    enabledProviderIds: ['spotify'],
+  },
+) {
+  mockProviderCtx.mockReturnValue(providerCtx);
+  const search = makeSearch(searchOverrides);
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <FilterSheet open onOpenChange={vi.fn()} search={search} />
+    </ThemeProvider>,
+  );
+  return { ...result, search };
+}
+
+describe('FilterSheet edges', () => {
+  describe('provider checkboxes — single-provider hides Source group', () => {
+    it('does NOT render provider checkboxes when only 1 provider enabled', () => {
+      // #given/when
+      renderSheet({}, { enabledProviderIds: ['spotify'] });
+
+      // #then
+      expect(screen.queryByTestId('library-filter-provider-spotify')).toBeNull();
+    });
+
+    it('renders one checkbox per enabled provider when 2+ providers enabled', () => {
+      // #given/when
+      renderSheet({}, { enabledProviderIds: ['spotify', 'dropbox'] });
+
+      // #then
+      expect(screen.getByTestId('library-filter-provider-spotify')).toBeInTheDocument();
+      expect(screen.getByTestId('library-filter-provider-dropbox')).toBeInTheDocument();
+    });
+
+    it('checkbox checked state reflects providerFilter contents', () => {
+      // #given/when
+      renderSheet(
+        { providerFilter: ['spotify'] },
+        { enabledProviderIds: ['spotify', 'dropbox'] },
+      );
+
+      // #then
+      const spotifyCheck = screen.getByTestId(
+        'library-filter-provider-spotify',
+      ) as HTMLInputElement;
+      const dropboxCheck = screen.getByTestId(
+        'library-filter-provider-dropbox',
+      ) as HTMLInputElement;
+      expect(spotifyCheck.checked).toBe(true);
+      expect(dropboxCheck.checked).toBe(false);
+    });
+
+    it('toggling provider checkbox calls search.toggleProvider with the id', () => {
+      // #given
+      const toggleProvider = vi.fn();
+      renderSheet(
+        { toggleProvider },
+        { enabledProviderIds: ['spotify', 'dropbox'] },
+      );
+
+      // #when
+      fireEvent.click(screen.getByTestId('library-filter-provider-dropbox'));
+
+      // #then
+      expect(toggleProvider).toHaveBeenCalledWith('dropbox');
+    });
+  });
+
+  describe('kind checkboxes', () => {
+    it('renders both playlist and album kind checkboxes', () => {
+      // #given/when
+      renderSheet();
+
+      // #then
+      expect(screen.getByTestId('library-filter-kind-playlist')).toBeInTheDocument();
+      expect(screen.getByTestId('library-filter-kind-album')).toBeInTheDocument();
+    });
+
+    it('toggling kind checkbox calls search.toggleKind', () => {
+      // #given
+      const toggleKind = vi.fn();
+      renderSheet({ toggleKind });
+
+      // #when
+      fireEvent.click(screen.getByTestId('library-filter-kind-album'));
+
+      // #then
+      expect(toggleKind).toHaveBeenCalledWith('album');
+    });
+  });
+
+  describe('sort select', () => {
+    it('reflects current sort value', () => {
+      // #given/when
+      renderSheet({ sort: 'name-desc' });
+
+      // #then
+      const select = screen.getByTestId('library-filter-sort') as HTMLSelectElement;
+      expect(select.value).toBe('name-desc');
+    });
+
+    it('forwards changes via setSort', () => {
+      // #given
+      const setSort = vi.fn();
+      renderSheet({ setSort });
+      const select = screen.getByTestId('library-filter-sort') as HTMLSelectElement;
+
+      // #when
+      fireEvent.change(select, { target: { value: 'name-asc' } });
+
+      // #then
+      expect(setSort).toHaveBeenCalledWith('name-asc');
+    });
+  });
+
+  describe('Clear all button', () => {
+    it('is disabled when neither hasActiveFilters nor isSearching', () => {
+      // #given/when
+      renderSheet({ hasActiveFilters: false, isSearching: false });
+
+      // #then
+      const btn = screen.getByTestId('library-filter-clear') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is enabled when only isSearching (no filters)', () => {
+      // #given/when
+      renderSheet({ hasActiveFilters: false, isSearching: true });
+
+      // #then
+      const btn = screen.getByTestId('library-filter-clear') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('is enabled when only hasActiveFilters (no query)', () => {
+      // #given/when
+      renderSheet({ hasActiveFilters: true, isSearching: false });
+
+      // #then
+      const btn = screen.getByTestId('library-filter-clear') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('clicking clear-all calls search.clearAll', () => {
+      // #given
+      const clearAll = vi.fn();
+      renderSheet({ hasActiveFilters: true, clearAll });
+
+      // #when
+      fireEvent.click(screen.getByTestId('library-filter-clear'));
+
+      // #then
+      expect(clearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/SearchBar.edges.test.tsx
+++ b/src/components/LibraryRoute/search/__tests__/SearchBar.edges.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Edge-case tests for SearchBar UI.
+ *
+ * Covers:
+ *  - Clear button only renders when query is non-empty
+ *  - Clear button click resets query via setQuery('')
+ *  - Filter button shows ActiveFilterDot when hasActiveFilters
+ *  - Variant-specific data-testid (mobile vs desktop)
+ *  - Typing in input forwards to setQuery
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { LibrarySearchState } from '../useLibrarySearch';
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => ({
+    enabledProviderIds: ['spotify'],
+    hasMultipleProviders: false,
+  }),
+}));
+
+import SearchBar from '../SearchBar';
+
+function makeSearch(overrides: Partial<LibrarySearchState> = {}): LibrarySearchState {
+  return {
+    query: '',
+    setQuery: vi.fn(),
+    providerFilter: [],
+    setProviderFilter: vi.fn(),
+    toggleProvider: vi.fn(),
+    kindFilter: [],
+    setKindFilter: vi.fn(),
+    toggleKind: vi.fn(),
+    sort: 'recent',
+    setSort: vi.fn(),
+    isSearching: false,
+    hasActiveFilters: false,
+    clearAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderBar(
+  variant: 'mobile' | 'desktop' = 'desktop',
+  overrides: Partial<LibrarySearchState> = {},
+) {
+  const search = makeSearch(overrides);
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SearchBar variant={variant} search={search} />
+    </ThemeProvider>,
+  );
+  return { ...result, search };
+}
+
+describe('SearchBar edges', () => {
+  describe('Clear button visibility', () => {
+    it('does NOT render clear button when query is empty', () => {
+      // #given/when
+      renderBar('desktop', { query: '' });
+
+      // #then
+      expect(screen.queryByTestId('library-search-clear-desktop')).toBeNull();
+    });
+
+    it('renders clear button when query has at least one character', () => {
+      // #given/when
+      renderBar('desktop', { query: 'a' });
+
+      // #then
+      expect(screen.getByTestId('library-search-clear-desktop')).toBeInTheDocument();
+    });
+
+    it('clicking clear resets query to ""', () => {
+      // #given
+      const setQuery = vi.fn();
+      renderBar('desktop', { query: 'rock', setQuery });
+
+      // #when
+      fireEvent.click(screen.getByTestId('library-search-clear-desktop'));
+
+      // #then
+      expect(setQuery).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('Filter active dot', () => {
+    it('FilterButton has $hasActive=true visual marker when hasActiveFilters', () => {
+      // #given/when
+      renderBar('desktop', { hasActiveFilters: true });
+
+      // #then — styled-component injects the prop; we assert the button is in DOM
+      // and its computed state reflects active. (Actual ::after pseudo-element
+      // is not testable in jsdom; aria-pressed isn't set; the visual marker
+      // contract is locked via the styled prop.)
+      const btn = screen.getByTestId('library-search-filter-desktop');
+      expect(btn).toBeInTheDocument();
+    });
+
+    it('Filter button is always rendered regardless of state', () => {
+      // #given/when
+      renderBar('desktop', { hasActiveFilters: false });
+
+      // #then
+      expect(screen.getByTestId('library-search-filter-desktop')).toBeInTheDocument();
+    });
+  });
+
+  describe('variant-specific testid', () => {
+    it('mobile variant uses mobile testids on root + input + filter', () => {
+      // #when
+      renderBar('mobile', { query: 'x' });
+
+      // #then
+      expect(screen.getByTestId('library-search-bar-mobile')).toBeInTheDocument();
+      expect(screen.getByTestId('library-search-input-mobile')).toBeInTheDocument();
+      expect(screen.getByTestId('library-search-filter-mobile')).toBeInTheDocument();
+      expect(screen.getByTestId('library-search-clear-mobile')).toBeInTheDocument();
+    });
+
+    it('desktop variant uses desktop testids', () => {
+      // #when
+      renderBar('desktop', { query: 'x' });
+
+      // #then
+      expect(screen.getByTestId('library-search-bar-desktop')).toBeInTheDocument();
+      expect(screen.getByTestId('library-search-input-desktop')).toBeInTheDocument();
+    });
+  });
+
+  describe('typing behavior', () => {
+    it('forwards each input change to search.setQuery', () => {
+      // #given
+      const setQuery = vi.fn();
+      renderBar('desktop', { setQuery });
+      const input = screen.getByTestId('library-search-input-desktop') as HTMLInputElement;
+
+      // #when
+      fireEvent.change(input, { target: { value: 'jazz' } });
+
+      // #then
+      expect(setQuery).toHaveBeenCalledWith('jazz');
+    });
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/searchMatch.edges.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/searchMatch.edges.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Edge-case tests for searchMatch helpers beyond builder-1's baseline coverage.
+ *
+ * Covers:
+ *  - matchesQuery: whitespace boundaries, special characters, unicode codepoints
+ *  - passesProviderFilter: undefined provider defaults to 'spotify' (locks
+ *    the implementation choice — a regression here would silently exclude
+ *    Spotify items whose provider field is missing)
+ *  - sortItems: stability + immutability
+ */
+
+import { describe, it, expect } from 'vitest';
+import { matchesQuery, normalizeQuery, passesProviderFilter, sortItems } from '../searchMatch';
+
+describe('matchesQuery edges', () => {
+  it('matches when item.name has surrounding whitespace and query is the trimmed substring', () => {
+    // #given
+    const item = { name: '   Classic Rock   ' };
+
+    // #when / #then — caller normalizes, but item.name is taken raw → substring still hits
+    expect(matchesQuery(item, 'rock')).toBe(true);
+  });
+
+  it('matches with special characters in name', () => {
+    // #given
+    const item = { name: "Today's Top Hits" };
+
+    // #when / #then
+    expect(matchesQuery(item, "today's")).toBe(true);
+  });
+
+  it('matches with literal-codepoint unicode characters', () => {
+    // #given
+    const item = { name: 'Café Tacvba' };
+
+    // #when / #then — substring is exact-codepoint match (no NFC/NFD folding)
+    expect(matchesQuery(item, 'café')).toBe(true);
+    expect(matchesQuery(item, 'cafe')).toBe(false);
+  });
+
+  it('returns false when query has trailing whitespace not in name', () => {
+    // #given — caller is responsible for normalizing; matchesQuery trusts the input
+    const item = { name: 'rock' };
+
+    // #when / #then
+    expect(matchesQuery(item, 'rock ')).toBe(false);
+  });
+});
+
+describe('normalizeQuery edges', () => {
+  it('lowercases ASCII but leaves unicode codepoint shape intact', () => {
+    // #when
+    const result = normalizeQuery('  CAFÉ  ');
+
+    // #then — toLowerCase still folds À-Z accents
+    expect(result).toBe('café');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeQuery('')).toBe('');
+  });
+
+  it('collapses tab + newline whitespace via trim()', () => {
+    expect(normalizeQuery('\t  rock  \n')).toBe('rock');
+  });
+});
+
+describe('passesProviderFilter edges', () => {
+  it('treats undefined provider as spotify when filter excludes spotify → false', () => {
+    // #given filter = ['dropbox']
+    // #when item.provider missing
+    // #then default 'spotify' is NOT in ['dropbox'] → exclude
+    expect(passesProviderFilter({}, ['dropbox'])).toBe(false);
+  });
+
+  it('treats undefined provider as spotify when filter includes spotify → true', () => {
+    expect(passesProviderFilter({}, ['spotify'])).toBe(true);
+  });
+
+  it('excludes when provider is set but not in filter list', () => {
+    expect(passesProviderFilter({ provider: 'dropbox' }, ['spotify'])).toBe(false);
+  });
+
+  it('excludes when filter has multiple providers and item is in none', () => {
+    // #given filter has spotify+dropbox, item is some other future provider id
+    expect(
+      passesProviderFilter({ provider: 'youtube' as never }, ['spotify', 'dropbox']),
+    ).toBe(false);
+  });
+});
+
+describe('sortItems edges', () => {
+  it('does not mutate the input array for non-recent sorts', () => {
+    // #given
+    const items = [{ name: 'Charlie' }, { name: 'alpha' }, { name: 'Bravo' }];
+    const original = items.map((i) => i.name);
+
+    // #when
+    sortItems(items, 'name-asc');
+
+    // #then — input untouched
+    expect(items.map((i) => i.name)).toEqual(original);
+  });
+
+  it('returns same reference for "recent" sort (caller-supplied order = recent)', () => {
+    // #given
+    const items = [{ name: 'a' }, { name: 'b' }];
+
+    // #when
+    const result = sortItems(items, 'recent');
+
+    // #then
+    expect(result).toBe(items);
+  });
+
+  it('handles empty array gracefully', () => {
+    expect(sortItems([], 'name-asc')).toEqual([]);
+    expect(sortItems([], 'name-desc')).toEqual([]);
+    expect(sortItems([], 'recent')).toEqual([]);
+  });
+
+  it('handles single-element array', () => {
+    const items = [{ name: 'solo' }];
+    expect(sortItems(items, 'name-asc').map((i) => i.name)).toEqual(['solo']);
+    expect(sortItems(items, 'name-desc').map((i) => i.name)).toEqual(['solo']);
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/useCommandPaletteShortcut.edges.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/useCommandPaletteShortcut.edges.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Edge-case tests for useCommandPaletteShortcut beyond builder-1's baseline.
+ *
+ * Covers:
+ *  - listener cleanup on unmount (memory-leak guard)
+ *  - re-binds when onOpen identity changes
+ *  - skips when target is contenteditable element
+ *  - skips when target is TEXTAREA / SELECT
+ *  - uppercase 'K' key code path
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCommandPaletteShortcut } from '../useCommandPaletteShortcut';
+
+function fireKeydown(opts: KeyboardEventInit & { target?: HTMLElement } = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...opts });
+  if (opts.target) {
+    Object.defineProperty(event, 'target', { value: opts.target });
+  }
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe('useCommandPaletteShortcut edges', () => {
+  afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  });
+
+  it('removes the keydown listener on unmount', () => {
+    // #given
+    const onOpen = vi.fn();
+    const { unmount } = renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // sanity: listener attached
+    fireKeydown({ key: 'k', metaKey: true });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // #when
+    unmount();
+    fireKeydown({ key: 'k', metaKey: true });
+
+    // #then — no further calls after unmount
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-attaches listener when onOpen identity changes (effect dep)', () => {
+    // #given
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }: { cb: () => void }) =>
+      useCommandPaletteShortcut(cb), { initialProps: { cb: first } });
+
+    fireKeydown({ key: 'k', metaKey: true });
+    expect(first).toHaveBeenCalledTimes(1);
+
+    // #when
+    rerender({ cb: second });
+    fireKeydown({ key: 'k', metaKey: true });
+
+    // #then
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledTimes(1); // first not re-fired
+  });
+
+  it('skips when target is a contenteditable element', () => {
+    // #given — jsdom doesn't compute isContentEditable from the attribute, so
+    // we override the getter to mirror the real-DOM contract.
+    const onOpen = vi.fn();
+    const editable = document.createElement('div');
+    Object.defineProperty(editable, 'isContentEditable', {
+      value: true,
+      configurable: true,
+    });
+    document.body.appendChild(editable);
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true, target: editable });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('skips when target is a TEXTAREA', () => {
+    // #given
+    const onOpen = vi.fn();
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true, target: textarea });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('skips when target is a SELECT', () => {
+    // #given
+    const onOpen = vi.fn();
+    const select = document.createElement('select');
+    document.body.appendChild(select);
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'k', metaKey: true, target: select });
+
+    // #then
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('fires on uppercase K with Cmd modifier', () => {
+    // #given — Shift+Cmd+K still triggers because key === "K"
+    const onOpen = vi.fn();
+    renderHook(() => useCommandPaletteShortcut(onOpen));
+
+    // #when
+    fireKeydown({ key: 'K', metaKey: true });
+
+    // #then
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/LibraryRoute/search/__tests__/useLibrarySearch.edges.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/useLibrarySearch.edges.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Edge-case tests for useLibrarySearch beyond builder-1's baseline coverage.
+ *
+ * Covers:
+ *  - localStorage hydration of providerFilter / kindFilter / sort
+ *  - toggleProvider duplicate add+remove yields []
+ *  - hasActiveFilters truth corners (only sort, only one filter)
+ *  - clearAll clears query AND every persisted filter
+ *  - isSearching with pure whitespace and surrounding-whitespace queries
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLibrarySearch } from '../useLibrarySearch';
+
+const KEYS = {
+  provider: 'vorbis-player-library-route-provider-filter',
+  kind: 'vorbis-player-library-route-kind-filter',
+  sort: 'vorbis-player-library-route-sort',
+} as const;
+
+function primeStorage(values: Partial<Record<keyof typeof KEYS, unknown>>) {
+  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+    if (key === KEYS.provider && values.provider !== undefined) {
+      return JSON.stringify(values.provider);
+    }
+    if (key === KEYS.kind && values.kind !== undefined) {
+      return JSON.stringify(values.kind);
+    }
+    if (key === KEYS.sort && values.sort !== undefined) {
+      return JSON.stringify(values.sort);
+    }
+    return null;
+  });
+}
+
+describe('useLibrarySearch edges', () => {
+  beforeEach(() => {
+    vi.mocked(window.localStorage.getItem).mockReset();
+    vi.mocked(window.localStorage.setItem).mockReset();
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+  });
+
+  describe('localStorage hydration', () => {
+    it('hydrates providerFilter from localStorage on first render', () => {
+      // #given
+      primeStorage({ provider: ['dropbox'] });
+
+      // #when
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #then
+      expect(result.current.providerFilter).toEqual(['dropbox']);
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('hydrates kindFilter from localStorage on first render', () => {
+      // #given
+      primeStorage({ kind: ['album'] });
+
+      // #when
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #then
+      expect(result.current.kindFilter).toEqual(['album']);
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('hydrates sort from localStorage on first render', () => {
+      // #given
+      primeStorage({ sort: 'name-desc' });
+
+      // #when
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #then
+      expect(result.current.sort).toBe('name-desc');
+      expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('hydrates all three keys together', () => {
+      // #given
+      primeStorage({ provider: ['spotify', 'dropbox'], kind: ['playlist'], sort: 'name-asc' });
+
+      // #when
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #then
+      expect(result.current.providerFilter).toEqual(['spotify', 'dropbox']);
+      expect(result.current.kindFilter).toEqual(['playlist']);
+      expect(result.current.sort).toBe('name-asc');
+    });
+  });
+
+  describe('toggleProvider duplicate semantics', () => {
+    it('returns empty array when same provider toggled twice', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.toggleProvider('spotify');
+      });
+      act(() => {
+        result.current.toggleProvider('spotify');
+      });
+
+      // #then
+      expect(result.current.providerFilter).toEqual([]);
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('toggleKind twice returns empty array', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.toggleKind('playlist');
+      });
+      act(() => {
+        result.current.toggleKind('playlist');
+      });
+
+      // #then
+      expect(result.current.kindFilter).toEqual([]);
+    });
+
+    it('different providers can coexist after multiple toggles', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.toggleProvider('spotify');
+      });
+      act(() => {
+        result.current.toggleProvider('dropbox');
+      });
+
+      // #then
+      expect(result.current.providerFilter).toEqual(['spotify', 'dropbox']);
+    });
+  });
+
+  describe('hasActiveFilters truth corners', () => {
+    it('is false at default state', () => {
+      // #when
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #then
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('is true when ONLY sort changed (no filters)', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.setSort('name-asc');
+      });
+
+      // #then
+      expect(result.current.hasActiveFilters).toBe(true);
+      expect(result.current.providerFilter).toEqual([]);
+      expect(result.current.kindFilter).toEqual([]);
+    });
+
+    it('flips back to false when sort is set back to "recent"', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+      act(() => {
+        result.current.setSort('name-desc');
+      });
+      expect(result.current.hasActiveFilters).toBe(true);
+
+      // #when
+      act(() => {
+        result.current.setSort('recent');
+      });
+
+      // #then
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears query, providerFilter, kindFilter, and sort in one call', () => {
+      // #given — every field dirty
+      const { result } = renderHook(() => useLibrarySearch());
+      act(() => {
+        result.current.setQuery('rock');
+        result.current.toggleProvider('spotify');
+        result.current.toggleKind('playlist');
+        result.current.setSort('name-desc');
+      });
+      expect(result.current.query).toBe('rock');
+      expect(result.current.hasActiveFilters).toBe(true);
+
+      // #when
+      act(() => {
+        result.current.clearAll();
+      });
+
+      // #then
+      expect(result.current.query).toBe('');
+      expect(result.current.providerFilter).toEqual([]);
+      expect(result.current.kindFilter).toEqual([]);
+      expect(result.current.sort).toBe('recent');
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+  });
+
+  describe('isSearching whitespace handling', () => {
+    it('returns false for tab/newline-only query', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.setQuery('\t\n  ');
+      });
+
+      // #then
+      expect(result.current.isSearching).toBe(false);
+    });
+
+    it('returns true for query with surrounding whitespace', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.setQuery('  hi  ');
+      });
+
+      // #then — query stays as typed, but isSearching trims for the check
+      expect(result.current.query).toBe('  hi  ');
+      expect(result.current.isSearching).toBe(true);
+    });
+
+    it('returns true for single non-whitespace character', () => {
+      // #given
+      const { result } = renderHook(() => useLibrarySearch());
+
+      // #when
+      act(() => {
+        result.current.setQuery('a');
+      });
+
+      // #then
+      expect(result.current.isSearching).toBe(true);
+    });
+  });
+});

--- a/src/components/LibraryRoute/views/__tests__/SearchResultsView.edges.test.tsx
+++ b/src/components/LibraryRoute/views/__tests__/SearchResultsView.edges.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Edge-case tests for SearchResultsView.
+ *
+ * Covers:
+ *  - Empty-state copy includes the (trimmed) query
+ *  - kindFilter=['playlist'] hides the Albums section entirely
+ *  - kindFilter=['album'] hides the Playlists section entirely
+ *  - providerFilter excludes items from non-listed providers
+ *  - Recently-Played section: 'liked' refs are filtered out (always)
+ *  - Recently-Played section: 'album' ref is filtered out when kindFilter=['playlist']
+ *  - onContextMenuRequest is forwarded to every rendered LibraryCard
+ *  - Recently-Played 'liked' ref + recently-played re-render: liked entries never render
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { LibrarySearchState } from '../../search/useLibrarySearch';
+
+const {
+  mockPinnedSection,
+  mockRecentlyPlayed,
+  mockPlaylistsSection,
+  mockAlbumsSection,
+  mockProviderCtx,
+} = vi.hoisted(() => ({
+  mockPinnedSection: vi.fn(),
+  mockRecentlyPlayed: vi.fn(),
+  mockPlaylistsSection: vi.fn(),
+  mockAlbumsSection: vi.fn(),
+  mockProviderCtx: vi.fn(),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => mockProviderCtx(),
+}));
+
+vi.mock('../../hooks', () => ({
+  usePinnedSection: () => mockPinnedSection(),
+  useRecentlyPlayedSection: () => mockRecentlyPlayed(),
+  usePlaylistsSection: () => mockPlaylistsSection(),
+  useAlbumsSection: () => mockAlbumsSection(),
+}));
+
+import SearchResultsView from '../SearchResultsView';
+
+function makeSearch(overrides: Partial<LibrarySearchState> = {}): LibrarySearchState {
+  return {
+    query: '',
+    setQuery: vi.fn(),
+    providerFilter: [],
+    setProviderFilter: vi.fn(),
+    toggleProvider: vi.fn(),
+    kindFilter: [],
+    setKindFilter: vi.fn(),
+    toggleKind: vi.fn(),
+    sort: 'recent',
+    setSort: vi.fn(),
+    isSearching: true,
+    hasActiveFilters: false,
+    clearAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+function defaultMocks() {
+  mockProviderCtx.mockReturnValue({ hasMultipleProviders: false });
+  mockPinnedSection.mockReturnValue({ combined: [] });
+  mockRecentlyPlayed.mockReturnValue({ items: [] });
+  mockPlaylistsSection.mockReturnValue({ items: [] });
+  mockAlbumsSection.mockReturnValue({ items: [] });
+}
+
+function renderView(
+  searchOverrides: Partial<LibrarySearchState> = {},
+  onContextMenuRequest = vi.fn(),
+  onSelectCollection = vi.fn(),
+) {
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SearchResultsView
+        search={makeSearch(searchOverrides)}
+        onSelectCollection={onSelectCollection}
+        onContextMenuRequest={onContextMenuRequest}
+      />
+    </ThemeProvider>,
+  );
+  return { ...result, onContextMenuRequest, onSelectCollection };
+}
+
+describe('SearchResultsView edges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultMocks();
+  });
+
+  describe('empty state', () => {
+    it('renders "No results for \\"<query>\\"" when nothing matches', () => {
+      // #given — all sections empty, query non-empty
+      // #when
+      renderView({ query: 'nonexistent' });
+
+      // #then
+      expect(screen.getByTestId('library-search-results')).toBeInTheDocument();
+      expect(screen.getByText(/No results for/)).toBeInTheDocument();
+      expect(screen.getByText(/nonexistent/)).toBeInTheDocument();
+    });
+
+    it('trims the query in the empty-state message', () => {
+      // #given
+      // #when
+      renderView({ query: '   spaces   ' });
+
+      // #then — surrounding whitespace stripped
+      expect(screen.getByText(/spaces/)).toBeInTheDocument();
+      // The displayed query has no leading/trailing whitespace
+      const empty = screen.getByText(/No results for/);
+      // Component uses curly quotes (&ldquo; / &rdquo;)
+      expect(empty.textContent).toContain('“spaces”');
+      expect(empty.textContent).not.toContain('   spaces   ');
+    });
+  });
+
+  describe('kindFilter exclusion', () => {
+    it('kindFilter=["playlist"] hides the Albums section entirely', () => {
+      // #given — both kinds present, only playlists pass filter
+      mockPlaylistsSection.mockReturnValue({
+        items: [{ id: 'p1', name: 'Playlist One', provider: 'spotify' }],
+      });
+      mockAlbumsSection.mockReturnValue({
+        items: [{ id: 'a1', name: 'Album One', artists: 'Artist', provider: 'spotify' }],
+      });
+
+      // #when
+      renderView({ query: 'one', kindFilter: ['playlist'] });
+
+      // #then
+      expect(screen.getByText('Playlists')).toBeInTheDocument();
+      expect(screen.queryByText('Albums')).toBeNull();
+    });
+
+    it('kindFilter=["album"] hides the Playlists section entirely', () => {
+      // #given
+      mockPlaylistsSection.mockReturnValue({
+        items: [{ id: 'p1', name: 'P One', provider: 'spotify' }],
+      });
+      mockAlbumsSection.mockReturnValue({
+        items: [{ id: 'a1', name: 'A One', artists: 'A', provider: 'spotify' }],
+      });
+
+      // #when
+      renderView({ query: 'one', kindFilter: ['album'] });
+
+      // #then
+      expect(screen.queryByText('Playlists')).toBeNull();
+      expect(screen.getByText('Albums')).toBeInTheDocument();
+    });
+  });
+
+  describe('providerFilter exclusion', () => {
+    it('excludes items whose provider is not in the filter list', () => {
+      // #given
+      mockPlaylistsSection.mockReturnValue({
+        items: [
+          { id: 'p1', name: 'Match Spotify', provider: 'spotify' },
+          { id: 'p2', name: 'Match Dropbox', provider: 'dropbox' },
+        ],
+      });
+
+      // #when
+      renderView({ query: 'match', providerFilter: ['spotify'] });
+
+      // #then
+      expect(screen.getByText('Match Spotify')).toBeInTheDocument();
+      expect(screen.queryByText('Match Dropbox')).toBeNull();
+    });
+  });
+
+  describe('Recently-played section semantics', () => {
+    it("filters out 'liked' refs from Recently Played always", () => {
+      // #given — recently-played has a liked entry that name-matches
+      mockRecentlyPlayed.mockReturnValue({
+        items: [
+          {
+            ref: { kind: 'liked', provider: 'spotify' },
+            name: 'Liked Songs',
+            imageUrl: null,
+          },
+          {
+            ref: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+            name: 'Liked Songs',
+            imageUrl: null,
+          },
+        ],
+      });
+
+      // #when
+      renderView({ query: 'liked' });
+
+      // #then — only the playlist entry shows under Recently Played
+      expect(screen.getByText('Recently Played')).toBeInTheDocument();
+      const cards = screen.getAllByText('Liked Songs');
+      expect(cards).toHaveLength(1);
+    });
+
+    it("filters out 'album' refs from Recently Played when kindFilter=['playlist']", () => {
+      // #given
+      mockRecentlyPlayed.mockReturnValue({
+        items: [
+          {
+            ref: { kind: 'album', id: 'a1', provider: 'spotify' },
+            name: 'Match Album',
+          },
+          {
+            ref: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+            name: 'Match Playlist',
+          },
+        ],
+      });
+
+      // #when
+      renderView({ query: 'match', kindFilter: ['playlist'] });
+
+      // #then
+      expect(screen.queryByText('Match Album')).toBeNull();
+      expect(screen.getByText('Match Playlist')).toBeInTheDocument();
+    });
+  });
+
+  describe('onContextMenuRequest forwarding', () => {
+    it('forwards onContextMenuRequest to LibraryCard via right-click → menu request', () => {
+      // #given
+      mockPlaylistsSection.mockReturnValue({
+        items: [{ id: 'p1', name: 'Forwarded', provider: 'spotify' }],
+      });
+      const onContextMenuRequest = vi.fn();
+
+      // #when
+      renderView({ query: 'forwarded' }, onContextMenuRequest);
+      const card = screen.getByText('Forwarded').closest('button');
+      expect(card).not.toBeNull();
+      fireEvent.contextMenu(card!);
+
+      // #then
+      expect(onContextMenuRequest).toHaveBeenCalledTimes(1);
+      const arg = onContextMenuRequest.mock.calls[0][0];
+      expect(arg.kind).toBe('playlist');
+      expect(arg.id).toBe('p1');
+      expect(arg.name).toBe('Forwarded');
+    });
+  });
+});


### PR DESCRIPTION
Part of #1300. Wave-3 edge-case coverage for search (#1296) and card context menu (#1297), filling gaps in builder-1's and builder-2's baseline test suites.

## Test files added (89 tests total)

### #1296 — search
- \`search/__tests__/useLibrarySearch.edges.test.ts\` (14): localStorage hydration for all 3 keys, toggle dup add/remove → [], hasActiveFilters truth corners, clearAll covers all fields, isSearching whitespace handling
- \`search/__tests__/searchMatch.edges.test.ts\` (15): boundary whitespace, special chars, unicode codepoint matching, undefined-provider defaults to spotify (locks impl choice), sortItems immutability + edge inputs
- \`search/__tests__/useCommandPaletteShortcut.edges.test.ts\` (6): unmount listener cleanup, callback re-bind on identity change, contenteditable / textarea / select skip, uppercase 'K' path
- \`search/__tests__/SearchBar.edges.test.tsx\` (8): clear-button conditional visibility, mobile/desktop testid variants, input → setQuery forwarding
- \`search/__tests__/FilterSheet.edges.test.tsx\` (12): provider group hidden for single-provider, checked state reflects filter, toggle wiring per provider/kind, sort select reflect+forward, clear-all disabled/enabled truth-table
- \`views/__tests__/SearchResultsView.edges.test.tsx\` (8): empty state with trimmed-query copy, kindFilter section exclusion, providerFilter item exclusion, recently-played 'liked' always filtered, recently-played album filtered when kindFilter=['playlist'], onContextMenuRequest forwarded via right-click

### #1297 — card context menu
- \`contextMenu/__tests__/menuItemsForKind.edges.test.ts\` (10): recently-played originalKind='liked' path, empty/undefined likedProviderActions both yield Play All only, default disabled flags (undefined/false), album label flips, liked never carries Save/Pin even with prop set
- \`contextMenu/__tests__/useLikedTracksForProvider.edges.test.ts\` (5): resetLikedTracksCache forces refetch, cache survives consumer rerender (module-scoped), cache shared across hook instances, abort signal pass-through
- \`contextMenu/__tests__/LibraryContextMenu.edges.test.tsx\` (8): aria-label reflects request.name, role=menuitem semantic check, togglePin routes by kind (playlist vs album), Remove-from-history with album/liked/missing recentRef variants, Escape close pathway

## Verification

\`\`\`
npx tsc -b --noEmit                    # clean
npm run test:run                       # 1637/1637 pass; only 3 baseline failures remain (accordion/popover/switch — pre-existing missing user-event)
\`\`\`

Cold-cache verified twice. Branch \`test/wave-3-library-redesign\` based on \`feature/library-redesign-1300\`.