### PR TITLE
fix(library): mount LibraryRoute on active-playlist surface

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -368,11 +368,40 @@ const AudioPlayerComponent = () => {
       );
     }
 
+    if (state.currentView === 'library') {
+      return (
+        <Suspense fallback={null}>
+          <LibraryRoute
+            onPlaylistSelect={(id, name, provider) => {
+              handlers.handleCloseLibrary();
+              handlePlaylistSelect(id, name ?? '', provider);
+            }}
+            onPlayLikedTracks={handlePlayLikedTracks}
+            onQueueLikedTracks={handleQueueLikedTracks}
+            onOpenSettings={handleOpenSettings}
+            onResume={handleResume}
+            lastSession={lastSession}
+            isPlaying={state.isPlaying}
+            isRadioAvailable={radio.isRadioAvailable}
+            isRadioGenerating={radio.radioState?.isGenerating}
+            onMiniPlay={playbackHandlers.onPlay}
+            onMiniPause={playbackHandlers.onPause}
+            onMiniNext={playbackHandlers.onNext}
+            onMiniPrevious={playbackHandlers.onPrevious}
+            onMiniExpand={handlers.handleCloseLibrary}
+            onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
+            onPlayNext={undefined}
+            onStartRadioForCollection={undefined}
+          />
+        </Suspense>
+      );
+    }
+
     return (
       <ProfiledComponent id="PlayerContent">
         <PlayerContent
           isPlaying={state.isPlaying}
-          showLibrary={state.currentView === 'library'}
+          showLibrary={false}
           handlers={playbackHandlers}
           radioState={radio.radioState}
           isRadioAvailable={radio.isRadioAvailable}


### PR DESCRIPTION
## Summary

- Restore the LibraryRoute mount that was lost when #1298a deleted `LibraryDrawer` + `MobileLibraryOverlay` from `DrawerOrchestrator`.
- Without this fix, an authenticated user with an active playlist who taps the library button in the BottomBar sees the bar hide and **nothing else** — `state.currentView === 'library'` flips, `bottomBarActions.hidden=showLibrary` hides the bar, but no LibraryRoute is rendered.

## Repro (on `feature/library-redesign-1300` HEAD before this fix)

1. Connect Spotify (or Dropbox), pick a playlist, start playback.
2. Tap the library icon in the BottomBar.
3. **Before**: BottomBar disappears, surface is blank.
4. **After**: BottomBar disappears, full LibraryRoute (sections home + nav + sticky mini-player) takes over. Tapping the mini-player expand returns to the player.

## Approach

Inside `AudioPlayer.tsx`'s `renderContent`, the active-playlist branch now checks `state.currentView === 'library'` and returns `<LibraryRoute>` instead of `<PlayerContent>`, mirroring how `PlayerStateRenderer` handles its cold-start `libraryView`. The handler wiring is copied verbatim from the existing `needsSetup`-gated overlay further down the file (line ~470).

`<PlayerContent>` is still rendered in non-library state and now receives `showLibrary={false}` directly (TS narrowing made the previous expression unreachable).

## Verification

- `npx tsc -b --noEmit` — clean
- `npm run test:run` — 1541/1541 passing. The 3 failing test files (`signOutButton.test.tsx`, `switch.test.tsx`, etc.) fail because `@testing-library/user-event` isn't in `package.json`; pre-existing in the epic, unrelated to this fix.
- Lint — no new errors in `AudioPlayer.tsx`.

## Test plan

- [ ] Manual test on `feature/library-redesign-1300` with this PR merged: open library while playing → LibraryRoute renders, mini-player visible, expand returns to player.
- [ ] Verify `needsSetup`-time browse-library still works (the overlay at `AudioPlayer.tsx:~498` is untouched).
- [ ] Verify cold-start library view (`PlayerStateRenderer.libraryView`) still works.