### PR TITLE
fix(library): remove duplicate clear button from SearchBar (#1329)

### DIFF
--- a/src/components/LibraryRoute/search/SearchBar.tsx
+++ b/src/components/LibraryRoute/search/SearchBar.tsx
@@ -27,7 +27,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ variant, search }) => {
           }}
         />
         <Input
-          type="search"
+          type="text"
           aria-label="Search library"
           placeholder="Search your library"
           value={search.query}


### PR DESCRIPTION
## Summary

- `SearchBar.tsx` was passing `type="search"` to the shadcn `<Input>`, which caused browsers to render a native clear (×) button alongside the component's own custom `<ClearButton>`.
- Fix: change `type="search"` → `type="text"`. The custom `ClearButton` (with `aria-label="Clear search"` and `data-testid`) remains the sole clear control; a11y is preserved.

## Changes

- `src/components/LibraryRoute/search/SearchBar.tsx`: 1-line change (`type` attribute)

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 144 test files, 1597 tests, all passed
- No existing tests assert on `type="search"` (grep confirmed)

Closes #1329