### PR TITLE
fix(mock): only register mock provider when explicitly opted in

### DIFF
--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -6,6 +6,7 @@ import { MockAuthAdapter } from './mockAuthAdapter';
 import { MockCatalogAdapter } from './mockCatalogAdapter';
 import { MockPlaybackAdapter } from './mockPlaybackAdapter';
 import { seedPinsFromSnapshots } from './pinSeeder';
+import { shouldUseMockProvider } from './shouldUseMockProvider';
 import { installMockTestApi } from './test-control';
 import { assertProviderSnapshot } from '../../../playwright/fixtures/data/snapshot.types';
 import spotifySnapshotJson from '../../../playwright/fixtures/data/spotify-snapshot.json' with { type: 'json' };
@@ -71,14 +72,20 @@ const dropboxDescriptor: ProviderDescriptor = {
   playback: new MockPlaybackAdapter('dropbox'),
 };
 
-providerRegistry.register(spotifyDescriptor);
-providerRegistry.register(dropboxDescriptor);
+// `main.tsx` eager-imports this module in any dev build so `?provider=mock`
+// activation works without a restart. Gate the registry mutation so the real
+// Spotify/Dropbox descriptors survive in dev unless the user has actually
+// opted in (VITE_MOCK_PROVIDER=true or ?provider=mock).
+if (shouldUseMockProvider()) {
+  providerRegistry.register(spotifyDescriptor);
+  providerRegistry.register(dropboxDescriptor);
 
-void seedPinsFromSnapshots(spotifySnapshotJson.pins, dropboxSnapshotJson.pins);
+  void seedPinsFromSnapshots(spotifySnapshotJson.pins, dropboxSnapshotJson.pins);
 
-installMockTestApi({
-  spotifyCatalog: spotifyDescriptor.catalog as MockCatalogAdapter,
-  dropboxCatalog: dropboxDescriptor.catalog as MockCatalogAdapter,
-  spotifyPlayback: spotifyDescriptor.playback as MockPlaybackAdapter,
-  dropboxPlayback: dropboxDescriptor.playback as MockPlaybackAdapter,
-});
+  installMockTestApi({
+    spotifyCatalog: spotifyDescriptor.catalog as MockCatalogAdapter,
+    dropboxCatalog: dropboxDescriptor.catalog as MockCatalogAdapter,
+    spotifyPlayback: spotifyDescriptor.playback as MockPlaybackAdapter,
+    dropboxPlayback: dropboxDescriptor.playback as MockPlaybackAdapter,
+  });
+}


### PR DESCRIPTION
## Summary
- Gate `providerRegistry.register()` calls in `mockProvider.ts` on `shouldUseMockProvider()` so importing the module in dev no longer auto-clobbers real Spotify/Dropbox descriptors.
- The module can still be eager-loaded by `main.tsx` in any dev build (so `?provider=mock` URL activation works without a restart) — it just no-ops when no opt-in signal is present.

## Why
Before this fix, every `npm run dev` session loaded the mock module via `main.tsx`'s `import.meta.env.DEV` branch, and the module unconditionally registered itself at import time. Result: real Spotify/Dropbox descriptors got replaced with mocks in regular dev, and songs played as synthetic tones — even without `VITE_MOCK_PROVIDER=true` or `?provider=mock`.

## Test plan
- `npx tsc -b --noEmit` clean
- `shouldUseMockProvider` unit tests still pass (6/6)
- Manual: `npm run dev` (no env, no URL param) → real Spotify path, real audio
- Manual: `npm run dev` with `?provider=mock` → mock provider activates and serves snapshot fixtures
- Manual: `VITE_MOCK_PROVIDER=true npm run dev` → mock activates from env var
- `npm run capture` → unaffected (sets `VITE_MOCK_PROVIDER=true` explicitly + `?provider=mock` in URL)

## Relationship to PR #1391
Complementary, not redundant:
- This PR ensures mock doesn't auto-activate in regular dev (controls **when** mock is active)
- #1391 prevents direct calls to `spotifyAuth.redirectToAuth()` / `spotifyPlayer.initialize()` from leaking to real Spotify when mock IS active (controls what mock does)

Both fixes need to be on the epic before it ships to develop.