### PR TITLE
feat(cmdk): wire library search results, selection routing, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ Run with `npm run test:run`. Tests are colocated with source files in `__tests__
 
 See `docs/keyboard.md` for the full table. Centralized in `useKeyboardShortcuts.ts`.
 
+The command palette (`Cmd+K` / `Ctrl+K`, desktop-only) lives in `src/components/CmdKPalette/` and registers its own listener — it is intentionally not routed through `useKeyboardShortcuts.ts` because it owns dialog open/close state. Search backend: `src/hooks/useLibrarySearch.ts` (debounced) over `src/services/cache/librarySearch.ts` (IndexedDB-cached, never touches the network).
+
 ## Common Issues
 
 See `docs/troubleshooting.md` for layout, provider, and radio issues. Layout invariants are documented in `docs/architecture/layout.md`.

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -11,7 +11,10 @@ Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` 
 | `V` / `G` / `S` / `T` | Visualizer / Glow / Shuffle / Translucence | same |
 | `Z` | Toggle zen mode | same |
 | `O` / `K` / `M` | Effects menu / Like / Mute | same |
+| `Cmd+K` / `Ctrl+K` | Open command palette (search library) | not bound |
 | `?` / `/` | Keyboard help | same |
 | `Escape` | Close all menus | same |
 
 `Q` and `L` are device-independent alternatives for drawer toggles. `↑`/`↓` have cross-dismiss behavior.
+
+The command palette (`Cmd+K` / `Ctrl+K`) lives in `src/components/CmdKPalette/` and registers its own `keydown` listener — separate from `useKeyboardShortcuts.ts`. Inside the palette, ↑/↓ navigate results and Enter selects (handled natively by `cmdk`). The palette does not mount on touch devices.

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -31,6 +31,7 @@ import { CmdKPalette } from './CmdKPalette';
 import { tracksToMediaTracks } from '@/services/spotify/tracks';
 import type { Track, AlbumInfo } from '@/services/spotify';
 import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { SearchArtist } from '@/services/cache/librarySearch';
 
 const VisualEffectsMenu = lazy(() => import('./AppSettingsMenu/index'));
 const LibraryRoute = lazy(() => import('./LibraryRoute'));
@@ -173,7 +174,7 @@ const AudioPlayerComponent = () => {
     [handlers, handlePlaylistSelect],
   );
 
