### PR TITLE
fix(library): close library route on Escape (#1337)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -398,6 +398,7 @@ const AudioPlayerComponent = () => {
             onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
             onPlayNext={undefined}
             onStartRadioForCollection={undefined}
+            onClose={handlers.handleCloseLibrary}
           />
         </Suspense>
       );
@@ -525,6 +526,7 @@ const AudioPlayerComponent = () => {
               onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
               onPlayNext={undefined}
               onStartRadioForCollection={undefined}
+              onClose={handlers.handleCloseLibrary}
             />
           </Suspense>
         )}

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -179,4 +179,46 @@ describe('LibraryRoute', () => {
     // #then
     expect(onMiniExpand).toHaveBeenCalledTimes(1);
   });
+
+  describe('Escape key handling', () => {
+    beforeEach(() => {
+      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+    });
+
+    it('calls onClose when Escape is pressed outside an input', () => {
+      // #given
+      const onClose = vi.fn();
+      renderRoute({ onClose });
+
+      // #when
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      // #then
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when Escape is pressed while focus is inside an input', () => {
+      // #given
+      const onClose = vi.fn();
+      renderRoute({ onClose });
+      const input = screen.getByTestId('library-search-input-desktop');
+
+      // #when
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      // #then
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClose when onClose prop is not provided', () => {
+      // #given — no onClose prop
+      renderRoute();
+
+      // #when
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      // #then — no error thrown, handler is a no-op
+      expect(true).toBe(true);
+    });
+  });
 });

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 import { useUnifiedLikedTracks } from '@/hooks/useUnifiedLikedTracks';
 import type { ProviderId, AddToQueueResult, MediaTrack } from '@/types/domain';
@@ -55,6 +55,7 @@ export interface LibraryRouteProps {
   onMiniPrevious: () => void;
   onMiniExpand: () => void;
   onMiniStartRadio?: () => void;
+  onClose?: () => void;
 }
 
 const LibraryRoute: React.FC<LibraryRouteProps> = ({
@@ -75,6 +76,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onMiniPrevious,
   onMiniExpand,
   onMiniStartRadio,
+  onClose,
 }) => {
   const { isMobile } = usePlayerSizingContext();
   const [view, setView] = useState<LibraryRouteView>('home');
@@ -82,6 +84,21 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   const search = useLibrarySearch();
   const [paletteOpen, setPaletteOpen] = useState(false);
   useCommandPaletteShortcut(() => setPaletteOpen(true), !isMobile);
+
+  useEffect(() => {
+    if (!onClose) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      const target = (e.composedPath?.()[0] ?? e.target) as HTMLElement | null;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+      }
+      onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const handleSelectCollection = useCallback(
     (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => {


### PR DESCRIPTION
## Summary
- `LibraryRoute` replaces `PlayerContent` entirely when `state.currentView === 'library'`, so the Escape handler registered in `PlayerControlsSection` via `useKeyboardShortcuts` is inactive during library browsing.
- Added a local `keydown` listener in `LibraryRoute` that fires the new `onClose` prop on Escape, with the same `INPUT`/`TEXTAREA`/`contenteditable` focus guard used in `useKeyboardShortcuts` — preserving SearchBar's native Escape-clears-text behaviour.
- Wired `onClose={handlers.handleCloseLibrary}` at both `LibraryRoute` render sites in `AudioPlayer.tsx` (normal player view + `needsSetup` variant).

## Changes
- `src/components/LibraryRoute/index.tsx` — new optional `onClose?: () => void` prop + Escape `useEffect`
- `src/components/AudioPlayer.tsx` — `onClose` wired at both call sites
- `src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx` — 3 new tests: Escape fires onClose, Escape inside input is blocked, no-onClose is a no-op

## Test plan
- [ ] Escape from library closes it (returns to player view)
- [ ] Escape while typing in SearchBar clears text, does not close library (native `<input type="search">` behaviour)
- [ ] Escape with empty/unfocused SearchBar closes library
- [ ] `npm run test:run` — 1558 tests pass; 3 pre-existing failures (`accordion`, `popover`, `switch`) are `@testing-library/user-event` missing dep, unrelated to this PR

Closes #1337