### PR TITLE
chore(agents): apply 2026-04-26 retro findings (stop-gap)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,6 +1,7 @@
 ---
 name: architect
 description: Read-only feature design — produces concrete blueprints (files to create/modify, component shapes, data flow, build sequence) matching codebase patterns.
+model: opus[1m]
 tools: Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
 ---
 

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -1,6 +1,7 @@
 ---
 name: builder
 description: Implementation — takes architect blueprints or direct lead tasks and writes code following existing patterns. Verifies with tsc + tests before reporting done.
+model: opus
 tools: "*"
 ---
 

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,6 +1,7 @@
 ---
 name: explorer
 description: Read-only codebase research — file/symbol location, dependency mapping, file:line citation. Fast, thorough, never invents paths or symbols.
+model: sonnet
 tools: Bash, Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, Skill, LSP, SendMessage, TaskGet, TaskList, TaskUpdate, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, ListMcpResourcesTool, ReadMcpResourceTool, mcp__grep-app__searchGitHub
 ---
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: reviewer
 description: Read-only code review — flags bugs, logic errors, security issues, convention violations, and AC failures using confidence-based filtering.
+model: opus[1m]
 tools: Bash, Read, Glob, Grep, LS, NotebookRead, BashOutput, WebFetch, WebSearch, TodoWrite, TaskGet, TaskList, TaskUpdate, SendMessage
 ---
 

--- a/.claude/agents/team-lead.md
+++ b/.claude/agents/team-lead.md
@@ -41,3 +41,51 @@ Before instructing builder to open a PR, verify the project's PR target branch b
 ## Skip architect for prescriptive specs
 
 If the issue body cites file:line locations and exact code patterns throughout, dispatch builder directly without an architect blueprint. The recon → augmented-dispatch → builder loop produces the same outcome faster, and an architect blueprint adds latency without adding signal. Reserve architect for ambiguous specs with real design surface (new abstractions, multi-file refactors with non-obvious boundaries, performance tradeoffs requiring options analysis). For epics where every child issue is prescriptive, consider not spawning architect at all rather than spawning and idling them.
