### PR TITLE
refactor(library): buff feature — reuse/quality/efficiency pass

### DIFF
--- a/src/components/LibraryRoute/hooks/useAlbumsSection.ts
+++ b/src/components/LibraryRoute/hooks/useAlbumsSection.ts
@@ -23,7 +23,8 @@ export function useAlbumsSection(
       result = result.filter((a) => allowed.has((a.provider ?? 'spotify') as ProviderId));
     }
     if (excludePinned) {
-      result = result.filter((a) => !pinnedAlbumIds.includes(a.id));
+      const pinnedSet = new Set(pinnedAlbumIds);
+      result = result.filter((a) => !pinnedSet.has(a.id));
     }
     return result;
   }, [albums, providerFilter, excludePinned, pinnedAlbumIds]);

--- a/src/components/LibraryRoute/hooks/usePinnedSection.ts
+++ b/src/components/LibraryRoute/hooks/usePinnedSection.ts
@@ -31,15 +31,15 @@ export function usePinnedSection(): PinnedSectionState {
   const { playlists, albums, isInitialLoadComplete } = useLibrarySync();
   const { totalCount, perProvider, isUnified, isLoading: likedIsLoading } = useLikedSection();
 
-  const pinnedPlaylists = useMemo(
-    () => playlists.filter((p) => pinnedPlaylistIds.includes(p.id)),
-    [playlists, pinnedPlaylistIds],
-  );
+  const pinnedPlaylists = useMemo(() => {
+    const pinnedSet = new Set(pinnedPlaylistIds);
+    return playlists.filter((p) => pinnedSet.has(p.id));
+  }, [playlists, pinnedPlaylistIds]);
 
-  const pinnedAlbums = useMemo(
-    () => albums.filter((a) => pinnedAlbumIds.includes(a.id)),
-    [albums, pinnedAlbumIds],
-  );
+  const pinnedAlbums = useMemo(() => {
+    const pinnedSet = new Set(pinnedAlbumIds);
+    return albums.filter((a) => pinnedSet.has(a.id));
+  }, [albums, pinnedAlbumIds]);
 
   const likedEntries = useMemo<PinnedItem[]>(() => {
     if (totalCount === 0) return [];

--- a/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
+++ b/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
@@ -23,7 +23,8 @@ export function usePlaylistsSection(
       result = result.filter((p) => allowed.has((p.provider ?? 'spotify') as ProviderId));
     }
     if (excludePinned) {
-      result = result.filter((p) => !pinnedPlaylistIds.includes(p.id));
+      const pinnedSet = new Set(pinnedPlaylistIds);
+      result = result.filter((p) => !pinnedSet.has(p.id));
     }
     return result;
   }, [playlists, providerFilter, excludePinned, pinnedPlaylistIds]);

--- a/src/components/LibraryRoute/hooks/useRecentlyPlayedSection.ts
+++ b/src/components/LibraryRoute/hooks/useRecentlyPlayedSection.ts
@@ -10,27 +10,39 @@ export function useRecentlyPlayedSection(): SectionState<RecentlyPlayedEntry> {
   const { history } = useRecentlyPlayedCollections();
   const { playlists, albums } = useLibrarySync();
 
+  const playlistImageMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of playlists) {
+      const url = p.images?.[0]?.url;
+      if (url) map.set(`${p.id}:${p.provider ?? 'spotify'}`, url);
+    }
+    return map;
+  }, [playlists]);
+
+  const albumImageMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of albums) {
+      const url = a.images?.[0]?.url;
+      if (url) map.set(`${a.id}:${a.provider ?? 'spotify'}`, url);
+    }
+    return map;
+  }, [albums]);
+
   const items = useMemo<RecentlyPlayedEntry[]>(() => {
     return history.map((entry) => {
       if (entry.imageUrl) return entry;
       const { ref } = entry;
       if (ref.kind === 'playlist') {
-        const match = playlists.find(
-          (p) => p.id === ref.id && (p.provider ?? 'spotify') === ref.provider,
-        );
-        const imageUrl = match?.images?.[0]?.url;
+        const imageUrl = playlistImageMap.get(`${ref.id}:${ref.provider ?? 'spotify'}`);
         return imageUrl ? { ...entry, imageUrl } : entry;
       }
       if (ref.kind === 'album') {
-        const match = albums.find(
-          (a) => a.id === ref.id && (a.provider ?? 'spotify') === ref.provider,
-        );
-        const imageUrl = match?.images?.[0]?.url;
+        const imageUrl = albumImageMap.get(`${ref.id}:${ref.provider ?? 'spotify'}`);
         return imageUrl ? { ...entry, imageUrl } : entry;
       }
       return entry;
     });
-  }, [history, playlists, albums]);
+  }, [history, playlistImageMap, albumImageMap]);
 
   return { items, isLoading: false, isEmpty: items.length === 0 };
 }

--- a/src/services/cache/libraryCache.ts
+++ b/src/services/cache/libraryCache.ts
@@ -7,7 +7,7 @@
  * Falls back to in-memory Maps if IndexedDB is unavailable.
  */
 
-import type { AlbumInfo } from '../spotify';
+import type { AlbumInfo, Track } from '../spotify';
 import type {
   CachedPlaylistInfo,
   CachedTrackList,
@@ -325,7 +325,7 @@ export async function getTrackList(id: string): Promise<CachedTrackList | undefi
   }
 }
 
