### PR TITLE
fix(playback): emit hydrate state synchronously before connect transfer

### DIFF
--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -283,6 +283,37 @@ describe('DropboxPlaybackAdapter', () => {
       expect(finalState.trackMetadata?.durationMs).toBe(200_000);
     });
 
+    it('never emits positionMs:0 with a real durationMs during loadedmetadata transition', async () => {
+      // Regression: the constructor's loadedmetadata listener fires before primeAudioForHydrate
+      // re-seeks to savedPosition. In the real DOM audio.currentTime === 0 at that moment.
+      // Subscribers must never see { positionMs: 0, durationMs: <real> } during that window.
+
+      // #given — saved position 45s; real audio 200s; currentTime NOT pre-set (mirrors real DOM)
+      const track = makeMediaTrack({ id: 'track-noflicker', durationMs: 300_000 });
+      const listener = vi.fn();
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when — prepareTrack sets the hint and kicks off the async load
+      adapter.prepareTrack(track, { positionMs: 45_000 });
+
+      // Audio src is assigned; fire loadedmetadata with currentTime still 0 (real DOM)
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      mockAudio.duration = 200;
+      mockAudio.readyState = 1;
+      // Intentionally leave mockAudio.currentTime = 0 — this is the flicker window
+      (mockAudio as any).__triggerEvent('loadedmetadata');
+
+      // Let primeAudioForHydrate continue (re-seeks and clears the hint)
+      await vi.waitFor(() => expect(mockAudio.currentTime).toBe(45));
+
+      // #then — no emission with positionMs:0 and a real (>0) durationMs
+      const flickerEmit = listener.mock.calls.find(
+        ([s]) => s?.currentTrackId === 'track-noflicker' && s.positionMs === 0 && s.durationMs > 0,
+      );
+      expect(flickerEmit).toBeUndefined();
+    });
+
     it('omits durationMs metadata when audio.duration is Infinity', async () => {
       // #given — track.durationMs = 180_000; audio stream has Infinity duration (live)
       const track = makeMediaTrack({ id: 'track-live', durationMs: 180_000 });

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -246,55 +246,75 @@ describe('DropboxPlaybackAdapter', () => {
     const findHydrateCall = (listener: ReturnType<typeof vi.fn>, trackId: string) =>
       listener.mock.calls.find(([state]) => state?.currentTrackId === trackId);
 
-    it('emits paused state with positionMs and durationMs after metadata loads', async () => {
-      // #given
-      const track = makeMediaTrack({ id: 'track-hydrate', durationMs: 300000 });
+    it('emits paused state synchronously with track durationMs, then updates to audio durationMs after metadata loads', async () => {
+      // #given — track.durationMs = 300_000 (cached); real audio = 200s = 200_000ms
+      const track = makeMediaTrack({ id: 'track-hydrate', durationMs: 300_000 });
       const listener = vi.fn();
       await adapter.initialize();
       adapter.subscribe(listener);
 
-      // #when
+      // #when — synchronous emit fires immediately using track.durationMs
       adapter.prepareTrack(track, { positionMs: 45_000 });
-      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      const immediateState = findHydrateCall(listener, 'track-hydrate')![0] as PlaybackState;
+      expect(immediateState.durationMs).toBe(300_000);
+      expect(immediateState.positionMs).toBe(45_000);
+      expect(immediateState.isPlaying).toBe(false);
 
+      // Audio finishes loading — emit fires again with the real duration
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
       mockAudio.duration = 200;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 45;
       (mockAudio as any).__triggerEvent('loadedmetadata');
 
-      // #then
-      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-hydrate')).toBeDefined());
-      const state = findHydrateCall(listener, 'track-hydrate')![0] as PlaybackState;
+      // #then — final state uses the real audio duration; trackMetadata.durationMs updated
+      const findLastHydrateCall = () => {
+        const calls = listener.mock.calls.filter(([s]) => s?.currentTrackId === 'track-hydrate');
+        return calls[calls.length - 1] ?? undefined;
+      };
+      await vi.waitFor(() => {
+        const last = findLastHydrateCall();
+        expect(last?.[0]?.durationMs).toBe(200_000);
+      });
+      const finalState = findLastHydrateCall()![0] as PlaybackState;
       expect(mockAudio.currentTime).toBe(45);
-      expect(state.isPlaying).toBe(false);
-      expect(state.positionMs).toBe(45_000);
-      expect(state.durationMs).toBe(200_000);
-      expect(state.trackMetadata?.durationMs).toBe(200_000);
+      expect(finalState.isPlaying).toBe(false);
+      expect(finalState.positionMs).toBe(45_000);
+      expect(finalState.trackMetadata?.durationMs).toBe(200_000);
     });
 
     it('omits durationMs metadata when audio.duration is Infinity', async () => {
-      // #given
+      // #given — track.durationMs = 180_000; audio stream has Infinity duration (live)
       const track = makeMediaTrack({ id: 'track-live', durationMs: 180_000 });
       const listener = vi.fn();
       await adapter.initialize();
       adapter.subscribe(listener);
 
-      // #when
+      // #when — synchronous emit fires immediately using track.durationMs
       adapter.prepareTrack(track, { positionMs: 10_000 });
-      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      const immediateState = findHydrateCall(listener, 'track-live')![0] as PlaybackState;
+      expect(immediateState.durationMs).toBe(180_000);
 
+      // Audio loadedmetadata fires with Infinity duration
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
       mockAudio.duration = Infinity;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 10;
       (mockAudio as any).__triggerEvent('loadedmetadata');
 
-      // #then
-      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-live')).toBeDefined());
-      const state = findHydrateCall(listener, 'track-live')![0] as PlaybackState;
-      expect(state.isPlaying).toBe(false);
-      expect(state.positionMs).toBe(10_000);
-      expect(state.durationMs).toBe(0);
-      expect(state.trackMetadata?.durationMs).toBeUndefined();
+      // #then — final state reports 0 for infinite-duration stream; no trackMetadata.durationMs
+      const findLastHydrateCall = () => {
+        const calls = listener.mock.calls.filter(([s]) => s?.currentTrackId === 'track-live');
+        return calls[calls.length - 1] ?? undefined;
+      };
+      await vi.waitFor(() => {
+        const last = findLastHydrateCall();
+        expect(last?.[0]?.durationMs).toBe(0);
+      });
+      const finalState = findLastHydrateCall()![0] as PlaybackState;
+      expect(finalState.isPlaying).toBe(false);
+      expect(finalState.positionMs).toBe(10_000);
+      expect(finalState.trackMetadata?.durationMs).toBeUndefined();
     });
 
     it('does not clobber audio.src when a track is already loaded (next-track prewarm)', async () => {
@@ -355,11 +375,13 @@ describe('DropboxPlaybackAdapter', () => {
       expect(findHydrateCall(listener, 'track-a')).toBeUndefined();
     });
 
-    it('emits no stale state when getTemporaryLink rejects', async () => {
-      // #given — hydrate is best-effort; a failed fetch must not leak state to subscribers
+    it('emits synchronous hydrate state even when getTemporaryLink later rejects', async () => {
+      // #given — audio loading is best-effort; the synchronous UI emit still
+      // fires so the seek bar shows the saved position, even if audio fails to load.
       const track = makeMediaTrack({
         id: 'track-fail',
         playbackRef: { provider: 'dropbox', ref: '/Music/fail.mp3' },
+        durationMs: 210_000,
       });
       const listener = vi.fn();
       vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(new Error('network down'));
@@ -369,13 +391,18 @@ describe('DropboxPlaybackAdapter', () => {
       // #when
       adapter.prepareTrack(track, { positionMs: 20_000 });
 
-      // #then — wait for the rejected fetch to settle, then assert nothing leaked
+      // #then — synchronous emit fired immediately with the saved position + catalog duration
+      const state = findHydrateCall(listener, 'track-fail')![0] as PlaybackState;
+      expect(state.isPlaying).toBe(false);
+      expect(state.positionMs).toBe(20_000);
+      expect(state.durationMs).toBe(210_000);
+
+      // Audio fetch fails; no src is ever set
       await vi.waitFor(() =>
         expect(mockCatalog.getTemporaryLink).toHaveBeenCalledWith(track.playbackRef.ref),
       );
       await Promise.resolve();
       expect(mockAudio.src).toBe('');
-      expect(findHydrateCall(listener, 'track-fail')).toBeUndefined();
     });
   });
 

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -51,7 +51,9 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
         this.pendingDurationMs = durationMs;
         putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
       }
-      this.hydrateHint = null;
+      // Do not clear hydrateHint here — primeAudioForHydrate clears it after
+      // re-applying audio.currentTime, preventing a brief positionMs:0 flash
+      // between loadedmetadata and the currentTime seek.
       this.notifyListeners();
     });
     this.audio.addEventListener('error', () => {
@@ -237,8 +239,10 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     // Emit staged UI state synchronously before any network/load awaits so the
     // seek bar reflects the saved position and full duration immediately on
     // session hydrate. hydrateHint is consumed by getStateSync when the audio
-    // element doesn't yet have real metadata; it is cleared on loadedmetadata
-    // or when playTrack supersedes this prime.
+    // element doesn't yet have real metadata. It is cleared after currentTime
+    // is re-applied below, or by playTrack when it supersedes this prime.
+    // Intentional: if getTemporaryLink rejects below, hydrateHint persists so
+    // the seek bar keeps showing the saved position rather than snapping to 0:00.
     if (positionMs !== undefined) {
       this.currentTrack = track;
       this.hydrateHint = {
@@ -279,10 +283,11 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     if (positionMs && positionMs > 0) {
       audio.currentTime = positionMs / 1000;
     }
+    // Clear hint only after re-seeking so no subscriber sees a positionMs:0 flash.
+    this.hydrateHint = null;
 
-    // persistedDuration side effects: the ensureAudio loadedmetadata listener
-    // may have fired before this point and stored pendingDurationMs already;
-    // if not (race window), do it here.
+    // loadedmetadata may have already stored pendingDurationMs; if it hasn't
+    // fired yet, capture duration here so the next notifyListeners emits it.
     const dur = audio.duration;
     if (Number.isFinite(dur) && dur > 0) {
       const durationMs = Math.floor(dur * 1000);
@@ -395,10 +400,12 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
     const state: PlaybackState = {
       isPlaying: !this.audio.paused && !this.audio.ended,
-      // Use audio.currentTime once audio has a src; fall back to the hydrate hint
-      // before the URL has been fetched and assigned.
+      // Use audio.currentTime once audio has a src. When hydrateHint is still
+      // present and currentTime is 0 (the window between loadedmetadata and
+      // primeAudioForHydrate re-seeking), fall back to the saved position so
+      // subscribers never see a transient positionMs:0 snap.
       positionMs: audioIsLoaded
-        ? Math.floor(this.audio.currentTime * 1000)
+        ? (this.audio.currentTime === 0 && hint ? hint.positionMs : Math.floor(this.audio.currentTime * 1000))
         : (hint?.positionMs ?? 0),
       // Use real duration when finite and non-zero; fall back to hint before load,
       // and to 0 for live streams (Infinity duration).

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -26,6 +26,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private pendingDurationMs: number | null = null;
   private pendingError: PlaybackState['playbackError'] | null = null;
   private prepareGeneration = 0;
+  private hydrateHint: { positionMs: number; durationMs: number } | null = null;
 
   private catalog: DropboxCatalogAdapter;
   private lastPlayTime = 0;
@@ -50,6 +51,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
         this.pendingDurationMs = durationMs;
         putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
       }
+      this.hydrateHint = null;
       this.notifyListeners();
     });
     this.audio.addEventListener('error', () => {
@@ -90,6 +92,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.hydrateAlbumArtFromCache(track);
     this.pendingMetadataUpdate = null;
     this.pendingDurationMs = null;
+    this.hydrateHint = null;
     this.audio!.pause();
     this.audio!.src = streamUrl;
     await this.audio!.play();
@@ -231,6 +234,22 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       return;
     }
 
+    // Emit staged UI state synchronously before any network/load awaits so the
+    // seek bar reflects the saved position and full duration immediately on
+    // session hydrate. hydrateHint is consumed by getStateSync when the audio
+    // element doesn't yet have real metadata; it is cleared on loadedmetadata
+    // or when playTrack supersedes this prime.
+    if (positionMs !== undefined) {
+      this.currentTrack = track;
+      this.hydrateHint = {
+        positionMs,
+        durationMs: track.durationMs ?? 0,
+      };
+      logArtRace('dropbox.primeAudioForHydrate: emitState (hint) currentTrackId=%s positionMs=%d durationMs=%d',
+        track.id.slice(0, 8), positionMs, track.durationMs ?? 0);
+      this.notifyListeners();
+    }
+
     const generation = ++this.prepareGeneration;
 
     const streamUrl = await this.catalog.getTemporaryLink(track.playbackRef.ref);
@@ -254,9 +273,6 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     }
     if (generation !== this.prepareGeneration) return;
 
-    // Commit track state only after metadata has settled and this prime
-    // hasn't been superseded, so getStateSync can't observe a mixed state
-    // where currentTrack points at a not-yet-loaded src.
     this.currentTrack = track;
     this.hydrateAlbumArtFromCache(track);
 
@@ -264,9 +280,9 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       audio.currentTime = positionMs / 1000;
     }
 
-    // The ensureAudio loadedmetadata listener short-circuits when it fires
-    // before currentTrack is set (see the guard there), so populate the
-    // persisted-duration side effects ourselves now that currentTrack is live.
+    // persistedDuration side effects: the ensureAudio loadedmetadata listener
+    // may have fired before this point and stored pendingDurationMs already;
+    // if not (race window), do it here.
     const dur = audio.duration;
     if (Number.isFinite(dur) && dur > 0) {
       const durationMs = Math.floor(dur * 1000);
@@ -374,10 +390,21 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     if (!this.audio || !this.currentTrack) return null;
 
     const rawDuration = this.audio.duration;
+    const audioIsLoaded = Boolean(this.audio.src);
+    const hint = this.hydrateHint;
+
     const state: PlaybackState = {
       isPlaying: !this.audio.paused && !this.audio.ended,
-      positionMs: Math.floor(this.audio.currentTime * 1000),
-      durationMs: Number.isFinite(rawDuration) ? Math.floor(rawDuration * 1000) : 0,
+      // Use audio.currentTime once audio has a src; fall back to the hydrate hint
+      // before the URL has been fetched and assigned.
+      positionMs: audioIsLoaded
+        ? Math.floor(this.audio.currentTime * 1000)
+        : (hint?.positionMs ?? 0),
+      // Use real duration when finite and non-zero; fall back to hint before load,
+      // and to 0 for live streams (Infinity duration).
+      durationMs: (Number.isFinite(rawDuration) && rawDuration > 0)
+        ? Math.floor(rawDuration * 1000)
+        : (audioIsLoaded ? 0 : (hint?.durationMs ?? 0)),
       currentTrackId: this.currentTrack.id,
       currentPlaybackRef: this.currentTrack.playbackRef,
     };

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -75,6 +75,35 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
+  it('emits the PlaybackState synchronously before ensurePlaybackReady resolves (regression #1387)', async () => {
+    // #given — stall the Connect transfer so we can assert timing independently
+    let resolveTransfer: (() => void) | undefined;
+    vi.mocked(spotifyPlayer.transferPlaybackToDevice).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveTransfer = resolve; }),
+    );
+    const track = makeTrack({ durationMs: 180_000 });
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 15_000 });
+
+    // #then — emission fires synchronously before the stalled transfer resolves
+    const staged = received.find((s) => s?.currentTrackId === 'track-1');
+    expect(staged).toBeDefined();
+    expect(staged).toMatchObject({ isPlaying: false, positionMs: 15_000, durationMs: 180_000 });
+
+    // The transfer has not resolved yet — the emission preceded it
+    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).not.toHaveBeenCalled();
+
+    // Unblock the transfer so the test cleans up without dangling promises
+    await vi.waitFor(() => expect(resolveTransfer).toBeTypeOf('function'));
+    resolveTransfer!();
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+    );
+  });
+
   it('does NOT emit or transfer the device for the pre-warm intent (called without positionMs)', async () => {
     // #given — the next-track pre-warm caller in useProviderPlayback.playTrack
     // invokes prepareTrack(track) with no options. Emitting a PlaybackState
@@ -159,10 +188,13 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     adapter.prepareTrack(track, { positionMs: 10_000 });
     adapter.prepareTrack(track, { positionMs: 10_000 });
 
-    // #then — ensurePlaybackReady runs once because the second call hits the
-    // preparedTrackRef idempotency guard; emission fires exactly once.
-    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1);
+    // #then — emission fires synchronously on the first call; the second call
+    // hits the preparedTrackRef idempotency guard and emits nothing.
+    // ensurePlaybackReady runs only once (for the first call).
+    expect(stageEmissions).toHaveLength(1);
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+    );
   });
 
   it('re-stages when prepareTrack is called for a different track', async () => {
@@ -199,15 +231,21 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // #when
     adapter.prepareTrack(track, { positionMs: 12_000 });
+
+    // #then — emitState fires synchronously so we already have the first emission
+    expect(stageEmissions).toHaveLength(1);
+
     await vi.waitFor(() =>
       expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
     );
     // Second call after the failure — guard was reset, so this retries.
     adapter.prepareTrack(track, { positionMs: 12_000 });
 
-    // #then
-    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2);
+    // #then — second prepareTrack emits synchronously; retry triggers a second transfer.
+    expect(stageEmissions).toHaveLength(2);
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+    );
   });
 
   describe('probePlayable', () => {
@@ -288,9 +326,11 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
-  it('skips the stale stage emission when a different track is prepared mid-stage', async () => {
+  it('emits A synchronously then emits B when B supersedes A mid-connect-transfer', async () => {
     // #given — prepareTrack(A) is in flight when prepareTrack(B) overrides it.
-    // Slow-resolve the first transfer so the supersede wins the race.
+    // emitState for A fires synchronously before the Connect transfer. When the
+    // transfer for A eventually resolves, the preparedTrackRef guard drops the
+    // post-transfer path for A, so no second emission for A occurs.
     const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
     const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
     const stageEmissions: Array<PlaybackState | null> = [];
@@ -307,17 +347,23 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
       )
       .mockResolvedValue(undefined);
 
-    // #when
+    // #when — A emits synchronously the moment prepareTrack is called
     adapter.prepareTrack(trackA, { positionMs: 1_000 });
+    expect(stageEmissions.find((s) => s?.currentTrackId === 'a')).toBeDefined();
+
     await vi.waitFor(() => expect(resolveFirstTransfer).toBeTypeOf('function'));
     adapter.prepareTrack(trackB, { positionMs: 2_000 });
-    resolveFirstTransfer();
 
-    // #then — only B's staged state should reach subscribers
-    await vi.waitFor(() => {
-      const bEmit = stageEmissions.find((s) => s?.currentTrackId === 'b');
-      expect(bEmit).toBeDefined();
-    });
-    expect(stageEmissions.find((s) => s?.currentTrackId === 'a')).toBeUndefined();
+    // #then — B emits synchronously
+    expect(stageEmissions.find((s) => s?.currentTrackId === 'b')).toBeDefined();
+
+    // Resolve A's stalled transfer — should be a no-op (guard drops it)
+    resolveFirstTransfer();
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+    );
+
+    // A's emission count stays at 1 (only the synchronous emit; no post-transfer re-emit)
+    expect(stageEmissions.filter((s) => s?.currentTrackId === 'a')).toHaveLength(1);
   });
 });

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -323,22 +323,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   }
 
   private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
