### PR TITLE
feat(cache): add IndexedDB-cached library search query

### DIFF
--- a/src/hooks/__tests__/useLibrarySearch.test.ts
+++ b/src/hooks/__tests__/useLibrarySearch.test.ts
@@ -1,0 +1,171 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { useLibrarySearch } from '@/hooks/useLibrarySearch';
+import {
+  initCache,
+  closeCache,
+  clearAll,
+  putAllPlaylists,
+  putAllAlbums,
+  putTrackList,
+} from '@/services/cache/libraryCache';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { AlbumInfo, Track, SpotifyImage } from '@/services/spotify';
+
+function makePlaylist(id: string, name: string): CachedPlaylistInfo {
+  return {
+    id,
+    name,
+    description: null,
+    images: [] as SpotifyImage[],
+    tracks: { total: 10 },
+    owner: { display_name: 'TestUser' },
+  };
+}
+
+function makeAlbum(id: string, name: string, artists = 'Test Artist'): AlbumInfo {
+  return {
+    id,
+    name,
+    artists,
+    images: [] as SpotifyImage[],
+    release_date: '2024-01-01',
+    total_tracks: 12,
+    uri: `spotify:album:${id}`,
+    added_at: '2024-06-15T00:00:00Z',
+  };
+}
+
+function makeTrack(id: string, name: string, artists = 'Artist'): Track {
+  return {
+    id,
+    name,
+    artists,
+    album: 'Album',
+    duration_ms: 200_000,
+    uri: `spotify:track:${id}`,
+  };
+}
+
+describe('useLibrarySearch', () => {
+  beforeEach(async () => {
+    await initCache();
+    await clearAll();
+    closeCache();
+    localStorage.clear();
+    await initCache();
+  });
+
+  afterEach(() => {
+    closeCache();
+  });
+
+  it('returns an empty result for an empty query without loading', () => {
+    // #when
+    const { result } = renderHook(() => useLibrarySearch(''));
+
+    // #then
+    expect(result.current.results).toEqual({
+      tracks: [],
+      albums: [],
+      artists: [],
+      playlists: [],
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not query the cache before the debounce window elapses', async () => {
+    // #given
+    await putAllPlaylists([makePlaylist('p1', 'Rock Mix')]);
+
+    const { result } = renderHook(() => useLibrarySearch('rock', { debounceMs: 150 }));
+
+    // #then — synchronously after the first render, no query has resolved
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.results.playlists).toHaveLength(0);
+
+    // #when — eventually the debounced query resolves
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.results.playlists.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('clears results immediately when the query is reset to empty', async () => {
+    // #given
+    await putAllPlaylists([makePlaylist('p1', 'Rock Mix')]);
+
+    const { result, rerender } = renderHook(
+      ({ q }: { q: string }) => useLibrarySearch(q, { debounceMs: 50 }),
+      { initialProps: { q: 'rock' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.results.playlists).toHaveLength(1);
+    });
+
+    // #when
+    rerender({ q: '' });
+
+    // #then
+    expect(result.current.results.playlists).toHaveLength(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('discards stale responses from superseded queries', async () => {
+    // #given
+    await putAllPlaylists([
+      makePlaylist('p1', 'Rock Mix'),
+      makePlaylist('p2', 'Jazz Hour'),
+    ]);
+    await putAllAlbums([makeAlbum('a1', 'Funeral', 'Arcade Fire')]);
+    await putTrackList('liked-songs', [makeTrack('t1', 'Wake Up', 'Arcade Fire')]);
+
+    const { result, rerender } = renderHook(
+      ({ q }: { q: string }) => useLibrarySearch(q, { debounceMs: 50 }),
+      { initialProps: { q: 'rock' } },
+    );
+
+    // #when — swap to "jazz" before "rock" can settle
+    rerender({ q: 'jazz' });
+
+    // #then — only the most recent query's result is reflected
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.results.playlists.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('respects a custom debounce window using fake timers', async () => {
+    // #given
+    await putAllPlaylists([makePlaylist('p1', 'Rock Mix')]);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { result } = renderHook(() => useLibrarySearch('rock', { debounceMs: 200 }));
+
+      // #then — before the timer runs, still loading with no results
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.results.playlists).toHaveLength(0);
+
+      // #when — let the debounce expire and async work flush
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(199);
+      });
+      expect(result.current.results.playlists).toHaveLength(0);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+      expect(result.current.results.playlists.map((p) => p.id)).toEqual(['p1']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/hooks/__tests__/useLibrarySearch.test.ts
+++ b/src/hooks/__tests__/useLibrarySearch.test.ts
@@ -41,6 +41,7 @@ function makeAlbum(id: string, name: string, artists = 'Test Artist'): AlbumInfo
 function makeTrack(id: string, name: string, artists = 'Artist'): Track {
   return {
     id,
+    provider: 'spotify',
     name,
     artists,
     album: 'Album',

--- a/src/hooks/useLibrarySearch.ts
+++ b/src/hooks/useLibrarySearch.ts
@@ -1,0 +1,80 @@
+/**
+ * Debounced consumer hook for the IndexedDB-cached library search.
+ *
+ * Wraps `searchLibraryCache` with a ~150 ms debounce to keep IndexedDB reads
+ * off the hot path while the user types. Strictly cache-only — never makes
+ * network calls.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  searchLibraryCache,
+  emptySearchResult,
+  type LibrarySearchResult,
+} from '@/services/cache/librarySearch';
+
+const DEFAULT_DEBOUNCE_MS = 150;
+
+export interface UseLibrarySearchOptions {
+  /** Debounce window in ms before the cache is queried. Defaults to 150. */
+  debounceMs?: number;
+  /** Maximum results per category. Defaults to 10. */
+  limitPerCategory?: number;
+}
+
+export interface UseLibrarySearchReturn {
+  results: LibrarySearchResult;
+  isLoading: boolean;
+}
+
+/**
+ * `useLibrarySearch(query)` — runs `searchLibraryCache` debounced.
+ *
+ * - An empty/whitespace query immediately resets to an empty result.
+ * - `isLoading` is true while the debounce timer is pending or the IndexedDB
+ *   read is in flight.
+ * - Stale responses (from queries the user has since changed) are discarded.
+ */
+export function useLibrarySearch(
+  query: string,
+  options: UseLibrarySearchOptions = {},
+): UseLibrarySearchReturn {
+  const { debounceMs = DEFAULT_DEBOUNCE_MS, limitPerCategory } = options;
+
+  const [results, setResults] = useState<LibrarySearchResult>(() => emptySearchResult());
+  const [isLoading, setIsLoading] = useState(false);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (query.trim().length === 0) {
+      requestIdRef.current += 1;
+      setResults(emptySearchResult());
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    const requestId = ++requestIdRef.current;
+
+    const timer = setTimeout(() => {
+      searchLibraryCache(query, { limitPerCategory })
+        .then((next) => {
+          if (requestIdRef.current !== requestId) return;
+          setResults(next);
+          setIsLoading(false);
+        })
+        .catch((err) => {
+          if (requestIdRef.current !== requestId) return;
+          console.warn('[useLibrarySearch] search failed:', err);
+          setResults(emptySearchResult());
+          setIsLoading(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [query, debounceMs, limitPerCategory]);
+
+  return { results, isLoading };
+}

--- a/src/services/cache/__tests__/librarySearch.test.ts
+++ b/src/services/cache/__tests__/librarySearch.test.ts
@@ -40,6 +40,7 @@ function makeAlbum(id: string, name: string, artists = 'Test Artist'): AlbumInfo
 function makeTrack(id: string, name: string, artists = 'Test Artist', album = 'Test Album'): Track {
   return {
     id,
+    provider: 'spotify',
     name,
     artists,
     album,
@@ -234,6 +235,48 @@ describe('searchLibraryCache', () => {
       expect(result.albums).toHaveLength(0);
       expect(result.artists).toHaveLength(0);
       expect(result.playlists).toHaveLength(0);
+    });
+  });
+
+  describe('artistsData structured path', () => {
+    it('derives artists from artistsData when present, matching and deduping by slug', async () => {
+      // #given — two tracks sharing one artist via the structured artistsData array
+      const trackWithArtistsData: Track = {
+        ...makeTrack('t1', 'Lose Yourself', ''),
+        artistsData: [
+          { name: 'Eminem', url: 'https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR' },
+        ],
+      };
+      const trackDuplicate: Track = {
+        ...makeTrack('t2', 'Rap God', ''),
+        artistsData: [
+          { name: 'Eminem', url: 'https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR' },
+        ],
+      };
+      await putTrackList('liked-songs', [trackWithArtistsData, trackDuplicate]);
+
+      // #when
+      const result = await searchLibraryCache('eminem');
+
+      // #then — matched via artistsData, deduped to a single entry
+      expect(result.artists).toEqual([{ id: 'eminem', name: 'Eminem' }]);
+    });
+  });
+
+  describe('multi-source deduplication', () => {
+    it('returns each track once when it appears in both liked-songs and a playlist', async () => {
+      // #given — same track id stored in two separate track lists
+      const sharedTrack = makeTrack('t1', 'Bohemian Rhapsody', 'Queen');
+      await putAllPlaylists([makePlaylist('p1', 'Classics')]);
+      await putTrackList('liked-songs', [sharedTrack]);
+      await putTrackList('playlist:p1', [sharedTrack]);
+
+      // #when
+      const result = await searchLibraryCache('bohemian');
+
+      // #then — deduplicated to a single result despite appearing in two lists
+      expect(result.tracks).toHaveLength(1);
+      expect(result.tracks[0].id).toBe('t1');
     });
   });
 

--- a/src/services/cache/__tests__/librarySearch.test.ts
+++ b/src/services/cache/__tests__/librarySearch.test.ts
@@ -1,0 +1,272 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  initCache,
+  closeCache,
+  clearAll,
+  putAllPlaylists,
+  putAllAlbums,
+  putTrackList,
+} from '../libraryCache';
+import { searchLibraryCache } from '../librarySearch';
+import type { CachedPlaylistInfo } from '../cacheTypes';
+import type { AlbumInfo, Track, SpotifyImage } from '../../spotify';
+
+function makePlaylist(id: string, name: string): CachedPlaylistInfo {
+  return {
+    id,
+    name,
+    description: null,
+    images: [] as SpotifyImage[],
+    tracks: { total: 10 },
+    owner: { display_name: 'TestUser' },
+  };
+}
+
+function makeAlbum(id: string, name: string, artists = 'Test Artist'): AlbumInfo {
+  return {
+    id,
+    name,
+    artists,
+    images: [] as SpotifyImage[],
+    release_date: '2024-01-01',
+    total_tracks: 12,
+    uri: `spotify:album:${id}`,
+    added_at: '2024-06-15T00:00:00Z',
+  };
+}
+
+function makeTrack(id: string, name: string, artists = 'Test Artist', album = 'Test Album'): Track {
+  return {
+    id,
+    name,
+    artists,
+    album,
+    duration_ms: 200_000,
+    uri: `spotify:track:${id}`,
+  };
+}
+
+describe('searchLibraryCache', () => {
+  beforeEach(async () => {
+    await initCache();
+    await clearAll();
+    closeCache();
+    localStorage.clear();
+    await initCache();
+  });
+
+  afterEach(() => {
+    closeCache();
+  });
+
+  describe('empty query', () => {
+    it('returns an empty categorized result for an empty string', async () => {
+      // #given
+      await putAllPlaylists([makePlaylist('p1', 'Rock Mix')]);
+
+      // #when
+      const result = await searchLibraryCache('');
+
+      // #then
+      expect(result).toEqual({ tracks: [], albums: [], artists: [], playlists: [] });
+    });
+
+    it('returns an empty result for whitespace-only queries', async () => {
+      // #given
+      await putAllPlaylists([makePlaylist('p1', 'Rock Mix')]);
+
+      // #when
+      const result = await searchLibraryCache('   \t\n ');
+
+      // #then
+      expect(result.tracks).toHaveLength(0);
+      expect(result.albums).toHaveLength(0);
+      expect(result.artists).toHaveLength(0);
+      expect(result.playlists).toHaveLength(0);
+    });
+  });
+
+  describe('substring matching', () => {
+    it('matches playlists by name substring', async () => {
+      // #given
+      await putAllPlaylists([
+        makePlaylist('p1', 'Rock Anthems'),
+        makePlaylist('p2', 'Jazz Lounge'),
+        makePlaylist('p3', 'Indie Rock Picks'),
+      ]);
+
+      // #when
+      const result = await searchLibraryCache('rock');
+
+      // #then
+      expect(result.playlists.map((p) => p.id).sort()).toEqual(['p1', 'p3']);
+    });
+
+    it('matches albums by name or artist', async () => {
+      // #given
+      await putAllAlbums([
+        makeAlbum('a1', 'Kid A', 'Radiohead'),
+        makeAlbum('a2', 'Funeral', 'Arcade Fire'),
+        makeAlbum('a3', 'Greatest Hits', 'Radiohead'),
+      ]);
+
+      // #when
+      const byName = await searchLibraryCache('funeral');
+      const byArtist = await searchLibraryCache('radiohead');
+
+      // #then
+      expect(byName.albums.map((a) => a.id)).toEqual(['a2']);
+      expect(byArtist.albums.map((a) => a.id).sort()).toEqual(['a1', 'a3']);
+    });
+
+    it('matches tracks by name or artist', async () => {
+      // #given
+      await putTrackList('liked-songs', [
+        makeTrack('t1', 'Karma Police', 'Radiohead'),
+        makeTrack('t2', 'Wake Up', 'Arcade Fire'),
+        makeTrack('t3', 'Idioteque', 'Radiohead'),
+      ]);
+
+      // #when
+      const byName = await searchLibraryCache('karma');
+      const byArtist = await searchLibraryCache('radiohead');
+
+      // #then
+      expect(byName.tracks.map((t) => t.id)).toEqual(['t1']);
+      expect(byArtist.tracks.map((t) => t.id).sort()).toEqual(['t1', 't3']);
+    });
+
+    it('derives artists from cached tracks and albums', async () => {
+      // #given
+      await putAllAlbums([makeAlbum('a1', 'Funeral', 'Arcade Fire')]);
+      await putTrackList('liked-songs', [makeTrack('t1', 'Karma Police', 'Radiohead')]);
+
+      // #when
+      const result = await searchLibraryCache('a');
+
+      // #then
+      const names = result.artists.map((a) => a.name).sort();
+      expect(names).toEqual(['Arcade Fire', 'Radiohead']);
+    });
+
+    it('reads tracks from per-playlist and per-album track lists', async () => {
+      // #given
+      await putAllPlaylists([makePlaylist('p1', 'Mix')]);
+      await putAllAlbums([makeAlbum('a1', 'Album One')]);
+      await putTrackList('playlist:p1', [makeTrack('t1', 'Aurora', 'Foo')]);
+      await putTrackList('album:a1', [makeTrack('t2', 'Aurelius', 'Bar')]);
+
+      // #when
+      const result = await searchLibraryCache('aur');
+
+      // #then
+      expect(result.tracks.map((t) => t.id).sort()).toEqual(['t1', 't2']);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('matches regardless of query and field casing', async () => {
+      // #given
+      await putAllPlaylists([makePlaylist('p1', 'Late Night Vibes')]);
+      await putAllAlbums([makeAlbum('a1', 'In Rainbows', 'Radiohead')]);
+      await putTrackList('liked-songs', [makeTrack('t1', 'Reckoner', 'RADIOHEAD')]);
+
+      // #when
+      const upper = await searchLibraryCache('VIBES');
+      const mixed = await searchLibraryCache('RaDiOhEaD');
+
+      // #then
+      expect(upper.playlists.map((p) => p.id)).toEqual(['p1']);
+      expect(mixed.albums.map((a) => a.id)).toEqual(['a1']);
+      expect(mixed.tracks.map((t) => t.id)).toEqual(['t1']);
+    });
+  });
+
+  describe('category caps', () => {
+    it('caps each category at 10 results by default', async () => {
+      // #given
+      const playlists = Array.from({ length: 15 }, (_, i) => makePlaylist(`p${i}`, `Match ${i}`));
+      const albums = Array.from({ length: 15 }, (_, i) => makeAlbum(`a${i}`, `Match Album ${i}`));
+      const tracks = Array.from({ length: 15 }, (_, i) =>
+        makeTrack(`t${i}`, `Match Track ${i}`, `Match Artist ${i}`),
+      );
+      await putAllPlaylists(playlists);
+      await putAllAlbums(albums);
+      await putTrackList('liked-songs', tracks);
+
+      // #when
+      const result = await searchLibraryCache('match');
+
+      // #then
+      expect(result.playlists).toHaveLength(10);
+      expect(result.albums).toHaveLength(10);
+      expect(result.tracks).toHaveLength(10);
+      expect(result.artists).toHaveLength(10);
+    });
+
+    it('honors a custom limitPerCategory', async () => {
+      // #given
+      const playlists = Array.from({ length: 8 }, (_, i) => makePlaylist(`p${i}`, `Match ${i}`));
+      await putAllPlaylists(playlists);
+
+      // #when
+      const result = await searchLibraryCache('match', { limitPerCategory: 3 });
+
+      // #then
+      expect(result.playlists).toHaveLength(3);
+    });
+  });
+
+  describe('no-match', () => {
+    it('returns empty arrays when nothing matches', async () => {
+      // #given
+      await putAllPlaylists([makePlaylist('p1', 'Rock')]);
+      await putAllAlbums([makeAlbum('a1', 'Funeral', 'Arcade Fire')]);
+      await putTrackList('liked-songs', [makeTrack('t1', 'Karma Police', 'Radiohead')]);
+
+      // #when
+      const result = await searchLibraryCache('zzzzznothing');
+
+      // #then
+      expect(result.tracks).toHaveLength(0);
+      expect(result.albums).toHaveLength(0);
+      expect(result.artists).toHaveLength(0);
+      expect(result.playlists).toHaveLength(0);
+    });
+  });
+
+  describe('artist deduplication', () => {
+    it('deduplicates artists across tracks and albums', async () => {
+      // #given
+      await putAllAlbums([
+        makeAlbum('a1', 'Kid A', 'Radiohead'),
+        makeAlbum('a2', 'In Rainbows', 'Radiohead'),
+      ]);
+      await putTrackList('liked-songs', [
+        makeTrack('t1', 'Karma Police', 'Radiohead'),
+        makeTrack('t2', 'Reckoner', 'Radiohead'),
+      ]);
+
+      // #when
+      const result = await searchLibraryCache('radiohead');
+
+      // #then
+      expect(result.artists).toEqual([{ id: 'radiohead', name: 'Radiohead' }]);
+    });
+
+    it('splits comma-separated artist strings when matching', async () => {
+      // #given
+      await putTrackList('liked-songs', [
+        makeTrack('t1', 'Track', 'Daft Punk, Pharrell Williams'),
+      ]);
+
+      // #when
+      const result = await searchLibraryCache('pharrell');
+
+      // #then
+      expect(result.artists.map((a) => a.name)).toEqual(['Pharrell Williams']);
+    });
+  });
+});

--- a/src/services/cache/librarySearch.ts
+++ b/src/services/cache/librarySearch.ts
@@ -46,10 +46,10 @@ export interface LibrarySearchOptions {
 }
 
 const EMPTY_RESULT: LibrarySearchResult = Object.freeze({
-  tracks: [],
-  albums: [],
-  artists: [],
-  playlists: [],
+  tracks: Object.freeze([]) as unknown as Track[],
+  albums: Object.freeze([]) as unknown as AlbumInfo[],
+  artists: Object.freeze([]) as unknown as SearchArtist[],
+  playlists: Object.freeze([]) as unknown as CachedPlaylistInfo[],
 }) as LibrarySearchResult;
 
 function isBlank(query: string): boolean {

--- a/src/services/cache/librarySearch.ts
+++ b/src/services/cache/librarySearch.ts
@@ -1,0 +1,202 @@
+/**
+ * Search query over the IndexedDB-cached library catalog.
+ *
+ * Returns categorized results (tracks, albums, artists, playlists) for a
+ * non-empty query string by reading already-cached records — never makes
+ * network calls and never triggers lazy provider catalog loads.
+ *
+ * Artists are derived from cached tracks + albums (the cache does not store
+ * a dedicated artist entity).
+ */
+
+import type { AlbumInfo, Track } from '../spotify';
+import type { CachedPlaylistInfo } from './cacheTypes';
+import {
+  getAllAlbums,
+  getAllPlaylists,
+  getTrackList,
+  _testing as cacheInternals,
+} from './libraryCache';
+
+const DEFAULT_LIMIT_PER_CATEGORY = 10;
+const LIKED_SONGS_TRACK_LIST_ID = 'liked-songs';
+
+/**
+ * Lightweight artist record produced by the search query.
+ *
+ * The cache does not store artists as a first-class entity; we synthesize
+ * them from the artist names that appear on cached tracks and albums.
+ * `id` is a stable slug derived from `name`.
+ */
+export interface SearchArtist {
+  id: string;
+  name: string;
+}
+
+export interface LibrarySearchResult {
+  tracks: Track[];
+  albums: AlbumInfo[];
+  artists: SearchArtist[];
+  playlists: CachedPlaylistInfo[];
+}
+
+export interface LibrarySearchOptions {
+  /** Maximum results returned per category. Defaults to 10. */
+  limitPerCategory?: number;
+}
+
+const EMPTY_RESULT: LibrarySearchResult = Object.freeze({
+  tracks: [],
+  albums: [],
+  artists: [],
+  playlists: [],
+}) as LibrarySearchResult;
+
+function isBlank(query: string): boolean {
+  return query.trim().length === 0;
+}
+
+function includesCI(haystack: string | undefined | null, needle: string): boolean {
+  if (!haystack) return false;
+  return haystack.toLowerCase().includes(needle);
+}
+
+function artistSlug(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+function splitArtists(rawArtists: string | undefined): string[] {
+  if (!rawArtists) return [];
+  return rawArtists
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * Collect every cached track. Reads from all stored track lists (per-playlist,
+ * per-album, and the liked-songs list). Strictly cache-only — no network.
+ */
+async function collectAllCachedTracks(
+  playlists: CachedPlaylistInfo[],
+  albums: AlbumInfo[],
+): Promise<Track[]> {
+  const trackListIds = new Set<string>();
+  trackListIds.add(LIKED_SONGS_TRACK_LIST_ID);
+  for (const p of playlists) trackListIds.add(`playlist:${p.id}`);
+  for (const a of albums) trackListIds.add(`album:${a.id}`);
+
+  const lists = await Promise.all(Array.from(trackListIds).map((id) => getTrackList(id)));
+  const seen = new Set<string>();
+  const out: Track[] = [];
+  for (const list of lists) {
+    if (!list) continue;
+    for (const track of list.tracks) {
+      if (!track?.id || seen.has(track.id)) continue;
+      seen.add(track.id);
+      out.push(track);
+    }
+  }
+  return out;
+}
+
+function deriveArtists(
+  tracks: Track[],
+  albums: AlbumInfo[],
+  needle: string,
+  limit: number,
+): SearchArtist[] {
+  const seen = new Map<string, SearchArtist>();
+
+  const consider = (name: string): void => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (!includesCI(trimmed, needle)) return;
+    const id = artistSlug(trimmed);
+    if (!seen.has(id)) {
+      seen.set(id, { id, name: trimmed });
+    }
+  };
+
+  for (const track of tracks) {
+    if (track.artistsData?.length) {
+      for (const a of track.artistsData) consider(a.name);
+    } else {
+      for (const name of splitArtists(track.artists)) consider(name);
+    }
+    if (seen.size >= limit) break;
+  }
+
+  if (seen.size < limit) {
+    for (const album of albums) {
+      for (const name of splitArtists(album.artists)) consider(name);
+      if (seen.size >= limit) break;
+    }
+  }
+
+  return Array.from(seen.values()).slice(0, limit);
+}
+
+/**
+ * Run a categorized search across the IndexedDB-cached library catalog.
+ *
+ * - Case-insensitive substring match.
+ * - Tracks match on `name` or `artists`.
+ * - Albums match on `name` or `artists`.
+ * - Artists match on `name` (derived from cached tracks + albums).
+ * - Playlists match on `name`.
+ * - Each category is capped (default: 10).
+ * - Empty/whitespace queries return an empty result without reading the cache.
+ */
+export async function searchLibraryCache(
+  query: string,
+  options: LibrarySearchOptions = {},
+): Promise<LibrarySearchResult> {
+  if (isBlank(query)) {
+    return { tracks: [], albums: [], artists: [], playlists: [] };
+  }
+
+  const limit = Math.max(1, options.limitPerCategory ?? DEFAULT_LIMIT_PER_CATEGORY);
+  const needle = query.trim().toLowerCase();
+
+  const [playlistsAll, albumsAll] = await Promise.all([getAllPlaylists(), getAllAlbums()]);
+  const tracksAll = await collectAllCachedTracks(playlistsAll, albumsAll);
+
+  const tracks: Track[] = [];
+  for (const t of tracksAll) {
+    if (includesCI(t.name, needle) || includesCI(t.artists, needle)) {
+      tracks.push(t);
+      if (tracks.length >= limit) break;
+    }
+  }
+
+  const albums: AlbumInfo[] = [];
+  for (const a of albumsAll) {
+    if (includesCI(a.name, needle) || includesCI(a.artists, needle)) {
+      albums.push(a);
+      if (albums.length >= limit) break;
+    }
+  }
+
+  const playlists: CachedPlaylistInfo[] = [];
+  for (const p of playlistsAll) {
+    if (includesCI(p.name, needle)) {
+      playlists.push(p);
+      if (playlists.length >= limit) break;
+    }
+  }
+
+  const artists = deriveArtists(tracksAll, albumsAll, needle, limit);
+
+  return { tracks, albums, artists, playlists };
+}
+
+/** Frozen empty-result singleton for hooks/consumers. */
+export function emptySearchResult(): LibrarySearchResult {
+  return EMPTY_RESULT;
+}
+
+/** Internal handle for tests — exposes the underlying cache state. */
+export const _searchTesting = {
+  cacheInternals,
+};


### PR DESCRIPTION
## Summary
- Adds `searchLibraryCache(query)` in `src/services/cache/librarySearch.ts` returning `{ tracks, albums, artists, playlists }` from the IndexedDB cache only (no network, no lazy catalog loads). Case-insensitive substring match, per-category cap (default 10), empty/whitespace query short-circuits to an empty result. Artists are derived from cached tracks + albums since the cache stores no dedicated artist entity.
- Adds `useLibrarySearch(query)` in `src/hooks/useLibrarySearch.ts` — a debounced (~150 ms) consumer hook that exposes `{ results, isLoading }` and discards stale responses from superseded queries.
- BDD-style tests cover substring correctness across all four categories, case-insensitivity, the 10-per-group cap (and a custom override), empty-query short-circuit, no-match behavior, artist dedup across tracks + albums, multi-source track reads (liked-songs + per-playlist + per-album track lists), debounce timing (with fake timers), immediate empty-query reset, and stale-response rejection.

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — 1667 tests pass (153 files), including the 13 new `librarySearch` tests and 5 new `useLibrarySearch` tests

Closes #1407