### PR TITLE
chore: graduate discovery-team skill to squadkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,4 +153,8 @@ For structured feature development, see `.claude/rules/`:
 
 ## Multi-Agent Team Workflows
 
-For epics that benefit from parallel specialist work, this project ships a six-role team (lead + explorer + architect + builder + reviewer + tester). See `.claude/agents/README.md` for spawn/retro skills (`/spawn-team`, `/agent-team-retro`), agent-definition conventions, and when to use the team.
+For epics that benefit from parallel specialist work, use **squadkit** crews:
+
+- `/squadkit:spawn-team --profile <name>` — execution crew (architect + builders + reviewer + tester) that ships PRs. Profiles: `all-rounder`, `builder`, `qa`, `design`.
+- `/squadkit:spawn-team --profile discovery-3-role --brief <text|@path>` — read-only discovery crew (architect + explorer + designer) that posts blueprint comments to a batch of GitHub issues. No code, no PRs.
+- `/squadkit:agent-team-retro` — run a retrospective on the active squad and feed findings into role contracts or `/speckit:catalog`.


### PR DESCRIPTION
## Summary

- Retires project-local `/discovery-team` skill in favor of `/squadkit:spawn-team --profile discovery-3-role --brief <text|@path>`, shipped in squadkit 0.6.0 (smallorbit-plugins [#681](https://github.com/smallorbit/smallorbit-plugins/pull/681) + [#682](https://github.com/smallorbit/smallorbit-plugins/pull/682)).
- Local skill stashed at `.skill-backups/discovery-team-graduated-2026-04-29/` (untracked, preserved per project convention) so Claude no longer loads it but the file is recoverable.
- `CLAUDE.md` Multi-Agent Team Workflows section pointed at a missing `.claude/agents/README.md`; replaced with an inline list of squadkit profiles (execution + discovery) and the spawn/retro skill names.

## Why

The `kind: discovery` field, the `discovery-3-role` profile, and `--brief` on `/squadkit:spawn-team` are now in squadkit 0.6.0 — they fully cover the local skill's spawn shape and architect-led coordination protocol. Keeping a project-local copy after graduation is duplication.

## Test plan
- [ ] Verify `/discovery-team` is no longer in the Skill picker
- [ ] Confirm `/squadkit:spawn-team --profile discovery-3-role --brief "<text>"` resolves the discovery profile (rejects `--epic`, requires `--brief`)
- [ ] Spot-check CLAUDE.md renders cleanly on GitHub