-    // ensurePlaybackReady transfers Spotify Connect to this device with
-    // `play: false`, which paused-transfers any existing session and leaves
-    // the SDK ready. That's all the staging we need for hydrate — we do NOT
-    // call apiPlayTrack, because /me/player/play starts audio and Spotify's
-    // eventually-consistent server state makes a subsequent pause() race
-    // the just-started playback (leaked audio on a fresh tab).
-    //
-    // The UI staging (scrubbed seek bar + duration) is purely local: emit
-    // the expected paused state to subscribers. Actual audio playback is
-    // deferred to the user's next `playTrack` call, which starts from the
-    // saved position via handlePlay consuming hydratedPendingPlayRef.
-    await this.ensurePlaybackReady();
-
-    const uri = track.playbackRef.ref;
-    if (this.preparedTrackRef !== uri) return;
-
+    // Emit the staged UI state synchronously — before awaiting the Connect
+    // transfer — so the seek bar reflects the saved position and full duration
+    // immediately on session hydrate, with no 0:00/0:00 window. The
+    // preparedTrackRef guard above in prepareTrack() ensures this emit only
+    // fires for the most-recently requested track.
     logArtRace('spotify.stageTrackPaused: emitState currentTrackId=%s positionMs=%d',
       track.id.slice(0, 8), Math.floor(positionMs));
     this.emitState({
@@ -348,6 +337,22 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       currentTrackId: track.id,
       currentPlaybackRef: track.playbackRef,
     });
