### PR TITLE
fix(spotify): restore await on apiSetShuffleOff to prevent first-play race (#1336)

### DIFF
--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -47,7 +47,7 @@ export async function apiPlayTrack(
 
   logSpotify('Web API play track deviceId=%s queueSize=%d positionMs=%s', deviceId, uris.length, positionMs ?? 0);
 
-  apiSetShuffleOff(deviceId);
+  await apiSetShuffleOff(deviceId);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
@@ -102,7 +102,7 @@ export async function apiPlayContext(
 
   logSpotify('Web API play context uri=%s offset=%s', contextUri, offsetPosition ?? '(none)');
 
-  apiSetShuffleOff(deviceId);
+  await apiSetShuffleOff(deviceId);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',
@@ -139,7 +139,7 @@ export async function apiPlayPlaylist(
 
   logSpotify('Web API play URIs list length=%d deviceId=%s', uris.length, deviceId);
 
-  apiSetShuffleOff(deviceId);
+  await apiSetShuffleOff(deviceId);
 
   const response = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary

- Three play functions (`apiPlayTrack`, `apiPlayContext`, `apiPlayPlaylist`) were calling `apiSetShuffleOff` fire-and-forget, allowing the shuffle `PUT` to race the play `PUT` on first play.
- Restores `await` at all three call sites. The `shuffleOffFired` flag ensures subsequent calls return immediately (zero cost), so the perf motivation of the original change is preserved — only the first-play call now awaits a single network round-trip.

## Changes

- `src/services/spotifyPlayerPlayback.ts`: 3 one-character additions (`await` at lines 50, 105, 142)

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 144 test files, 1597 tests, all passed

Closes #1336