### PR TITLE
fix(mock): route capture flow through provider abstraction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import AudioPlayerComponent from './components/AudioPlayer';
 import { spotifyAuth } from './services/spotify';
+import { shouldUseMockProvider } from './providers/mock/shouldUseMockProvider';
 import { ThemeProvider } from './styles/ThemeProvider';
 import { flexCenter, buttonPrimary } from './styles/utils';
 import { AuthCallbackPage } from './components/AuthCallbackPage';
@@ -190,6 +191,7 @@ function App() {
             <RetryButton
               onClick={() => {
                 setAuthError(null);
+                if (shouldUseMockProvider()) return;
                 spotifyAuth.redirectToAuth();
               }}
             >

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -285,11 +285,8 @@ const AudioPlayerComponent = () => {
     autoSelectFired.current = true;
     window.history.replaceState({}, '', '/');
 
-    // Accept both raw playlist IDs (legacy) and `provider:kind:id` keys
-    // (used by capture/Playwright via `?playlist=spotify:playlist:<id>`).
-    // The key form decomposes into a CollectionRef so the mock catalog can
-    // resolve the playlist by its actual snapshot id, instead of falling
-    // through to the Spotify SDK fallback.
+    // Structured `provider:kind:id` keys let the mock catalog resolve by snapshot id
+    // instead of falling through to the Spotify SDK; raw IDs work for legacy links.
     const ref = keyToCollectionRef(playlistParam);
     if (ref) {
       const playlistId = ref.kind === 'liked'

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -22,7 +22,8 @@ import {
 import { PlayerSizingProvider } from '@/contexts/PlayerSizingContext';
 import { useTrackListContext, useCurrentTrackContext } from '@/contexts/TrackContext';
 import { useProviderContext } from '@/contexts/ProviderContext';
-import { toAlbumPlaylistId } from '@/constants/playlist';
+import { toAlbumPlaylistId, LIKED_SONGS_ID } from '@/constants/playlist';
+import { keyToCollectionRef } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/AppSettingsMenu';
 import { useSessionPersistence } from '@/hooks/useSessionPersistence';
@@ -283,7 +284,23 @@ const AudioPlayerComponent = () => {
     if (!playlistParam) return;
     autoSelectFired.current = true;
     window.history.replaceState({}, '', '/');
-    handlers.loadCollection(playlistParam);
+
+    // Accept both raw playlist IDs (legacy) and `provider:kind:id` keys
+    // (used by capture/Playwright via `?playlist=spotify:playlist:<id>`).
+    // The key form decomposes into a CollectionRef so the mock catalog can
+    // resolve the playlist by its actual snapshot id, instead of falling
+    // through to the Spotify SDK fallback.
+    const ref = keyToCollectionRef(playlistParam);
+    if (ref) {
+      const playlistId = ref.kind === 'liked'
+        ? LIKED_SONGS_ID
+        : ref.kind === 'album'
+          ? toAlbumPlaylistId(ref.id)
+          : ref.id;
+      handlers.loadCollection(playlistId, ref.provider);
+    } else {
+      handlers.loadCollection(playlistParam);
+    }
   }, [needsSetup, selectedPlaylistId, handlers]);
 
   const isMainPlayerActive = !state.isLoading && !state.error && selectedPlaylistId !== null && tracks.length > 0;

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -5,6 +5,12 @@ import { makeTrack } from '@/test/fixtures';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import type { MediaTrack } from '@/types/domain';
 
+vi.mock('@/providers/mock/shouldUseMockProvider', () => ({
+  shouldUseMockProvider: vi.fn(() => false),
+}));
+
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
+
 function makeMediaTrack(id: string, addedAt?: number): MediaTrack {
   return {
     id,
@@ -195,6 +201,44 @@ describe('useCollectionLoader', () => {
     // #then
     expect(mockSetError).toHaveBeenCalledWith('No tracks found in this collection.');
     expect(mockSetTracks).toHaveBeenCalledWith([]);
+    expect(trackCount).toBe(0);
+  });
+
+  it('skips the legacy SDK fallback when the mock provider is active even if playCollection is defined', async () => {
+    // #given — mock active, empty catalog, playback advertises playCollection
+    vi.mocked(shouldUseMockProvider).mockReturnValueOnce(true);
+    const mockCatalog = {
+      listTracks: vi.fn().mockResolvedValue([]),
+    };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn(), playCollection: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    const trackCount = await act(async () => {
+      return result.current.loadCollection('playlist_123');
+    });
+
+    // #then — legacy spotify path is never invoked; surfaces empty-collection state
+    expect(mockSpotifyHandlePlaylistSelect).not.toHaveBeenCalled();
+    expect(mockSetError).toHaveBeenCalledWith('No tracks found in this collection.');
     expect(trackCount).toBe(0);
   });
 

--- a/src/hooks/__tests__/usePlaylistManager.test.ts
+++ b/src/hooks/__tests__/usePlaylistManager.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { makeTrack } from '@/test/fixtures';
+import type { MediaTrack } from '@/types/domain';
+
+vi.mock('@/providers/mock/shouldUseMockProvider', () => ({
+  shouldUseMockProvider: vi.fn().mockReturnValue(false),
+}));
 
 vi.mock('@/services/spotifyPlayer', () => ({
   spotifyPlayer: {
@@ -29,6 +34,7 @@ vi.mock('@/services/spotify', () => ({
 
 import { useSpotifyPlaylistManager as usePlaylistManager } from '@/providers/spotify/useSpotifyPlaylistManager';
 import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth } from '@/services/spotify';
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 
 describe('usePlaylistManager', () => {
   const setError = vi.fn();
@@ -170,5 +176,24 @@ describe('usePlaylistManager', () => {
 
     // #then
     expect(setIsLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  describe('mock provider short-circuit', () => {
+    it('returns [] without calling spotifyPlayer.initialize when mock provider is active', async () => {
+      // #given — mock provider is active
+      vi.mocked(shouldUseMockProvider).mockReturnValue(true);
+      const { spotifyPlayer } = await import('@/services/spotifyPlayer');
+      const { result } = renderHook(() => usePlaylistManager(defaultProps));
+
+      // #when
+      let tracks: MediaTrack[] = [];
+      await act(async () => {
+        tracks = await result.current.handlePlaylistSelect('playlist-123');
+      });
+
+      // #then
+      expect(tracks).toEqual([]);
+      expect(spotifyPlayer.initialize).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -5,6 +5,7 @@ import type { TrackOperations } from '@/types/trackOperations';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logQueue } from '@/lib/debugLog';
 import { queueSnapshot } from './playerLogicUtils';
 
@@ -166,7 +167,7 @@ export function useCollectionLoader({
       const collectionRef = { provider: providerId, kind: collectionKind, id: collectionId } as const;
       const list = await targetDescriptor.catalog.listTracks(collectionRef);
 
-      if (list.length === 0 && targetDescriptor.playback.playCollection) {
+      if (list.length === 0 && targetDescriptor.playback.playCollection && !shouldUseMockProvider()) {
         return loadContextPlayback(playlistId, providerId);
       }
 

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -16,6 +16,7 @@ import { shuffleArray } from '@/utils/shuffleArray';
 import type { ProviderId, MediaTrack } from '@/types/domain';
 import type { TrackOperations } from '@/types/trackOperations';
 import { logQueue } from '@/lib/debugLog';
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { SPOTIFY_POST_ACTION_DELAY_MS, SPOTIFY_RETRY_DELAY_MS, SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
 
 const SPOTIFY_PROVIDER_ID: ProviderId = 'spotify';
@@ -76,6 +77,16 @@ export const useSpotifyPlaylistManager = ({
 
   const handlePlaylistSelect = useCallback(async (playlistId: string): Promise<MediaTrack[]> => {
     logQueue('useSpotifyPlaylistManager.handlePlaylistSelect — playlistId=%s, shuffle=%s', playlistId, String(shuffleEnabled));
+
+    // The mock provider replaces the spotify descriptor at the registry level,
+    // but this hook still calls real Spotify SDK/API helpers directly. Short-
+    // circuit when the mock is active so capture/Playwright runs never hit
+    // accounts.spotify.com or the Web Playback SDK.
+    if (shouldUseMockProvider()) {
+      logQueue('useSpotifyPlaylistManager — mock provider active, skipping real Spotify path');
+      return [];
+    }
+
     try {
       setError(null);
       setIsLoading(true);

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -1,5 +1,6 @@
 import { spotifyAuth } from './spotify';
 import { AuthExpiredError } from '@/providers/errors';
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logSpotify } from '@/lib/debugLog';
 import {
   SPOTIFY_MAX_RETRIES,
@@ -73,6 +74,7 @@ class SpotifyPlayerService {
       name: 'Vorbis Player',
       getOAuthToken: (cb) => {
         spotifyAuth.ensureValidToken().then(cb).catch(() => {
+          if (shouldUseMockProvider()) return;
           spotifyAuth.redirectToAuth();
         });
       },
@@ -98,6 +100,7 @@ class SpotifyPlayerService {
 
     this.player.addListener('authentication_error', ({ message }: { message: string }) => {
       console.error('Failed to authenticate', message);
+      if (shouldUseMockProvider()) return;
       spotifyAuth.redirectToAuth();
     });
 


### PR DESCRIPTION
## Summary
- AudioPlayer URL handler decomposes `provider:kind:id` keys via `keyToCollectionRef` so the mock catalog can resolve the playlist by its snapshot id instead of falling through to the Spotify SDK fallback
- `useSpotifyPlaylistManager.handlePlaylistSelect` short-circuits when the mock provider is active, returning an empty array before any `spotifyPlayer`/`spotifyAuth` calls
- `useCollectionLoader` skips the legacy SDK fallback (`loadContextPlayback`) when the mock provider is active even if `playCollection` is advertised
- Direct `spotifyAuth.redirectToAuth()` calls in `spotifyPlayer.ts` (token refresh, SDK `authentication_error`) and the `App.tsx` Try Again button guarded by `shouldUseMockProvider()`

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (1758 tests, +1 new test covering the mock-guard short-circuit in `useCollectionLoader`)
- Manual: `VITE_MOCK_PROVIDER=true npm run dev` -> load `?playlist=spotify:playlist:<anonymized-id>` -> no `accounts.spotify.com` redirect, mock playback starts
- Manual: `npm run capture` completes all scenarios without OAuth redirect

Closes #1385