### PR TITLE
fix(library): anchor mobile SearchBar to bottom of scroll area

### DIFF
--- a/src/components/LibraryRoute/search/SearchBar.styled.ts
+++ b/src/components/LibraryRoute/search/SearchBar.styled.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
-import { MINI_PLAYER_HEIGHT_MOBILE } from '../MiniPlayer/MiniPlayer.styled';
 
 export const SearchBarRoot = styled.div<{ $variant: 'mobile' | 'desktop' }>`
   position: sticky;
@@ -15,7 +14,7 @@ export const SearchBarRoot = styled.div<{ $variant: 'mobile' | 'desktop' }>`
 
   ${({ $variant }) =>
     $variant === 'mobile'
-      ? `bottom: ${MINI_PLAYER_HEIGHT_MOBILE}px; border-top: 1px solid ${theme.colors.borderSubtle};`
+      ? `bottom: 0; border-top: 1px solid ${theme.colors.borderSubtle};`
       : `top: 0; border-bottom: 1px solid ${theme.colors.borderSubtle};`}
 `;
 


### PR DESCRIPTION
Fix mobile SearchBar floating mid-screen. `bottom: ${MINI_PLAYER_HEIGHT_MOBILE}px` was double-counting since MiniPlayer renders outside MobileLayout — the offset put the bar in the middle of the viewport. Change to `bottom: 0`. Refs #1315.