### PR TITLE
fix(playback): UI/audio mismatch — sync queue before playTrack

### DIFF
--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -93,6 +93,14 @@ export const useProviderPlayback = ({
       return;
     }
 
+    // Sync the queue to the provider synchronously before playTrack so the
+    // adapter sees the current track list. The persistent useEffect-based
+    // onQueueChanged in usePlayerLogic only fires after React commits new
+    // state — too late for the playTrack we're about to await, which would
+    // otherwise hand Spotify a stale upcomingUris list (or no list at all
+    // on cold start) and let the SDK auto-advance into the wrong tracks.
+    descriptor.playback.onQueueChanged?.(tracks, index);
+
     try {
       await descriptor.playback.playTrack(mediaTrack, options);
       setCurrentTrackIndex(index);


### PR DESCRIPTION
## Summary

Fixes Roman's symptom: \"playing the wrong song in the playlist. It'll show the name of one song in the album art for that song, but they'll be playing a completely different song.\"

## Root cause

\`SpotifyPlaybackAdapter.pendingUpcomingUris\` (the list Spotify auto-advances through) is updated via a \`useEffect\` in \`usePlayerLogic\` that watches \`[tracks, currentTrackIndex]\`. The effect fires only **after** React commits new state.

When a new collection loads, \`useCollectionLoader\` runs:

\`\`\`ts
applyTracks(list);       // schedules state updates
await playTrack(0);      // ← runs before the useEffect commits
\`\`\`

So when \`playTrack\` calls into Spotify with \`[list[0].uri, ...pendingUpcomingUris]\`, \`pendingUpcomingUris\` is still pointing at the previous queue (or empty on a cold session). Spotify plays \`list[0]\` correctly, then auto-advances into:
- previous album's tracks (if there was one), or
- Spotify's track-radio recommendations (cold start).

Subscription's \`findIndex(advancedTrackId, list)\` returns -1, so \`currentTrackIndex\` stays at 0 in the UI while audio plays a stale/random track.

## Fix

In \`useProviderPlayback.playTrack\`, call \`descriptor.playback.onQueueChanged?.(tracks, index)\` synchronously right before \`descriptor.playback.playTrack(mediaTrack)\`. This pushes the current track list into the adapter before Spotify is told to play, eliminating the React-lifecycle race.

The persistent \`useEffect\`-based \`onQueueChanged\` in \`usePlayerLogic\` continues to fire on subsequent mutations (next/prev, queue reorder); now it just re-asserts a queue that's already current.

## Verification

- \`npx tsc -b --noEmit\` clean
- \`npm run test:run\` — 1548/1548 passing (3 pre-existing test-file failures unrelated; see #1319)

## Test plan

- [ ] Manual: open library, tap album, confirm UI track name + audio match for track 1.
- [ ] Manual: let track 1 finish, confirm Spotify auto-advances to album's track 2 (not previous album / not radio recommendation).
- [ ] Manual: switch albums mid-playback, confirm new album plays through correctly.
- [ ] Manual: works for both Spotify and Dropbox (Dropbox \`onQueueChanged\` is a no-op).