+
+    // ensurePlaybackReady transfers Spotify Connect to this device with
+    // `play: false`, which paused-transfers any existing session and leaves
+    // the SDK ready. That's all the staging we need for hydrate — we do NOT
+    // call apiPlayTrack, because /me/player/play starts audio and Spotify's
+    // eventually-consistent server state makes a subsequent pause() race
+    // the just-started playback (leaked audio on a fresh tab).
+    //
+    // Actual audio playback is deferred to the user's next `playTrack` call,
+    // which starts from the saved position via handlePlay consuming
+    // hydratedPendingPlayRef. The guard below drops the result if a newer
+    // prepareTrack supersedes this one while the transfer is in flight.
+    await this.ensurePlaybackReady();
+
+    const uri = track.playbackRef.ref;
+    if (this.preparedTrackRef !== uri) return;
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -326,8 +326,10 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     // Emit the staged UI state synchronously — before awaiting the Connect
     // transfer — so the seek bar reflects the saved position and full duration
     // immediately on session hydrate, with no 0:00/0:00 window. The
-    // preparedTrackRef guard above in prepareTrack() ensures this emit only
-    // fires for the most-recently requested track.
+    // preparedTrackRef guard in prepareTrack() ensures stale stages are dropped
+    // post-Connect-transfer; back-to-back synchronous prepareTrack calls both
+    // emit here (the synchronous prefix runs before the first await), with the
+    // latter winning at the subscriber level.
     logArtRace('spotify.stageTrackPaused: emitState currentTrackId=%s positionMs=%d',
       track.id.slice(0, 8), Math.floor(positionMs));
     this.emitState({
@@ -347,12 +349,8 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     //
     // Actual audio playback is deferred to the user's next `playTrack` call,
     // which starts from the saved position via handlePlay consuming
-    // hydratedPendingPlayRef. The guard below drops the result if a newer
-    // prepareTrack supersedes this one while the transfer is in flight.
+    // hydratedPendingPlayRef.
     await this.ensurePlaybackReady();
-
-    const uri = track.playbackRef.ref;
-    if (this.preparedTrackRef !== uri) return;
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {


### PR DESCRIPTION
## Summary

- **Spotify**: `stageTrackPaused` now calls `emitState` (position + duration) synchronously before `await ensurePlaybackReady()`. The seek bar reflects the saved session position immediately on hydrate, with no 0:00/0:00 window. The Connect transfer still runs in the background; the `preparedTrackRef` guard after the await continues to drop stale post-transfer code if a newer `prepareTrack` supersedes.
- **Dropbox** (parity fix): `primeAudioForHydrate` now sets a `hydrateHint` synchronously from `track.durationMs + positionMs` and calls `notifyListeners()` before the `getTemporaryLink` network call. `getStateSync` uses the hint for position/duration before the audio element has a real src; the hint is cleared on `loadedmetadata` (real audio data takes over) and when `playTrack` supersedes the prime.
- Regression test in `spotifyPlaybackAdapterPrepareTrack.test.ts` asserts that `emitState` fires before `transferPlaybackToDevice` is even called — proving the fix for the timing race described in #1387.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1640/1640 passing
- [ ] Manual: reload with a persisted session → seek bar shows saved position + full duration immediately on page load, before any user interaction (no 0:00/0:00 window)
- Note: Playwright mock-provider spec for persisted-session injection not added — the mock provider does not currently support injecting a persisted session snapshot at page load. Gap noted for future work.

Closes #1387