### PR TITLE
fix(toast): queue 'View' action closes library before opening queue

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -171,7 +171,13 @@ const AudioPlayerComponent = () => {
         const trackWord = result.added === 1 ? 'track' : 'tracks';
         toast(`Added ${result.added} ${trackWord} from ${label} to your queue.`, {
           id: 'qap-add-queue',
-          action: { label: 'View', onClick: () => setShowQueue(true) },
+          action: {
+            label: 'View',
+            onClick: () => {
+              handlers.handleCloseLibrary();
+              setShowQueue(true);
+            },
+          },
         });
       }
       return result;
@@ -197,7 +203,13 @@ const AudioPlayerComponent = () => {
         const trackWord = result.added === 1 ? 'track' : 'tracks';
         toast(`Added ${result.added} liked ${trackWord} from ${label} to your queue.`, {
           id: 'qap-queue-liked',
-          action: { label: 'View', onClick: () => setShowQueue(true) },
+          action: {
+            label: 'View',
+            onClick: () => {
+              handlers.handleCloseLibrary();
+              setShowQueue(true);
+            },
+          },
         });
       }
     },


### PR DESCRIPTION
## Summary
- The two queue confirmation toasts (`Added N tracks…` and `Added N liked tracks…`) wired their `View` action to `setShowQueue(true)` only. When the library overlay was open, the queue drawer opened underneath it — making the View affordance a dead end and forcing users to discover the mini-player workaround to dismiss the library.
- Adds `handlers.handleCloseLibrary()` to both `View` `onClick` handlers in `AudioPlayer.tsx` so the queue is always brought to the foreground over an open library.

Closes #1389

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — affected component + hook tests (14 files, 155 tests) pass
- [ ] Manual: open library → add a collection to queue → click toast `View` → library dismisses, queue drawer appears
- [ ] Manual: same flow with a Liked Songs subset (different toast id, separate code path)