-export async function putTrackList(id: string, tracks: import('../spotify').Track[], snapshotId?: string): Promise<void> {
+export async function putTrackList(id: string, tracks: Track[], snapshotId?: string): Promise<void> {
   const entry: CachedTrackList = { id, tracks, timestamp: Date.now(), snapshotId };
   await initCache();
   if (fallbackMode) { fallbackStores.trackLists.set(id, entry); return; }

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -213,10 +213,9 @@ export class LibrarySyncEngine {
   // =========================================================================
 
   private async initialLoad(): Promise<void> {
-    const [cachedPlaylists, cachedAlbums, , likedMeta] = await Promise.all([
+    const [cachedPlaylists, cachedAlbums, likedMeta] = await Promise.all([
       cache.getAllPlaylists(),
       cache.getAllAlbums(),
-      cache.getMeta('playlists'),
       cache.getMeta('likedSongs'),
     ]);
 


### PR DESCRIPTION
## Summary

Single-pass cross-cutting cleanup on the Library feature (LibraryRoute hooks + supporting cache/sync). Behavior preserved; all public surfaces untouched.

## Changes

### Performance / Efficiency
- **`useAlbumsSection`**, **`usePlaylistsSection`**: Replaced `pinnedIds.includes(id)` (O(n) per item → O(n²) total) with a `Set` built once inside `useMemo`. Filter is now O(n).
- **`usePinnedSection`**: Same O(n²)→O(n) fix for both `pinnedPlaylists` and `pinnedAlbums` filtering.
- **`useRecentlyPlayedSection`**: Replaced two `Array.find` calls per history entry (O(history × catalog)) with pre-built `Map<"id:provider", imageUrl>` lookups for playlists and albums. Image-url enrichment is now O(history + catalog).
- **`librarySyncEngine` `initialLoad`**: Removed `cache.getMeta('playlists')` from the `Promise.all` — the result was destructured but never used (blank slot `, ,`), wasting one IDB read on every app start.

### Quality / Type hygiene
- **`libraryCache`**: Moved inline dynamic `import('../spotify').Track[]` type annotation in `putTrackList` signature to a top-level `import type { Track }` alongside the existing `AlbumInfo` import. No runtime change.

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (152 test files, 1663 tests)

## Findings deferred to issues

The 55-file scope vastly exceeded the 15-file cap. The following were triaged but not applied:

| Location | Finding |
|---|---|
| `hooks/useAlbumsSection.ts:8-11` + `hooks/usePlaylistsSection.ts:8-11` | The param interfaces `UseAlbumsSectionParams` / `UsePlaylistsSectionParams` are structurally identical. Could be unified as `UseCollectionSectionParams` in `types.ts`, but changing the exported interface shapes touches consumers — defer. |
| `views/SearchResultsView.tsx:46-91` | Four `useMemo` blocks each independently call `normalizeQuery(search.query)` → `q` is recomputed the same way for every memo. The `q` derivation (line 41) is already a local `const`, so this is a naming/clarity issue rather than a perf bug. Low priority. |
| `views/SearchResultsView.tsx:55-65` | `recentlyFiltered` memo chains three separate `.filter()` passes over the same `recently` array. Could be merged into one, but the current form is readable and the array is short (recent history is capped). Defer. |
| `contextMenu/LibraryContextMenu.tsx:95-103` | `closeAfter` wraps every action in a `Promise.resolve().catch()` swallowing non-Error rejections silently with a generic toast. The catch only logs to `toast`; the error type is untyped. Adding structured error handling would require changing the `MenuActions` public contract. |
| `contextMenu/LibraryContextMenu.tsx:216-235` | `removeRecent` dispatch inside `onRemoveFromHistory` conditionals duplicates the `CollectionRef` union discrimination from `useRecentlyPlayedCollections`. Refactoring into a helper would simplify, but touches the context hook's public API. |
| `contextMenu/menuItemsForKind.ts:27-100` | `buildPlaylistItems` and `buildAlbumItems` share 4 of their 5 common items (Play, Add to Queue, Play Next, Toggle Pin, Start Radio). The duplication is structural; extracting shared items into a helper is straightforward but would change the module's private layout — defer as a standalone cleanup. |
| `search/useLibrarySearch.ts` (component-local) | `toggleProvider` and `toggleKind` implement the same toggle-in-array pattern independently. Could share a generic `toggleInArray` util, but the hook is already small and the pattern is clear inline. |
| `contextMenu/useAlbumSavedStatus.ts:56-78` | `run()` async inner function is created inside `toggleSaved` callback on every call. Minor — no closure capture issues, but could be a `useCallback`-stable helper. Low leverage. |
| `sections/` (5 section components) | Not read during this pass; likely contain repeated Section+SectionSkeleton boilerplate. Defer to a follow-up buff. |
| `MiniPlayer/` (3 files) | Not read during this pass. |
| `card/LibraryCard.tsx`, `card/useLongPress.ts` | Not read during this pass. |
| `contextMenu/useLikedTracksForProvider.ts`, `contextMenu/useQueueLikedFromCollection.ts` | Not read during this pass. |
| `views/SeeAllView.tsx`, `views/views.styled.ts` | Not read during this pass. |
| `search/FilterSheet.tsx`, `search/SearchBar.tsx` | Not read during this pass. |
| `src/components/LibraryProviderBar.tsx`, `src/hooks/useLibrarySync.ts` | Not read during this pass. |