### PR TITLE
fix(library): album menu Unlike-only and live refresh after unlike

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -202,7 +202,6 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
 
     if (isAlbumKind && canToggleSaved && isSaved !== null) {
       actions.onToggleSave = closeAfter(toggleSaved);
-      actions.isSaved = isSaved;
     }
 
     if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -346,9 +346,9 @@ describe('LibraryContextMenu', () => {
     expect(screen.queryByTestId('menu-queue-liked')).not.toBeInTheDocument();
   });
 
-  describe('album Like/Unlike toggle', () => {
-    it('shows "Unlike" label when album is already liked (isSaved=true)', () => {
-      // #given
+  describe('album Unlike toggle', () => {
+    it('always labels the toggle as "Unlike" for liked albums', () => {
+      // #given — library only ever surfaces albums already saved by the user
       mockUseAlbumSavedStatus.mockReturnValue({
         isSaved: true,
         toggleSaved: vi.fn(),
@@ -362,23 +362,6 @@ describe('LibraryContextMenu', () => {
 
       // #then
       expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Unlike');
-    });
-
-    it('shows "Like" label when album is not liked (isSaved=false)', () => {
-      // #given
-      mockUseAlbumSavedStatus.mockReturnValue({
-        isSaved: false,
-        toggleSaved: vi.fn(),
-        canToggle: true,
-        saveError: null,
-        clearSaveError: vi.fn(),
-      });
-
-      // #when
-      renderMenu({ request: makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }) });
-
-      // #then
-      expect(screen.getByTestId('menu-toggle-save').textContent).toBe('Like');
     });
 
     it('omits toggle-save when isSaved is null (status still loading)', () => {

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.edges.test.ts
@@ -136,15 +136,15 @@ describe('buildMenuItems edges', () => {
       expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
     });
 
-    it('Like label is shown when isSaved is false', () => {
-      // #given
-      const actions = makeActions({ onToggleSave: vi.fn(), isSaved: false });
+    it('toggle-save label stays Unlike for albums regardless of caller flags', () => {
+      // #given — library only ever surfaces albums the user has already liked
+      const actions = makeActions({ onToggleSave: vi.fn() });
 
       // #when
       const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);
 
       // #then
-      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Like');
+      expect(items.find((i) => i.id === 'toggle-save')?.label).toBe('Unlike');
     });
   });
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/menuItemsForKind.test.ts
@@ -147,9 +147,9 @@ describe('buildMenuItems', () => {
     expect(items.find((i) => i.id === 'toggle-pin')?.label).toBe('Unpin');
   });
 
-  it('flips Like label to Unlike when isSaved=true', () => {
+  it('always labels album toggle-save as Unlike (library only shows liked albums)', () => {
     // #given
-    const actions = makeActions({ onToggleSave: vi.fn(), isSaved: true });
+    const actions = makeActions({ onToggleSave: vi.fn() });
 
     // #when
     const items = buildMenuItems(makeRequest({ kind: 'album' }), actions);

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -20,7 +20,6 @@ export interface MenuActions {
   likedProviderActions?: Array<{ provider: ProviderId; label: string; onPlay: () => void }>;
   onRemoveFromHistory?: () => void;
   isPinned?: boolean;
-  isSaved?: boolean;
   startRadioDisabled?: boolean;
   playNextDisabled?: boolean;
 }
@@ -74,11 +73,13 @@ function buildAlbumItems(actions: MenuActions): MenuItem[] {
     },
   ];
   if (actions.onToggleSave) {
-    // User-facing copy uses "Like"/"Unlike" for vocabulary parity with the track heart;
-    // internal field names mirror the Spotify API ("saved"). See #1386.
+    // Library only surfaces albums the user has already liked, so the toggle is
+    // always Unlike. If the menu is reused in a non-library context (e.g. search
+    // results) the caller should branch via an explicit prop, not by inferring
+    // from a saved flag. See #1395.
     items.push({
       id: 'toggle-save',
-      label: actions.isSaved ? 'Unlike' : 'Like',
+      label: 'Unlike',
       onSelect: actions.onToggleSave,
     });
   }

--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -52,25 +52,31 @@ export function useAlbumSavedStatus(
     const next = !isSaved;
     setIsSaved(next);
     setSaveError(null);
-    descriptor!
-      .catalog
-      .setAlbumSaved!(albumId, next)
-      .then(() => {
-        // Optimistically refresh the library view so an unliked album disappears
-        // from LibraryRoute within a frame instead of waiting for the next poll.
-        // Spotify is the only provider with a saved-album surface today; mirror
-        // the pattern when Dropbox (or others) gain one.
-        if (descriptor!.id === 'spotify' && !next) {
-          librarySyncEngine.optimisticRemoveAlbum(albumId).catch((err) => {
-            logLibrary('optimisticRemoveAlbum failed', err);
-          });
-        }
-      })
-      .catch((err) => {
+
+    async function run() {
+      try {
+        await descriptor!.catalog.setAlbumSaved!(albumId!, next);
+      } catch (err) {
         logLibrary('setAlbumSaved failed', err);
         setIsSaved(!next);
         setSaveError(next ? 'Failed to add album.' : 'Failed to remove album.');
-      });
+        return;
+      }
+
+      // Optimistically refresh the library view so an unliked album disappears
+      // from LibraryRoute within a frame instead of waiting for the next poll.
+      // Spotify is the only provider with a saved-album surface today; mirror
+      // the pattern when Dropbox (or others) gain one.
+      if (descriptor!.id === 'spotify' && !next) {
+        try {
+          await librarySyncEngine.optimisticRemoveAlbum(albumId!);
+        } catch (err) {
+          logLibrary('optimisticRemoveAlbum failed', err);
+        }
+      }
+    }
+
+    run().catch((err) => logLibrary('toggleSaved unexpected error', err));
   }, [canToggle, albumId, isSaved, descriptor]);
 
   const clearSaveError = useCallback(() => setSaveError(null), []);

--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import type { ProviderId } from '@/types/domain';
 import { logLibrary } from '@/lib/debugLog';
+import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
 
 export interface UseAlbumSavedStatusResult {
   isSaved: boolean | null;
@@ -54,6 +55,17 @@ export function useAlbumSavedStatus(
     descriptor!
       .catalog
       .setAlbumSaved!(albumId, next)
+      .then(() => {
+        // Optimistically refresh the library view so an unliked album disappears
+        // from LibraryRoute within a frame instead of waiting for the next poll.
+        // Spotify is the only provider with a saved-album surface today; mirror
+        // the pattern when Dropbox (or others) gain one.
+        if (descriptor!.id === 'spotify' && !next) {
+          librarySyncEngine.optimisticRemoveAlbum(albumId).catch((err) => {
+            logLibrary('optimisticRemoveAlbum failed', err);
+          });
+        }
+      })
       .catch((err) => {
         logLibrary('setAlbumSaved failed', err);
         setIsSaved(!next);

--- a/src/services/cache/__tests__/librarySyncEngine.test.ts
+++ b/src/services/cache/__tests__/librarySyncEngine.test.ts
@@ -391,4 +391,73 @@ describe('LibrarySyncEngine', () => {
       expect(playlists).toHaveLength(1);
     });
   });
+
+  describe('optimisticRemoveAlbum', () => {
+    it('should evict the album from the cached album list', async () => {
+      // #given
+      await seedCacheMeta({
+        albums: [makeAlbum('a1', 'Keep'), makeAlbum('a2', 'Remove')],
+        albumCount: 2,
+      });
+
+      // #when
+      await engine.optimisticRemoveAlbum('a2');
+
+      // #then
+      const albums = await cache.getAllAlbums();
+      expect(albums).toHaveLength(1);
+      expect(albums[0].id).toBe('a1');
+    });
+
+    it('should decrement the album totalCount in cache metadata', async () => {
+      // #given
+      await seedCacheMeta({
+        albums: [makeAlbum('a1'), makeAlbum('a2')],
+        albumCount: 2,
+      });
+
+      // #when
+      await engine.optimisticRemoveAlbum('a1');
+
+      // #then
+      const meta = await cache.getMeta('albums');
+      expect(meta!.totalCount).toBe(1);
+    });
+
+    it('should notify subscribers with the updated album list', async () => {
+      // #given
+      await seedCacheMeta({
+        albums: [makeAlbum('a1', 'Keep'), makeAlbum('a2', 'Remove')],
+        albumCount: 2,
+      });
+
+      let notifiedAlbums: AlbumInfo[] | undefined;
+      engine.subscribe((_state, _playlists, albums) => {
+        if (albums) notifiedAlbums = albums;
+      });
+
+      // #when
+      await engine.optimisticRemoveAlbum('a2');
+
+      // #then
+      expect(notifiedAlbums).toBeDefined();
+      expect(notifiedAlbums!.some((a) => a.id === 'a2')).toBe(false);
+      expect(notifiedAlbums!.some((a) => a.id === 'a1')).toBe(true);
+    });
+
+    it('should not go below zero when totalCount is already zero', async () => {
+      // #given
+      await seedCacheMeta({
+        albums: [makeAlbum('a1')],
+        albumCount: 0,
+      });
+
+      // #when
+      await engine.optimisticRemoveAlbum('a1');
+
+      // #then — totalCount must not underflow below zero
+      const meta = await cache.getMeta('albums');
+      expect(meta!.totalCount).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Drop the `isSaved`-conditional Like branch from `menuItemsForKind.buildAlbumItems` — the library only ever surfaces albums the user has already saved, so the toggle is now hardcoded to `Unlike`. Removed the now-unused `isSaved` field from `MenuActions` and the wire-through in `LibraryContextMenu`.
- After a successful Spotify unlike, evict the album via `librarySyncEngine.optimisticRemoveAlbum` (which already prunes the in-memory `albumSavedCache` and the cached library snapshot, then notifies `LibraryRoute` subscribers). The evict only fires on the success branch so a failed unlike does not desync the UI.
- **Dropbox parity**: Dropbox has no saved-album surface today (no `setAlbumSaved` / `isAlbumSaved` in its catalog adapter), so the optimistic refresh is gated on the spotify provider id. Mirror the pattern when other providers gain album-save capability.

## Test plan
- [x] Type check passes (`npx tsc -b --noEmit`).
- [x] Unit tests pass (`npm run test:run`) — 1645/1645.
- [ ] Manual: open library → context-menu an album → menu shows only "Unlike" → click → row disappears immediately without reload.

Closes #1395