### PR TITLE
release: 2026-04-29

### DIFF
--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -29,8 +29,9 @@ vi.mock('../useLikedTracksForProvider', () => ({
   useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
 }));
 
-const { mockQueueLikedFromCollection } = vi.hoisted(() => ({
+const { mockQueueLikedFromCollection, mockUseAlbumSavedStatus } = vi.hoisted(() => ({
   mockQueueLikedFromCollection: vi.fn(),
+  mockUseAlbumSavedStatus: vi.fn(),
 }));
 
 vi.mock('../useQueueLikedFromCollection', () => ({
@@ -38,13 +39,7 @@ vi.mock('../useQueueLikedFromCollection', () => ({
 }));
 
 vi.mock('../useAlbumSavedStatus', () => ({
-  useAlbumSavedStatus: () => ({
-    isSaved: null,
-    toggleSaved: vi.fn(),
-    canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
-  }),
+  useAlbumSavedStatus: (...args: unknown[]) => mockUseAlbumSavedStatus(...args),
 }));
 
 import LibraryContextMenu, { type LibraryContextMenuProps } from '../LibraryContextMenu';
@@ -72,6 +67,13 @@ function defaultMocks() {
   });
   mockRecent.mockReturnValue({ remove: vi.fn() });
   mockLoadLiked.mockResolvedValue([]);
+  mockUseAlbumSavedStatus.mockReturnValue({
+    isSaved: null,
+    toggleSaved: vi.fn(),
+    canToggle: false,
+    saveError: null,
+    clearSaveError: vi.fn(),
+  });
 }
 
 function renderMenu(propsOverrides: Partial<LibraryContextMenuProps> = {}) {
@@ -342,5 +344,60 @@ describe('LibraryContextMenu', () => {
 
     // #then
     expect(screen.queryByTestId('menu-queue-liked')).not.toBeInTheDocument();
+  });
+
+  describe('album Like/Unlike toggle', () => {
+    it('shows "Unlike" label when album is already liked (isSaved=true)', () => {
+      // #given
+      mockUseAlbumSavedStatus.mockReturnValue({
+        isSaved: true,
+        toggleSaved: vi.fn(),
+        canToggle: true,
+        saveError: null,
+        clearSaveError: vi.fn(),
+      });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Unlike');
+    });
+
+    it('shows "Like" label when album is not liked (isSaved=false)', () => {
+      // #given
+      mockUseAlbumSavedStatus.mockReturnValue({
+        isSaved: false,
+        toggleSaved: vi.fn(),
+        canToggle: true,
+        saveError: null,
+        clearSaveError: vi.fn(),
+      });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Like');
+    });
+
+    it('omits toggle-save when isSaved is null (status still loading)', () => {
+      // #given — default mock: isSaved=null, canToggle=false
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
+
+      // #then
+      expect(screen.queryByTestId('menu-toggle-save')).not.toBeInTheDocument();
+    });
+
+    it('useAlbumSavedStatus is called with the album id and provider', () => {
+      // #when
+      renderMenu({
+        request: makeRequest({ kind: 'album', id: 'album99', provider: 'spotify' as ProviderId }),
+      });
+
+      // #then
+      expect(mockUseAlbumSavedStatus).toHaveBeenCalledWith('album99', 'spotify');
+    });
   });
 });

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
@@ -136,7 +136,7 @@ describe('buildMenuItems edges', () => {
       expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
     });
 
-    it('Save label remains "Save" when isSaved is false', () => {
+    it('Like label is shown when isSaved is false', () => {
       // #given
       const actions = makeActions({ onToggleSave: vi.fn(), isSaved: false });
 
@@ -144,7 +144,7 @@ describe('buildMenuItems edges', () => {
       const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
 
       // #then
-      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Save');
+      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Like');
     });
   });
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
@@ -147,7 +147,7 @@ describe('buildMenuItems', () => {
     expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
   });
 
-  it('flips Save label to Unsave when isSaved=true', () => {
+  it('flips Like label to Unlike when isSaved=true', () => {
     // #given
     const actions = makeActions({ onToggleSave: vi.fn(), isSaved: true });
 
@@ -155,7 +155,7 @@ describe('buildMenuItems', () => {
     const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
 
     // #then
-    expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unsave');
+    expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unlike');
   });
 
   it('marks Start Radio disabled when startRadioDisabled=true', () => {

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -74,9 +74,11 @@ function buildAlbumItems(actions: MenuActions): MenuItem[] {
     },
   ];
   if (actions.onToggleSave) {
+    // User-facing copy uses "Like"/"Unlike" for vocabulary parity with the track heart;
+    // internal field names mirror the Spotify API ("saved"). See #1386.
     items.push({
       id: 'toggle-save',
-      label: actions.isSaved ? 'Unsave' : 'Save',
+      label: actions.isSaved ? 'Unlike' : 'Like',
       onSelect: actions.onToggleSave,
     });
   }

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -246,55 +246,106 @@ describe('DropboxPlaybackAdapter', () => {
     const findHydrateCall = (listener: ReturnType<typeof vi.fn>, trackId: string) =>
       listener.mock.calls.find(([state]) => state?.currentTrackId === trackId);
 
-    it('emits paused state with positionMs and durationMs after metadata loads', async () => {
-      // #given
-      const track = makeMediaTrack({ id: 'track-hydrate', durationMs: 300000 });
+    it('emits paused state synchronously with track durationMs, then updates to audio durationMs after metadata loads', async () => {
+      // #given — track.durationMs = 300_000 (cached); real audio = 200s = 200_000ms
+      const track = makeMediaTrack({ id: 'track-hydrate', durationMs: 300_000 });
       const listener = vi.fn();
       await adapter.initialize();
       adapter.subscribe(listener);
 
-      // #when
+      // #when — synchronous emit fires immediately using track.durationMs
       adapter.prepareTrack(track, { positionMs: 45_000 });
-      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      const immediateState = findHydrateCall(listener, 'track-hydrate')![0] as PlaybackState;
+      expect(immediateState.durationMs).toBe(300_000);
+      expect(immediateState.positionMs).toBe(45_000);
+      expect(immediateState.isPlaying).toBe(false);
 
+      // Audio finishes loading — emit fires again with the real duration
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
       mockAudio.duration = 200;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 45;
       (mockAudio as any).__triggerEvent('loadedmetadata');
 
-      // #then
-      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-hydrate')).toBeDefined());
-      const state = findHydrateCall(listener, 'track-hydrate')![0] as PlaybackState;
+      // #then — final state uses the real audio duration; trackMetadata.durationMs updated
+      const findLastHydrateCall = () => {
+        const calls = listener.mock.calls.filter(([s]) => s?.currentTrackId === 'track-hydrate');
+        return calls[calls.length - 1] ?? undefined;
+      };
+      await vi.waitFor(() => {
+        const last = findLastHydrateCall();
+        expect(last?.[0]?.durationMs).toBe(200_000);
+      });
+      const finalState = findLastHydrateCall()![0] as PlaybackState;
       expect(mockAudio.currentTime).toBe(45);
-      expect(state.isPlaying).toBe(false);
-      expect(state.positionMs).toBe(45_000);
-      expect(state.durationMs).toBe(200_000);
-      expect(state.trackMetadata?.durationMs).toBe(200_000);
+      expect(finalState.isPlaying).toBe(false);
+      expect(finalState.positionMs).toBe(45_000);
+      expect(finalState.trackMetadata?.durationMs).toBe(200_000);
+    });
+
+    it('never emits positionMs:0 with a real durationMs during loadedmetadata transition', async () => {
+      // Regression: the constructor's loadedmetadata listener fires before primeAudioForHydrate
+      // re-seeks to savedPosition. In the real DOM audio.currentTime === 0 at that moment.
+      // Subscribers must never see { positionMs: 0, durationMs: <real> } during that window.
+
+      // #given — saved position 45s; real audio 200s; currentTime NOT pre-set (mirrors real DOM)
+      const track = makeMediaTrack({ id: 'track-noflicker', durationMs: 300_000 });
+      const listener = vi.fn();
+      await adapter.initialize();
+      adapter.subscribe(listener);
+
+      // #when — prepareTrack sets the hint and kicks off the async load
+      adapter.prepareTrack(track, { positionMs: 45_000 });
+
+      // Audio src is assigned; fire loadedmetadata with currentTime still 0 (real DOM)
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      mockAudio.duration = 200;
+      mockAudio.readyState = 1;
+      // Intentionally leave mockAudio.currentTime = 0 — this is the flicker window
+      (mockAudio as any).__triggerEvent('loadedmetadata');
+
+      // Let primeAudioForHydrate continue (re-seeks and clears the hint)
+      await vi.waitFor(() => expect(mockAudio.currentTime).toBe(45));
+
+      // #then — no emission with positionMs:0 and a real (>0) durationMs
+      const flickerEmit = listener.mock.calls.find(
+        ([s]) => s?.currentTrackId === 'track-noflicker' && s.positionMs === 0 && s.durationMs > 0,
+      );
+      expect(flickerEmit).toBeUndefined();
     });
 
     it('omits durationMs metadata when audio.duration is Infinity', async () => {
-      // #given
+      // #given — track.durationMs = 180_000; audio stream has Infinity duration (live)
       const track = makeMediaTrack({ id: 'track-live', durationMs: 180_000 });
       const listener = vi.fn();
       await adapter.initialize();
       adapter.subscribe(listener);
 
-      // #when
+      // #when — synchronous emit fires immediately using track.durationMs
       adapter.prepareTrack(track, { positionMs: 10_000 });
-      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
+      const immediateState = findHydrateCall(listener, 'track-live')![0] as PlaybackState;
+      expect(immediateState.durationMs).toBe(180_000);
 
+      // Audio loadedmetadata fires with Infinity duration
+      await vi.waitFor(() => expect(mockAudio.src).toBe('https://example.com/stream.mp3'));
       mockAudio.duration = Infinity;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 10;
       (mockAudio as any).__triggerEvent('loadedmetadata');
 
-      // #then
-      await vi.waitFor(() => expect(findHydrateCall(listener, 'track-live')).toBeDefined());
-      const state = findHydrateCall(listener, 'track-live')![0] as PlaybackState;
-      expect(state.isPlaying).toBe(false);
-      expect(state.positionMs).toBe(10_000);
-      expect(state.durationMs).toBe(0);
-      expect(state.trackMetadata?.durationMs).toBeUndefined();
+      // #then — final state reports 0 for infinite-duration stream; no trackMetadata.durationMs
+      const findLastHydrateCall = () => {
+        const calls = listener.mock.calls.filter(([s]) => s?.currentTrackId === 'track-live');
+        return calls[calls.length - 1] ?? undefined;
+      };
+      await vi.waitFor(() => {
+        const last = findLastHydrateCall();
+        expect(last?.[0]?.durationMs).toBe(0);
+      });
+      const finalState = findLastHydrateCall()![0] as PlaybackState;
+      expect(finalState.isPlaying).toBe(false);
+      expect(finalState.positionMs).toBe(10_000);
+      expect(finalState.trackMetadata?.durationMs).toBeUndefined();
     });
 
     it('does not clobber audio.src when a track is already loaded (next-track prewarm)', async () => {
@@ -355,11 +406,13 @@ describe('DropboxPlaybackAdapter', () => {
       expect(findHydrateCall(listener, 'track-a')).toBeUndefined();
     });
 
-    it('emits no stale state when getTemporaryLink rejects', async () => {
-      // #given — hydrate is best-effort; a failed fetch must not leak state to subscribers
+    it('emits synchronous hydrate state even when getTemporaryLink later rejects', async () => {
+      // #given — audio loading is best-effort; the synchronous UI emit still
+      // fires so the seek bar shows the saved position, even if audio fails to load.
       const track = makeMediaTrack({
         id: 'track-fail',
         playbackRef: { provider: 'dropbox', ref: '/Music/fail.mp3' },
+        durationMs: 210_000,
       });
       const listener = vi.fn();
       vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(new Error('network down'));
@@ -369,13 +422,18 @@ describe('DropboxPlaybackAdapter', () => {
       // #when
       adapter.prepareTrack(track, { positionMs: 20_000 });
 
-      // #then — wait for the rejected fetch to settle, then assert nothing leaked
+      // #then — synchronous emit fired immediately with the saved position + catalog duration
+      const state = findHydrateCall(listener, 'track-fail')![0] as PlaybackState;
+      expect(state.isPlaying).toBe(false);
+      expect(state.positionMs).toBe(20_000);
+      expect(state.durationMs).toBe(210_000);
+
+      // Audio fetch fails; no src is ever set
       await vi.waitFor(() =>
         expect(mockCatalog.getTemporaryLink).toHaveBeenCalledWith(track.playbackRef.ref),
       );
       await Promise.resolve();
       expect(mockAudio.src).toBe('');
-      expect(findHydrateCall(listener, 'track-fail')).toBeUndefined();
     });
   });
 

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -26,6 +26,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private pendingDurationMs: number | null = null;
   private pendingError: PlaybackState['playbackError'] | null = null;
   private prepareGeneration = 0;
+  private hydrateHint: { positionMs: number; durationMs: number } | null = null;
 
   private catalog: DropboxCatalogAdapter;
   private lastPlayTime = 0;
@@ -50,6 +51,9 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
         this.pendingDurationMs = durationMs;
         putDurationMs(this.currentTrack.id, durationMs).catch(() => {});
       }
+      // Do not clear hydrateHint here — primeAudioForHydrate clears it after
+      // re-applying audio.currentTime, preventing a brief positionMs:0 flash
+      // between loadedmetadata and the currentTime seek.
       this.notifyListeners();
     });
     this.audio.addEventListener('error', () => {
@@ -90,6 +94,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.hydrateAlbumArtFromCache(track);
     this.pendingMetadataUpdate = null;
     this.pendingDurationMs = null;
+    this.hydrateHint = null;
     this.audio!.pause();
     this.audio!.src = streamUrl;
     await this.audio!.play();
@@ -231,6 +236,24 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       return;
     }
 
+    // Emit staged UI state synchronously before any network/load awaits so the
+    // seek bar reflects the saved position and full duration immediately on
+    // session hydrate. hydrateHint is consumed by getStateSync when the audio
+    // element doesn't yet have real metadata. It is cleared after currentTime
+    // is re-applied below, or by playTrack when it supersedes this prime.
+    // Intentional: if getTemporaryLink rejects below, hydrateHint persists so
+    // the seek bar keeps showing the saved position rather than snapping to 0:00.
+    if (positionMs !== undefined) {
+      this.currentTrack = track;
+      this.hydrateHint = {
+        positionMs,
+        durationMs: track.durationMs ?? 0,
+      };
+      logArtRace('dropbox.primeAudioForHydrate: emitState (hint) currentTrackId=%s positionMs=%d durationMs=%d',
+        track.id.slice(0, 8), positionMs, track.durationMs ?? 0);
+      this.notifyListeners();
+    }
+
     const generation = ++this.prepareGeneration;
 
     const streamUrl = await this.catalog.getTemporaryLink(track.playbackRef.ref);
@@ -254,19 +277,17 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     }
     if (generation !== this.prepareGeneration) return;
 
-    // Commit track state only after metadata has settled and this prime
-    // hasn't been superseded, so getStateSync can't observe a mixed state
-    // where currentTrack points at a not-yet-loaded src.
     this.currentTrack = track;
     this.hydrateAlbumArtFromCache(track);
 
     if (positionMs && positionMs > 0) {
       audio.currentTime = positionMs / 1000;
     }
+    // Clear hint only after re-seeking so no subscriber sees a positionMs:0 flash.
+    this.hydrateHint = null;
 
-    // The ensureAudio loadedmetadata listener short-circuits when it fires
-    // before currentTrack is set (see the guard there), so populate the
-    // persisted-duration side effects ourselves now that currentTrack is live.
+    // loadedmetadata may have already stored pendingDurationMs; if it hasn't
+    // fired yet, capture duration here so the next notifyListeners emits it.
     const dur = audio.duration;
     if (Number.isFinite(dur) && dur > 0) {
       const durationMs = Math.floor(dur * 1000);
@@ -374,10 +395,23 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     if (!this.audio || !this.currentTrack) return null;
 
     const rawDuration = this.audio.duration;
+    const audioIsLoaded = Boolean(this.audio.src);
+    const hint = this.hydrateHint;
+
     const state: PlaybackState = {
       isPlaying: !this.audio.paused && !this.audio.ended,
-      positionMs: Math.floor(this.audio.currentTime * 1000),
-      durationMs: Number.isFinite(rawDuration) ? Math.floor(rawDuration * 1000) : 0,
+      // Use audio.currentTime once audio has a src. When hydrateHint is still
+      // present and currentTime is 0 (the window between loadedmetadata and
+      // primeAudioForHydrate re-seeking), fall back to the saved position so
+      // subscribers never see a transient positionMs:0 snap.
+      positionMs: audioIsLoaded
+        ? (this.audio.currentTime === 0 && hint ? hint.positionMs : Math.floor(this.audio.currentTime * 1000))
+        : (hint?.positionMs ?? 0),
+      // Use real duration when finite and non-zero; fall back to hint before load,
+      // and to 0 for live streams (Infinity duration).
+      durationMs: (Number.isFinite(rawDuration) && rawDuration > 0)
+        ? Math.floor(rawDuration * 1000)
+        : (audioIsLoaded ? 0 : (hint?.durationMs ?? 0)),
       currentTrackId: this.currentTrack.id,
       currentPlaybackRef: this.currentTrack.playbackRef,
     };

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -75,6 +75,35 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
+  it('emits the PlaybackState synchronously before ensurePlaybackReady resolves (regression #1387)', async () => {
+    // #given — stall the Connect transfer so we can assert timing independently
+    let resolveTransfer: (() => void) | undefined;
+    vi.mocked(spotifyPlayer.transferPlaybackToDevice).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveTransfer = resolve; }),
+    );
+    const track = makeTrack({ durationMs: 180_000 });
+    const received: Array<PlaybackState | null> = [];
+    adapter.subscribe((state) => received.push(state));
+
+    // #when
+    adapter.prepareTrack(track, { positionMs: 15_000 });
+
+    // #then — emission fires synchronously before the stalled transfer resolves
+    const staged = received.find((s) => s?.currentTrackId === 'track-1');
+    expect(staged).toBeDefined();
+    expect(staged).toMatchObject({ isPlaying: false, positionMs: 15_000, durationMs: 180_000 });
+
+    // The transfer has not resolved yet — the emission preceded it
+    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).not.toHaveBeenCalled();
+
+    // Unblock the transfer so the test cleans up without dangling promises
+    await vi.waitFor(() => expect(resolveTransfer).toBeTypeOf('function'));
+    resolveTransfer!();
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+    );
+  });
+
   it('does NOT emit or transfer the device for the pre-warm intent (called without positionMs)', async () => {
     // #given — the next-track pre-warm caller in useProviderPlayback.playTrack
     // invokes prepareTrack(track) with no options. Emitting a PlaybackState
@@ -159,10 +188,13 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     adapter.prepareTrack(track, { positionMs: 10_000 });
     adapter.prepareTrack(track, { positionMs: 10_000 });
 
-    // #then — ensurePlaybackReady runs once because the second call hits the
-    // preparedTrackRef idempotency guard; emission fires exactly once.
-    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1);
+    // #then — emission fires synchronously on the first call; the second call
+    // hits the preparedTrackRef idempotency guard and emits nothing.
+    // ensurePlaybackReady runs only once (for the first call).
+    expect(stageEmissions).toHaveLength(1);
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+    );
   });
 
   it('re-stages when prepareTrack is called for a different track', async () => {
@@ -199,15 +231,21 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // #when
     adapter.prepareTrack(track, { positionMs: 12_000 });
+
+    // #then — emitState fires synchronously so we already have the first emission
+    expect(stageEmissions).toHaveLength(1);
+
     await vi.waitFor(() =>
       expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
     );
     // Second call after the failure — guard was reset, so this retries.
     adapter.prepareTrack(track, { positionMs: 12_000 });
 
-    // #then
-    await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
-    expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2);
+    // #then — second prepareTrack emits synchronously; retry triggers a second transfer.
+    expect(stageEmissions).toHaveLength(2);
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+    );
   });
 
   describe('probePlayable', () => {
@@ -288,9 +326,11 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
     });
   });
 
-  it('skips the stale stage emission when a different track is prepared mid-stage', async () => {
+  it('emits A synchronously then emits B when B supersedes A mid-connect-transfer', async () => {
     // #given — prepareTrack(A) is in flight when prepareTrack(B) overrides it.
-    // Slow-resolve the first transfer so the supersede wins the race.
+    // emitState for A fires synchronously before the Connect transfer. When the
+    // transfer for A eventually resolves, the preparedTrackRef guard drops the
+    // post-transfer path for A, so no second emission for A occurs.
     const trackA = makeTrack({ id: 'a', playbackRef: { provider: 'spotify', ref: 'spotify:track:a' } });
     const trackB = makeTrack({ id: 'b', playbackRef: { provider: 'spotify', ref: 'spotify:track:b' } });
     const stageEmissions: Array<PlaybackState | null> = [];
@@ -307,17 +347,23 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
       )
       .mockResolvedValue(undefined);
 
-    // #when
+    // #when — A emits synchronously the moment prepareTrack is called
     adapter.prepareTrack(trackA, { positionMs: 1_000 });
+    expect(stageEmissions.find((s) => s?.currentTrackId === 'a')).toBeDefined();
+
     await vi.waitFor(() => expect(resolveFirstTransfer).toBeTypeOf('function'));
     adapter.prepareTrack(trackB, { positionMs: 2_000 });
-    resolveFirstTransfer();
 
-    // #then — only B's staged state should reach subscribers
-    await vi.waitFor(() => {
-      const bEmit = stageEmissions.find((s) => s?.currentTrackId === 'b');
-      expect(bEmit).toBeDefined();
-    });
-    expect(stageEmissions.find((s) => s?.currentTrackId === 'a')).toBeUndefined();
+    // #then — B emits synchronously
+    expect(stageEmissions.find((s) => s?.currentTrackId === 'b')).toBeDefined();
+
+    // Resolve A's stalled transfer — should be a no-op (guard drops it)
+    resolveFirstTransfer();
+    await vi.waitFor(() =>
+      expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+    );
+
+    // A's emission count stays at 1 (only the synchronous emit; no post-transfer re-emit)
+    expect(stageEmissions.filter((s) => s?.currentTrackId === 'a')).toHaveLength(1);
   });
 });

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -323,22 +323,13 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   }
 
   private async stageTrackPaused(track: MediaTrack, positionMs: number): Promise<void> {
-    // ensurePlaybackReady transfers Spotify Connect to this device with
-    // `play: false`, which paused-transfers any existing session and leaves
-    // the SDK ready. That's all the staging we need for hydrate — we do NOT
-    // call apiPlayTrack, because /me/player/play starts audio and Spotify's
-    // eventually-consistent server state makes a subsequent pause() race
-    // the just-started playback (leaked audio on a fresh tab).
-    //
-    // The UI staging (scrubbed seek bar + duration) is purely local: emit
-    // the expected paused state to subscribers. Actual audio playback is
-    // deferred to the user's next `playTrack` call, which starts from the
-    // saved position via handlePlay consuming hydratedPendingPlayRef.
-    await this.ensurePlaybackReady();
-
-    const uri = track.playbackRef.ref;
-    if (this.preparedTrackRef !== uri) return;
-
+    // Emit the staged UI state synchronously — before awaiting the Connect
+    // transfer — so the seek bar reflects the saved position and full duration
+    // immediately on session hydrate, with no 0:00/0:00 window. The
+    // preparedTrackRef guard in prepareTrack() ensures stale stages are dropped
+    // post-Connect-transfer; back-to-back synchronous prepareTrack calls both
+    // emit here (the synchronous prefix runs before the first await), with the
+    // latter winning at the subscriber level.
     logArtRace('spotify.stageTrackPaused: emitState currentTrackId=%s positionMs=%d',
       track.id.slice(0, 8), Math.floor(positionMs));
     this.emitState({
@@ -348,6 +339,18 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       currentTrackId: track.id,
       currentPlaybackRef: track.playbackRef,
     });
+
+    // ensurePlaybackReady transfers Spotify Connect to this device with
+    // `play: false`, which paused-transfers any existing session and leaves
+    // the SDK ready. That's all the staging we need for hydrate — we do NOT
+    // call apiPlayTrack, because /me/player/play starts audio and Spotify's
+    // eventually-consistent server state makes a subsequent pause() race
+    // the just-started playback (leaked audio on a fresh tab).
+    //
+    // Actual audio playback is deferred to the user's next `playTrack` call,
+    // which starts from the saved position via handlePlay consuming
+    // hydratedPendingPlayRef.
+    await this.ensurePlaybackReady();
   }
 
   onQueueChanged(tracks: MediaTrack[], fromIndex: number): void {

--- a/src/services/spotify/__tests__/playlists.cachePrime.test.ts
+++ b/src/services/spotify/__tests__/playlists.cachePrime.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { albumSavedCache } from '../cache';
+
+vi.mock('../auth', () => ({
+  spotifyAuth: {
+    ensureValidToken: vi.fn().mockResolvedValue('mock-token'),
+  },
+}));
+
+const mockSpotifyApiRequest = vi.fn();
+vi.mock('../api', () => ({
+  spotifyApiRequest: (...args: unknown[]) => mockSpotifyApiRequest(...args),
+  fetchAllPaginated: vi.fn(),
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  getTrackList: vi.fn().mockResolvedValue(null),
+  putTrackList: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getUserLibraryInterleaved } from '../playlists';
+import { checkAlbumSaved } from '../albums';
+
+describe('getUserLibraryInterleaved — albumSavedCache priming', () => {
+  beforeEach(() => {
+    albumSavedCache.clear();
+    mockSpotifyApiRequest.mockReset();
+  });
+
+  it('checkAlbumSaved returns true from cache without a network call after getUserLibraryInterleaved', async () => {
+    // #given
+    const albumId = 'album-abc';
+
+    mockSpotifyApiRequest.mockImplementation((url: string) => {
+      if (url.includes('me/playlists')) {
+        return Promise.resolve({ items: [], next: null, total: 0 });
+      }
+      if (url.includes('me/albums')) {
+        return Promise.resolve({
+          items: [
+            {
+              added_at: '2024-01-01T00:00:00Z',
+              album: {
+                id: albumId,
+                name: 'Test Album',
+                artists: [{ name: 'Test Artist' }],
+                images: [],
+                release_date: '2024-01-01',
+                total_tracks: 10,
+                uri: `spotify:album:${albumId}`,
+              },
+            },
+          ],
+          next: null,
+          total: 1,
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    // #when
+    await getUserLibraryInterleaved(
+      () => {},
+      () => {},
+    );
+
+    const callCountAfterInterleaved = mockSpotifyApiRequest.mock.calls.length;
+
+    const isSaved = await checkAlbumSaved(albumId);
+
+    // #then
+    expect(isSaved).toBe(true);
+    expect(mockSpotifyApiRequest.mock.calls.length).toBe(callCountAfterInterleaved);
+  });
+});

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -14,6 +14,7 @@ const SCOPES = [
   'user-read-playback-state',
   'user-modify-playback-state',
   'user-read-currently-playing',
+  'user-read-recently-played',
   'playlist-read-private',
   'playlist-read-collaborative',
   'user-library-read',

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -2,7 +2,7 @@ import type { MediaTrack } from '@/types/domain';
 import type { Track, PlaylistInfo, AlbumInfo, SpotifyAlbum, SpotifyTrackItem, PaginatedResponse } from './types';
 import { spotifyApiRequest, fetchAllPaginated } from './api';
 import { spotifyAuth } from './auth';
-import { trackListCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSIST_TTL } from './cache';
+import { trackListCache, albumSavedCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSIST_TTL } from './cache';
 import { formatArtists, transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import * as libraryCache from '../cache/libraryCache';
 
@@ -90,8 +90,12 @@ export async function getUserLibraryInterleaved(
       fetches.push(
         spotifyApiRequest<PaginatedResponse<SavedAlbumItem>>(url, token, { signal })
           .then((data) => {
+            const now = Date.now();
             for (const item of data.items ?? []) {
               albumResults.push(transformAlbum(item));
+              if (item.album.id) {
+                albumSavedCache.set(item.album.id, { value: true, timestamp: now });
+              }
             }
             albumNextUrl = data.next;
             const isComplete = albumNextUrl === null;


### PR DESCRIPTION
## Summary

Library, playback, and Spotify-auth fixes: album context menu now reflects liked state with refined Like/Unlike copy, the seek bar shows saved position immediately on session resume (no more 0:00/0:00 stall), and the Spotify OAuth scope set picks up `user-read-recently-played` ahead of upcoming snapshot tooling.

## Release summary

**Built from**: `rc/2026-04-29.2`

### Changes

**other**
- fix(snapshot): add user-read-recently-played scope for snapshot tooling (#1397)
- fix(playback): emit hydrate state synchronously before connect transfer (#1392)
- fix(library): album menu uses Like/Unlike and reflects saved state (#1390)

Closes #1386
Closes #1387