### PR TITLE
fix(library): context menu wiring + search by artist + visualizer z-index

### DIFF
--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -60,6 +60,7 @@ export interface LibraryRouteProps {
 const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onPlaylistSelect,
   onPlayLikedTracks,
+  onQueueLikedTracks,
   onResume,
   lastSession,
   onAddToQueue,
@@ -210,6 +211,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         onPlayNext={onPlayNext}
         onStartRadioForCollection={onStartRadioForCollection}
         onPlayLikedTracks={handlePlayLikedFromMenu}
+        onQueueLikedTracks={onQueueLikedTracks}
       />
       <MiniPlayer
         isPlaying={isPlaying}

--- a/src/components/LibraryRoute/search/searchMatch.ts
+++ b/src/components/LibraryRoute/search/searchMatch.ts
@@ -5,9 +5,14 @@ export function normalizeQuery(q: string): string {
   return q.trim().toLowerCase();
 }
 
-export function matchesQuery(item: { name: string }, normalizedQuery: string): boolean {
+export function matchesQuery(
+  item: { name: string; ownerName?: string | null },
+  normalizedQuery: string,
+): boolean {
   if (!normalizedQuery) return true;
-  return item.name.toLowerCase().includes(normalizedQuery);
+  if (item.name.toLowerCase().includes(normalizedQuery)) return true;
+  if (item.ownerName && item.ownerName.toLowerCase().includes(normalizedQuery)) return true;
+  return false;
 }
 
 export function passesProviderFilter(

--- a/src/components/LibraryRoute/styled.ts
+++ b/src/components/LibraryRoute/styled.ts
@@ -8,6 +8,8 @@ export const LibraryRouteRoot = styled.div`
   height: 100vh;
   height: 100dvh;
   min-height: 0;
+  position: relative;
+  z-index: 2;
 `;
 
 export const MobileLayout = styled.div`


### PR DESCRIPTION
## Summary

Three small post-merge bugs Roman caught while testing #1315:

1. **Queue Liked Songs context-menu item didn't render** — PR #1322 added the action but LibraryRoute didn't forward \`onQueueLikedTracks\` to LibraryContextMenu, so the conditional gate stayed falsy.
2. **Search only matched collection name** — \"stone\" returned only \"Milestones\" (Miles Davis album), missing Stone Temple Pilots because artist/owner wasn't searched.
3. **Background visualizer bled through the library** — visualizer is position:fixed z-index:1, LibraryRouteRoot was non-positioned, so the visualizer painted on top by CSS stacking rules.

## Fixes

- \`LibraryRoute/index.tsx\` — destructure and forward \`onQueueLikedTracks\` to LibraryContextMenu (2 lines).
- \`LibraryRoute/search/searchMatch.ts\` — extend matchesQuery to also test \`item.ownerName\` (the album artist or playlist owner).
- \`LibraryRoute/styled.ts\` — add \`position: relative; z-index: 2\` to LibraryRouteRoot so it sits above visualizers (1) and accent background (0).

## Verification

- \`npx tsc -b --noEmit\` clean
- \`npm run test:run\` — 1548/1548 passing (3 pre-existing test-file failures, see #1319)

## Test plan

- [ ] Right-click an album/playlist in the library → \"Queue Liked Songs\" appears (when \`onQueueLikedTracks\` is plumbed; currently always plumbed via AudioPlayer).
- [ ] Search \"stone\" with Stone Temple Pilots albums in library → matches.
- [ ] Open library while a track plays with a visualizer enabled → no bleed-through.