### PR TITLE
fix(library): vertical scroll + hide resume card mid-session

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -380,7 +380,7 @@ const AudioPlayerComponent = () => {
             onQueueLikedTracks={handleQueueLikedTracks}
             onOpenSettings={handleOpenSettings}
             onResume={handleResume}
-            lastSession={lastSession}
+            lastSession={null}
             isPlaying={state.isPlaying}
             isRadioAvailable={radio.isRadioAvailable}
             isRadioGenerating={radio.radioState?.isGenerating}

--- a/src/components/LibraryRoute/styled.ts
+++ b/src/components/LibraryRoute/styled.ts
@@ -5,7 +5,8 @@ export const LibraryRouteRoot = styled.div`
   flex-direction: column;
   flex: 1;
   width: 100%;
-  height: 100%;
+  height: 100vh;
+  height: 100dvh;
   min-height: 0;
 `;
 


### PR DESCRIPTION
## Summary

- **Scroll fix**: `LibraryRouteRoot` was using `height: 100%`, which resolved to the content size because its ancestor (`Container` in AudioPlayer) only sets `min-height: 100dvh`, not a fixed height. The inner `MobileLayout`/`DesktopLayout` containers have `overflow-y: auto` but had nothing to scroll against. Changed `LibraryRouteRoot` to `height: 100dvh` (with `height: 100vh` fallback) so the overflow containers receive a bounded height and scroll activates on both desktop and mobile.

- **Resume card**: The active-playlist LibraryRoute mount added in PR #1318 was passing `lastSession={lastSession}` unconditionally, causing `ResumeSection`/`ResumeHero` to render a full Resume card while a track was already playing. The MiniPlayer at the bottom already provides the resume/expand affordance in that state. Fixed by passing `lastSession={null}` in the `state.currentView === 'library'` branch (active-playlist path); cold-start paths via `PlayerStateRenderer` are unaffected.

## Changes

- `src/components/LibraryRoute/styled.ts` — `LibraryRouteRoot`: `height: 100%` → `height: 100dvh` (with `100vh` fallback)
- `src/components/AudioPlayer.tsx` — active-playlist LibraryRoute mount: `lastSession={lastSession}` → `lastSession={null}`

## Test plan

- [ ] Open library mid-session (playlist loaded, track playing): verify no Resume card appears at top; MiniPlayer sticky bar visible at bottom
- [ ] Open library at cold-start (no active playlist): verify Resume card still appears when a previous session is available
- [ ] Scroll vertically through library sections on desktop (mouse wheel + scrollbar): confirm all sections reachable
- [ ] Scroll vertically on mobile (touch): confirm all sections reachable
- [ ] Confirm horizontal carousels (Recently Played, Pinned) still scroll horizontally
- [ ] Confirm MiniPlayer remains sticky at bottom during vertical scroll
- [ ] `npm run test:run`: 1541 tests pass; 3 pre-existing failures (popover/switch/accordion, issue #1319) are unrelated

Addresses vertical-scroll and resume-card-mid-session bugs found during manual testing of PR #1315.
Related: #1315, #1318