### PR TITLE
feat(visualizer): dim background while library is open

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -470,6 +470,7 @@ const AudioPlayerComponent = () => {
             speed={backgroundVisualizerSpeed}
             accentColor={accentColor}
             isPlaying={state.isPlaying}
+            dimmed={state.currentView === 'library'}
           />
         </ProfiledComponent>
         {renderContent()}

--- a/src/components/BackgroundVisualizer.tsx
+++ b/src/components/BackgroundVisualizer.tsx
@@ -13,11 +13,12 @@ interface BackgroundVisualizerProps {
   speed?: number;
   accentColor: string;
   isPlaying: boolean;
+  dimmed?: boolean;
   /** When style is 'comet', the trail head is constrained to this rect so it appears to come from the album art */
   albumArtBounds?: AlbumArtBounds | null;
 }
 
-const VisualizerContainer = styled.div`
+const VisualizerContainer = styled.div<{ $dimmed: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
@@ -26,6 +27,9 @@ const VisualizerContainer = styled.div`
   z-index: 1;
   pointer-events: none;
   overflow: hidden;
+  opacity: ${({ $dimmed }) => ($dimmed ? 0.2 : 1)};
+  transition: opacity 250ms ease;
+  will-change: opacity;
 `;
 
 /**
@@ -50,6 +54,7 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   speed,
   accentColor,
   isPlaying,
+  dimmed = false,
   albumArtBounds,
 }) => {
   const VisualizerComponent = useMemo(() => {
@@ -74,7 +79,7 @@ const BackgroundVisualizer: React.FC<BackgroundVisualizerProps> = React.memo(({
   }
 
   return (
-    <VisualizerContainer>
+    <VisualizerContainer $dimmed={dimmed}>
       <VisualizerComponent
         intensity={intensity}
         speed={speed ?? 1.0}


### PR DESCRIPTION
## Summary
- Gates `VisualizerContainer` opacity to 20% via a CSS transition when `state.currentView === 'library'`, restoring to full opacity when the library closes
- Visualizer stays mounted throughout — comet/trail/firefly motion state in `useRef`s is preserved, so the animation resumes seamlessly from its current position when the library is dismissed

## Test plan
- TypeScript: `npx tsc -b --noEmit` — clean
- Tests: `npm run test:run` — 1649/1649 passed
- Manual: open library with a bright visualizer active; confirm it dims smoothly; dismiss library and confirm it restores without the comet snapping back to origin

Closes #1370