### PR TITLE
refactor(library): make LibraryRoute.onAddToQueue a required prop

### DIFF
--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -23,7 +23,7 @@ import { LibraryContextMenuOpenContext } from './contextMenu/LibraryContextMenuO
 
 export interface LibraryRouteProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
-  onAddToQueue?: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  onAddToQueue: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
   onPlayLikedTracks?: (
     tracks: MediaTrack[],
     collectionId: string,
@@ -140,7 +140,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
 
   const handleAddToQueueAction = useCallback(
     (id: string, name: string, provider?: ProviderId) => {
-      void onAddToQueue?.(id, name, provider);
+      void onAddToQueue(id, name, provider);
     },
     [onAddToQueue],
   );

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
-import type { MediaTrack } from '@/types/domain';
+import type { AddToQueueResult, MediaTrack, ProviderId } from '@/types/domain';
 import { isSessionStale, type SessionSnapshot } from '@/services/sessionPersistence';
 import type { HydrateResult } from '@/hooks/usePlayerLogic';
 import { Card, CardHeader, CardContent } from '../components/styled';
@@ -174,9 +174,9 @@ interface PlayerStateRendererProps {
   error: string | null;
   selectedPlaylistId: string | null;
   tracks: MediaTrack[];
-  onPlaylistSelect: (playlistId: string, playlistName?: string, provider?: import('@/types/domain').ProviderId) => void;
-  onAddToQueue: (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => void;
-  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: import('@/types/domain').ProviderId) => Promise<void>;
+  onPlaylistSelect: (playlistId: string, playlistName?: string, provider?: ProviderId) => void;
+  onAddToQueue: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
+  onPlayLikedTracks?: (tracks: MediaTrack[], collectionId: string, collectionName: string, provider?: ProviderId) => Promise<void>;
   onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
   lastSession: SessionSnapshot | null;
   onResume: () => void;
@@ -337,6 +337,7 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
         }>
           <LibraryRouteLazy
             onPlaylistSelect={(id, name, provider) => handlePlaylistSelectWrapped(id, name ?? '', provider)}
+            onAddToQueue={onAddToQueue}
             onPlayLikedTracks={onPlayLikedTracks}
             onQueueLikedTracks={onQueueLikedTracks}
             onOpenSettings={onOpenSettings}


### PR DESCRIPTION
## Summary
- Tightened `onAddToQueue` in `LibraryRouteProps` from optional (`?:`) to required, preventing silent no-op regressions
- Removed `?.()` short-circuit in `handleAddToQueueAction`; call is now direct. Also wired the missing `onAddToQueue` prop in `PlayerStateRenderer`'s `LibraryRouteLazy` call site and aligned its prop type to `Promise<AddToQueueResult | null>` so `tsc` catches any future omission

## Test plan
- `npx tsc -b --noEmit` passes with zero errors
- `npm run test:run` — 151 test files, 1649 tests, all green

Closes #1368