### PR TITLE
fix(deps): add @testing-library/user-event devDependency (#1319)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/debug": "^4.1.13",
         "@types/node": "^24.10.13",
         "@types/react": "^18.3.9",
@@ -3453,6 +3454,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/debug": "^4.1.13",
     "@types/node": "^24.10.13",
     "@types/react": "^18.3.9",


### PR DESCRIPTION
## Summary

- Adds `@testing-library/user-event@^14.6.1` to `devDependencies` — the v14 major is compatible with the project's existing `@testing-library/react@^16` and `@testing-library/dom@^10` versions.
- The package was already referenced by tests but not declared; this makes the dependency explicit.

## Changes

- `package.json`: +1 line in `devDependencies`
- `package-lock.json`: +15 lines (new package entry only; no unexpected transitive bumps)

## Test plan

- [x] `npm run test:run` — 144 test files, 1597 tests, all passed

Closes #1319