### PR TITLE
fix(spotify): add user-read-recently-played OAuth scope

### DIFF
--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -14,6 +14,7 @@ const SCOPES = [
   'user-read-playback-state',
   'user-modify-playback-state',
   'user-read-currently-playing',
+  'user-read-recently-played',
   'playlist-read-private',
   'playlist-read-collaborative',
   'user-library-read',


### PR DESCRIPTION
## Summary
- Adds \`user-read-recently-played\` to the Spotify OAuth scope set in \`src/services/spotify/auth.ts\`.
- Cherry-picked from the mock-provider epic (commit bec8ca7) where it was originally added to enable snapshot tooling. The change itself lives in app code, not snapshot code, so it benefits any future feature that wants \`/me/player/recently-played\` regardless of whether the snapshot tooling ever lands.

## User impact
Existing users will be prompted to log out / log back in once at next token refresh — Spotify enforces scope changes via re-consent.

## Test plan
- \`npx tsc -b --noEmit\` clean
- Manual: log out, log back in, confirm scope grant prompt includes \"recently played\"