### PR TITLE
fix(spotify): throw AuthExpiredError on missing player auth

### DIFF
--- a/src/hooks/__tests__/usePlaylistManager.test.ts
+++ b/src/hooks/__tests__/usePlaylistManager.test.ts
@@ -140,8 +140,9 @@ describe('usePlaylistManager', () => {
   it('calls redirectToAuth on auth error', async () => {
     // #given - mock auth failure
     const { spotifyPlayer } = await import('@/services/spotifyPlayer');
+    const { AuthExpiredError } = await import('@/providers/errors');
     vi.mocked(spotifyPlayer.initialize).mockRejectedValueOnce(
-      new Error('User must be authenticated before initializing player')
+      new AuthExpiredError('spotify')
     );
 
     const { result } = renderHook(() => usePlaylistManager(defaultProps));

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -10,6 +10,7 @@
 import { useCallback } from 'react';
 import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth, getLargestImage } from '@/services/spotify';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
+import { AuthExpiredError } from '@/providers/errors';
 import { isAlbumId, extractAlbumId, LIKED_SONGS_ID } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import type { ProviderId, MediaTrack } from '@/types/domain';
@@ -218,7 +219,7 @@ export const useSpotifyPlaylistManager = ({
       return tracksToPlay;
 
     } catch (err: unknown) {
-      if (err instanceof Error && err.message.includes('authenticated')) {
+      if (err instanceof AuthExpiredError) {
         setError("Authentication expired. Redirecting to Spotify login...");
         spotifyAuth.redirectToAuth();
       } else {

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -1,4 +1,5 @@
 import { spotifyAuth } from './spotify';
+import { AuthExpiredError } from '@/providers/errors';
 import { logSpotify } from '@/lib/debugLog';
 import {
   SPOTIFY_MAX_RETRIES,
@@ -52,7 +53,7 @@ class SpotifyPlayerService {
 
   async initialize(): Promise<void> {
     if (!spotifyAuth.isAuthenticated()) {
-      throw new Error('User must be authenticated before initializing player');
+      throw new AuthExpiredError('spotify');
     }
 
     if (this.player) {
@@ -65,7 +66,7 @@ class SpotifyPlayerService {
 
   private setupPlayer(): void {
     if (!spotifyAuth.isAuthenticated()) {
-      throw new Error('No Spotify access token available');
+      throw new AuthExpiredError('spotify');
     }
 
     this.player = new window.Spotify.Player({


### PR DESCRIPTION
## Summary

- Stops the cascading \"Failed to play track\" errors Roman saw when Spotify auth went stale during the new library flow.
- Routes auth failures from \`spotifyPlayer.initialize\` through the existing \`AuthExpiredError\` plumbing so the reconnect toast surfaces instead of the skip-on-error loop walking every track in the album.

## Root cause

\`spotifyPlayer.initialize\` (and \`setupPlayer\`) threw a generic \`Error('User must be authenticated before initializing player')\` when \`spotifyAuth.isAuthenticated()\` returned false. \`useProviderPlayback\`'s catch handler only recognizes \`AuthExpiredError\` as the auth-failure signal:

\`\`\`ts
if (error instanceof AuthExpiredError) {
  onAuthExpired?.(error.providerId);
  return;
}
// ... otherwise fall through to skip-on-error
\`\`\`

The generic error fell through to the recursive \`playTrack(index + 1, skipOnError)\` path, which walked the entire album queue, each track failing identically. That's the 6+ identical errors Roman saw per album attempt — and no reconnect prompt because the structured handler never fired.

## Fix

1. \`spotifyPlayer.initialize\` and \`setupPlayer\` now throw \`AuthExpiredError('spotify')\`.
2. \`useSpotifyPlaylistManager\` detects \`AuthExpiredError\` via \`instanceof\` instead of string-matching \`err.message.includes('authenticated')\`.
3. Corresponding test (\`usePlaylistManager.test.ts\`) updated to inject \`AuthExpiredError\` rather than a free-text Error string.

The existing \`SESSION_EXPIRED_EVENT\` listener in \`ProviderContext\` handles the rest — sets the reconnect prompt and disconnect toast.

## Verification

- \`npx tsc -b --noEmit\` clean
- \`npm run test:run\` — 1541/1541 passing (3 pre-existing test-file failures unrelated; see #1319)

## Test plan

- [ ] Manual: revoke Spotify token mid-session (e.g., \`localStorage.removeItem('spotify_token')\` + \`location.reload()\`), then click an album to play. Expect: single error log, reconnect toast appears, no skip-loop.
- [ ] Manual: with valid auth, normal album play still works.
- [ ] Manual: Dropbox-only flow unaffected (different provider, AuthExpiredError already worked there).

## Out of scope

\`SpotifyAuth.ensureValidToken\` at \`auth.ts:199\` still throws a generic \`Error('No authentication token available')\`. Callers like \`tracks.ts:_flushBatch\` and \`spotifyPlaybackAdapter.activateDevice\` swallow the error in their own try/catch, so it doesn't cascade — but if more callers surface, lift this to \`AuthExpiredError\` too.