### PR TITLE
fix(library): wrap raw album id in LibraryContextMenu add-to-queue (#1354)

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -9,6 +9,7 @@ import type { ProviderId, MediaTrack } from '@/types/domain';
 import { useLikedTracksForProvider } from './useLikedTracksForProvider';
 import { useAlbumSavedStatus } from './useAlbumSavedStatus';
 import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
+import { toAlbumPlaylistId } from '@/constants/playlist';
 import {
   buildMenuItems,
   type MenuActions,
@@ -176,11 +177,15 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
         }
       }),
       onAddToQueue: closeAfter(() => {
-        if (onAddToQueue) onAddToQueue(request.id, request.name, request.provider);
+        if (onAddToQueue) {
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onAddToQueue(id, request.name, request.provider);
+        }
       }),
       onPlayNext: closeAfter(() => {
         if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
-          onPlayNext(effectiveKind, request.id, request.name, request.provider);
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onPlayNext(effectiveKind, id, request.name, request.provider);
         }
       }),
       onTogglePin: closeAfter(togglePin),

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -267,7 +267,7 @@ describe('LibraryContextMenu', () => {
     expect(onReturnFocusClose).toHaveBeenCalled();
   });
 
-  it('Add to Queue invokes onAddToQueue', () => {
+  it('Add to Queue passes raw id for playlist kind', () => {
     // #given
     const onAddToQueue = vi.fn();
 
@@ -277,6 +277,21 @@ describe('LibraryContextMenu', () => {
 
     // #then
     expect(onAddToQueue).toHaveBeenCalledWith('p1', 'My Playlist', 'spotify');
+  });
+
+  it('Add to Queue wraps raw album id with album: prefix for album kind', () => {
+    // #given
+    const onAddToQueue = vi.fn();
+
+    // #when
+    renderMenu({
+      request: makeRequest({ kind: 'album', id: 'abc123', name: 'My Album' }),
+      onAddToQueue,
+    });
+    fireEvent.click(screen.getByTestId('menu-add-to-queue'));
+
+    // #then
+    expect(onAddToQueue).toHaveBeenCalledWith('album:abc123', 'My Album', 'spotify');
   });
 
   it('shows Queue Liked Songs item when onQueueLikedTracks provided for playlist', () => {


### PR DESCRIPTION
## Summary
- Wrap `request.id` with `toAlbumPlaylistId(...)` when `effectiveKind === 'album'` before invoking `onAddToQueue` / `onPlayNext` in `LibraryContextMenu`, mirroring the existing wrapping in `LibraryRoute.handleSelectCollection` for the `Play` action.
- Eliminates the 404 path where a raw Spotify album id flows through `resolvePlaylistRef` and is mis-classified as `kind: 'playlist'`.
- Test added in `LibraryContextMenu.test.tsx` asserts the album branch passes `album:<id>` to `onAddToQueue`; playlist branch still passes the raw id.

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` passes (existing + new assertions)
- Manual: right-click a Spotify album in Albums / Pinned / Recently Played / Search → "Add to Queue" appends the album's tracks (no 404), both with a populated and an empty queue
- Manual: "Play" on the same album still works as before
- Manual: right-click a playlist → "Add to Queue" still works (no behavior change)

Closes #1354