### PR TITLE
fix(library): suppress native search input clear button

### DIFF
--- a/src/components/LibraryRoute/search/SearchBar.styled.ts
+++ b/src/components/LibraryRoute/search/SearchBar.styled.ts
@@ -32,6 +32,14 @@ export const InputWrap = styled.div`
   & > input::placeholder {
     color: ${theme.colors.muted.foreground};
   }
+
+  & > input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  & > input::-webkit-search-decoration {
+    display: none;
+  }
 `;
 
 export const ClearButton = styled.button`


### PR DESCRIPTION
## Summary

- Hides the webkit native search-input cancel button (`::-webkit-search-cancel-button`) and decoration (`::-webkit-search-decoration`) via CSS in `InputWrap`
- Keeps `type="search"` on the input so mobile keyboards show the "Search" return key and screen readers identify it as a search field
- Net result: only the custom `ClearButton` (lucide `X` icon) renders; no duplicate X

## Changes

- `src/components/LibraryRoute/search/SearchBar.styled.ts` — two CSS pseudo-element declarations added to `InputWrap`

## Test plan

- [ ] `npx tsc -b --noEmit` — clean
- [ ] `npm run test:run` — 1553 passed, 3 pre-existing file failures (#1319)
- [ ] Manual: type in the library search bar; only one X button appears; clicking it clears the query

Closes #1329
Part of epic PR #1315