### PR TITLE
fix(library): structurally anchor mobile SearchBar

### DIFF
--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -201,8 +201,8 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
       <Layout data-testid={layoutTestId}>
         {!isMobile && <SearchBar variant="desktop" search={search} />}
         {body}
-        {isMobile && <SearchBar variant="mobile" search={search} />}
       </Layout>
+      {isMobile && <SearchBar variant="mobile" search={search} />}
       <LibraryContextMenu
         request={contextRequest}
         onClose={handleCloseContextMenu}

--- a/src/components/LibraryRoute/search/SearchBar.styled.ts
+++ b/src/components/LibraryRoute/search/SearchBar.styled.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 
 export const SearchBarRoot = styled.div<{ $variant: 'mobile' | 'desktop' }>`
-  position: sticky;
   z-index: 6;
   display: flex;
   align-items: center;
@@ -14,8 +13,8 @@ export const SearchBarRoot = styled.div<{ $variant: 'mobile' | 'desktop' }>`
 
   ${({ $variant }) =>
     $variant === 'mobile'
-      ? `bottom: 0; border-top: 1px solid ${theme.colors.borderSubtle};`
-      : `top: 0; border-bottom: 1px solid ${theme.colors.borderSubtle};`}
+      ? `border-top: 1px solid ${theme.colors.borderSubtle}; flex: 0 0 auto;`
+      : `position: sticky; top: 0; border-bottom: 1px solid ${theme.colors.borderSubtle};`}
 `;
 
 export const InputWrap = styled.div`


### PR DESCRIPTION
Structural anchor instead of sticky-bottom — moves mobile SearchBar out of inner scroll container, sits as flex sibling between MobileLayout and MiniPlayer in the column layout. Sticky-bottom on a last child was unreliable on mobile due to dvh changes. Refs #1315 #1326.