### PR TITLE
fix(library): album menu uses Like/Unlike and reflects saved state

### DIFF
--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -29,8 +29,9 @@ vi.mock('../useLikedTracksForProvider', () => ({
   useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
 }));
 
-const { mockQueueLikedFromCollection } = vi.hoisted(() => ({
+const { mockQueueLikedFromCollection, mockUseAlbumSavedStatus } = vi.hoisted(() => ({
   mockQueueLikedFromCollection: vi.fn(),
+  mockUseAlbumSavedStatus: vi.fn(),
 }));
 
 vi.mock('../useQueueLikedFromCollection', () => ({
@@ -38,13 +39,7 @@ vi.mock('../useQueueLikedFromCollection', () => ({
 }));
 
 vi.mock('../useAlbumSavedStatus', () => ({
-  useAlbumSavedStatus: () => ({
-    isSaved: null,
-    toggleSaved: vi.fn(),
-    canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
-  }),
+  useAlbumSavedStatus: (...args: unknown[]) => mockUseAlbumSavedStatus(...args),
 }));
 
 import LibraryContextMenu, { type LibraryContextMenuProps } from '../LibraryContextMenu';
@@ -72,6 +67,13 @@ function defaultMocks() {
   });
   mockRecent.mockReturnValue({ remove: vi.fn() });
   mockLoadLiked.mockResolvedValue([]);
+  mockUseAlbumSavedStatus.mockReturnValue({
+    isSaved: null,
+    toggleSaved: vi.fn(),
+    canToggle: false,
+    saveError: null,
+    clearSaveError: vi.fn(),
+  });
 }
 
 function renderMenu(propsOverrides: Partial<LibraryContextMenuProps> = {}) {
@@ -342,5 +344,60 @@ describe('LibraryContextMenu', () => {
 
     // #then
     expect(screen.queryByTestId('menu-queue-liked')).not.toBeInTheDocument();
+  });
+
+  describe('album Like/Unlike toggle', () => {
+    it('shows "Unlike" label when album is already liked (isSaved=true)', () => {
+      // #given
+      mockUseAlbumSavedStatus.mockReturnValue({
+        isSaved: true,
+        toggleSaved: vi.fn(),
+        canToggle: true,
+        saveError: null,
+        clearSaveError: vi.fn(),
+      });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Unlike');
+    });
+
+    it('shows "Like" label when album is not liked (isSaved=false)', () => {
+      // #given
+      mockUseAlbumSavedStatus.mockReturnValue({
+        isSaved: false,
+        toggleSaved: vi.fn(),
+        canToggle: true,
+        saveError: null,
+        clearSaveError: vi.fn(),
+      });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Like');
+    });
+
+    it('omits toggle-save when isSaved is null (status still loading)', () => {
+      // #given — default mock: isSaved=null, canToggle=false
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.queryByTestId('menu-toggle-save')).not.toBeInTheDocument();
+    });
+
+    it('useAlbumSavedStatus is called with the album id and provider', () => {
+      // #when
+      renderMenu({
+        request: makeRequest({ kind: 'album', id: 'album99', provider: 'spotify' as ProviderId }),
+      });
+
+      // #then
+      expect(mockUseAlbumSavedStatus).toHaveBeenCalledWith('album99', 'spotify');
+    });
   });
 });

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
@@ -136,7 +136,7 @@ describe('buildMenuItems edges', () => {
       expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
     });
 
-    it('Save label remains "Save" when isSaved is false', () => {
+    it('Like label remains "Like" when isSaved is false', () => {
       // #given
       const actions = makeActions({ onToggleSave: vi.fn(), isSaved: false });
 
@@ -144,7 +144,7 @@ describe('buildMenuItems edges', () => {
       const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
 
       // #then
-      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Save');
+      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Like');
     });
   });
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
@@ -136,7 +136,7 @@ describe('buildMenuItems edges', () => {
       expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
     });
 
-    it('Like label remains "Like" when isSaved is false', () => {
+    it('Like label is shown when isSaved is false', () => {
       // #given
       const actions = makeActions({ onToggleSave: vi.fn(), isSaved: false });
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
@@ -147,7 +147,7 @@ describe('buildMenuItems', () => {
     expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
   });
 
-  it('flips Save label to Unsave when isSaved=true', () => {
+  it('flips Like label to Unlike when isSaved=true', () => {
     // #given
     const actions = makeActions({ onToggleSave: vi.fn(), isSaved: true });
 
@@ -155,7 +155,7 @@ describe('buildMenuItems', () => {
     const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
 
     // #then
-    expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unsave');
+    expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unlike');
   });
 
   it('marks Start Radio disabled when startRadioDisabled=true', () => {

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -76,7 +76,7 @@ function buildAlbumItems(actions: MenuActions): MenuItem[] {
   if (actions.onToggleSave) {
     items.push({
       id: 'toggle-save',
-      label: actions.isSaved ? 'Unsave' : 'Save',
+      label: actions.isSaved ? 'Unlike' : 'Like',
       onSelect: actions.onToggleSave,
     });
   }

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -74,6 +74,8 @@ function buildAlbumItems(actions: MenuActions): MenuItem[] {
     },
   ];
   if (actions.onToggleSave) {
+    // User-facing copy uses "Like"/"Unlike" for vocabulary parity with the track heart;
+    // internal field names mirror the Spotify API ("saved"). See #1386.
     items.push({
       id: 'toggle-save',
       label: actions.isSaved ? 'Unlike' : 'Like',

--- a/src/services/spotify/__tests__/playlists.cachePrime.test.ts
+++ b/src/services/spotify/__tests__/playlists.cachePrime.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { albumSavedCache } from '../cache';
+
+vi.mock('../auth', () => ({
+  spotifyAuth: {
+    ensureValidToken: vi.fn().mockResolvedValue('mock-token'),
+  },
+}));
+
+const mockSpotifyApiRequest = vi.fn();
+vi.mock('../api', () => ({
+  spotifyApiRequest: (...args: unknown[]) => mockSpotifyApiRequest(...args),
+  fetchAllPaginated: vi.fn(),
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  getTrackList: vi.fn().mockResolvedValue(null),
+  putTrackList: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getUserLibraryInterleaved } from '../playlists';
+import { checkAlbumSaved } from '../albums';
+
+describe('getUserLibraryInterleaved — albumSavedCache priming', () => {
+  beforeEach(() => {
+    albumSavedCache.clear();
+    mockSpotifyApiRequest.mockReset();
+  });
+
+  it('checkAlbumSaved returns true from cache without a network call after getUserLibraryInterleaved', async () => {
+    // #given
+    const albumId = 'album-abc';
+
+    mockSpotifyApiRequest.mockImplementation((url: string) => {
+      if (url.includes('me/playlists')) {
+        return Promise.resolve({ items: [], next: null, total: 0 });
+      }
+      if (url.includes('me/albums')) {
+        return Promise.resolve({
+          items: [
+            {
+              added_at: '2024-01-01T00:00:00Z',
+              album: {
+                id: albumId,
+                name: 'Test Album',
+                artists: [{ name: 'Test Artist' }],
+                images: [],
+                release_date: '2024-01-01',
+                total_tracks: 10,
+                uri: `spotify:album:${albumId}`,
+              },
+            },
+          ],
+          next: null,
+          total: 1,
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    // #when
+    await getUserLibraryInterleaved(
+      () => {},
+      () => {},
+    );
+
+    const callCountAfterInterleaved = mockSpotifyApiRequest.mock.calls.length;
+
+    const isSaved = await checkAlbumSaved(albumId);
+
+    // #then
+    expect(isSaved).toBe(true);
+    expect(mockSpotifyApiRequest.mock.calls.length).toBe(callCountAfterInterleaved);
+  });
+});

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -2,7 +2,7 @@ import type { MediaTrack } from '@/types/domain';
 import type { Track, PlaylistInfo, AlbumInfo, SpotifyAlbum, SpotifyTrackItem, PaginatedResponse } from './types';
 import { spotifyApiRequest, fetchAllPaginated } from './api';
 import { spotifyAuth } from './auth';
-import { trackListCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSIST_TTL } from './cache';
+import { trackListCache, albumSavedCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSIST_TTL } from './cache';
 import { formatArtists, transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import * as libraryCache from '../cache/libraryCache';
 
@@ -90,8 +90,12 @@ export async function getUserLibraryInterleaved(
       fetches.push(
         spotifyApiRequest<PaginatedResponse<SavedAlbumItem>>(url, token, { signal })
           .then((data) => {
+            const now = Date.now();
             for (const item of data.items ?? []) {
               albumResults.push(transformAlbum(item));
+              if (item.album.id) {
+                albumSavedCache.set(item.album.id, { value: true, timestamp: now });
+              }
             }
             albumNextUrl = data.next;
             const isComplete = albumNextUrl === null;


### PR DESCRIPTION
## Summary
- Renamed Save/Unsave → Like/Unlike in the album context menu to align with the heart/liked-songs vocabulary used across the rest of the app
- Fixed stale `isSaved=false` by priming `albumSavedCache` when the user's saved-albums list is fetched via `getUserLibraryInterleaved`; subsequent `isAlbumSaved` calls now return from cache with the correct `true` value instead of always requiring a network round-trip
- Updated context-menu tests: asserted Like/Unlike labels and added four new cases covering liked/unliked/loading states and hook call-site arguments

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run -- src/components/LibraryRoute/contextMenu` — 76 tests green
- Manual: long-press an album already saved in Spotify → menu shows "Unlike"; long-press an album not saved → menu shows "Like"

Closes #1386