### PR TITLE
fix: resolve eslint react-hooks false positives in Playwright fixtures

### DIFF
--- a/playwright/capture/fixtures.ts
+++ b/playwright/capture/fixtures.ts
@@ -23,7 +23,7 @@ function loadAuthState(): AuthState | null {
 }
 
 export const test = base.extend<{ capturePage: Page }>({
-  capturePage: async ({}, use, testInfo) => {
+  capturePage: async (_fixtures, runFixture, testInfo) => {
     const playlist = process.env.PLAYLIST || DEFAULT_PLAYLIST;
     const useCdp = process.env.USE_CDP === '1';
     const headless = process.env.HEADLESS === '1';
@@ -90,7 +90,7 @@ export const test = base.extend<{ capturePage: Page }>({
       };
     }
 
-    await use(page);
+    await runFixture(page);
     await cleanup();
   },
 });

--- a/playwright/fixtures/auth.ts
+++ b/playwright/fixtures/auth.ts
@@ -1,7 +1,7 @@
 import { test as base } from '@playwright/test';
 
 export const test = base.extend({
-  page: async ({ page }, use) => {
+  page: async ({ page }, runFixture) => {
     await page.addInitScript(() => {
       localStorage.setItem('spotify_token', JSON.stringify({
         access_token: 'fake-e2e-token',
@@ -10,7 +10,7 @@ export const test = base.extend({
       }));
       localStorage.setItem('vorbis-player-active-provider', JSON.stringify('spotify'));
     });
-    await use(page);
+    await runFixture(page);
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes issue #1359 by avoiding `react-hooks/rules-of-hooks` false positives in Playwright fixture callbacks.
- Renames fixture callback parameter from `use` to `runFixture` in:
  - `playwright/capture/fixtures.ts`
  - `playwright/fixtures/auth.ts`
- Removes an empty object destructuring pattern in `playwright/capture/fixtures.ts` to satisfy `no-empty-pattern`.

## Validation
- `npx eslint playwright/capture/fixtures.ts playwright/fixtures/auth.ts`
- `npm run test:run`

## Notes
- `npm run lint` currently reports multiple unrelated pre-existing lint issues across the repository; this PR focuses strictly on the fixture lint false positive from issue #1359.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87954a2f-db94-4ea0-8e40-4339c72de75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87954a2f-db94-4ea0-8e40-4339c72de75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

