### PR TITLE
fix(library): pass kind explicitly to queueLikedFromCollection to fix album 404 (#1345)

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { usePinnedItems } from '@/hooks/usePinnedItems';
 import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
@@ -95,7 +96,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
       () => {
         onReturnFocusClose();
         Promise.resolve(fn()).catch(() => {
-          /* swallow — toast surfaces user-facing errors */
+          toast("Couldn't complete that action. Try again.");
         });
       },
     [onReturnFocusClose],
@@ -204,7 +205,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
       const collectionName = request.name;
       const provider = request.provider;
       actions.onQueueLikedFromCollection = closeAfter(() =>
-        queueLikedFromCollection(collectionId, collectionName, provider),
+        queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
       );
     }
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -304,7 +304,7 @@ describe('LibraryContextMenu', () => {
     fireEvent.click(screen.getByTestId('menu-queue-liked'));
 
     // #then
-    expect(mockQueueLikedFromCollection).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify');
+    expect(mockQueueLikedFromCollection).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify', 'playlist');
     expect(onReturnFocusClose).toHaveBeenCalled();
   });
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/useQueueLikedFromCollection.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useQueueLikedFromCollection.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+
+const { mockListTracks, mockIsTrackSaved } = vi.hoisted(() => ({
+  mockListTracks: vi.fn(),
+  mockIsTrackSaved: vi.fn(),
+}));
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn().mockReturnValue({
+      catalog: {
+        listTracks: (...args: unknown[]) => mockListTracks(...args),
+        isTrackSaved: (...args: unknown[]) => mockIsTrackSaved(...args),
+      },
+    }),
+  },
+}));
+
+import { useQueueLikedFromCollection } from '../useQueueLikedFromCollection';
+
+const TRACK_A: MediaTrack = { id: 'a' } as MediaTrack;
+const TRACK_B: MediaTrack = { id: 'b' } as MediaTrack;
+
+describe('useQueueLikedFromCollection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes kind:album and raw id directly to listTracks (engine-path fix)', async () => {
+    // #given — raw album id as the engine provides (no "album:" prefix)
+    mockListTracks.mockResolvedValue([TRACK_A]);
+    mockIsTrackSaved.mockResolvedValue(true);
+    const onQueue = vi.fn();
+    const { result } = renderHook(() => useQueueLikedFromCollection(onQueue));
+
+    // #when
+    await act(async () => {
+      await result.current.queueLikedFromCollection(
+        '1KNUCVXgIxKUGiuEB8eG0i',
+        'Jazz Album',
+        'spotify' as ProviderId,
+        'album',
+      );
+    });
+
+    // #then — listTracks called with album kind, raw id (not 'playlist' kind)
+    expect(mockListTracks).toHaveBeenCalledWith({
+      provider: 'spotify',
+      kind: 'album',
+      id: '1KNUCVXgIxKUGiuEB8eG0i',
+    });
+    expect(onQueue).toHaveBeenCalledWith([TRACK_A], 'Jazz Album');
+  });
+
+  it('passes kind:playlist and id directly to listTracks', async () => {
+    // #given
+    mockListTracks.mockResolvedValue([TRACK_A]);
+    mockIsTrackSaved.mockResolvedValue(true);
+    const onQueue = vi.fn();
+    const { result } = renderHook(() => useQueueLikedFromCollection(onQueue));
+
+    // #when
+    await act(async () => {
+      await result.current.queueLikedFromCollection(
+        'pl-xyz',
+        'My Playlist',
+        'spotify' as ProviderId,
+        'playlist',
+      );
+    });
+
+    // #then
+    expect(mockListTracks).toHaveBeenCalledWith({
+      provider: 'spotify',
+      kind: 'playlist',
+      id: 'pl-xyz',
+    });
+    expect(onQueue).toHaveBeenCalledWith([TRACK_A], 'My Playlist');
+  });
+
+  it('filters to only saved tracks before queuing', async () => {
+    // #given
+    mockListTracks.mockResolvedValue([TRACK_A, TRACK_B]);
+    mockIsTrackSaved.mockImplementation((id: string) =>
+      Promise.resolve(id === 'a'),
+    );
+    const onQueue = vi.fn();
+    const { result } = renderHook(() => useQueueLikedFromCollection(onQueue));
+
+    // #when
+    await act(async () => {
+      await result.current.queueLikedFromCollection('pl-xyz', 'Pl', 'spotify' as ProviderId, 'playlist');
+    });
+
+    // #then — only TRACK_A (saved) passes through
+    expect(onQueue).toHaveBeenCalledWith([TRACK_A], 'Pl');
+  });
+
+  it('does not call onQueue when no liked tracks exist in the collection', async () => {
+    // #given
+    mockListTracks.mockResolvedValue([TRACK_A]);
+    mockIsTrackSaved.mockResolvedValue(false);
+    const onQueue = vi.fn();
+    const { result } = renderHook(() => useQueueLikedFromCollection(onQueue));
+
+    // #when
+    await act(async () => {
+      await result.current.queueLikedFromCollection('pl-xyz', 'Pl', 'spotify' as ProviderId, 'playlist');
+    });
+
+    // #then
+    expect(onQueue).not.toHaveBeenCalled();
+  });
+
+  it('propagates listTracks rejection so callers can catch it', async () => {
+    // #given
+    const error = new Error('API error');
+    mockListTracks.mockRejectedValue(error);
+    const { result } = renderHook(() => useQueueLikedFromCollection(vi.fn()));
+
+    // #when / #then
+    await expect(
+      act(async () => {
+        await result.current.queueLikedFromCollection(
+          'album-id',
+          'Album',
+          'spotify' as ProviderId,
+          'album',
+        );
+      }),
+    ).rejects.toThrow('API error');
+  });
+
+  it('resolves immediately when onQueueLikedTracks is not provided', async () => {
+    // #given
+    const { result } = renderHook(() => useQueueLikedFromCollection(undefined));
+
+    // #when / #then — should not throw
+    await act(async () => {
+      await result.current.queueLikedFromCollection('id', 'Name', 'spotify' as ProviderId, 'playlist');
+    });
+    expect(mockListTracks).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/useQueueLikedFromCollection.ts
+++ b/src/components/LibraryRoute/contextMenu/useQueueLikedFromCollection.ts
@@ -1,17 +1,16 @@
 import { useCallback } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
-import { resolvePlaylistRef } from '@/constants/playlist';
 
 async function fetchLikedTracksForCollection(
   collectionId: string,
   provider: ProviderId,
+  kind: 'playlist' | 'album',
 ): Promise<MediaTrack[]> {
   const descriptor = providerRegistry.get(provider);
   if (!descriptor?.catalog.listTracks || !descriptor.catalog.isTrackSaved) return [];
 
-  const { id, kind } = resolvePlaylistRef(collectionId, provider);
-  const allTracks = await descriptor.catalog.listTracks({ provider, kind, id });
+  const allTracks = await descriptor.catalog.listTracks({ provider, kind, id: collectionId });
 
   const savedResults = await Promise.all(
     allTracks.map((track) => descriptor.catalog.isTrackSaved!(track.id).catch(() => false)),
@@ -25,16 +24,17 @@ export interface UseQueueLikedFromCollectionResult {
     collectionId: string,
     collectionName: string,
     provider: ProviderId,
-  ) => void;
+    kind: 'playlist' | 'album',
+  ) => Promise<void>;
 }
 
 export function useQueueLikedFromCollection(
   onQueueLikedTracks: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined,
 ): UseQueueLikedFromCollectionResult {
   const queueLikedFromCollection = useCallback(
-    (collectionId: string, collectionName: string, provider: ProviderId) => {
-      if (!onQueueLikedTracks) return;
-      void fetchLikedTracksForCollection(collectionId, provider).then((tracks) => {
+    (collectionId: string, collectionName: string, provider: ProviderId, kind: 'playlist' | 'album'): Promise<void> => {
+      if (!onQueueLikedTracks) return Promise.resolve();
+      return fetchLikedTracksForCollection(collectionId, provider, kind).then((tracks) => {
         if (tracks.length > 0) onQueueLikedTracks(tracks, collectionName);
       });
     },

--- a/src/providers/spotify/__tests__/spotifyCatalogAdapter.test.ts
+++ b/src/providers/spotify/__tests__/spotifyCatalogAdapter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MediaTrack } from '@/types/domain';
+
+const { mockGetPlaylistTracks, mockGetAlbumTracks, mockGetLikedSongs } = vi.hoisted(() => ({
+  mockGetPlaylistTracks: vi.fn(),
+  mockGetAlbumTracks: vi.fn(),
+  mockGetLikedSongs: vi.fn(),
+}));
+
+vi.mock('@/services/spotify', () => ({
+  getPlaylistTracks: (...args: unknown[]) => mockGetPlaylistTracks(...args),
+  getAlbumTracks: (...args: unknown[]) => mockGetAlbumTracks(...args),
+  getLikedSongs: (...args: unknown[]) => mockGetLikedSongs(...args),
+  getLikedSongsCount: vi.fn().mockResolvedValue(0),
+  checkTrackSaved: vi.fn().mockResolvedValue(false),
+  saveTrack: vi.fn().mockResolvedValue(undefined),
+  unsaveTrack: vi.fn().mockResolvedValue(undefined),
+  checkAlbumSaved: vi.fn().mockResolvedValue(false),
+  saveAlbum: vi.fn().mockResolvedValue(undefined),
+  unsaveAlbum: vi.fn().mockResolvedValue(undefined),
+  unfollowPlaylist: vi.fn().mockResolvedValue(undefined),
+  getLargestImage: vi.fn().mockReturnValue(undefined),
+  searchTrack: vi.fn().mockResolvedValue(null),
+  getUserLibraryInterleaved: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { SpotifyCatalogAdapter } from '@/providers/spotify/spotifyCatalogAdapter';
+
+const TRACK: MediaTrack = {
+  id: 't1',
+  provider: 'spotify',
+  playbackRef: { provider: 'spotify', ref: 'spotify:track:t1' },
+  name: 'Track',
+  artists: 'Artist',
+  album: 'Album',
+  durationMs: 180000,
+};
+
+describe('SpotifyCatalogAdapter.listTracks', () => {
+  let adapter: SpotifyCatalogAdapter;
+
+  beforeEach(() => {
+    adapter = new SpotifyCatalogAdapter();
+    vi.clearAllMocks();
+    mockGetPlaylistTracks.mockResolvedValue([TRACK]);
+    mockGetAlbumTracks.mockResolvedValue([TRACK]);
+    mockGetLikedSongs.mockResolvedValue([TRACK]);
+  });
+
+  it('routes playlist kind to getPlaylistTracks', async () => {
+    // #given
+    const ref = { provider: 'spotify' as const, kind: 'playlist' as const, id: 'pl-abc' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(mockGetPlaylistTracks).toHaveBeenCalledWith('pl-abc');
+    expect(mockGetAlbumTracks).not.toHaveBeenCalled();
+    expect(result).toEqual([TRACK]);
+  });
+
+  it('routes album kind with raw id to getAlbumTracks', async () => {
+    // #given — raw id as supplied by the engine path (no "album:" prefix)
+    const ref = { provider: 'spotify' as const, kind: 'album' as const, id: '1KNUCVXgIxKUGiuEB8eG0i' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(mockGetAlbumTracks).toHaveBeenCalledWith('1KNUCVXgIxKUGiuEB8eG0i');
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(result).toEqual([TRACK]);
+  });
+
+  it('routes album kind with prefixed id to getAlbumTracks (strips prefix)', async () => {
+    // #given — prefixed id as supplied by the catalog-adapter path
+    const ref = { provider: 'spotify' as const, kind: 'album' as const, id: 'album:1KNUCVXgIxKUGiuEB8eG0i' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(mockGetAlbumTracks).toHaveBeenCalledWith('1KNUCVXgIxKUGiuEB8eG0i');
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(result).toEqual([TRACK]);
+  });
+
+  it('routes liked kind to getLikedSongs', async () => {
+    // #given
+    const ref = { provider: 'spotify' as const, kind: 'liked' as const, id: '' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(mockGetLikedSongs).toHaveBeenCalled();
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(result).toEqual([TRACK]);
+  });
+
+  it('returns [] for non-spotify provider without calling any API', async () => {
+    // #given
+    const ref = { provider: 'dropbox' as const, kind: 'playlist' as const, id: 'pl-1' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(result).toEqual([]);
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(mockGetAlbumTracks).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for unknown kind without calling any API', async () => {
+    // #given
+    const ref = { provider: 'spotify' as const, kind: 'folder' as const, id: 'x' };
+
+    // #when
+    const result = await adapter.listTracks(ref);
+
+    // #then
+    expect(result).toEqual([]);
+    expect(mockGetPlaylistTracks).not.toHaveBeenCalled();
+    expect(mockGetAlbumTracks).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Root cause: Spotify albums from the sync engine carry raw IDs (no `album:` prefix). `useQueueLikedFromCollection` was calling `resolvePlaylistRef` to infer `kind` from the ID string — a raw ID falls through to `kind:'playlist'`, so `listTracks` called `getPlaylistTracks(<albumId>)` → `GET /v1/playlists/<albumId>/tracks` → 404.
- Fix: accept `kind: 'playlist' | 'album'` as an explicit parameter; `LibraryContextMenu` already holds `effectiveKind` and threads it through. `SpotifyCatalogAdapter.listTracks` already dispatches correctly for both raw and prefixed album IDs, so no adapter changes are needed.
- Defensive: `queueLikedFromCollection` now returns `Promise<void>` (was `void`) so errors propagate; `closeAfter`'s catch now fires `toast()` instead of silently swallowing.

## Changes

| File | Change |
|---|---|
| `useQueueLikedFromCollection.ts` | Add `kind` param; return `Promise<void>`; drop `resolvePlaylistRef` |
| `LibraryContextMenu.tsx` | Thread `effectiveKind`; import `toast`; fire it in `closeAfter` catch |
| `LibraryContextMenu.test.tsx` | Update assertion to include `kind` arg |
| `spotifyCatalogAdapter.test.ts` | New — 6 `listTracks` kind-dispatch cases |
| `useQueueLikedFromCollection.test.ts` | New — 5 hook routing + error propagation cases |

## Test plan

- [ ] `npm run test:run` passes (1630/1630)
- [ ] `npx tsc -b --noEmit` clean
- [ ] Manual: right-click an album in library → "Queue Liked Songs" no longer 404s; liked tracks from the album are queued
- [ ] Manual: right-click a playlist → "Queue Liked Songs" still works as before
- [ ] Manual: trigger a deliberate failure (disconnect network mid-queue) → toast appears instead of silent failure

Closes #1345