### PR TITLE
fix: resolve conditional hook in ProviderSetupScreen

### DIFF
--- a/src/components/ProviderSetupScreen.tsx
+++ b/src/components/ProviderSetupScreen.tsx
@@ -321,13 +321,11 @@ export default function ProviderSetupScreen({ onOpenSettings, onOpenLibrary }: P
   // The active provider is surfaced first even if it isn't in enabledProviderIds —
   // otherwise a user who disabled their active provider after its session expired
   // would see a "reconnect" card for a provider they weren't trying to use.
-  const expiredProviders = useMemo(() => {
-    const inEnabled = providers.filter(p => enabledProviderIds.includes(p.id));
-    if (activeDescriptor && !enabledProviderIds.includes(activeDescriptor.id)) {
-      return [activeDescriptor, ...inEnabled];
-    }
-    return inEnabled;
-  }, [providers, enabledProviderIds, activeDescriptor]);
+  const inEnabledProviders = providers.filter(p => enabledProviderIds.includes(p.id));
+  const expiredProviders =
+    activeDescriptor && !enabledProviderIds.includes(activeDescriptor.id)
+      ? [activeDescriptor, ...inEnabledProviders]
+      : inEnabledProviders;
 
   return (
     <Wrapper>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the conditional `useMemo` invocation in `ProviderSetupScreen`
- compute `expiredProviders` using plain derived values after the early-return branch
- preserve reconnect-screen behavior while keeping hook order stable across renders

## Testing
- `npx eslint src/components/ProviderSetupScreen.tsx`
- `npm run test:run`

## Notes
- `npm run lint` currently fails due to pre-existing repository-wide lint errors unrelated to this issue; this change eliminates the hook-order violation in `ProviderSetupScreen`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a314b5c8-7395-4353-8705-810cf8418fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a314b5c8-7395-4353-8705-810cf8418fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

