### PR TITLE
fix(queue): surface silent failures in handleAddToQueue via toasts

### DIFF
--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { toast } from 'sonner';
 import { useQueueManagement } from '../useQueueManagement';
 import { makeTrack } from '@/test/fixtures';
 import type { MediaTrack } from '@/types/domain';
+
+vi.mock('sonner', () => ({
+  toast: vi.fn(),
+}));
 
 function makeMediaTrack(id: string): MediaTrack {
   return {
@@ -35,6 +40,7 @@ describe('useQueueManagement', () => {
     mockGetDescriptor = vi.fn();
     mockActiveDescriptor = { id: 'spotify' };
     mediaTracksRef = { current: [] };
+    vi.mocked(toast).mockClear();
   });
 
   it('handleRemoveFromQueue does nothing when index equals currentTrackIndex', () => {
@@ -264,5 +270,147 @@ describe('useQueueManagement', () => {
     expect(mockSetOriginalTracks).toHaveBeenCalled();
     expect(response).toEqual({ added: 2, collectionName: undefined });
     expect(mockSetCurrentTrackIndex).not.toHaveBeenCalled();
+  });
+
+  it('handleAddToQueue toasts the empty-collection message when loadCollection returns 0', async () => {
+    // #given — empty queue, descriptor present, but loadCollection yields nothing
+    mockHandlePlaylistSelect.mockResolvedValue(0);
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks: [],
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () => result.current.handleAddToQueue('empty_playlist'));
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith('This collection is empty.', { id: 'qap-add-queue-empty' });
+  });
+
+  it('handleAddToQueue toasts the failure message when no descriptor resolves', async () => {
+    // #given — no active descriptor and no resolvable provider
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks: [makeTrack({ id: 'a' })],
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: undefined,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () => result.current.handleAddToQueue('playlist_id'));
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+    expect(mockSetTracks).not.toHaveBeenCalled();
+  });
+
+  it('handleAddToQueue toasts the duplicate message when every fetched track is already queued', async () => {
+    // #given — queue already contains every track listTracks will return
+    mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+    const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+    const mockCatalog = {
+      listTracks: vi.fn().mockResolvedValue([makeMediaTrack('1'), makeMediaTrack('2')]),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () => result.current.handleAddToQueue('playlist_id'));
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith('Already in your queue.', { id: 'qap-add-queue-dup' });
+    expect(mockSetTracks).not.toHaveBeenCalled();
+  });
+
+  it('handleAddToQueue toasts the failure message when listTracks throws', async () => {
+    // #given — non-empty queue, descriptor whose catalog rejects
+    mediaTracksRef.current = [makeMediaTrack('1')];
+    const tracks = [makeTrack({ id: '1' })];
+    const mockCatalog = {
+      listTracks: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () => result.current.handleAddToQueue('playlist_id'));
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+    errorSpy.mockRestore();
+  });
+
+  it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
+    // #given — queue already contains every incoming track
+    mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+    const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    let response: ReturnType<typeof result.current.queueTracksDirectly> = null;
+    act(() => {
+      response = result.current.queueTracksDirectly([makeMediaTrack('1'), makeMediaTrack('2')], 'Liked');
+    });
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith('Already in your queue.', { id: 'qap-add-queue-dup' });
+    expect(mockSetTracks).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -14,6 +14,13 @@ import {
 } from '@/utils/queueTrackMirror';
 import { trkSummary } from './playerLogicUtils';
 
+const ADD_TO_QUEUE_ERROR_ID = 'qap-add-queue-error';
+const ADD_TO_QUEUE_DUP_ID = 'qap-add-queue-dup';
+const ADD_TO_QUEUE_EMPTY_ID = 'qap-add-queue-empty';
+const ADD_TO_QUEUE_ERROR_MSG = "Couldn't add to queue. Try again.";
+const ADD_TO_QUEUE_DUP_MSG = 'Already in your queue.';
+const ADD_TO_QUEUE_EMPTY_MSG = 'This collection is empty.';
+
 interface UseQueueManagementProps {
   trackOps: Pick<TrackOperations, 'setTracks' | 'setOriginalTracks' | 'setCurrentTrackIndex' | 'mediaTracksRef'>;
   tracks: MediaTrack[];
@@ -62,21 +69,21 @@ export function useQueueManagement({
         mediaTracksRef.current.length,
       );
 
+      const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
+      const targetProviderId = provider ?? activeDescriptor?.id;
+
+      if (!targetDescriptor || !targetProviderId) {
+        toast(ADD_TO_QUEUE_ERROR_MSG, { id: ADD_TO_QUEUE_ERROR_ID });
+        return null;
+      }
+
       if (isQueueEmpty) {
         logQueue('handleAddToQueue — queue empty, delegating to loadCollection');
         const loaded = await loadCollection(playlistId, provider, collectionName);
         if (loaded > 0) {
           return { added: loaded, collectionName };
         }
-        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
-        return null;
-      }
-
-      const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
-      const targetProviderId = provider ?? activeDescriptor?.id;
-
-      if (!targetDescriptor || !targetProviderId) {
-        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+        toast(ADD_TO_QUEUE_EMPTY_MSG, { id: ADD_TO_QUEUE_EMPTY_ID });
         return null;
       }
 
@@ -94,7 +101,7 @@ export function useQueueManagement({
         }
 
         if (uniqueNewTracks.length === 0) {
-          toast('Already in your queue.', { id: 'qap-add-queue-dup' });
+          toast(ADD_TO_QUEUE_DUP_MSG, { id: ADD_TO_QUEUE_DUP_ID });
           return null;
         }
 
@@ -116,7 +123,7 @@ export function useQueueManagement({
         return { added: uniqueNewTracks.length, collectionName };
       } catch (err) {
         console.error('[Queue] Failed to add to queue:', err);
-        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+        toast(ADD_TO_QUEUE_ERROR_MSG, { id: ADD_TO_QUEUE_ERROR_ID });
         return null;
       }
     },
@@ -202,7 +209,10 @@ export function useQueueManagement({
       const existingIds = new Set(tracksRef.current.map((t) => t.id));
       const uniqueNewTracks = newTracks.filter((t) => !existingIds.has(t.id));
 
-      if (uniqueNewTracks.length === 0) return null;
+      if (uniqueNewTracks.length === 0) {
+        toast(ADD_TO_QUEUE_DUP_MSG, { id: ADD_TO_QUEUE_DUP_ID });
+        return null;
+      }
 
       logQueue(
         'queueTracksDirectly — appending %d tracks. Before: tracks=%d, mediaRef=%d',

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import { toast } from 'sonner';
 import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
@@ -67,13 +68,17 @@ export function useQueueManagement({
         if (loaded > 0) {
           return { added: loaded, collectionName };
         }
+        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
         return null;
       }
 
       const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
       const targetProviderId = provider ?? activeDescriptor?.id;
 
-      if (!targetDescriptor || !targetProviderId) return null;
+      if (!targetDescriptor || !targetProviderId) {
+        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+        return null;
+      }
 
       try {
         const catalog = targetDescriptor.catalog;
@@ -88,7 +93,10 @@ export function useQueueManagement({
           logQueue('handleAddToQueue — deduped: %d → %d tracks', newMediaTracks.length, uniqueNewTracks.length);
         }
 
-        if (uniqueNewTracks.length === 0) return null;
+        if (uniqueNewTracks.length === 0) {
+          toast('Already in your queue.', { id: 'qap-add-queue-dup' });
+          return null;
+        }
 
         // Append to existing queue
         logQueue(
@@ -108,6 +116,7 @@ export function useQueueManagement({
         return { added: uniqueNewTracks.length, collectionName };
       } catch (err) {
         console.error('[Queue] Failed to add to queue:', err);
+        toast("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
         return null;
       }
     },


### PR DESCRIPTION
## Summary

Right-click → Add to Queue (and any caller of `useQueueManagement.handleAddToQueue` / `queueTracksDirectly`) previously had silent-return paths where the user got zero feedback when the operation didn't actually add anything. Each of those paths now fires a sonner toast so the click no longer vanishes into the void. Mirrors the defensive pattern introduced in #1350.

## Changes

- `src/hooks/useQueueManagement.ts`
  - Toast IDs and copy extracted to module-level constants.
  - Descriptor resolution hoisted above the empty-queue branch so the path can distinguish:
    - missing target descriptor / provider id → `"Couldn't add to queue. Try again."`
    - empty-queue load returning 0 (now means: collection is empty) → `"This collection is empty."`
  - Non-empty queue path keeps the existing branches:
    - all candidate tracks already in queue → `"Already in your queue."` (informational)
    - thrown error from `catalog.listTracks` (previously console.error only) → `"Couldn't add to queue. Try again."`
  - `queueTracksDirectly` now toasts `"Already in your queue."` on the dedupe-zero path used by Queue Liked.
- Failure toasts share id `qap-add-queue-error`; duplicate toast uses `qap-add-queue-dup`; empty-collection toast uses `qap-add-queue-empty`. All distinct from the existing success-toast id `qap-add-queue` in `AudioPlayer.tsx`, so they coexist cleanly.
- Added 5 tests covering the new toast branches in `src/hooks/__tests__/useQueueManagement.test.ts`.

## Test plan

- [x] `npm run test:run` — 1639/1639 pass locally
- [x] `npx tsc -b --noEmit` — clean
- [ ] Manual: add a collection whose tracks are already in the queue → "Already in your queue." appears
- [ ] Manual: add an empty collection → "This collection is empty." appears
- [ ] Manual: trigger a deliberate failure (e.g. disconnect network mid-add) → "Couldn't add to queue. Try again." appears
- [ ] Manual: happy path still toasts the existing success message with View action

## Notes

A separate dev-environment issue surfaced while running the suite — 3 ui test files fail to load when `node_modules` drifts from `package-lock.json`. Filed as #1377; unrelated to this PR.