### PR TITLE
refactor(providers): tighten error handling across spotify and dropbox adapters

### DIFF
--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -1,6 +1,7 @@
 import type { DropboxFileEntry, DropboxListFolderResult, CachedLink } from './dropboxCatalogHelpers';
 import { TEMP_LINK_TTL_MS } from './dropboxCatalogHelpers';
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
+import { AuthExpiredError } from '@/providers/errors';
 
 const DEFAULT_RETRY_AFTER_SECONDS = 5;
 const MAX_RETRY_AFTER_SECONDS = 30;
@@ -53,7 +54,7 @@ export class DropboxApiClient {
     signal?: AbortSignal,
   ): Promise<T> {
     let token = await this.auth.ensureValidToken();
-    if (!token) throw new Error('Not authenticated with Dropbox');
+    if (!token) throw new AuthExpiredError('dropbox');
 
     const makeRequest = (accessToken: string) =>
       fetch(`https://api.dropboxapi.com/2${endpoint}`, {
@@ -70,11 +71,11 @@ export class DropboxApiClient {
 
     if (response.status === 401) {
       token = await this.auth.refreshAccessToken();
-      if (!token) throw new Error('Dropbox authentication expired');
+      if (!token) throw new AuthExpiredError('dropbox');
       response = await makeRequest(token);
       if (response.status === 401) {
         this.auth.reportUnauthorized();
-        throw new Error('Dropbox authentication expired');
+        throw new AuthExpiredError('dropbox');
       }
     }
 

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -394,12 +394,7 @@ export async function loadPlaylistTracks(
   const data = await loadPlaylistFile(auth, playlistPath);
   if (!data) return [];
 
-  try {
-    return data.tracks.map(savedTrackToMediaTrack);
-  } catch {
-    console.warn('[DropboxPlaylistStorage] Failed to parse playlist file');
-    return [];
-  }
+  return data.tracks.map(savedTrackToMediaTrack);
 }
 
 /**

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -173,7 +173,8 @@ export class SpotifyCatalogAdapter implements CatalogProvider {
       const track = await searchTrack(artist, title);
       if (!track) return null;
       return spotifyTrackToMediaTrack(track);
-    } catch {
+    } catch (err) {
+      console.warn('[SpotifyCatalog] searchTrack failed:', err);
       return null;
     }
   }

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -112,7 +112,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
           });
         }
       } catch (error) {
-        console.error('Failed to activate device:', error);
+        console.error('[SpotifyPlayback] Failed to activate device:', error);
       }
     };
 


### PR DESCRIPTION
## Summary
- Replace plain \`Error\` throws with typed \`AuthExpiredError\` in the Dropbox API client so callers can distinguish auth expiry from other failures
- Remove a dead try/catch wrapping a pure function that can never throw
- Surface a completely silent search failure in the Spotify catalog adapter

## Changes

### Typed-error usage gaps fixed
- **\`dropboxApiClient.ts\`**: The three \`throw new Error('Not authenticated...')\` / \`throw new Error('Dropbox authentication expired')\` paths now throw \`AuthExpiredError('dropbox')\` from \`src/providers/errors.ts\`, consistent with how the Dropbox playback adapter already catches auth errors from this client.

### Redundant try/catch removed
- **\`dropboxPlaylistStorage.ts\` — \`loadPlaylistTracks\`**: \`savedTrackToMediaTrack\` is a pure synchronous mapping function; the surrounding \`try/catch { console.warn; return [] }\` was unreachable dead code and has been removed.

### Silent failures surfaced
- **\`spotifyCatalogAdapter.ts\` — \`searchTrack\`**: The bare \`catch { return null }\` swallowed all search errors with no visibility. Now logs \`console.warn('[SpotifyCatalog] searchTrack failed:', err)\` before returning null.
- **\`spotifyPlaybackAdapter.ts\` — \`activateDevice\`**: The catch label was a bare unqualified string \`'Failed to activate device:'\`; changed to \`'[SpotifyPlayback] Failed to activate device:'\` to match the rest of the file's logging convention.

## Test plan
- \`npx tsc -b --noEmit\` — clean (0 errors)
- \`npm run test:run\` — green (1649/1649 passing)
- Behaviour-level: \`AuthExpiredError\` thrown by \`dropboxApiClient\` is caught in \`dropboxPlaybackAdapter.probePlayable\` which already has \`if (error instanceof AuthExpiredError) throw error\` — no regression.

## Findings deferred to issues

| Location | Finding | Reason deferred |
|---|---|---|
| \`dropboxApiClient.ts:139\` | \`prefetchTemporaryLink.catch(() => {})\` | Intentional fire-and-forget pre-fetch; empty catch is correct |
| \`dropboxArtworkResolver.ts:49\` | \`catch { return null }\` in \`doFetchArtDataUrl\` | Domain boundary — artwork is optional, null is the correct fallback |
| \`dropboxArtworkResolver.ts:120\` | \`catch { return null }\` in \`resolveAlbumArt\` | Same as above |
| \`dropboxCatalogAdapter.ts:203\` | \`scanAlbumDatesInBackground().catch(() => {})\` | Explicitly fire-and-forget background scan; caller comment confirms |
| \`dropboxPlaybackAdapter.ts:87\` | \`audio.play().catch(() => {})\` | Intentional iOS Safari user-gesture pre-activate; code comment explains |
| \`dropboxPlaybackAdapter.ts:125\` | \`.catch(() => {})` on \`hydrateAlbumArtFromCache\` | Best-effort cache hydration at domain boundary |
| \`dropboxPlaybackAdapter.ts:203\` | \`.catch(() => {})` on \`doEnrich\` | Best-effort ID3 background enrichment; would regress on network issues |
| \`spotifyPlaybackAdapter.ts:292\` | \`ensureValidToken().catch(() => {})\` | Intentional pre-warm to amortise refresh latency; failure is harmless |
| \`spotifyQueueSync.ts:101-106\` | \`catch { }\` in \`resolveTracksInBackground\` — doesn't cache miss | Correct by design: network errors should not cache null so next attempt can retry |
| \`useSpotifyPlaylistManager.ts:157,202\` | Fire-and-forget \`setTimeout(() => void async()...)\` | Changing would alter observable retry behaviour; public contract risk |

## Considered and kept

- **\`dropboxArtCache.ts\` — IndexedDB write helpers** (\`putDurationMs\`, \`putTagMetadata\`, \`putTrackDate\`): empty \`catch {}\` blocks are intentional — these are fire-and-forget cache-warming writes and the caller comment says so. Surfacing them would add noise for non-critical storage failures.
- **\`dropboxLikesCache.ts\` — \`withStore\`/\`withTombstoneStore\`**: Returns a typed fallback on IDB errors. This is the correct domain-boundary pattern for IndexedDB (unavailable in SSR/workers); null/empty-array fallbacks are observable and documented.
- **\`dropboxLikesSync.ts\` / \`dropboxPreferencesSync.ts\` — \`initialSync catch (error) { console.warn }\`**: Top-level sync is best-effort; swallowing and warning is the right behaviour here (the user's local state is still usable).