### PR TITLE
fix(library): restore left padding on horizontal-scroll sections (#1346)

### DIFF
--- a/src/components/LibraryRoute/sections/Section.styled.ts
+++ b/src/components/LibraryRoute/sections/Section.styled.ts
@@ -53,6 +53,7 @@ export const Body = styled.div<{ $layout: 'row' | 'grid' }>`
           overflow-x: auto;
           overflow-y: hidden;
           scroll-snap-type: x proximity;
+          scroll-padding-inline-start: ${theme.spacing.md};
           -webkit-overflow-scrolling: touch;
           scrollbar-width: none;
           &::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- `scroll-snap-type: x proximity` on the `Body` scroll container combined with `scroll-snap-align: start` on each card caused the browser to snap the first card's start edge to the container's raw x=0 edge, scrolling the `padding-inline-start` gutter (16 px) out of view. Cards appeared flush to the viewport's left edge.
- Fix: add `scroll-padding-inline-start: ${theme.spacing.md}` to the row-layout `Body` in `Section.styled.ts`. This aligns the snap port start with the existing `padding-inline-start` so the first card snaps to `scroll_x = 0`, keeping the left gutter visible.
- One-token change, no structural or behavioural side-effects. Right-trailing padding preserved by `padding-inline-end` (works in Safari 14.1+).

## Changes

- `src/components/LibraryRoute/sections/Section.styled.ts` — add `scroll-padding-inline-start: ${theme.spacing.md}` to `Body` row layout

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 148 files, 1618 tests passed
- [ ] Manual: open library in mobile viewport (DevTools), verify Recently Played and Pinned first card has ~16 px left gutter at rest and after scrolling back to start

Closes #1346