### PR TITLE
chore(lint): clear unused-vars and prefer-const errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,14 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
 )

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
@@ -260,8 +260,6 @@ describe('MusicSourcesSection', () => {
       );
 
       // The popup window is immediately closed (user dismissed the OAuth popup)
-      const mockPopup = { closed: true } as Window;
-      // Use Object.defineProperty to bypass any lingering spy on window.open
       const mockPopupObj = { closed: true };
       const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
       Object.defineProperty(window, 'open', {

--- a/src/components/__tests__/PlayerContent.test.tsx
+++ b/src/components/__tests__/PlayerContent.test.tsx
@@ -8,7 +8,6 @@ import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import PlayerContent from '../PlayerContent';
 import type { PlaybackHandlers } from '../PlayerContent';
-import { makeMediaTrack } from '@/test/fixtures';
 import { theme } from '@/styles/theme';
 
 // Mock ResizeObserver

--- a/src/components/__tests__/ProviderSetupScreen.test.tsx
+++ b/src/components/__tests__/ProviderSetupScreen.test.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { theme } from '@/styles/theme';
 import { makeProviderDescriptor } from '@/test/fixtures';
-import type { ProviderDescriptor } from '@/types/providers';
 
 const mockSetActiveProviderId = vi.fn();
 const mockToggleProvider = vi.fn();

--- a/src/components/__tests__/QueueDrawer.test.tsx
+++ b/src/components/__tests__/QueueDrawer.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/contexts/PlayerSizingContext', () => ({
 }));
 
 vi.mock('@/components/QueueTrackList', () => ({
-  default: ({ tracks, currentTrackIndex, onTrackSelect, onRemoveTrack }: {
+  default: ({ tracks, currentTrackIndex: _currentTrackIndex, onTrackSelect, onRemoveTrack }: {
     tracks: { id: string; name: string }[];
     currentTrackIndex: number;
     onTrackSelect: (i: number) => void;

--- a/src/components/__tests__/ResumeToast.test.tsx
+++ b/src/components/__tests__/ResumeToast.test.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { toast } from 'sonner';

--- a/src/contexts/__tests__/PinnedItemsContext.test.tsx
+++ b/src/contexts/__tests__/PinnedItemsContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { PinnedItemsProvider, usePinnedItemsContext } from '@/contexts/PinnedItemsContext';
 import { LIKED_SONGS_ID, ALL_MUSIC_PIN_ID } from '@/constants/playlist';

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -174,7 +174,7 @@ export async function saveQueueAsPlaylist(
     tracks: mediaTracks.map(mediaTrackToSavedTrack),
   };
 
-  let token = await auth.ensureValidToken();
+  const token = await auth.ensureValidToken();
   if (!token) return null;
 
   const apiArg = jsonToHttpHeader(
@@ -347,7 +347,7 @@ async function loadPlaylistFile(
   auth: DropboxAuthAdapter,
   playlistPath: string,
 ): Promise<PlaylistFile | null> {
-  let token = await auth.ensureValidToken();
+  const token = await auth.ensureValidToken();
   if (!token) return null;
 
   const apiArg = jsonToHttpHeader(JSON.stringify({ path: playlistPath }));
@@ -404,7 +404,7 @@ export async function deleteSavedPlaylist(
   auth: DropboxAuthAdapter,
   playlistPath: string,
 ): Promise<boolean> {
-  let token = await auth.ensureValidToken();
+  const token = await auth.ensureValidToken();
   if (!token) return false;
 
   const deleteFile = (accessToken: string) =>

--- a/src/services/devbug/__tests__/circularBuffer.test.ts
+++ b/src/services/devbug/__tests__/circularBuffer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { CircularBuffer } from '../circularBuffer';
 
 describe('CircularBuffer', () => {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,6 +1,6 @@
-import type { AlbumInfo, PlaylistInfo, SpotifyPlaybackState } from '@/services/spotify';
+import type { AlbumInfo } from '@/services/spotify';
 import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
-import type { MediaTrack, PlaybackState, ProviderId } from '@/types/domain';
+import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import { vi } from 'vitest';
 


### PR DESCRIPTION
## Summary
- Drops 10 unused imports / variables across test files and fixtures
- Underscore-renames 1 unused-but-required destructure param per existing convention (`currentTrackIndex → _currentTrackIndex` in QueueDrawer mock)
- Converts 3 `let → const` where the token binding is never reassigned (dropboxPlaylistStorage)
- Configures `@typescript-eslint/no-unused-vars` with `argsIgnorePattern: '^_'` / `varsIgnorePattern: '^_'` so the project's existing `_`-prefix convention is respected by ESLint
- Lint baseline: 58 errors → 18 errors (target: the unused-vars + prefer-const slice of #1363)

## Changes
**ESLint config** (`eslint.config.js`)
- Add `argsIgnorePattern`, `varsIgnorePattern`, and `caughtErrorsIgnorePattern` set to `'^_'` — silences all 22 already-prefixed parameters flagged across visualizers, hooks, adapters, and catalog adapters

**prefer-const** (`src/providers/dropbox/dropboxPlaylistStorage.ts`)
- `savePlaylistFile`, `loadPlaylistFile`, `deleteSavedPlaylist`: `let token` → `const token` (none of these three bindings are reassigned)

**Unused imports / variables in tests and fixtures**
- `src/test/fixtures.ts`: remove `PlaylistInfo`, `SpotifyPlaybackState`, `PlaybackState` type imports
- `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx`: remove `act` import; delete dead `mockPopup` variable (shadowed by `mockPopupObj`)
- `src/components/__tests__/PlayerContent.test.tsx`: remove `makeMediaTrack` import
- `src/components/__tests__/ProviderSetupScreen.test.tsx`: remove `ProviderDescriptor` type import
- `src/components/__tests__/QueueDrawer.test.tsx`: rename `currentTrackIndex` → `_currentTrackIndex` in mock component destructure
- `src/components/__tests__/ResumeToast.test.tsx`: remove `waitFor` import (tests use `vi.waitFor`)
- `src/contexts/__tests__/PinnedItemsContext.test.tsx`: remove `waitFor` import
- `src/services/devbug/__tests__/circularBuffer.test.ts`: remove `beforeEach` import

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (1649 tests, 151 files)
- `npm run lint 2>&1 | grep -cE "no-unused-vars|prefer-const"` → 0
- Remaining 18 errors in #1363 are `no-explicit-any` (17) and `no-useless-catch` (1), deferred to a follow-up pass

## Findings deferred to issues
All `_`-prefixed parameters in visualizers, hooks, and adapters were already correctly named per the project convention — the ESLint config simply lacked the ignore pattern. No behavioral change was needed for any of those 22 parameters; they are intentional stubs in function signatures required by a shared interface contract:
- `src/components/visualizers/GridWaveVisualizer.tsx` — `_height`, `_intensity`, `_width`
- `src/components/visualizers/ParticleVisualizer.tsx` — `_intensityValue`
- `src/components/visualizers/TrailVisualizer.tsx` — `_intensityValue`
- `src/components/visualizers/WaveVisualizer.tsx` — `_width`, `_height`, `_intensity`
- `src/hooks/useLongPress.ts` — `_e` (×2)
- `src/hooks/useQueueBundlePrefetch.ts` — `_currentTrackId`
- `src/hooks/useZenTouchGestures.ts` — `_e` (×2)
- `src/hooks/__tests__/freshLoadArtRace.test.tsx` — `_v`
- `src/providers/dropbox/dropboxCatalogAdapter.ts` — `_artist`, `_title`
- `src/providers/dropbox/dropboxPlaybackAdapter.ts` — `_collectionRef`, `_options`, `_tracks`, `_fromIndex`
- `src/providers/spotify/spotifyCatalogAdapter.ts` — `_isComplete` (×2)
- `src/components/PlayerContent/AlbumArtSection.tsx` — `_e`
- `src/components/QueueTrackList.tsx` — `_event`
- `src/utils/playlistFilters.ts` — `_selectedGenres`

Closes part of #1363.