### PR TITLE
fix(library): context menu parity + provider logo on cards

### DIFF
--- a/src/components/LibraryRoute/card/LibraryCard.styled.ts
+++ b/src/components/LibraryRoute/card/LibraryCard.styled.ts
@@ -62,16 +62,11 @@ export const ArtPlaceholder = styled.div`
   color: ${theme.colors.muted.foreground};
 `;
 
-export const ProviderBadge = styled.span`
+export const ProviderBadge = styled.div`
   position: absolute;
   top: ${theme.spacing.xs};
   right: ${theme.spacing.xs};
-  padding: 0 ${theme.spacing.xs};
-  border-radius: ${theme.borderRadius.sm};
-  background: rgba(0, 0, 0, 0.6);
-  color: ${theme.colors.white};
-  font-size: ${theme.fontSize.xs};
-  text-transform: capitalize;
+  line-height: 0;
 `;
 
 export const Title = styled.div`

--- a/src/components/LibraryRoute/card/LibraryCard.tsx
+++ b/src/components/LibraryRoute/card/LibraryCard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import type { ContextMenuRequest, LibraryItemKind } from '../types';
 import type { ProviderId } from '@/types/domain';
 import { useLongPress } from './useLongPress';
+import ProviderIcon from '@/components/ProviderIcon';
 import {
   CardButton,
   ArtWrap,
@@ -96,7 +97,11 @@ const LibraryCard: React.FC<LibraryCardProps> = ({
         ) : (
           <ArtPlaceholder>{placeholderGlyphForKind(kind)}</ArtPlaceholder>
         )}
-        {showProviderBadge && provider && <ProviderBadge>{provider}</ProviderBadge>}
+        {showProviderBadge && provider && (
+          <ProviderBadge>
+            <ProviderIcon provider={provider} size={20} />
+          </ProviderBadge>
+        )}
       </ArtWrap>
       <Title>{name}</Title>
       {subtitle && <Subtitle>{subtitle}</Subtitle>}

--- a/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
+++ b/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
@@ -3,6 +3,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import LibraryCard from '../LibraryCard';
 
+vi.mock('@/components/ProviderIcon', () => ({
+  default: ({ provider }: { provider: string }) => (
+    <span data-testid={`provider-icon-${provider}`} />
+  ),
+}));
+
 const baseProps = {
   kind: 'playlist' as const,
   id: 'p1',
@@ -29,16 +35,16 @@ describe('LibraryCard', () => {
     expect(screen.getByText('♪')).toBeInTheDocument();
   });
 
-  it('shows provider badge only when showProviderBadge is true', () => {
+  it('shows provider icon only when showProviderBadge is true', () => {
     // #given
     const { rerender } = render(<LibraryCard {...baseProps} provider="spotify" />);
-    expect(screen.queryByText('spotify')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('provider-icon-spotify')).not.toBeInTheDocument();
 
     // #when
     rerender(<LibraryCard {...baseProps} provider="spotify" showProviderBadge />);
 
     // #then
-    expect(screen.getByText('spotify')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-icon-spotify')).toBeInTheDocument();
   });
 
   it('fires onSelect on click when no onContextMenuRequest', () => {

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -7,6 +7,7 @@ import type { ContextMenuRequest } from '../types';
 import type { ProviderId, MediaTrack } from '@/types/domain';
 import { useLikedTracksForProvider } from './useLikedTracksForProvider';
 import { useAlbumSavedStatus } from './useAlbumSavedStatus';
+import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
 import {
   buildMenuItems,
   type MenuActions,
@@ -50,6 +51,7 @@ export interface LibraryContextMenuProps {
     collectionName: string,
     provider?: ProviderId,
   ) => Promise<void> | void;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
 }
 
 const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
@@ -60,6 +62,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
   onPlayNext,
   onStartRadioForCollection,
   onPlayLikedTracks,
+  onQueueLikedTracks,
 }) => {
   const {
     isPlaylistPinned,
@@ -70,6 +73,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
   const { remove: removeRecent } = useRecentlyPlayedCollections();
   const { perProvider } = useLikedSection();
   const { loadLikedTracks } = useLikedTracksForProvider();
+  const { queueLikedFromCollection } = useQueueLikedFromCollection(onQueueLikedTracks);
 
   const albumIdForSaveStatus =
     request?.kind === 'album'
@@ -169,6 +173,15 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
       actions.isSaved = isSaved;
     }
 
+    if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
+      const collectionId = request.id;
+      const collectionName = request.name;
+      const provider = request.provider;
+      actions.onQueueLikedFromCollection = closeAfter(() =>
+        queueLikedFromCollection(collectionId, collectionName, provider),
+      );
+    }
+
     if (request.kind === 'recently-played' && request.recentRef) {
       const recentRef = request.recentRef;
       actions.onRemoveFromHistory = closeAfter(() => {
@@ -211,6 +224,8 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     canToggleSaved,
     isSaved,
     toggleSaved,
+    onQueueLikedTracks,
+    queueLikedFromCollection,
   ]);
 
   if (!request) return null;

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -29,6 +29,14 @@ vi.mock('../useLikedTracksForProvider', () => ({
   useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
 }));
 
+const { mockQueueLikedFromCollection } = vi.hoisted(() => ({
+  mockQueueLikedFromCollection: vi.fn(),
+}));
+
+vi.mock('../useQueueLikedFromCollection', () => ({
+  useQueueLikedFromCollection: () => ({ queueLikedFromCollection: mockQueueLikedFromCollection }),
+}));
+
 vi.mock('../useAlbumSavedStatus', () => ({
   useAlbumSavedStatus: () => ({
     isSaved: null,
@@ -268,5 +276,55 @@ describe('LibraryContextMenu', () => {
 
     // #then
     expect(onAddToQueue).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify');
+  });
+
+  it('shows Queue Liked Songs item when onQueueLikedTracks provided for playlist', () => {
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+      onQueueLikedTracks: vi.fn(),
+    });
+
+    // #then
+    expect(screen.getByTestId('menu-queue-liked')).toBeInTheDocument();
+  });
+
+  it('Queue Liked Songs invokes queueLikedFromCollection with collection id/name/provider', () => {
+    // #given
+    const onQueueLikedTracks = vi.fn();
+    const onClose = vi.fn();
+
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+      onQueueLikedTracks,
+      onClose,
+    });
+    fireEvent.click(screen.getByTestId('menu-queue-liked'));
+
+    // #then
+    expect(mockQueueLikedFromCollection).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('omits Queue Liked Songs when onQueueLikedTracks is not provided', () => {
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist' }),
+    });
+
+    // #then
+    expect(screen.queryByTestId('menu-queue-liked')).not.toBeInTheDocument();
+  });
+
+  it('omits Queue Liked Songs when provider is missing', () => {
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'playlist', provider: undefined }),
+      onQueueLikedTracks: vi.fn(),
+    });
+
+    // #then
+    expect(screen.queryByTestId('menu-queue-liked')).not.toBeInTheDocument();
   });
 });

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
@@ -179,4 +179,38 @@ describe('buildMenuItems', () => {
     // #then
     expect(items.find((i) => i.id === 'play-next')?.disabled).toBe(true);
   });
+
+  it('adds queue-liked item for playlist when onQueueLikedFromCollection provided', () => {
+    // #given
+    const actions = makeActions({ onQueueLikedFromCollection: vi.fn() });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'queue-liked')).toBeDefined();
+    expect(items.find((i) => i.id === 'queue-liked')?.label).toBe('Queue Liked Songs');
+  });
+
+  it('adds queue-liked item for album when onQueueLikedFromCollection provided', () => {
+    // #given
+    const actions = makeActions({ onQueueLikedFromCollection: vi.fn() });
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'queue-liked')).toBeDefined();
+  });
+
+  it('omits queue-liked item when onQueueLikedFromCollection is undefined', () => {
+    // #given
+    const actions = makeActions();
+
+    // #when
+    const items = buildMenuItems(makeRequest({ kind: 'playlist' }), actions);
+
+    // #then
+    expect(items.find((i) => i.id === 'queue-liked')).toBeUndefined();
+  });
 });

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -16,6 +16,7 @@ export interface MenuActions {
   onTogglePin: () => void;
   onToggleSave?: () => void;
   onStartRadio: () => void;
+  onQueueLikedFromCollection?: () => void;
   likedProviderActions?: Array<{ provider: ProviderId; label: string; onPlay: () => void }>;
   onRemoveFromHistory?: () => void;
   isPinned?: boolean;
@@ -25,7 +26,7 @@ export interface MenuActions {
 }
 
 function buildPlaylistItems(actions: MenuActions): MenuItem[] {
-  return [
+  const items: MenuItem[] = [
     { id: 'play', label: 'Play', onSelect: actions.onPlay },
     { id: 'add-to-queue', label: 'Add to Queue', onSelect: actions.onAddToQueue },
     {
@@ -46,6 +47,14 @@ function buildPlaylistItems(actions: MenuActions): MenuItem[] {
       disabled: actions.startRadioDisabled === true,
     },
   ];
+  if (actions.onQueueLikedFromCollection) {
+    items.push({
+      id: 'queue-liked',
+      label: 'Queue Liked Songs',
+      onSelect: actions.onQueueLikedFromCollection,
+    });
+  }
+  return items;
 }
 
 function buildAlbumItems(actions: MenuActions): MenuItem[] {
@@ -77,6 +86,13 @@ function buildAlbumItems(actions: MenuActions): MenuItem[] {
     onSelect: actions.onStartRadio,
     disabled: actions.startRadioDisabled === true,
   });
+  if (actions.onQueueLikedFromCollection) {
+    items.push({
+      id: 'queue-liked',
+      label: 'Queue Liked Songs',
+      onSelect: actions.onQueueLikedFromCollection,
+    });
+  }
   return items;
 }
 

--- a/src/components/LibraryRoute/contextMenu/useQueueLikedFromCollection.ts
+++ b/src/components/LibraryRoute/contextMenu/useQueueLikedFromCollection.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { providerRegistry } from '@/providers/registry';
+import { resolvePlaylistRef } from '@/constants/playlist';
+
+async function fetchLikedTracksForCollection(
+  collectionId: string,
+  provider: ProviderId,
+): Promise<MediaTrack[]> {
+  const descriptor = providerRegistry.get(provider);
+  if (!descriptor?.catalog.listTracks || !descriptor.catalog.isTrackSaved) return [];
+
+  const { id, kind } = resolvePlaylistRef(collectionId, provider);
+  const allTracks = await descriptor.catalog.listTracks({ provider, kind, id });
+
+  const savedResults = await Promise.all(
+    allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false)),
+  );
+
+  return allTracks.filter((_, i) => savedResults[i]);
+}
+
+export interface UseQueueLikedFromCollectionResult {
+  queueLikedFromCollection: (
+    collectionId: string,
+    collectionName: string,
+    provider: ProviderId,
+  ) => void;
+}
+
+export function useQueueLikedFromCollection(
+  onQueueLikedTracks: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined,
+): UseQueueLikedFromCollectionResult {
+  const queueLikedFromCollection = useCallback(
+    (collectionId: string, collectionName: string, provider: ProviderId) => {
+      if (!onQueueLikedTracks) return;
+      void fetchLikedTracksForCollection(collectionId, provider).then((tracks) => {
+        if (tracks.length > 0) onQueueLikedTracks(tracks, collectionName);
+      });
+    },
+    [onQueueLikedTracks],
+  );
+
+  return { queueLikedFromCollection };
+}


