### PR TITLE
refactor(dropbox): buff provider — reuse/quality/efficiency pass

### DIFF
--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -157,6 +157,7 @@ export async function putTagMetadata(trackId: string, tags: Omit<CachedTagMetada
 }
 
 function batchGetFromStore<T>(database: IDBDatabase, storeName: string, ids: string[]): Promise<Map<string, T>> {
+  if (ids.length === 0) return Promise.resolve(new Map<string, T>());
   return new Promise((resolve) => {
     const result = new Map<string, T>();
     try {

--- a/src/providers/dropbox/dropboxLikesCache.ts
+++ b/src/providers/dropbox/dropboxLikesCache.ts
@@ -18,13 +18,14 @@ export interface LikedEntry {
   likedAt: number;
 }
 
-/**
- * Open a transaction on the likes store and run the callback.
- * Returns `fallback` if the database is unavailable or the transaction fails.
- */
 const TOMBSTONE_STORE = 'tombstones';
 
-async function withStore<T>(
+/**
+ * Open a transaction on the given store name and run the callback.
+ * Returns `fallback` if the database is unavailable or the transaction fails.
+ */
+async function withIdbStore<T>(
+  storeName: string,
   mode: IDBTransactionMode,
   fallback: T,
   fn: (store: IDBObjectStore, resolve: (value: T) => void) => void,
@@ -33,8 +34,8 @@ async function withStore<T>(
   if (!database) return fallback;
   return new Promise((resolve) => {
     try {
-      const tx = database.transaction(STORE, mode);
-      const store = tx.objectStore(STORE);
+      const tx = database.transaction(storeName, mode);
+      const store = tx.objectStore(storeName);
       fn(store, resolve);
       tx.onerror = () => resolve(fallback);
     } catch {
@@ -43,23 +44,20 @@ async function withStore<T>(
   });
 }
 
-async function withTombstoneStore<T>(
+function withStore<T>(
   mode: IDBTransactionMode,
   fallback: T,
   fn: (store: IDBObjectStore, resolve: (value: T) => void) => void,
 ): Promise<T> {
-  const database = await getDb();
-  if (!database) return fallback;
-  return new Promise((resolve) => {
-    try {
-      const tx = database.transaction(TOMBSTONE_STORE, mode);
-      const store = tx.objectStore(TOMBSTONE_STORE);
-      fn(store, resolve);
-      tx.onerror = () => resolve(fallback);
-    } catch {
-      resolve(fallback);
-    }
-  });
+  return withIdbStore(STORE, mode, fallback, fn);
+}
+
+function withTombstoneStore<T>(
+  mode: IDBTransactionMode,
+  fallback: T,
+  fn: (store: IDBObjectStore, resolve: (value: T) => void) => void,
+): Promise<T> {
+  return withIdbStore(TOMBSTONE_STORE, mode, fallback, fn);
 }
 
 export async function getLikedTracks(): Promise<MediaTrack[]> {

--- a/src/providers/dropbox/dropboxPreferencesSync.ts
+++ b/src/providers/dropbox/dropboxPreferencesSync.ts
@@ -26,6 +26,16 @@ export interface RemotePreferencesFile {
 const PREFERENCES_FILE_PATH = '/.vorbis/preferences.json';
 const UPLOAD_DEBOUNCE_MS = 2000;
 
+function parseJsonObject(raw: string | null): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
 // ── Adapter: build from local / apply to local ───────────────────────────────
 
 export async function buildPreferencesFromLocal(): Promise<Omit<RemotePreferencesFile, 'version' | 'updatedAt'>> {
@@ -33,24 +43,8 @@ export async function buildPreferencesFromLocal(): Promise<Omit<RemotePreference
     getPins(UNIFIED_PROVIDER, 'playlists'),
     getPins(UNIFIED_PROVIDER, 'albums'),
   ]);
-  const overridesRaw = localStorage.getItem(STORAGE_KEYS.ACCENT_COLOR_OVERRIDES);
-  const customRaw = localStorage.getItem(STORAGE_KEYS.CUSTOM_ACCENT_COLORS);
-  const overrides: Record<string, string> = overridesRaw ? (() => {
-    try {
-      const o = JSON.parse(overridesRaw);
-      return typeof o === 'object' && o !== null ? o : {};
-    } catch {
-      return {};
-    }
-  })() : {};
-  const customColors: Record<string, string> = customRaw ? (() => {
-    try {
-      const o = JSON.parse(customRaw);
-      return typeof o === 'object' && o !== null ? o : {};
-    } catch {
-      return {};
-    }
-  })() : {};
+  const overrides = parseJsonObject(localStorage.getItem(STORAGE_KEYS.ACCENT_COLOR_OVERRIDES));
+  const customColors = parseJsonObject(localStorage.getItem(STORAGE_KEYS.CUSTOM_ACCENT_COLORS));
   return {
     pins: { playlists, albums },
     accent: { overrides, customColors },

--- a/src/providers/dropbox/dropboxSyncFolder.ts
+++ b/src/providers/dropbox/dropboxSyncFolder.ts
@@ -11,51 +11,54 @@ const RETRY_DELAY_MS = 1500;
 let folderConfirmed = false;
 let inflightPromise: Promise<boolean> | null = null;
 
+const MAX_RATE_LIMIT_RETRIES = 3;
+
 async function doEnsureFolder(auth: DropboxAuthAdapter): Promise<boolean> {
-  const token = await auth.ensureValidToken();
+  let token = await auth.ensureValidToken();
   if (!token) return false;
 
-  let response = await fetch('https://api.dropboxapi.com/2/files/create_folder_v2', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ path: FOLDER_PATH, autorename: false }),
-  });
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return false;
-    response = await fetch('https://api.dropboxapi.com/2/files/create_folder_v2', {
+  const createFolder = (accessToken: string) =>
+    fetch('https://api.dropboxapi.com/2/files/create_folder_v2', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${refreshed}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ path: FOLDER_PATH, autorename: false }),
     });
+
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+    let response = await createFolder(token);
+
     if (response.status === 401) {
-      auth.reportUnauthorized();
+      const refreshed = await auth.refreshAccessToken();
+      if (!refreshed) return false;
+      token = refreshed;
+      response = await createFolder(token);
+      if (response.status === 401) {
+        auth.reportUnauthorized();
+        return false;
+      }
+    }
+
+    if (response.status === 409) return true;
+
+    if (response.status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+      const retryAfter = response.headers.get('Retry-After');
+      const delayMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : RETRY_DELAY_MS;
+      await new Promise((r) => setTimeout(r, delayMs));
+      continue;
+    }
+
+    if (!response.ok) {
+      console.warn('[DropboxSyncFolder] Failed to ensure /.vorbis folder:', response.status);
       return false;
     }
+
+    return true;
   }
 
-  if (response.status === 409) return true;
-
-  if (response.status === 429) {
-    const retryAfter = response.headers.get('Retry-After');
-    const delayMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : RETRY_DELAY_MS;
-    await new Promise((r) => setTimeout(r, delayMs));
-    return doEnsureFolder(auth);
-  }
-
-  if (!response.ok) {
-    console.warn('[DropboxSyncFolder] Failed to ensure /.vorbis folder:', response.status);
-    return false;
-  }
-
-  return true;
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Single-pass cross-cutting cleanup on the Dropbox provider (`src/providers/dropbox/`). All public surfaces preserved; behavior unchanged.

## Changes

### Reuse
- **`dropboxLikesCache.ts`**: Collapsed the near-identical `withStore` / `withTombstoneStore` helpers into a single `withIdbStore(storeName, ...)` generic. The two thin wrappers remain as call-site aliases so no call sites change.
- **`dropboxPreferencesSync.ts`**: Extracted a `parseJsonObject` helper to replace the two duplicated IIFE `JSON.parse` + type-guard patterns in `buildPreferencesFromLocal`.

### Quality (bug fixes)
- **`dropboxArtCache.ts`**: Fixed a latent hang in `batchGetFromStore` when called with an empty `ids` array — `pending` started at 0, the loop never fired, and the Promise never resolved. Callers guard this already, but the function was unsafe in isolation.
- **`dropboxSyncFolder.ts`**: Replaced the recursive 429-retry in `doEnsureFolder` with a bounded iterative loop (max 3 retries). Under sustained rate-limiting the old recursion could stack-overflow. Also consolidated two duplicate `fetch(create_folder_v2, ...)` calls into a single `createFolder` closure.

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (152 test files, 1663 tests)

## Findings deferred to issues

The following issues were identified but not fixed here — either they touch public contracts, cross multiple modules outside the 15-file soft cap, or require design decisions:

- **Auth-retry duplication across content API callers** (`dropboxLikesSync.ts:79-101`, `dropboxPreferencesSync.ts:104-118`, `dropboxPlaylistStorage.ts:71-79`, `dropboxSyncFolder.ts` before this PR): each module hand-rolls the same `401 → refresh → retry → reportUnauthorized` pattern against `content.dropboxapi.com`. Extracting a shared `contentApiRequest(auth, requestFn)` wrapper would reduce this significantly, but it would add a new shared dependency and touches the public call shapes of `DropboxLikesSyncService` and `DropboxPreferencesSyncService`.
- **`dropboxArtworkResolver.ts:81` double-write**: `resolveAlbumArtByDir` writes art via `fetchArtDataUrl` (which calls `putArt` at the file path) and then also calls `putAlbumArt(dir, imageUrl)` — two separate cache keys for the same art. The album-path write is intentional (separate lookup key), but the relationship is undocumented. Low impact.
- **`dropboxLikesSync.ts:38-54` O(n) equality checks**: `likesEqual` and `tombstonesEqual` rebuild a Map on every call; these are only called during sync so not a hot path, but they could share a common `entriesEqual` implementation.