### PR TITLE
fix(playback): force Spotify shuffle off + stop hydrate from re-firing

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -137,11 +137,17 @@ const AudioPlayerComponent = () => {
   const handleCloseQuickAccessPanel = useCallback(() => setShowQuickAccessPanel(false), []);
 
   const handleHydrateFired = useCallback((track: import('@/types/domain').MediaTrack, skipped: boolean) => {
+    // Hydrate has been consumed — clear the saved session so a subsequent
+    // collection load (which transiently shows isLoading=true and remounts
+    // PlayerStateRenderer) doesn't trigger a second hydrate that would
+    // overwrite the just-loaded collection's index and position with the
+    // resumed session's.
+    resetLastSession();
     const message = skipped
       ? `Couldn't resume previous track — starting from next in queue.`
       : `Resuming '${track.name}' — press play to continue.`;
     toast(message, { id: RESUME_TOAST_ID, duration: Infinity });
-  }, []);
+  }, [resetLastSession]);
   const handleHydrateFailed = useCallback(() => {
     resetLastSession();
     toast(`Couldn't resume your last session.`, { id: RESUME_TOAST_ID, duration: Infinity });

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -3,6 +3,33 @@ import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 import { TRANSFER_RETRY_DELAY_MS } from '@/constants/timing';
 
+/**
+ * Force Spotify shuffle off so the queue we hand the SDK plays in our order.
+ * If the user has shuffle on at the account level (set in another client),
+ * Spotify shuffles our `uris` list and plays a random track first; the SDK
+ * then auto-advances through the rest in shuffled order, breaking UI/audio
+ * sync because our subscription expects the linear order.
+ *
+ * Best-effort: failures are swallowed because shuffle-off is a courtesy,
+ * not a precondition for play. A 403 here usually means the user is on
+ * Spotify Free (no playback control) — the play call will fail next anyway
+ * with a clearer error.
+ */
+export async function apiSetShuffleOff(deviceId: string): Promise<void> {
+  try {
+    const token = await spotifyAuth.ensureValidToken();
+    await fetch(
+      `https://api.spotify.com/v1/me/player/shuffle?state=false&device_id=${deviceId}`,
+      {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+  } catch (err) {
+    logSpotify('apiSetShuffleOff failed: %o', err);
+  }
+}
+
 export async function apiPlayTrack(
   deviceId: string,
   uri: string,
@@ -13,6 +40,8 @@ export async function apiPlayTrack(
   const uris = upcomingUris?.length ? [uri, ...upcomingUris] : [uri];
 
   logSpotify('Web API play track deviceId=%s queueSize=%d positionMs=%s', deviceId, uris.length, positionMs ?? 0);
+
+  await apiSetShuffleOff(deviceId);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
@@ -67,6 +96,8 @@ export async function apiPlayContext(
 
   logSpotify('Web API play context uri=%s offset=%s', contextUri, offsetPosition ?? '(none)');
 
+  await apiSetShuffleOff(deviceId);
+
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
     body: JSON.stringify(body),
@@ -101,6 +132,8 @@ export async function apiPlayPlaylist(
   const token = await spotifyAuth.ensureValidToken();
 
   logSpotify('Web API play URIs list length=%d deviceId=%s', uris.length, deviceId);
+
+  await apiSetShuffleOff(deviceId);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary

Two playback bugs caught from Roman's debug trace:

### Bug A: Spotify shuffle was on at the account level

The SDK reported \`currentTrackId\` for tracks at index 4 (then 8) of our queue when we asked for index 0. The Web API \`PUT /play\` returned 204 OK with the right URIs in the right order — Spotify was reordering them itself because shuffle was enabled on the user's account (set in another client). We never disabled it.

Fix: add \`apiSetShuffleOff(deviceId)\` and call it before \`apiPlayTrack\`, \`apiPlayContext\`, \`apiPlayPlaylist\`.

### Bug B: \`handleHydrate\` re-fired after collection load

\`loadProviderCollection → beginLoad\` calls \`setIsLoading(true)\`, which flips the gate in \`AudioPlayer.renderContent\` to render \`PlayerStateRenderer\`. PlayerStateRenderer remounts with \`hydrateFiredRef\` reset, sees \`lastSession\` still populated, and re-runs \`handleHydrate\` on the previous session — overwriting trackIndex/position on top of the just-loaded album.

Trace excerpt:
\`\`\`
loadCollection album:1KNUC...
playTrack(0) Nomad
spotify.prepareTrack: skip (already prepared) Blank Space   ← session track
handleHydrate index=1 \"Blank Space\" position=89246ms
session save trackIndex=1 position=89246ms queueLength=11   ← album len, session pos
\`\`\`

Fix: in \`handleHydrateFired\`, call \`resetLastSession()\`. Hydrate has fired, the resume toast has been shown — the session is consumed and shouldn't replay on the next \`isLoading=true\` flip. Persisted localStorage session still survives a reload, preserving cross-session resume.

## Verification

- \`npx tsc -b --noEmit\` clean
- \`npm run test:run\` — 1548/1548 passing (3 pre-existing test-file failures unrelated; #1319)

## Test plan

- [ ] Manual: with Spotify shuffle ON in another Spotify client, tap a Spotify album in vorbis. Album plays in order, UI matches audio.
- [ ] Manual: cold-start with a saved session, tap a different album before pressing the resume toast → album plays cleanly, no Blank Space ghost-state.
- [ ] Manual: cold-start with saved session, press resume → resumes correctly. Then tap a different album → album plays without re-hydrating.