### PR TITLE
fix(library): search by artist for Spotify albums

### DIFF
--- a/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
+++ b/src/components/LibraryRoute/search/__tests__/searchMatch.test.ts
@@ -51,6 +51,30 @@ describe('matchesQuery', () => {
     // #when / #then
     expect(matchesQuery(item, 'rock')).toBe(false);
   });
+
+  it('matches on ownerName when name does not match', () => {
+    // #given — album named "Core" by "Stone Temple Pilots"
+    const item = { name: 'Core', ownerName: 'Stone Temple Pilots' };
+
+    // #when / #then — query "stone" matches ownerName
+    expect(matchesQuery(item, 'stone')).toBe(true);
+  });
+
+  it('does not match when neither name nor ownerName contains the query', () => {
+    // #given
+    const item = { name: 'Core', ownerName: 'Stone Temple Pilots' };
+
+    // #when / #then
+    expect(matchesQuery(item, 'nirvana')).toBe(false);
+  });
+
+  it('matches ownerName case-insensitively', () => {
+    // #given
+    const item = { name: 'Purple', ownerName: 'Stone Temple Pilots' };
+
+    // #when / #then — normalizeQuery lowercases before calling matchesQuery
+    expect(matchesQuery(item, 'temple')).toBe(true);
+  });
 });
 
 describe('passesProviderFilter', () => {

--- a/src/components/LibraryRoute/views/SearchResultsView.tsx
+++ b/src/components/LibraryRoute/views/SearchResultsView.tsx
@@ -83,7 +83,7 @@ const SearchResultsView: React.FC<SearchResultsViewProps> = ({
       showAlbums
         ? sortItems(
             albums
-              .filter((a) => matchesQuery({ name: a.name }, q))
+              .filter((a) => matchesQuery({ name: a.name, ownerName: a.artists }, q))
               .filter((a) => passesProviderFilter({ provider: a.provider }, search.providerFilter)),
             search.sort,
           )

--- a/src/components/LibraryRoute/views/__tests__/SearchResultsView.edges.test.tsx
+++ b/src/components/LibraryRoute/views/__tests__/SearchResultsView.edges.test.tsx
@@ -229,6 +229,40 @@ describe('SearchResultsView edges', () => {
     });
   });
 
+  describe('artist search for albums', () => {
+    it('includes an album when the query matches the artist name (not the album title)', () => {
+      // #given — album title "Core" does NOT contain "stone"; artist does
+      mockAlbumsSection.mockReturnValue({
+        items: [
+          { id: 'a1', name: 'Core', artists: 'Stone Temple Pilots', provider: 'spotify', images: [] },
+        ],
+      });
+
+      // #when
+      renderView({ query: 'stone' });
+
+      // #then — album appears even though the title "Core" doesn't match
+      expect(screen.getByText('Albums')).toBeInTheDocument();
+      expect(screen.getByText('Core')).toBeInTheDocument();
+    });
+
+    it('excludes an album when neither title nor artist matches the query', () => {
+      // #given
+      mockAlbumsSection.mockReturnValue({
+        items: [
+          { id: 'a1', name: 'Core', artists: 'Stone Temple Pilots', provider: 'spotify', images: [] },
+        ],
+      });
+
+      // #when
+      renderView({ query: 'nirvana' });
+
+      // #then
+      expect(screen.queryByText('Albums')).toBeNull();
+      expect(screen.queryByText('Core')).toBeNull();
+    });
+  });
+
   describe('onContextMenuRequest forwarding', () => {
     it('forwards onContextMenuRequest to LibraryCard via right-click → menu request', () => {
       // #given


### PR DESCRIPTION
## Summary

- The `SearchResultsView` album filter called `matchesQuery({ name: a.name }, q)` — omitting the artist name entirely. Queries like "stone" never matched albums by Stone Temple Pilots even though `matchesQuery` already accepted an `ownerName` field added in PR #1324.
- Fix: pass `ownerName: a.artists` so the artist participates in substring matching.
- `CommandPalette` was already correct — it includes the artist in the cmdk `value` prop (`value=\`album \${a.name} \${a.artists}\``), so desktop ⌘K search worked; only the SearchBar/`SearchResultsView` path was broken.

## Changes

- `SearchResultsView.tsx`: one-line fix — `matchesQuery({ name: a.name }, q)` → `matchesQuery({ name: a.name, ownerName: a.artists }, q)`
- `searchMatch.test.ts`: 3 new `matchesQuery` tests covering ownerName matching
- `SearchResultsView.edges.test.tsx`: 2 new integration tests asserting album artist search works end-to-end

## Cache note

No cache migration needed. `AlbumInfo.artists` is always populated from the Spotify API album response and is stored as-is in IndexedDB — the field was never missing, it was just not being passed to `matchesQuery`.

## Test plan

- [ ] `npx tsc -b --noEmit` — clean (verified)
- [ ] `npm run test:run` — 1553 pass, 3 pre-existing file failures unrelated (issue #1319) (verified)
- [ ] Search "stone" in library → Stone Temple Pilots albums appear
- [ ] Search "core" → same albums appear (title match still works)
- [ ] Search "nirvana" → no STP albums appear

Closes #1315