### PR TITLE
chore(lint): clear no-explicit-any and no-useless-catch errors (slice 2 of #1363)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,15 +112,11 @@ function App() {
           let handled = false;
           let handledProviderId: string | null = null;
           for (const descriptor of providerRegistry.getAll()) {
-            try {
-              const result = await descriptor.auth.handleCallback(currentUrl);
-              if (result) {
-                handled = true;
-                handledProviderId = descriptor.id;
-                break;
-              }
-            } catch (providerError) {
-              throw providerError;
+            const result = await descriptor.auth.handleCallback(currentUrl);
+            if (result) {
+              handled = true;
+              handledProviderId = descriptor.id;
+              break;
             }
           }
 

--- a/src/components/__tests__/PlayerContent.test.tsx
+++ b/src/components/__tests__/PlayerContent.test.tsx
@@ -15,7 +15,7 @@ global.ResizeObserver = vi.fn(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
   disconnect: vi.fn(),
-})) as any;
+})) as unknown as typeof ResizeObserver;
 
 vi.mock('@/hooks/useLibrarySync', () => ({
   useLibrarySync: vi.fn(() => ({

--- a/src/hooks/__tests__/useAutoAdvance.test.ts
+++ b/src/hooks/__tests__/useAutoAdvance.test.ts
@@ -24,7 +24,7 @@ import { ProviderWrapper } from '@/test/providerTestUtils';
 
 const opts = { wrapper: ProviderWrapper };
 
-const createMockPlaybackDescriptor = (playbackOverrides?: Record<string, any>) => {
+const createMockPlaybackDescriptor = (playbackOverrides?: Record<string, unknown>) => {
   return makeProviderDescriptor({
     playback: {
       providerId: 'spotify',

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -31,7 +31,7 @@ describe('useCollectionLoader', () => {
   let mockSpotifyHandlePlaylistSelect: ReturnType<typeof vi.fn>;
   let mockStopRadioBase: ReturnType<typeof vi.fn>;
   let mockRecord: ReturnType<typeof vi.fn>;
-  let mockActiveDescriptor: any;
+  let mockActiveDescriptor: { id: string; [key: string]: unknown };
   let mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
   let drivingProviderRef: React.MutableRefObject<string | null>;
 

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -28,7 +28,7 @@ describe('useQueueManagement', () => {
   let mockSetOriginalTracks: ReturnType<typeof vi.fn>;
   let mockSetCurrentTrackIndex: ReturnType<typeof vi.fn>;
   let mockGetDescriptor: ReturnType<typeof vi.fn>;
-  let mockActiveDescriptor: any;
+  let mockActiveDescriptor: { id: string; [key: string]: unknown };
   let mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
 
   beforeEach(() => {

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -19,7 +19,21 @@ const mockCatalog: Partial<DropboxCatalogAdapter> = {
 };
 
 // Mock HTML5 Audio API
-const mockAudio = {
+const mockAudio: {
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  paused: boolean;
+  ended: boolean;
+  currentTime: number;
+  duration: number;
+  volume: number;
+  src: string;
+  preload: string;
+  readyState: number;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  __triggerEvent?: (event: string) => void;
+} = {
   play: vi.fn().mockResolvedValue(undefined),
   pause: vi.fn(),
   paused: true,
@@ -34,8 +48,8 @@ const mockAudio = {
   removeEventListener: vi.fn(),
 };
 
-vi.stubGlobal('Audio', vi.fn(() => mockAudio) as any);
-vi.stubGlobal('HTMLMediaElement', { HAVE_METADATA: 1 } as any);
+vi.stubGlobal('Audio', vi.fn(() => mockAudio) as unknown as typeof Audio);
+vi.stubGlobal('HTMLMediaElement', { HAVE_METADATA: 1 } as unknown as typeof HTMLMediaElement);
 
 // Mock ID3 parser
 vi.mock('@/utils/id3Parser', () => ({
@@ -57,8 +71,8 @@ describe('DropboxPlaybackAdapter', () => {
     listeners = new Map();
 
     // Track event listeners for testing
-    const eventListeners: { [key: string]: ((event: any) => void)[] } = {};
-    mockAudio.addEventListener.mockImplementation((event: string, listener: (e: any) => void) => {
+    const eventListeners: { [key: string]: ((event: Event) => void)[] } = {};
+    mockAudio.addEventListener.mockImplementation((event: string, listener: (e: Event) => void) => {
       if (!eventListeners[event]) eventListeners[event] = [];
       eventListeners[event].push(listener);
       const mock = vi.fn();
@@ -66,9 +80,9 @@ describe('DropboxPlaybackAdapter', () => {
     });
 
     // Helper to trigger events
-    (mockAudio as any).__triggerEvent = (event: string) => {
+    mockAudio.__triggerEvent = (event: string) => {
       if (eventListeners[event]) {
-        eventListeners[event].forEach((listener) => listener({}));
+        eventListeners[event].forEach((listener) => listener({} as Event));
       }
     };
 
@@ -79,7 +93,7 @@ describe('DropboxPlaybackAdapter', () => {
     mockAudio.volume = 1;
     mockAudio.src = '';
     mockAudio.readyState = 0;
-    mockAudio.removeEventListener.mockImplementation((event: string, listener: (e: any) => void) => {
+    mockAudio.removeEventListener.mockImplementation((event: string, listener: (e: Event) => void) => {
       if (eventListeners[event]) {
         eventListeners[event] = eventListeners[event].filter((l) => l !== listener);
       }
@@ -139,7 +153,7 @@ describe('DropboxPlaybackAdapter', () => {
     const unsubscribe = adapter.subscribe(listener);
 
     // Trigger a state change
-    (mockAudio as any).__triggerEvent('play');
+    mockAudio.__triggerEvent?.('play');
 
     // #then
     expect(listener).toHaveBeenCalled();
@@ -149,7 +163,7 @@ describe('DropboxPlaybackAdapter', () => {
 
     unsubscribe();
     listener.mockClear();
-    (mockAudio as any).__triggerEvent('play');
+    mockAudio.__triggerEvent?.('play');
     expect(listener).not.toHaveBeenCalled();
   });
 
@@ -265,7 +279,7 @@ describe('DropboxPlaybackAdapter', () => {
       mockAudio.duration = 200;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 45;
-      (mockAudio as any).__triggerEvent('loadedmetadata');
+      mockAudio.__triggerEvent?.('loadedmetadata');
 
       // #then — final state uses the real audio duration; trackMetadata.durationMs updated
       const findLastHydrateCall = () => {
@@ -302,7 +316,7 @@ describe('DropboxPlaybackAdapter', () => {
       mockAudio.duration = 200;
       mockAudio.readyState = 1;
       // Intentionally leave mockAudio.currentTime = 0 — this is the flicker window
-      (mockAudio as any).__triggerEvent('loadedmetadata');
+      mockAudio.__triggerEvent?.('loadedmetadata');
 
       // Let primeAudioForHydrate continue (re-seeks and clears the hint)
       await vi.waitFor(() => expect(mockAudio.currentTime).toBe(45));
@@ -331,7 +345,7 @@ describe('DropboxPlaybackAdapter', () => {
       mockAudio.duration = Infinity;
       mockAudio.readyState = 1;
       mockAudio.currentTime = 10;
-      (mockAudio as any).__triggerEvent('loadedmetadata');
+      mockAudio.__triggerEvent?.('loadedmetadata');
 
       // #then — final state reports 0 for infinite-duration stream; no trackMetadata.durationMs
       const findLastHydrateCall = () => {
@@ -399,7 +413,7 @@ describe('DropboxPlaybackAdapter', () => {
       // Now the stale loadedmetadata for the prior src fires.
       mockAudio.duration = 220;
       mockAudio.readyState = 1;
-      (mockAudio as any).__triggerEvent('loadedmetadata');
+      mockAudio.__triggerEvent?.('loadedmetadata');
       await Promise.resolve();
 
       // #then

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -79,7 +79,7 @@ export function backfillProvider(tracks: Track[]): Track[] {
  * Convert Spotify Track objects to provider-neutral MediaTrack format.
  */
 export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
-  return tracks.map((t: any) => ({
+  return tracks.map((t) => ({
     id: t.id,
     provider: t.provider as ProviderId,
     playbackRef: { provider: 'spotify' as ProviderId, ref: t.uri },


### PR DESCRIPTION
## Summary
- Slice 2 of the lint cleanup, following [#1403](https://github.com/smallorbit/vorbis-player/pull/1403). Clears the remaining **18 errors** (17 `no-explicit-any` + 1 `no-useless-catch`) that slice 1 deferred.
- **Production (2)**: removed a useless `try/catch` rethrow in `App.tsx` and dropped a redundant `(t: any)` annotation in `services/spotify/tracks.ts` where the parameter type already covered every destructured field.
- **Tests (16)**: all were `as any` casts on mocked globals or event listener signatures. Replaced with idiomatic patterns — `as unknown as TypeName` for global stubs, `Record<string, unknown>` for loose override params, explicit `mockAudio` shape with `__triggerEvent?` to drop eight repeat casts, and `Event` types on listener signatures.

Closes #1363

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — `0 errors` (was 18); 41 pre-existing warnings remain (all `react-hooks/exhaustive-deps`, untouched)
- [x] `npm run test:run` — 151 files, 1649 tests pass
- [ ] No runtime behavior changes — type-only edits