### PR TITLE
fix(library): wire onAddToQueue prop to LibraryRoute (#1356)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -382,6 +382,7 @@ const AudioPlayerComponent = () => {
               handlers.handleCloseLibrary();
               handlePlaylistSelect(id, name ?? '', provider);
             }}
+            onAddToQueue={handleAddToQueueFromPanel}
             onPlayLikedTracks={handlePlayLikedTracks}
             onQueueLikedTracks={handleQueueLikedTracks}
             onOpenSettings={handleOpenSettings}
@@ -510,6 +511,7 @@ const AudioPlayerComponent = () => {
                 handlers.handleCloseLibrary();
                 handlePlaylistSelect(id, name ?? '', provider);
               }}
+              onAddToQueue={handleAddToQueueFromPanel}
               onPlayLikedTracks={handlePlayLikedTracks}
               onQueueLikedTracks={handleQueueLikedTracks}
               onOpenSettings={handleOpenSettings}


### PR DESCRIPTION
## Summary

- Pass `onAddToQueue={handleAddToQueueFromPanel}` to both `<LibraryRoute>` instances in `AudioPlayer.tsx` (the main library route and the `needsSetup` fallback).
- Without this prop, `LibraryRoute.handleAddToQueueAction` becomes a silent no-op (the inner `onAddToQueue?.(...)` short-circuits), so right-click → **Add to Queue** in the library context menu never reached `useQueueManagement.handleAddToQueue`. PR #1355's prefix-wrap fix was correct but unreachable from the library route.

## Test plan

- `npx tsc -b --noEmit` clean
- `npm run test:run` passes (1634/1634)
- Manual on preview: right-click a Spotify album in Albums / Pinned / Recently Played / Search → **Add to Queue** appends the album's tracks (with both populated and empty queue); previously a silent no-op.
- Manual: right-click a playlist → **Add to Queue** likewise works.

Closes #1356