### PR TITLE
docs: add mock provider + snapshot workflow documentation (#1375)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ npm run lint           # Lint
 npm run test           # Watch mode
 npm run test:run       # Run once
 npm run test:coverage  # Coverage
+npm run test:e2e       # Playwright specs
+npm run capture        # Visual capture (desktop + mobile)
+npm run snapshot:spotify   # Regenerate Spotify fixture snapshot
+npm run snapshot:dropbox   # Regenerate Dropbox fixture snapshot
 npm run deploy         # Deploy to production
 npm run deploy:preview # Deploy preview
 ```
@@ -113,6 +117,12 @@ Optional (enables radio recommendations):
 VITE_LASTFM_API_KEY="your_lastfm_api_key"
 ```
 
+Optional (activates mock provider for dev/test; tree-shaken from prod):
+
+```
+VITE_MOCK_PROVIDER="true"
+```
+
 Vite dev server: host `127.0.0.1`, port `3000` (required for Spotify OAuth).
 Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`).
 
@@ -127,7 +137,58 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 
 ## Testing
 
+### Unit / integration (Vitest)
+
 Run with `npm run test:run`. Tests are colocated with source files in `__tests__/` subdirectories. Verify actual behavior, not mock implementations. See `docs/testing.md` for test utilities (`src/test/`) and the BDD `// #given / #when / #then` comment convention.
+
+### Playwright (end-to-end + visual capture)
+
+All Playwright work runs against the **mock provider** — no credentials, no browser login, no Spotify SDK.
+
+```bash
+npm run test:e2e       # run specs
+npm run capture        # visual capture (desktop + mobile)
+```
+
+The mock provider (`src/providers/mock/`) serves catalog from `playwright/fixtures/data/spotify-snapshot.json` and `dropbox-snapshot.json` and plays bundled audio. Activate manually with `VITE_MOCK_PROVIDER=true npm run dev` or `?provider=mock` URL param.
+
+### Curating fixtures
+
+Vorbis Player's Playwright tests run against committed JSON snapshots of a real
+Spotify/Dropbox library. Because each user's library is different, you curate which
+playlists/albums get captured before generating the snapshot.
+
+1. **Enumerate** your library (read-only):
+   ```
+   npm run dev &
+   npm run snapshot:spotify -- --list
+   npm run snapshot:dropbox -- --list
+   ```
+   Each command logs you in interactively (Chromium pops up; log in once and press
+   Enter when ready) and prints a list of available playlists / albums / folders
+   with their IDs.
+
+2. **Edit `playwright/fixtures/data/snapshot.config.json`** to include the IDs and
+   folder paths you want to curate. Aim for a small, representative set — about
+   5–10 playlists, a few saved albums, and the most-played folders. The committed
+   file ships with empty arrays so you can populate from scratch.
+
+3. **Generate the snapshot** (writes JSON + downloads art):
+   ```
+   npm run snapshot:spotify
+   npm run snapshot:dropbox
+   ```
+   Personal data is anonymized automatically (display name, owner names, profile
+   picture). Public catalog data (album/track/artist names, durations, ISRCs) is
+   preserved verbatim.
+
+4. **Review the diff** in `playwright/fixtures/data/*.json` and
+   `public/playwright-fixtures/art/` and commit. The PR review is the human gate
+   for any PII that slips past the automatic scrubber.
+
+Re-curate any time your library changes substantially. Re-running with the same
+`scripts/snapshot/seed.json` produces deterministic diffs (only changed content
+shows up).
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,78 @@ For radio recommendations, also set `VITE_LASTFM_API_KEY` in `.env.local` (see `
 |----------|-------|
 | Vercel | **[Deploy to Vercel](./docs/deployment/deploy-to-vercel.md)** |
 
+## Testing & Playwright
+
+Unit and integration tests run with Vitest (`npm run test:run`).
+
+End-to-end and visual-capture tests run with Playwright against the **mock provider** — a drop-in replacement for Spotify and Dropbox that serves catalog from committed JSON snapshots and plays bundled audio. No real credentials, no browser login, no SDK required.
+
+### Running Playwright tests
+
+```bash
+npm run test:e2e          # run all specs
+npm run test:e2e:ui       # Playwright UI mode
+```
+
+### Visual capture (screenshots / snapshots)
+
+```bash
+npm run capture           # both desktop + mobile
+npm run capture:desktop
+npm run capture:mobile
+```
+
+The dev server starts automatically with `VITE_MOCK_PROVIDER=true`. No login required.
+
+### Mock provider
+
+Activate in any environment:
+
+```bash
+VITE_MOCK_PROVIDER=true npm run dev   # env var
+# or open http://127.0.0.1:3000?provider=mock
+```
+
+The mock provider is tree-shaken from production builds — it only activates when `VITE_MOCK_PROVIDER=true` at build time or the `?provider=mock` URL parameter is present.
+
+### Curating fixtures
+
+Vorbis Player's Playwright tests run against committed JSON snapshots of a real
+Spotify/Dropbox library. Because each user's library is different, you curate which
+playlists/albums get captured before generating the snapshot.
+
+1. **Enumerate** your library (read-only):
+   ```
+   npm run dev &
+   npm run snapshot:spotify -- --list
+   npm run snapshot:dropbox -- --list
+   ```
+   Each command logs you in interactively (Chromium pops up; log in once and press
+   Enter when ready) and prints a list of available playlists / albums / folders
+   with their IDs.
+
+2. **Edit `playwright/fixtures/data/snapshot.config.json`** to include the IDs and
+   folder paths you want to curate. Aim for a small, representative set — about
+   5–10 playlists, a few saved albums, and the most-played folders. The committed
+   file ships with empty arrays so you can populate from scratch.
+
+3. **Generate the snapshot** (writes JSON + downloads art):
+   ```
+   npm run snapshot:spotify
+   npm run snapshot:dropbox
+   ```
+   Personal data is anonymized automatically (display name, owner names, profile
+   picture). Public catalog data (album/track/artist names, durations, ISRCs) is
+   preserved verbatim.
+
+4. **Review the diff** in `playwright/fixtures/data/*.json` and
+   `public/playwright-fixtures/art/` and commit. The PR review is the human gate
+   for any PII that slips past the automatic scrubber.
+
+Re-curate any time your library changes substantially. Re-running with the same
+`scripts/snapshot/seed.json` produces deterministic diffs (only changed content
+shows up).
+
 ## Tech Stack
 
 React 18 · TypeScript 5 · Vite 6 · styled-components · Tailwind CSS · shadcn/ui · Radix UI · Vitest

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -53,6 +53,40 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 
 ## Provider implementation details
 
+### Mock provider (dev/test only)
+
+`src/providers/mock/` — a drop-in replacement for Spotify and Dropbox used by Playwright tests and visual-capture runs. Never included in production builds.
+
+**Activation**
+
+- Build-time env var: `VITE_MOCK_PROVIDER=true` (sets the Vite build flag; the entire module is tree-shaken when the var is absent or `false`)
+- Runtime URL param: `?provider=mock` (overrides at page load without a rebuild)
+
+**Catalog**
+
+Served from committed JSON snapshots:
+
+- `playwright/fixtures/data/spotify-snapshot.json`
+- `playwright/fixtures/data/dropbox-snapshot.json`
+
+Both files are validated against the `ProviderSnapshot` schema (`playwright/fixtures/data/snapshot.types.ts`) at module load. Regenerate with `npm run snapshot:spotify` / `npm run snapshot:dropbox` (requires a real authenticated session; see README.md § Curating fixtures).
+
+**Playback**
+
+HTML5 `<audio>` element driven by `MockPlaybackAdapter` — no Spotify Web Playback SDK. Bundled audio clips in `src/providers/mock/audioMapping.ts` stand in for real tracks so capture tests produce consistent waveforms without network calls.
+
+**Auth**
+
+`MockAuthAdapter` returns a pre-authenticated session immediately; no OAuth popup. The provider is auto-connected on page load when the mock is active.
+
+**Test-control surface**
+
+`src/providers/mock/test-control.ts` exposes `window.__mockProvider` for Playwright scripts to drive playback state (skip, seek, force-error) without UI interaction.
+
+**Pin seeding**
+
+`pinSeeder.ts` pre-populates pinned playlists from the snapshot on first load so the Library view is populated without user interaction.
+
 ### Dropbox folder structure
 
 ```

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -81,7 +81,7 @@ HTML5 `<audio>` element driven by `MockPlaybackAdapter` — no Spotify Web Playb
 
 **Test-control surface**
 
-`src/providers/mock/test-control.ts` exposes `window.__mockProvider` for Playwright scripts to drive playback state (skip, seek, force-error) without UI interaction.
+`src/providers/mock/test-control.ts` exposes `window.__mockTest` for Playwright scripts to drive playback state (skip, seek, force-error) without UI interaction.
 
 **Pin seeding**
 


### PR DESCRIPTION
## Summary

- Add `## Testing & Playwright` section to `README.md` covering mock provider activation, zero-setup capture commands, and the verbatim "Curating fixtures" workflow
- Expand `CLAUDE.md` with Playwright commands in the dev commands table, `VITE_MOCK_PROVIDER` in environment config, and a full Playwright + Curating fixtures section under Testing
- Add `### Mock provider (dev/test only)` to `docs/architecture/providers.md` as the first subsection under Provider implementation details — documents activation, catalog, playback (HTML5, no SDK), auth, test-control surface, and pin seeding

## Changes

- `README.md` — new `## Testing & Playwright` section (after Documentation table, before Tech Stack)
- `CLAUDE.md` — three additions: dev commands table, environment config, Testing section expansion
- `docs/architecture/providers.md` — new `### Mock provider (dev/test only)` subsection

## Test plan

- [ ] Orphan grep: `capture:login`, `capture:cdp`, `capture:auth`, `.auth-state.json`, `save-auth.ts`, `Web Playback SDK shim` — none found in README.md, CLAUDE.md, or docs/
- [ ] `npx tsc -b --noEmit` — clean
- [ ] "Curating fixtures" block is verbatim from `scripts/snapshot-spotify.ts` header

Closes #1375