### PR DESCRIPTION
## Summary

- Restores **Queue Liked Songs** from collection in `LibraryContextMenu` (Task 3 — parity gap vs legacy `useItemActions`)
- Replaces provider **name text** with provider **logo icon** on collection cards (Task 4)

## Changes

### Task 3 — Queue Liked Songs from collection

**New file:** `contextMenu/useQueueLikedFromCollection.ts`
- Fetches all tracks for the collection via `catalog.listTracks`
- Filters to liked tracks via `catalog.isTrackSaved` per-track
- Calls `onQueueLikedTracks(tracks, collectionName)` if any liked tracks found

**`menuItemsForKind.ts`**
- `MenuActions` gains `onQueueLikedFromCollection?: () => void`
- `buildPlaylistItems` and `buildAlbumItems` both append `queue-liked` item when the action is present

**`LibraryContextMenu.tsx`**
- `LibraryContextMenuProps` gains `onQueueLikedTracks?: (tracks, name?) => void` (already in `LibraryRouteProps` — no AudioPlayer.tsx changes needed)
- Wires `useQueueLikedFromCollection` hook; injects `onQueueLikedFromCollection` into `actions` for playlist/album kinds when `request.provider` is present

### Task 4 — Provider logo on cards

**`LibraryCard.tsx`** — imports `ProviderIcon`, renders it inside `ProviderBadge` instead of the raw provider string
**`LibraryCard.styled.ts`** — `ProviderBadge` converted from styled `span` (text layout) to styled `div` (icon wrapper, `line-height: 0`)