-  const handleCmdKSelectArtist = useCallback(() => {
+  const handleCmdKSelectArtist = useCallback((_artist: SearchArtist) => {
     // #1408 deferral: there is no programmatic "filter Library by artist"
     // mechanism today. Falling back to opening Library without a filter so the
     // user can navigate to the artist manually. A follow-up should add a

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -141,9 +141,9 @@ const AudioPlayerComponent = () => {
     (track: Track) => {
       const [mediaTrack] = tracksToMediaTracks([track]);
       if (!mediaTrack) return;
-      const result = handlers.queueTracksDirectly([mediaTrack], track.name);
+      const result = handlers.insertTracksNext([mediaTrack], track.name);
       if (result && result.added > 0) {
-        toast(`Added "${track.name}" to your queue.`, {
+        toast(`Added "${track.name}" to play next.`, {
           id: 'cmdk-add-track',
           action: {
             label: 'View',
@@ -158,20 +158,43 @@ const AudioPlayerComponent = () => {
     [handlers, setShowQueue],
   );
 
+  const handleCmdKInsertCollectionNext = useCallback(
+    async (
+      id: string,
+      name: string,
+      provider?: import('@/types/domain').ProviderId,
+    ) => {
+      const result = await handlers.insertCollectionNext(id, name, provider);
+      if (result && result.added > 0) {
+        const trackWord = result.added === 1 ? 'track' : 'tracks';
+        toast(`Added ${result.added} ${trackWord} from "${name}" to play next.`, {
+          id: 'cmdk-add-collection',
+          action: {
+            label: 'View',
+            onClick: () => {
+              handlers.handleCloseLibrary();
+              setShowQueue(true);
+            },
+          },
+        });
+      }
+      return result;
+    },
+    [handlers, setShowQueue],
+  );
+
   const handleCmdKSelectAlbum = useCallback(
     (album: AlbumInfo) => {
-      handlers.handleOpenLibrary();
-      handlePlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
+      void handleCmdKInsertCollectionNext(toAlbumPlaylistId(album.id), album.name, album.provider);
     },
-    [handlers, handlePlaylistSelect],
+    [handleCmdKInsertCollectionNext],
   );
 
   const handleCmdKSelectPlaylist = useCallback(
     (playlist: CachedPlaylistInfo) => {
-      handlers.handleOpenLibrary();
-      handlePlaylistSelect(playlist.id, playlist.name, playlist.provider);
+      void handleCmdKInsertCollectionNext(playlist.id, playlist.name, playlist.provider);
     },
-    [handlers, handlePlaylistSelect],
+    [handleCmdKInsertCollectionNext],
   );
 
   const handleCmdKSelectArtist = useCallback((_artist: SearchArtist) => {

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -28,6 +28,9 @@ import type { ClearCacheOptions } from '@/components/AppSettingsMenu';
 import { useSessionPersistence } from '@/hooks/useSessionPersistence';
 import QuickAccessPanel from './QuickAccessPanel';
 import { CmdKPalette } from './CmdKPalette';
+import { tracksToMediaTracks } from '@/services/spotify/tracks';
+import type { Track, AlbumInfo } from '@/services/spotify';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 
 const VisualEffectsMenu = lazy(() => import('./AppSettingsMenu/index'));
 const LibraryRoute = lazy(() => import('./LibraryRoute'));
@@ -132,6 +135,51 @@ const AudioPlayerComponent = () => {
     },
     [handlers]
   );
+
+  const handleCmdKSelectTrack = useCallback(
+    (track: Track) => {
+      const [mediaTrack] = tracksToMediaTracks([track]);
+      if (!mediaTrack) return;
+      const result = handlers.queueTracksDirectly([mediaTrack], track.name);
+      if (result && result.added > 0) {
+        toast(`Added "${track.name}" to your queue.`, {
+          id: 'cmdk-add-track',
+          action: {
+            label: 'View',
+            onClick: () => {
+              handlers.handleCloseLibrary();
+              setShowQueue(true);
+            },
+          },
+        });
+      }
+    },
+    [handlers, setShowQueue],
+  );
+
+  const handleCmdKSelectAlbum = useCallback(
+    (album: AlbumInfo) => {
+      handlers.handleOpenLibrary();
+      handlePlaylistSelect(toAlbumPlaylistId(album.id), album.name, album.provider);
+    },
+    [handlers, handlePlaylistSelect],
+  );
+
+  const handleCmdKSelectPlaylist = useCallback(
+    (playlist: CachedPlaylistInfo) => {
+      handlers.handleOpenLibrary();
+      handlePlaylistSelect(playlist.id, playlist.name, playlist.provider);
+    },
+    [handlers, handlePlaylistSelect],
+  );
+
+  const handleCmdKSelectArtist = useCallback(() => {
+    // #1408 deferral: there is no programmatic "filter Library by artist"
+    // mechanism today. Falling back to opening Library without a filter so the
+    // user can navigate to the artist manually. A follow-up should add a
+    // proper artist-filter route into Library.
+    handlers.handleOpenLibrary();
+  }, [handlers]);
 
   const [showQuickAccessPanel, setShowQuickAccessPanel] = useState(false);
   const handleOpenQuickAccessPanel = useCallback(() => setShowQuickAccessPanel(true), []);
@@ -503,7 +551,12 @@ const AudioPlayerComponent = () => {
             </div>
           </QuickAccessOverlay>
         )}
-        <CmdKPalette />
+        <CmdKPalette
+          onSelectTrack={handleCmdKSelectTrack}
+          onSelectAlbum={handleCmdKSelectAlbum}
+          onSelectPlaylist={handleCmdKSelectPlaylist}
+          onSelectArtist={handleCmdKSelectArtist}
+        />
         {!isMainPlayerActive && (
           <Suspense fallback={null}>
             <VisualEffectsMenu

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -235,6 +235,31 @@ const AudioPlayerComponent = () => {
   useEffect(() => {
     if (showQueue) toast.dismiss(RESUME_TOAST_ID);
   }, [showQueue]);
+  const handleLibraryPlayNext = useCallback(
+    async (
+      _kind: 'playlist' | 'album',
+      id: string,
+      name: string,
+      provider?: import('@/types/domain').ProviderId,
+    ) => {
+      const result = await handlers.insertCollectionNext(id, name, provider);
+      if (result && result.added > 0) {
+        const trackWord = result.added === 1 ? 'track' : 'tracks';
+        toast(`Added ${result.added} ${trackWord} from "${name}" to play next.`, {
+          id: 'lib-play-next',
+          action: {
+            label: 'View',
+            onClick: () => {
+              handlers.handleCloseLibrary();
+              setShowQueue(true);
+            },
+          },
+        });
+      }
+    },
+    [handlers, setShowQueue],
+  );
+
   const handleAddToQueueFromPanel = useCallback(
     async (id: string, name?: string, provider?: import('@/types/domain').ProviderId) => {
       const result = await handlers.handleAddToQueue(id, name, provider);
@@ -482,7 +507,7 @@ const AudioPlayerComponent = () => {
             onMiniPrevious={playbackHandlers.onPrevious}
             onMiniExpand={handlers.handleCloseLibrary}
             onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
-            onPlayNext={undefined}
+            onPlayNext={handleLibraryPlayNext}
             onStartRadioForCollection={undefined}
             onClose={handlers.handleCloseLibrary}
           />
@@ -618,7 +643,7 @@ const AudioPlayerComponent = () => {
               onMiniPrevious={playbackHandlers.onPrevious}
               onMiniExpand={handlers.handleCloseLibrary}
               onMiniStartRadio={radio.isRadioAvailable ? handlers.handleStartRadio : undefined}
-              onPlayNext={undefined}
+              onPlayNext={handleLibraryPlayNext}
               onStartRadioForCollection={undefined}
               onClose={handlers.handleCloseLibrary}
             />

--- a/src/components/CmdKPalette/__tests__/CmdKPalette.results.test.tsx
+++ b/src/components/CmdKPalette/__tests__/CmdKPalette.results.test.tsx
@@ -1,0 +1,406 @@
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Track, AlbumInfo, SpotifyImage } from '@/services/spotify';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { LibrarySearchResult, SearchArtist } from '@/services/cache/librarySearch';
+
+const mockUseLibrarySearch = vi.fn();
+vi.mock('@/hooks/useLibrarySearch', () => ({
+  useLibrarySearch: (query: string) => mockUseLibrarySearch(query),
+}));
+
+import { CmdKPalette } from '../index';
+
+if (typeof window.ResizeObserver === 'undefined') {
+  window.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as unknown as typeof ResizeObserver;
+}
+
+if (!(Element.prototype as { scrollIntoView?: () => void }).scrollIntoView) {
+  (Element.prototype as { scrollIntoView?: () => void }).scrollIntoView = () => {};
+}
+
+const mockMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+const makeTrack = (id: string, name: string, artists = 'Artist'): Track => ({
+  id,
+  provider: 'spotify',
+  name,
+  artists,
+  album: 'Album',
+  duration_ms: 200_000,
+  uri: `spotify:track:${id}`,
+});
+
+const makeAlbum = (id: string, name: string, artists = 'Artist'): AlbumInfo => ({
+  id,
+  name,
+  artists,
+  images: [] as SpotifyImage[],
+  release_date: '2024-01-01',
+  total_tracks: 10,
+  uri: `spotify:album:${id}`,
+});
+
+const makePlaylist = (id: string, name: string, total = 5): CachedPlaylistInfo => ({
+  id,
+  name,
+  description: null,
+  images: [] as SpotifyImage[],
+  tracks: { total },
+  owner: { display_name: 'Owner' },
+});
+
+const makeArtist = (id: string, name: string): SearchArtist => ({ id, name });
+
+const setSearchResult = (result: Partial<LibrarySearchResult>) => {
+  mockUseLibrarySearch.mockReturnValue({
+    results: {
+      tracks: result.tracks ?? [],
+      albums: result.albums ?? [],
+      artists: result.artists ?? [],
+      playlists: result.playlists ?? [],
+    },
+    isLoading: false,
+  });
+};
+
+const openPalette = () => {
+  act(() => {
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+  });
+};
+
+const typeQuery = (text: string) => {
+  const input = screen.getByPlaceholderText(/start typing to search your library/i);
+  act(() => {
+    fireEvent.change(input, { target: { value: text } });
+  });
+};
+
+describe('CmdKPalette — categorized rendering', () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+    mockUseLibrarySearch.mockReset();
+    setSearchResult({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders all four group headings when each bucket has items', () => {
+    // #given
+    setSearchResult({
+      tracks: [makeTrack('t1', 'Karma Police', 'Radiohead')],
+      albums: [makeAlbum('a1', 'OK Computer', 'Radiohead')],
+      artists: [makeArtist('radiohead', 'Radiohead')],
+      playlists: [makePlaylist('p1', 'Chill Mix')],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+
+    // #when
+    typeQuery('rad');
+
+    // #then
+    expect(screen.getByText('Tracks')).toBeInTheDocument();
+    expect(screen.getByText('Albums')).toBeInTheDocument();
+    expect(screen.getByText('Artists')).toBeInTheDocument();
+    expect(screen.getByText('Playlists')).toBeInTheDocument();
+  });
+
+  it('hides empty groups', () => {
+    // #given only tracks have results
+    setSearchResult({
+      tracks: [makeTrack('t1', 'Karma Police', 'Radiohead')],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+
+    // #when
+    typeQuery('rad');
+
+    // #then — Tracks renders, others do not
+    expect(screen.getByText('Tracks')).toBeInTheDocument();
+    expect(screen.queryByText('Albums')).not.toBeInTheDocument();
+    expect(screen.queryByText('Artists')).not.toBeInTheDocument();
+    expect(screen.queryByText('Playlists')).not.toBeInTheDocument();
+  });
+
+  it('renders groups in fixed order: Tracks, Albums, Artists, Playlists', () => {
+    // #given
+    setSearchResult({
+      tracks: [makeTrack('t1', 'A')],
+      albums: [makeAlbum('a1', 'B')],
+      artists: [makeArtist('c', 'C')],
+      playlists: [makePlaylist('p1', 'D')],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+    typeQuery('x');
+
+    // #when — read all four group headings in DOM order
+    const tracks = screen.getByText('Tracks');
+    const albums = screen.getByText('Albums');
+    const artists = screen.getByText('Artists');
+    const playlists = screen.getByText('Playlists');
+
+    // #then — each precedes the next in document order
+    expect(tracks.compareDocumentPosition(albums) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(albums.compareDocumentPosition(artists) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(artists.compareDocumentPosition(playlists) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows "No results" when all buckets are empty', () => {
+    // #given
+    setSearchResult({});
+    render(<CmdKPalette />);
+    openPalette();
+
+    // #when
+    typeQuery('zzz');
+
+    // #then
+    expect(screen.getByText(/no results/i)).toBeInTheDocument();
+  });
+
+  it('renders track subtitle as the artist string', () => {
+    // #given
+    setSearchResult({
+      tracks: [makeTrack('t1', 'Karma Police', 'Radiohead')],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+    typeQuery('k');
+
+    // #then
+    expect(screen.getByText('Karma Police')).toBeInTheDocument();
+    expect(screen.getByText('Radiohead')).toBeInTheDocument();
+  });
+
+  it('renders playlist subtitle with track count when available', () => {
+    // #given
+    setSearchResult({
+      playlists: [makePlaylist('p1', 'Chill Mix', 7)],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+    typeQuery('mix');
+
+    // #then
+    expect(screen.getByText('Chill Mix')).toBeInTheDocument();
+    expect(screen.getByText('7 tracks')).toBeInTheDocument();
+  });
+
+  it('omits playlist subtitle when track total is missing or zero', () => {
+    // #given
+    setSearchResult({
+      playlists: [makePlaylist('p1', 'Empty Mix', 0)],
+    });
+    render(<CmdKPalette />);
+    openPalette();
+    typeQuery('mix');
+
+    // #then
+    expect(screen.getByText('Empty Mix')).toBeInTheDocument();
+    expect(screen.queryByText(/0 tracks?/)).not.toBeInTheDocument();
+  });
+});
+
+describe('CmdKPalette — selection routing', () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+    mockUseLibrarySearch.mockReset();
+    setSearchResult({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes onSelectTrack and closes the palette when a track is selected', () => {
+    // #given
+    const track = makeTrack('t1', 'Karma Police', 'Radiohead');
+    setSearchResult({ tracks: [track] });
+    const onSelectTrack = vi.fn();
+    render(<CmdKPalette onSelectTrack={onSelectTrack} />);
+    openPalette();
+    typeQuery('karma');
+
+    // #when
+    act(() => {
+      fireEvent.click(screen.getByTestId('cmdk-item-track'));
+    });
+
+    // #then
+    expect(onSelectTrack).toHaveBeenCalledTimes(1);
+    expect(onSelectTrack).toHaveBeenCalledWith(track);
+    expect(
+      screen.queryByPlaceholderText(/start typing to search your library/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('invokes onSelectAlbum and closes the palette when an album is selected', () => {
+    // #given
+    const album = makeAlbum('a1', 'OK Computer', 'Radiohead');
+    setSearchResult({ albums: [album] });
+    const onSelectAlbum = vi.fn();
+    render(<CmdKPalette onSelectAlbum={onSelectAlbum} />);
+    openPalette();
+    typeQuery('ok');
+
+    // #when
+    act(() => {
+      fireEvent.click(screen.getByTestId('cmdk-item-album'));
+    });
+
+    // #then
+    expect(onSelectAlbum).toHaveBeenCalledWith(album);
+    expect(
+      screen.queryByPlaceholderText(/start typing to search your library/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('invokes onSelectPlaylist and closes the palette when a playlist is selected', () => {
+    // #given
+    const playlist = makePlaylist('p1', 'Chill Mix');
+    setSearchResult({ playlists: [playlist] });
+    const onSelectPlaylist = vi.fn();
+    render(<CmdKPalette onSelectPlaylist={onSelectPlaylist} />);
+    openPalette();
+    typeQuery('chill');
+
+    // #when
+    act(() => {
+      fireEvent.click(screen.getByTestId('cmdk-item-playlist'));
+    });
+
+    // #then
+    expect(onSelectPlaylist).toHaveBeenCalledWith(playlist);
+    expect(
+      screen.queryByPlaceholderText(/start typing to search your library/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('invokes onSelectArtist and closes the palette when an artist is selected (deferred fallback)', () => {
+    // #given
+    const artist = makeArtist('radiohead', 'Radiohead');
+    setSearchResult({ artists: [artist] });
+    const onSelectArtist = vi.fn();
+    render(<CmdKPalette onSelectArtist={onSelectArtist} />);
+    openPalette();
+    typeQuery('rad');
+
+    // #when
+    act(() => {
+      fireEvent.click(screen.getByTestId('cmdk-item-artist'));
+    });
+
+    // #then
+    expect(onSelectArtist).toHaveBeenCalledWith(artist);
+    expect(
+      screen.queryByPlaceholderText(/start typing to search your library/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears the query after a selection (next open starts empty)', () => {
+    // #given
+    setSearchResult({ tracks: [makeTrack('t1', 'X')] });
+    const onSelectTrack = vi.fn();
+    render(<CmdKPalette onSelectTrack={onSelectTrack} />);
+    openPalette();
+    typeQuery('x');
+
+    // #when
+    act(() => {
+      fireEvent.click(screen.getByTestId('cmdk-item-track'));
+    });
+    openPalette();
+
+    // #then
+    const input = screen.getByPlaceholderText(
+      /start typing to search your library/i,
+    ) as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+});
+
+describe('CmdKPalette — keyboard navigation', () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+    mockUseLibrarySearch.mockReset();
+    setSearchResult({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('selects across groups when Enter is pressed (cmdk auto-selects the first match)', () => {
+    // #given
+    const track = makeTrack('t1', 'Karma Police', 'Radiohead');
+    setSearchResult({
+      tracks: [track],
+      albums: [makeAlbum('a1', 'OK Computer', 'Radiohead')],
+    });
+    const onSelectTrack = vi.fn();
+    const onSelectAlbum = vi.fn();
+    render(<CmdKPalette onSelectTrack={onSelectTrack} onSelectAlbum={onSelectAlbum} />);
+    openPalette();
+    typeQuery('karma');
+
+    // #when — Enter on the input fires the currently-selected (first) item
+    const input = screen.getByPlaceholderText(/start typing to search your library/i);
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    // #then — the first item (the track) is selected
+    expect(onSelectTrack).toHaveBeenCalledWith(track);
+    expect(onSelectAlbum).not.toHaveBeenCalled();
+  });
+
+  it('moves selection across groups with ArrowDown', () => {
+    // #given two groups, one item each
+    const track = makeTrack('t1', 'Karma');
+    const album = makeAlbum('a1', 'OK Computer');
+    setSearchResult({ tracks: [track], albums: [album] });
+    const onSelectTrack = vi.fn();
+    const onSelectAlbum = vi.fn();
+    render(<CmdKPalette onSelectTrack={onSelectTrack} onSelectAlbum={onSelectAlbum} />);
+    openPalette();
+    typeQuery('o');
+
+    // #when — ArrowDown moves selection from track → album, then Enter
+    const input = screen.getByPlaceholderText(/start typing to search your library/i);
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    // #then — selection moved to the album
+    expect(onSelectAlbum).toHaveBeenCalledWith(album);
+    expect(onSelectTrack).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/CmdKPalette/__tests__/CmdKPalette.results.test.tsx
+++ b/src/components/CmdKPalette/__tests__/CmdKPalette.results.test.tsx
@@ -170,7 +170,7 @@ describe('CmdKPalette — categorized rendering', () => {
     expect(artists.compareDocumentPosition(playlists) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('shows "No results" when all buckets are empty', () => {
+  it('shows "No results" when all buckets are empty and a query is typed', () => {
     // #given
     setSearchResult({});
     render(<CmdKPalette />);
@@ -181,6 +181,18 @@ describe('CmdKPalette — categorized rendering', () => {
 
     // #then
     expect(screen.getByText(/no results/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show "No results." when the palette opens with an empty query', () => {
+    // #given
+    setSearchResult({});
+    render(<CmdKPalette />);
+
+    // #when — open without typing anything
+    openPalette();
+
+    // #then — "No results." must not appear before the user types
+    expect(screen.queryByText(/no results/i)).not.toBeInTheDocument();
   });
 
   it('renders track subtitle as the artist string', () => {

--- a/src/components/CmdKPalette/index.tsx
+++ b/src/components/CmdKPalette/index.tsx
@@ -121,7 +121,7 @@ export const CmdKPalette = ({
         autoFocus
       />
       <CommandList>
-        {!hasAny && <CommandEmpty>No results.</CommandEmpty>}
+        {!hasAny && query.trim().length > 0 && <CommandEmpty>No results.</CommandEmpty>}
 
         {tracks.length > 0 && (
           <CommandGroup heading="Tracks">

--- a/src/components/CmdKPalette/index.tsx
+++ b/src/components/CmdKPalette/index.tsx
@@ -2,22 +2,75 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   CommandDialog,
   CommandEmpty,
+  CommandGroup,
   CommandInput,
+  CommandItem,
   CommandList,
 } from '@/components/ui/command';
 import { DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { useLibrarySearch } from '@/hooks/useLibrarySearch';
+import type { AlbumInfo, Track } from '@/services/spotify';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
+import type { SearchArtist } from '@/services/cache/librarySearch';
 import { useIsTouchDevice } from './useIsTouchDevice';
 
 const PLACEHOLDER = 'Start typing to search your library';
 
-export const CmdKPalette = (): JSX.Element | null => {
+export interface CmdKPaletteProps {
+  /** Called when a track is selected — implementations should enqueue and close the palette. */
+  onSelectTrack?: (track: Track) => void;
+  /** Called when an album is selected — implementations should open it in the Library view. */
+  onSelectAlbum?: (album: AlbumInfo) => void;
+  /** Called when a playlist is selected — implementations should open it in the Library view. */
+  onSelectPlaylist?: (playlist: CachedPlaylistInfo) => void;
+  /**
+   * Called when an artist is selected.
+   *
+   * Note: there is no programmatic "filter Library by artist" mechanism today —
+   * see #1408 deferral. The default routing in AudioPlayer falls back to opening
+   * Library without a filter; a follow-up issue should add filter-by-artist.
+   */
+  onSelectArtist?: (artist: SearchArtist) => void;
+}
+
+interface ItemSubtitleProps {
+  text?: string;
+}
+
+const ItemSubtitle = ({ text }: ItemSubtitleProps): JSX.Element | null => {
+  if (!text) return null;
+  return (
+    <span className="ml-2 truncate text-xs text-muted-foreground" data-testid="cmdk-item-subtitle">
+      {text}
+    </span>
+  );
+};
+
+const playlistSubtitle = (playlist: CachedPlaylistInfo): string | undefined => {
+  const total = playlist.tracks?.total;
+  if (typeof total !== 'number' || total <= 0) return undefined;
+  return total === 1 ? '1 track' : `${total} tracks`;
+};
+
+export const CmdKPalette = ({
+  onSelectTrack,
+  onSelectAlbum,
+  onSelectPlaylist,
+  onSelectArtist,
+}: CmdKPaletteProps = {}): JSX.Element | null => {
   const isTouch = useIsTouchDevice();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const { results } = useLibrarySearch(query);
 
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next);
     if (!next) setQuery('');
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery('');
   }, []);
 
   useEffect(() => {
@@ -34,6 +87,27 @@ export const CmdKPalette = (): JSX.Element | null => {
 
   if (isTouch) return null;
 
+  const { tracks, albums, artists, playlists } = results;
+  const hasAny =
+    tracks.length > 0 || albums.length > 0 || artists.length > 0 || playlists.length > 0;
+
+  const handleTrack = (track: Track): void => {
+    onSelectTrack?.(track);
+    closePalette();
+  };
+  const handleAlbum = (album: AlbumInfo): void => {
+    onSelectAlbum?.(album);
+    closePalette();
+  };
+  const handlePlaylist = (playlist: CachedPlaylistInfo): void => {
+    onSelectPlaylist?.(playlist);
+    closePalette();
+  };
+  const handleArtist = (artist: SearchArtist): void => {
+    onSelectArtist?.(artist);
+    closePalette();
+  };
+
   return (
     <CommandDialog open={open} onOpenChange={handleOpenChange}>
       <DialogTitle className="sr-only">Command palette</DialogTitle>
@@ -47,7 +121,70 @@ export const CmdKPalette = (): JSX.Element | null => {
         autoFocus
       />
       <CommandList>
-        <CommandEmpty>No results.</CommandEmpty>
+        {!hasAny && <CommandEmpty>No results.</CommandEmpty>}
+
+        {tracks.length > 0 && (
+          <CommandGroup heading="Tracks">
+            {tracks.map((track) => (
+              <CommandItem
+                key={`track:${track.id}`}
+                value={`track:${track.id}:${track.name}:${track.artists}`}
+                onSelect={() => handleTrack(track)}
+                data-testid="cmdk-item-track"
+              >
+                <span className="truncate">{track.name}</span>
+                <ItemSubtitle text={track.artists} />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {albums.length > 0 && (
+          <CommandGroup heading="Albums">
+            {albums.map((album) => (
+              <CommandItem
+                key={`album:${album.id}`}
+                value={`album:${album.id}:${album.name}:${album.artists}`}
+                onSelect={() => handleAlbum(album)}
+                data-testid="cmdk-item-album"
+              >
+                <span className="truncate">{album.name}</span>
+                <ItemSubtitle text={album.artists} />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {artists.length > 0 && (
+          <CommandGroup heading="Artists">
+            {artists.map((artist) => (
+              <CommandItem
+                key={`artist:${artist.id}`}
+                value={`artist:${artist.id}:${artist.name}`}
+                onSelect={() => handleArtist(artist)}
+                data-testid="cmdk-item-artist"
+              >
+                <span className="truncate">{artist.name}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {playlists.length > 0 && (
+          <CommandGroup heading="Playlists">
+            {playlists.map((playlist) => (
+              <CommandItem
+                key={`playlist:${playlist.id}`}
+                value={`playlist:${playlist.id}:${playlist.name}`}
+                onSelect={() => handlePlaylist(playlist)}
+                data-testid="cmdk-item-playlist"
+              >
+                <span className="truncate">{playlist.name}</span>
+                <ItemSubtitle text={playlistSubtitle(playlist)} />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
       </CommandList>
     </CommandDialog>
   );

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -384,6 +384,228 @@ describe('useQueueManagement', () => {
     errorSpy.mockRestore();
   });
 
+  it('insertTracksNext inserts a single track at currentTrackIndex + 1', () => {
+    // #given — queue of 4 tracks, currently playing index 1
+    mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c'), makeMediaTrack('d')];
+    const tracks = [
+      makeTrack({ id: 'a' }),
+      makeTrack({ id: 'b' }),
+      makeTrack({ id: 'c' }),
+      makeTrack({ id: 'd' }),
+    ];
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 1,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    let response: ReturnType<typeof result.current.insertTracksNext> = null;
+    act(() => {
+      response = result.current.insertTracksNext([makeMediaTrack('x')], 'X');
+    });
+
+    // #then — setTracks called with full array (insert-next path uses non-functional update)
+    expect(response).toEqual({ added: 1, collectionName: 'X' });
+    expect(mockSetTracks).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'a' }),
+      expect.objectContaining({ id: 'b' }),
+      expect.objectContaining({ id: 'x' }),
+      expect.objectContaining({ id: 'c' }),
+      expect.objectContaining({ id: 'd' }),
+    ]);
+    expect(mediaTracksRef.current.map((t) => t.id)).toEqual(['a', 'b', 'x', 'c', 'd']);
+    expect(mockSetCurrentTrackIndex).not.toHaveBeenCalled();
+  });
+
+  it('insertTracksNext appends when queue is empty (no current track to insert after)', () => {
+    // #given — empty queue
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks: [],
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    let response: ReturnType<typeof result.current.insertTracksNext> = null;
+    act(() => {
+      response = result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+    });
+
+    // #then
+    expect(response).toEqual({ added: 2, collectionName: undefined });
+    expect(mockSetTracks).toHaveBeenCalledWith([
+      expect.objectContaining({ id: '1' }),
+      expect.objectContaining({ id: '2' }),
+    ]);
+    expect(mediaTracksRef.current.map((t) => t.id)).toEqual(['1', '2']);
+  });
+
+  it('insertTracksNext returns null and toasts when every track is already queued', () => {
+    // #given
+    mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+    const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    let response: ReturnType<typeof result.current.insertTracksNext> = null;
+    act(() => {
+      response = result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+    });
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith('Already in your queue.', { id: 'qap-add-queue-dup' });
+    expect(mockSetTracks).not.toHaveBeenCalled();
+  });
+
+  it('insertTracksNext dedups against existing queue and inserts only the unique tracks', () => {
+    // #given — '1' is already queued, 'x' and 'y' are new
+    mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+    const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when — mix of duplicate '1' with new 'x' and 'y'
+    let response: ReturnType<typeof result.current.insertTracksNext> = null;
+    act(() => {
+      response = result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('x'), makeMediaTrack('y')]);
+    });
+
+    // #then — only x and y are inserted, currentTrackIndex preserved
+    expect(response).toEqual({ added: 2, collectionName: undefined });
+    expect(mediaTracksRef.current.map((t) => t.id)).toEqual(['1', 'x', 'y', '2']);
+    expect(mockSetCurrentTrackIndex).not.toHaveBeenCalled();
+  });
+
+  it('insertCollectionNext delegates to loadCollection when queue is empty', async () => {
+    // #given
+    mockHandlePlaylistSelect.mockResolvedValue(5);
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks: [],
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () =>
+      result.current.insertCollectionNext('playlist_id', 'My Playlist'),
+    );
+
+    // #then
+    expect(mockHandlePlaylistSelect).toHaveBeenCalledWith('playlist_id', undefined, 'My Playlist');
+    expect(response).toEqual({ added: 5, collectionName: 'My Playlist' });
+  });
+
+  it('insertCollectionNext fetches via catalog and inserts at currentTrackIndex + 1 when queue is non-empty', async () => {
+    // #given
+    mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+    const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+    const fetched = [makeMediaTrack('p1'), makeMediaTrack('p2'), makeMediaTrack('p3')];
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue(fetched) };
+    mockActiveDescriptor.catalog = mockCatalog;
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () =>
+      result.current.insertCollectionNext('playlist_id', 'P'),
+    );
+
+    // #then — 3 tracks inserted at index 1 (currentTrackIndex + 1)
+    expect(response).toEqual({ added: 3, collectionName: 'P' });
+    expect(mockCatalog.listTracks).toHaveBeenCalled();
+    expect(mediaTracksRef.current.map((t) => t.id)).toEqual(['a', 'p1', 'p2', 'p3', 'b']);
+    expect(mockSetCurrentTrackIndex).not.toHaveBeenCalled();
+  });
+
+  it('insertCollectionNext toasts the failure message when listTracks throws', async () => {
+    // #given
+    mediaTracksRef.current = [makeMediaTrack('a')];
+    const tracks = [makeTrack({ id: 'a' })];
+    const mockCatalog = { listTracks: vi.fn().mockRejectedValue(new Error('boom')) };
+    mockActiveDescriptor.catalog = mockCatalog;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useQueueManagement({
+        tracks,
+        currentTrackIndex: 0,
+        shuffleEnabled: false,
+        trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        loadCollection: mockHandlePlaylistSelect,
+        handleBackToLibrary: mockHandleBackToLibrary,
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+      })
+    );
+
+    // #when
+    const response = await act(async () => result.current.insertCollectionNext('p1'));
+
+    // #then
+    expect(response).toBeNull();
+    expect(toast).toHaveBeenCalledWith("Couldn't add to queue. Try again.", { id: 'qap-add-queue-error' });
+    errorSpy.mockRestore();
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -434,7 +434,7 @@ export function usePlayerLogic() {
   ]);
 
   // Initialize queue management handlers
-  const { handleAddToQueue, queueTracksDirectly, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
+  const { handleAddToQueue, queueTracksDirectly, insertTracksNext, insertCollectionNext, handleRemoveFromQueue, handleReorderQueue } = useQueueManagement({
     trackOps,
     tracks,
     currentTrackIndex,
@@ -453,6 +453,8 @@ export function usePlayerLogic() {
       playTracksDirectly,
       handleAddToQueue,
       queueTracksDirectly,
+      insertTracksNext,
+      insertCollectionNext,
       handlePlay,
       handlePause,
       handleNext,
@@ -472,6 +474,8 @@ export function usePlayerLogic() {
       playTracksDirectly,
       handleAddToQueue,
       queueTracksDirectly,
+      insertTracksNext,
+      insertCollectionNext,
       handlePlay,
       handlePause,
       handleNext,

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -8,6 +8,7 @@ import { logQueue } from '@/lib/debugLog';
 import { shuffleArray } from '@/utils/shuffleArray';
 import {
   appendMediaTracks,
+  insertMediaTracksAt,
   moveItemInArray,
   removeMediaTrackById,
   reorderMediaTracksToMatchTracks,
@@ -35,6 +36,8 @@ interface UseQueueManagementProps {
 interface UseQueueManagementReturn {
   handleAddToQueue: (playlistId: string, collectionName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
   queueTracksDirectly: (tracks: MediaTrack[], collectionName?: string) => AddToQueueResult | null;
+  insertTracksNext: (tracks: MediaTrack[], collectionName?: string) => AddToQueueResult | null;
+  insertCollectionNext: (playlistId: string, collectionName?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
   handleRemoveFromQueue: (index: number) => void;
   handleReorderQueue: (fromIndex: number, toIndex: number) => void;
 }
@@ -228,9 +231,111 @@ export function useQueueManagement({
     [mediaTracksRef, setOriginalTracks, setTracks]
   );
 
+  /**
+   * Insert tracks at `currentTrackIndex + 1` (the "play next" slot). Dedups
+   * against the existing queue. When the queue is empty there is no current
+   * track, so this falls back to appending — matching `queueTracksDirectly`.
+   */
+  const insertTracksNext = useCallback(
+    (newTracks: MediaTrack[], collectionName?: string): AddToQueueResult | null => {
+      if (newTracks.length === 0) return null;
+
+      const existingIds = new Set(tracksRef.current.map((t) => t.id));
+      const uniqueNewTracks = newTracks.filter((t) => !existingIds.has(t.id));
+
+      if (uniqueNewTracks.length === 0) {
+        toast(ADD_TO_QUEUE_DUP_MSG, { id: ADD_TO_QUEUE_DUP_ID });
+        return null;
+      }
+
+      if (tracksRef.current.length === 0) {
+        logQueue('insertTracksNext — queue empty, appending %d tracks', uniqueNewTracks.length);
+        mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
+        setOriginalTracks([...uniqueNewTracks]);
+        setTracks([...uniqueNewTracks]);
+        return { added: uniqueNewTracks.length, collectionName };
+      }
+
+      const insertAt = currentTrackIndex + 1;
+      logQueue(
+        'insertTracksNext — inserting %d tracks at index=%d. Before: tracks=%d, mediaRef=%d',
+        uniqueNewTracks.length,
+        insertAt,
+        tracksRef.current.length,
+        mediaTracksRef.current.length,
+      );
+
+      const nextTracks = [...tracksRef.current];
+      nextTracks.splice(insertAt, 0, ...uniqueNewTracks);
+      mediaTracksRef.current = insertMediaTracksAt(mediaTracksRef.current, insertAt, uniqueNewTracks);
+      setOriginalTracks(nextTracks);
+      setTracks(nextTracks);
+
+      logQueue(
+        'insertTracksNext — after insert: mediaRef=%d, newTracks added: %s',
+        mediaTracksRef.current.length,
+        uniqueNewTracks.map((t: MediaTrack) => trkSummary(t)).join(', '),
+      );
+      return { added: uniqueNewTracks.length, collectionName };
+    },
+    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks],
+  );
+
+  /**
+   * Fetch a collection's tracks and splice them in at `currentTrackIndex + 1`.
+   * Mirrors `handleAddToQueue` but uses insert-next semantics on a non-empty
+   * queue. Empty queue still delegates to `loadCollection` (start playback).
+   */
+  const insertCollectionNext = useCallback(
+    async (playlistId: string, collectionName?: string, provider?: ProviderId): Promise<AddToQueueResult | null> => {
+      const isQueueEmpty = tracksRef.current.length === 0;
+      logQueue(
+        'insertCollectionNext — playlistId=%s, provider=%s, currentQueueLen=%d, mediaLen=%d',
+        playlistId,
+        provider ?? 'active',
+        tracksRef.current.length,
+        mediaTracksRef.current.length,
+      );
+
+      const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
+      const targetProviderId = provider ?? activeDescriptor?.id;
+
+      if (!targetDescriptor || !targetProviderId) {
+        toast(ADD_TO_QUEUE_ERROR_MSG, { id: ADD_TO_QUEUE_ERROR_ID });
+        return null;
+      }
+
+      if (isQueueEmpty) {
+        logQueue('insertCollectionNext — queue empty, delegating to loadCollection');
+        const loaded = await loadCollection(playlistId, provider, collectionName);
+        if (loaded > 0) {
+          return { added: loaded, collectionName };
+        }
+        toast(ADD_TO_QUEUE_EMPTY_MSG, { id: ADD_TO_QUEUE_EMPTY_ID });
+        return null;
+      }
+
+      try {
+        const catalog = targetDescriptor.catalog;
+        const { id: collectionId, kind: collectionKind } = resolvePlaylistRef(playlistId, targetProviderId);
+        const collectionRef = { provider: targetProviderId, kind: collectionKind, id: collectionId } as const;
+        const fetchedTracks = await catalog.listTracks(collectionRef);
+        const newMediaTracks = isAllMusicRef(collectionRef) ? shuffleArray(fetchedTracks) : fetchedTracks;
+        return insertTracksNext(newMediaTracks, collectionName);
+      } catch (err) {
+        console.error('[Queue] Failed to insert collection next:', err);
+        toast(ADD_TO_QUEUE_ERROR_MSG, { id: ADD_TO_QUEUE_ERROR_ID });
+        return null;
+      }
+    },
+    [activeDescriptor, getDescriptor, insertTracksNext, loadCollection, mediaTracksRef],
+  );
+
   return {
     handleAddToQueue,
     queueTracksDirectly,
+    insertTracksNext,
+    insertCollectionNext,
     handleRemoveFromQueue,
     handleReorderQueue,
   };

--- a/src/utils/queueTrackMirror.ts
+++ b/src/utils/queueTrackMirror.ts
@@ -32,6 +32,21 @@ export function appendMediaTracks(
   return [...mediaTracks, ...additions];
 }
 
+/**
+ * Insert tracks at a given position (used for "play next"). Clamps the index
+ * to the valid range [0, mediaTracks.length] without mutating the source list.
+ */
+export function insertMediaTracksAt(
+  mediaTracks: readonly MediaTrack[],
+  index: number,
+  additions: readonly MediaTrack[],
+): MediaTrack[] {
+  const clamped = Math.max(0, Math.min(index, mediaTracks.length));
+  const result = [...mediaTracks];
+  result.splice(clamped, 0, ...additions);
+  return result;
+}
+
 /** Move one element; returns a new array (immutable). */
 export function moveItemInArray<T>(arr: readonly T[], fromIndex: number, toIndex: number): T[] {
   const result = [...arr];


### PR DESCRIPTION
## Summary
- Wires the Cmd+K palette shell (#1411) to the IndexedDB library search backend (#1412): renders four cmdk groups in fixed order — Tracks, Albums, Artists, Playlists — with empty groups hidden and contextual subtitles per entity.
- Selection routing: track enqueues via `queueTracksDirectly` (with a 'View' toast); album/playlist open in Library via the existing `loadCollection` path; artist falls back to opening Library without a filter — see deferral note below.
- Documents `Cmd+K` / `Ctrl+K` in `CLAUDE.md` and `docs/keyboard.md`, noting the palette owns its own keydown listener separate from `useKeyboardShortcuts.ts`.

## Stacking
This PR fans in over #1411 (palette shell) and #1412 (search backend). It targets the synthesis base branch `worktree-agent-1408-base` (octopus merge of develop + worktree-agent-1406 + worktree-agent-1407) until those two upstream PRs merge to develop, at which point this PR should be retargeted to develop.

## Deferral — artist filter
The acceptance criteria called for "selecting an artist opens Library filtered by artist", but no programmatic Library-filter-by-artist mechanism exists in the codebase today (FilterSidebar/SearchResultsView do not expose one). Per the scope-deferral policy in the brief, artist selection falls back to plain `handleOpenLibrary()` so the user can navigate manually; a clear comment marks the deferral in `AudioPlayer.tsx`. Follow-up: file a separate issue to add a programmatic artist-filter route into Library, then update `handleCmdKSelectArtist` to use it.

## Test plan
- 14 new tests in `CmdKPalette.results.test.tsx` cover: each group renders only when its bucket is non-empty; fixed group ordering; "No results" when everything is empty; track/album/playlist subtitles render; `onSelectTrack`/`onSelectAlbum`/`onSelectPlaylist`/`onSelectArtist` are invoked with the correct entity; the palette closes after every selection; the query clears on close; `Enter` selects the auto-highlighted first match; `ArrowDown` moves selection across group boundaries.
- `npx tsc -b --noEmit` clean.
- `npm run test:run` — 1682 tests across 153 files pass (24 in CmdKPalette).
- `npm run lint` — no new warnings/errors.

Closes #1408