### PR TITLE
fix(dropbox): coalesce listCollections + honor 429 retry_after

### DIFF
--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -2,6 +2,43 @@ import type { DropboxFileEntry, DropboxListFolderResult, CachedLink } from './dr
 import { TEMP_LINK_TTL_MS } from './dropboxCatalogHelpers';
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 
+const DEFAULT_RETRY_AFTER_SECONDS = 5;
+const MAX_RETRY_AFTER_SECONDS = 30;
+
+async function parseRetryAfterSeconds(response: Response): Promise<number> {
+  const header = response.headers.get('retry-after');
+  if (header) {
+    const parsed = Number.parseInt(header, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  try {
+    const body = await response.clone().json() as { retry_after?: number };
+    if (typeof body?.retry_after === 'number' && body.retry_after > 0) return body.retry_after;
+  } catch {
+    // 429 body wasn't JSON; fall through to default.
+  }
+  return DEFAULT_RETRY_AFTER_SECONDS;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Request aborted', 'AbortError'));
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      reject(new DOMException('Request aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
 export class DropboxApiClient {
   private auth: DropboxAuthAdapter;
   private tempLinkCache = new Map<string, CachedLink>();
@@ -39,6 +76,13 @@ export class DropboxApiClient {
         this.auth.reportUnauthorized();
         throw new Error('Dropbox authentication expired');
       }
+    }
+
+    if (response.status === 429) {
+      const retryAfter = await parseRetryAfterSeconds(response);
+      const waitMs = Math.min(Math.max(retryAfter, 1), MAX_RETRY_AFTER_SECONDS) * 1000;
+      await sleep(waitMs, signal);
+      response = await makeRequest(token);
     }
 
     if (!response.ok) {

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -58,6 +58,11 @@ export class DropboxCatalogAdapter implements CatalogProvider {
   private apiClient: DropboxApiClient;
   private artworkResolver: DropboxArtworkResolver;
   private knownTracks = new Map<string, MediaTrack>();
+  // Coalesce concurrent listCollections() callers onto a single in-flight fetch.
+  // Multiple LibraryRoute section hooks (albums/liked/pinned/playlists/recents) each
+  // call useLibrarySync() and fan out to listCollections() in parallel; without this,
+  // a cold cache triggers 5 simultaneous list_folder requests → Dropbox 429 storm.
+  private inflightListCollections: Promise<MediaCollection[]> | null = null;
 
   constructor(auth: DropboxAuthAdapter) {
     this.auth = auth;
@@ -92,6 +97,24 @@ export class DropboxCatalogAdapter implements CatalogProvider {
       }
     }
 
+    if (!options?.forceRefresh && this.inflightListCollections) {
+      return this.inflightListCollections;
+    }
+
+    const fetchPromise = this.fetchCollectionsFresh(signal);
+    if (!options?.forceRefresh) {
+      this.inflightListCollections = fetchPromise;
+    }
+    try {
+      return await fetchPromise;
+    } finally {
+      if (this.inflightListCollections === fetchPromise) {
+        this.inflightListCollections = null;
+      }
+    }
+  }
+
+  private async fetchCollectionsFresh(signal?: AbortSignal): Promise<MediaCollection[]> {
     try {
       const dirDisplayName = new Map<string, string>();
       const dirParent = new Map<string, string>();


### PR DESCRIPTION
## Summary

- Resolves the Dropbox 429 storm Roman saw while testing PR #1315.
- Two-layer fix: in-flight de-dup at the catalog adapter, and retry_after-aware backoff at the API client.

## Root cause

The new \`LibraryRoute\` has 5 section hooks — \`useAlbumsSection\`, \`useLikedSection\`, \`usePinnedSection\`, \`usePlaylistsSection\`, \`useRecentlyPlayedSection\` — and each one calls \`useLibrarySync()\` independently. \`useLibrarySync\` runs a mount effect that fans out \`catalog.listCollections()\` to every enabled provider. With a cold IndexedDB cache, that's 5 simultaneous \`/files/list_folder\` requests to Dropbox per LibraryRoute mount. Dropbox returns 429 \`{\"retry_after\": 5}\`, but \`DropboxApiClient.dropboxApi\` threw on any non-401, ignoring the hint, so callers immediately retried — keeping the rate-limit window pinned open.

The console trace Roman pasted (4 cycles of \`Failed to list collections: ... 429\`) is exactly this.

## Fix 1: in-flight de-dup (\`dropboxCatalogAdapter.ts\`)

Hold a single \`Promise<MediaCollection[]>\` on the adapter while a fetch is in flight. Concurrent callers share it. Cleared in \`finally\` so retries-after-error don't get stuck. \`forceRefresh\` callers bypass the in-flight slot (they're explicit "go fresh"). Cold-start fan-out collapses from N → 1.

## Fix 2: retry_after backoff (\`dropboxApiClient.ts\`)

On 429, parse \`retry_after\` (Dropbox returns it in the JSON body; \`Retry-After\` header used as fallback), sleep up to 30s honoring \`AbortSignal\`, retry once. Defensive — covers paths that bypass the adapter (e.g., \`prefetchTemporaryLink\` chains).

## Verification

- \`npx tsc -b --noEmit\` clean
- \`npm run test:run\` — 1541/1541 passing (3 pre-existing test-file failures unrelated; see #1319)

## Test plan

- [ ] Manual: with a cold cache (clear IndexedDB), open the new LibraryRoute and confirm only ONE \`list_folder\` request fires per provider in the Network tab.
- [ ] Manual: simulate a 429 by throttling requests in DevTools or temporarily lowering the dedup window — confirm the request retries once after ~5s instead of cascading.
- [ ] Cold-start path (no playlist active) still loads the library normally.

## Followup

Spotify catalog (\`spotifyCatalogAdapter.ts\`) has the same fan-out shape but Spotify's rate limit is more permissive and didn't surface in Roman's logs. If we see Spotify 429s later, lift the in-flight pattern there too. Out of scope for this PR.