### Legacy options audit (Task 3 — full comparison)

All actions from the legacy `useItemActions` / `popoverOptions` were compared against the new `menuItemsForKind`. Findings:

| Legacy action | Status in new menu |
|---|---|
| Play collection | Present (play) |
| Add to Queue (collection) | Present (add-to-queue) |
| Play Liked | Present (play via onPlayLikedTracks) |
| **Queue Liked Songs** | **Restored in this PR** |
| Save/Unsave album | Present (toggle-save, album only) |
| Pin/Unpin | Present (toggle-pin) |
| Play Next | Present (play-next) |
| Start Radio | Present (start-radio) |
| Remove from history | Present (recently-played only) |
| Delete playlist | Not present — legacy required `hasDeleteCollection` capability; deferred per blueprint |
| View externally | Not present — legacy used `getExternalUrl`; deferred per blueprint |

Only the named gap and one obvious behavioral gap (Queue Liked) were restored. Delete and external-link are capability-gated features deferred to follow-up.

## Test plan

- 7 new tests covering `queue-liked` item presence/absence and invocation wiring
- `LibraryCard.test.tsx` provider badge assertion updated to check for `ProviderIcon` test id
- `npm run test:run`: 1535 passed, 5 pre-existing failures (cmdk + @testing-library/user-event resolution)
- `npx tsc -b --noEmit`: 1 pre-existing error (cmdk), no new errors

Closes #1315 (parity gaps)