### PR TITLE
fix(test): exclude nested node_modules and .claude worktrees from vitest discovery

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
-    exclude: ['node_modules', 'dist', 'playwright/**', 'proxy-server/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'playwright/**', 'proxy-server/**', '.claude/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

`vite.config.ts:83` was overriding vitest's default `**/node_modules/**` exclusion with a narrower `'node_modules'` pattern that only matches the top-level directory. This bit us when squadkit/swarmkit creates per-builder worktrees under `.claude/worktrees/<member>/` inside the repo:

1. The worktrees' `node_modules/<dep>/**/*.test.ts` files get picked up — third-party deps that ship their own test suites (zod, etc.) ran as if part of this project's tests.
2. The worktrees' `src/**/*.test.tsx` are also discovered as duplicates of the main src tree, doubling test counts and causing module-resolution conflicts (worker imports resolve to the worktree's `node_modules` instead of the root).

## Repro

```bash
/squadkit:spawn-team --epic <slug> --builders 2  # creates .claude/worktrees/builder-{1,2}/
npm run test:run
# Test Files  794 (688 noise from worktrees) | Tests 9113 (vs 1597 expected)
```

## Fix

```diff
-exclude: ['node_modules', 'dist', 'playwright/**', 'proxy-server/**'],
+exclude: ['**/node_modules/**', '**/dist/**', 'playwright/**', 'proxy-server/**', '.claude/**'],
```

The `**/node_modules/**` change matches vitest's own default exclude; the `.claude/**` addition catches the duplicated-src-tree case (since the worktree's `src/` is just a copy of the main src tree, the same `*.test.tsx` files would otherwise get scanned twice).

## Verify

- `npm run test:run` → 144 files / 1597 tests, all green
- `npx tsc -b --noEmit` → clean

## Test plan

- [ ] Run `npm run test:run` on a fresh checkout (without worktrees) — confirms baseline still passes
- [ ] Run `/squadkit:spawn-team --builders 2` and then `npm run test:run` — confirms worktree noise no longer leaks
- [ ] Confirm `playwright/**` and `proxy-server/**` exclusions still work as before