+
+## Epic-branch pre-flight (≥3 child issues)
+
+Before dispatching the first builder of any new wave, check: does this epic have ≥3 child issues? If so, ensure a `feature/<slug>-<epic#>` branch exists and `claude.flowkit.prBase` is pinned to it. Use `flowkit:cut-epic` if not. Sub-PRs use `Part of #EPIC`, never `Closes #N` (auto-close fires only on default-branch merges; "Closes" on a feature-branch PR leaves the issue stuck open). Only the final feature → develop merge should `Closes #1 #2 ...` to close the children.
+
+This rule prevents the failure mode where wave-1 PRs get dispatched to `develop` directly, requiring halt + recovery once the user catches the missing epic branch.
+
+## Order TaskCreate AFTER TeamCreate
+
+Tasks created via `TaskCreate` *before* `TeamCreate` land in the lead's session-local task list, not the team's shared list. After `TeamCreate`, those tasks are invisible to the team and must be recreated. **Always call `TeamCreate` first, then `TaskCreate`.** This applies whether you're spawning the team via `/spawn-team` (which calls `TeamCreate` internally) or manually.
+
+If you find yourself with tasks in flight before the team is created, either delay the team spawn or accept the duplication cost.
+
+## Proactive between-wave swaps
+
+Long-lived roles (architect, reviewer, tester) accumulate context across waves. Reactive swaps mid-wave are expensive: a context-saturated agent stops processing inbox messages, the lead can't shut it down, and replacement requires user-level pane intervention.
+
+**Between every wave-merge boundary, audit context budgets:**
+- If tester / reviewer / architect have been alive across ≥2 waves of work, swap them proactively before dispatching the next wave.
+- The wave-boundary swap is cheap: handoff is implicit (task list + merged PRs encode all state), no in-flight rebases, no half-written test branches, no dangling review verdicts.
+- Builders are exception: they reset their worktree between tasks, so context resets naturally per-task. No swap unless an individual builder shows context strain.
+
+**Default heuristic if you have no direct insight into an agent's context budget:** swap after 2 waves of activity. Cheap insurance.
+
+**Swap procedure:**
+1. SendMessage shutdown_request to the outgoing agent (with reason)
+2. Wait for `teammate_terminated` notification (avoid name collision auto-suffix)
+3. Spawn replacement via `Agent` with same `name`, `subagent_type`, `team_name`, and explicit `model:` param (since frontmatter `model:` is not honored by the spawn pathway)
+4. Brief the replacement with inherited state (worktree path, branch, open PRs, in-flight contracts, gotchas the predecessor discovered)
+
+For tester/reviewer/architect, the explicit `model: "opus"` is currently the best available — `[1m]` suffix is rejected by the Agent validator at all sites.
+
+## PR review gate workflow
+
+The builder.md rule is "no commit/push/PR without explicit lead PASS-acknowledged go-ahead" (see `builder.md` § "Reviewer FAIL gates the PR"). Lead's responsibility is to issue the green-light at the right point in the cycle. Sequence:
+
+1. **Builder ships `gates green` status** to lead via SendMessage — no commit yet, no PR yet, just a diff summary + verification results
+2. **Lead green-lights** with the explicit `gh pr create` command (lead can briefly skim the ship report; full review is the reviewer's job)
+3. **Builder commits + pushes + opens PR** — reports PR # back, then idles
+4. **Lead routes PR # to reviewer** with the standing spot-check list
+5. **Reviewer verdict**: APPROVE / APPROVE WITH NOTES / FAIL
+6. **On FAIL**: lead routes change requests to builder; builder pushes fixes to same branch (PR auto-updates); lead re-routes to reviewer for the delta-only check
+7. **On APPROVE**: lead merges (squash, with PR title + "Part of #EPIC" body for sub-PRs)
+8. **Lead instructs builder** to reset worktree to post-merge head + await next dispatch
+
+Don't pipeline ack-required steps (e.g. "open PR for #X then start #Y") — per-deliverable ack gating applies (per its own rule above). Each PR-open and each merge is a separate ack-required round-trip.
+
+**Common drift to prevent**: lead sometimes sends two messages — first a "GO commit/push/PR" green-light, then a follow-up "actually wait for reviewer first." Builder may execute the first before reading the second. Either commit to the original green-light OR send the hold *before* the GO. Don't send conflicting instructions in adjacent messages.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,6 +1,7 @@
 ---
 name: tester
 description: Test authoring + execution — writes Vitest tests following project BDD/colocation conventions; runs the suite to verify.
+model: opus[1m]
 tools: "*"
 ---
 

--- a/.claude/skills/spawn-team/skill.md
+++ b/.claude/skills/spawn-team/skill.md
@@ -32,33 +32,72 @@ The user may override the count explicitly: *"spawn the team with 3 builders"*, 
 - Count = 1: name is `builder` (no suffix). Preserves the historical singleton convention.
 - Count > 1: names are `builder-1`, `builder-2`, ... `builder-N`. Numbered from 1 (not 0). The `-N` suffix here is **intentional and stable**, distinct from the spawn-flake `-2` ghost-name pattern that arises from failed retries.
 
-## Isolation mode — default to worktrees for parallel waves
+## Worktree isolation — manual creation required
 
-**Default for `BUILDER_COUNT > 1`: spawn each builder with `isolation: "worktree"`.** Each builder gets its own clean checkout of `main` (or develop), independent `node_modules`, isolated branch space. Strictly better than shared workspace for parallel-builder waves:
+**Background**: `Agent({isolation: "worktree", team_name: ...})` does NOT fire — verified 2026-04-26. The `isolation` parameter is silently dropped when combined with `team_name`, and spawned agents land in the main workspace. Until the harness is fixed, **the lead must create worktrees manually before spawning** any builder beyond the first AND for the tester.
 
+**Why isolation matters**:
 - Zero verification-gate contamination — sibling builders' destructive edits (file deletions, shared-export removals) cannot break your `npx tsc -b --noEmit` baseline
 - Zero workspace HEAD drift — no risk of `git status` reporting you on a sibling's branch
 - Clean PR diffs — your commit cannot silently absorb sibling work in shared files
 - Each builder commits + pushes from their own worktree → reviewer pickup is canonical
+- Tester runs `git checkout`/`git commit`/`npm run test:run` operations that swap branch context — sharing the workspace with the lead corrupts the lead's commit graph
 
-**Cost** (acceptable, paid once per worktree): `npm install` (~30s), `cp ../../.env.local .env.local` (Spotify env for tests, ~instant), node_modules disk space duplication (~500MB × N). Worth it.
+**Cost** (paid once per worktree): `npm install` (~30s), `cp ../.env.local .env.local` (Spotify env for tests, ~instant), node_modules disk space duplication (~500MB × N). Acceptable.
 
-**`BUILDER_COUNT == 1`** can stay in shared workspace (no parallel conflict possible). But for any wave with parallel builders, set `isolation: "worktree"` on the spawn `Agent` call.
+### Worktree setup pattern (run BEFORE spawning each isolated agent)
 
-**Default for tester: spawn with `isolation: "worktree"` whenever the lead operates in the main workspace** (which is essentially always — the lead cannot easily move). The tester runs `git checkout`, `git commit`, and `npm run test:run` operations that swap branch context; when both lead and tester share `/Users/roman/src/vorbis-player`, the tester's branch operations land under the lead's open session and corrupt the lead's commit graph. Worktree isolation eliminates this class of contamination at the same ~30s `npm install` cost paid by builders:
+```bash
+# Once, up front: fetch latest develop
+git fetch origin develop --quiet
 
-- Lead's branch context stays stable for the entire session
-- Tester's `git commit` / `npm run test:run` operations are fully sandboxed
-- Test PRs from the tester carry clean diffs with no accidental lead-session commits absorbed
+# Per agent that needs isolation (each builder when BUILDER_COUNT > 1, plus tester):
+NAME="builder-1"  # or builder-2, ..., or "tester"
+WORKTREE_PATH=".claude/worktrees/${NAME}"
+git worktree add "${WORKTREE_PATH}" -b "worktree-agent-${NAME}" origin/develop
+cp .env.local "${WORKTREE_PATH}/.env.local" 2>/dev/null || true
+(cd "${WORKTREE_PATH}" && npm install) &  # background; wait at end
+```
 
-When using worktrees, the spawn prompt should include the pre-flight setup instructions:
+Run all `npm install` invocations in parallel (background `&`), then `wait` once before proceeding to spawn. Saves ~90s when spawning 3 builders + tester.
+
+After worktrees exist, spawn each agent and pass the worktree path explicitly in the prompt — agents otherwise have no knowledge of which directory they should target. **Do NOT pass `isolation: "worktree"`** on the Agent call — it's a no-op and creates confusion in logs.
+
+### Spawn prompt template (worktree-aware)
 
 ```
-## Pre-flight (run first in your isolated worktree)
-npm install
-cp ../../.env.local .env.local 2>/dev/null || true
-# (then any task-specific dep install, e.g. `npm install @radix-ui/react-switch`)
+You are "{name}" on the vorbis-crew team. Your full role definition is in
+.claude/agents/{role}.md — read it now.
+
+## YOUR ISOLATED WORKTREE
+**Working directory: `/Users/roman/src/vorbis-player/.claude/worktrees/{name}`**
+**Current branch: `worktree-agent-{name}`** (off origin/develop, clean)
+
+ALL work — Read, Edit, Write, Bash, git operations — must use absolute paths
+inside this worktree, NOT the main workspace at /Users/roman/src/vorbis-player.
+The main workspace is the lead's session; do not touch files there.
+
+`npm install` is already complete; `.env.local` is already copied.
+
+When you start an actual task, create a feature branch from your current
+worktree-agent-{name}:
+  git -C /Users/roman/src/vorbis-player/.claude/worktrees/{name} checkout -b feat/<slug>-<issue>
+
+Acknowledge in one sentence. Then go idle.
 ```
+
+**`BUILDER_COUNT == 1`** can stay in shared workspace (no parallel conflict possible) — skip worktree creation for that single builder.
+
+### When to clean up
+
+After the team disbands or the epic ships, remove worktrees and prune local branches:
+
+```bash
+git worktree remove .claude/worktrees/<name>
+git branch -D worktree-agent-<name>
+```
+
+Or use `swarmkit:clean-worktrees` for batch cleanup of all `worktree-agent-*` worktrees.
 
 ## Route interface contracts to BOTH builder AND tester
 
@@ -133,16 +172,23 @@ The current session becomes the team-lead by default.
 
 For each specialist not already alive, spawn via `Agent` in a single message with multiple parallel tool calls (background mode so the lead can continue). Builders are templated — instantiate one `Agent` call per builder name resolved in Phase 1.
 
-| Role | `subagent_type` | `name` | `model` (override) |
+| Role | `subagent_type` | `name` | `model` (Agent param) |
 |---|---|---|---|
-| explorer | `explorer` | `explorer` | (default) |
-| architect | `architect` | `architect` | `opus[1m]` |
+| explorer | `explorer` | `explorer` | `sonnet` |
+| architect | `architect` | `architect` | `opus` |
 | builder (singleton, count=1) | `builder` | `builder` | `opus` |
 | builder (multi, count>1) | `builder` | `builder-1`, `builder-2`, … `builder-N` | `opus` |
-| reviewer | `reviewer` | `reviewer` | `sonnet` |
-| tester | `tester` | `tester` | `sonnet` |
+| reviewer | `reviewer` | `reviewer` | `opus` |
+| tester | `tester` | `tester` | `opus` |
 
 All builder instances share the same `subagent_type` (`builder`) and the same `.claude/agents/builder.md` definition — they're parallel workers, not differentiated specialists. The `name` is the only thing that varies.
+
+**Model param constraints (verified 2026-04-26)**: `Agent({model})` strictly accepts ONE of `"sonnet" | "opus" | "haiku"`. Any other form is rejected with `InputValidationError`:
+- `"opus[1m]"` → ❌ rejected
+- `"sonnet[1m]"` → ❌ rejected
+- `"claude-opus-4-7[1m]"` → ❌ rejected
+
+Frontmatter `model:` in `.claude/agents/*.md` is **also ignored** by the spawn pathway — only the explicit Agent param controls the spawned model. The `[1m]` mechanism documented for top-level Claude Code config does not propagate to subagent spawns. The 1M context is unreachable until the harness is fixed; **compensate via proactive between-wave swaps** (per `team-lead.md`).
 
 **Use the project-local `subagent_type`** (the lowercase role name matching the `.claude/agents/{name}.md` file). This loads the agent definition with the correct tools (including `SendMessage` for architect and reviewer — the upstream `feature-dev:*` types omit it, which structurally breaks team communication).
 


### PR DESCRIPTION
## Summary
- Stop-gap apply of `vorbis-crew-retro-2026-04-26` findings from the library-redesign epic team session.
- Canonical updates are tracked upstream in [smallorbit-plugins#612](https://github.com/smallorbit/smallorbit-plugins/issues/612); this PR carries them locally until the plugin update lands.

## Changes
- `agents/*.md`: pin `model: opus[1m]` for opus-tier roles
- `agents/team-lead.md`: epic-branch pre-flight, TaskCreate-after-TeamCreate ordering, proactive between-wave swaps, PR review gate workflow
- `skills/spawn-team/skill.md`: document manual worktree creation pattern (`Agent({isolation: "worktree"})` is a no-op when combined with `team_name`)

## Test plan
- [ ] Local edits only — no production code touched
- [ ] Confirm next team spawn picks up the updated guidance