### PR TITLE
refactor(library): polish pass — extract shared menu items, remove no-op callback wrapper

### DIFF
--- a/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo } from 'react';
 import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import MiniArt from './MiniArt';
 import MiniControls from './MiniControls';
@@ -35,10 +35,6 @@ const MiniPlayer: React.FC<MiniPlayerProps> = ({
 }) => {
   const { currentTrack } = useCurrentTrackContext();
 
-  const handleExpand = useCallback(() => {
-    onExpand();
-  }, [onExpand]);
-
   if (!currentTrack) return null;
 
   const trackName = currentTrack.name ?? '';
@@ -51,7 +47,7 @@ const MiniPlayer: React.FC<MiniPlayerProps> = ({
         type="button"
         aria-label={`Expand player — ${trackName}`}
         data-testid="mini-expand"
-        onClick={handleExpand}
+        onClick={onExpand}
       >
         <MiniArt imageUrl={artUrl} alt={trackName || 'Now playing'} isPlaying={isPlaying} />
         <TextStack>

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -24,8 +24,8 @@ export interface MenuActions {
   playNextDisabled?: boolean;
 }
 
-function buildPlaylistItems(actions: MenuActions): MenuItem[] {
-  const items: MenuItem[] = [
+function buildCommonItems(actions: MenuActions): MenuItem[] {
+  return [
     { id: 'play', label: 'Play', onSelect: actions.onPlay },
     { id: 'add-to-queue', label: 'Add to Queue', onSelect: actions.onAddToQueue },
     {
@@ -39,13 +39,17 @@ function buildPlaylistItems(actions: MenuActions): MenuItem[] {
       label: actions.isPinned ? 'Unpin' : 'Pin',
       onSelect: actions.onTogglePin,
     },
-    {
-      id: 'start-radio',
-      label: 'Start Radio',
-      onSelect: actions.onStartRadio,
-      disabled: actions.startRadioDisabled === true,
-    },
   ];
+}
+
+function buildPlaylistItems(actions: MenuActions): MenuItem[] {
+  const items = buildCommonItems(actions);
+  items.push({
+    id: 'start-radio',
+    label: 'Start Radio',
+    onSelect: actions.onStartRadio,
+    disabled: actions.startRadioDisabled === true,
+  });
   if (actions.onQueueLikedFromCollection) {
     items.push({
       id: 'queue-liked',
@@ -57,21 +61,7 @@ function buildPlaylistItems(actions: MenuActions): MenuItem[] {
 }
 
 function buildAlbumItems(actions: MenuActions): MenuItem[] {
-  const items: MenuItem[] = [
-    { id: 'play', label: 'Play', onSelect: actions.onPlay },
-    { id: 'add-to-queue', label: 'Add to Queue', onSelect: actions.onAddToQueue },
-    {
-      id: 'play-next',
-      label: 'Play Next',
-      onSelect: actions.onPlayNext,
-      disabled: actions.playNextDisabled === true,
-    },
-    {
-      id: 'toggle-pin',
-      label: actions.isPinned ? 'Unpin' : 'Pin',
-      onSelect: actions.onTogglePin,
-    },
-  ];
+  const items = buildCommonItems(actions);
   if (actions.onToggleSave) {
     // Library only surfaces albums the user has already liked, so the toggle is
     // always Unlike. If the menu is reused in a non-library context (e.g. search


### PR DESCRIPTION
## Summary

- Closes [#1435](https://github.com/smallorbit/vorbis-player/issues/1435): `buildPlaylistItems` and `buildAlbumItems` in `menuItemsForKind.ts` shared the Play / Add to Queue / Play Next / Toggle Pin quartet verbatim; factored into a `buildCommonItems` helper consumed by both. Exported surface unchanged.
- Removed a passthrough `useCallback` wrapper in `MiniPlayer.tsx` that wrapped `onExpand` in a single-line closure with no memoisation benefit.

## Changes

**`src/components/LibraryRoute/contextMenu/menuItemsForKind.ts`**
- Added `buildCommonItems(actions)` helper that builds the four shared items.
- `buildPlaylistItems` and `buildAlbumItems` now compose from `buildCommonItems`; album-specific "Unlike" insert and post-common items remain unchanged.

**`src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx`**
- Removed `handleExpand` `useCallback` wrapper; pass `onExpand` directly.
- Removed now-unused `useCallback` import.

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1629 tests, 151 files, all pass
- [x] `npm run build` — clean

## Findings deferred to issues

| File:line | Finding | Rationale for deferral |
|---|---|---|
| `src/hooks/useLibrarySync.ts:36` | `refreshNow` interface type `() => Promise<void>` is narrower than implementation `(scopeProviderId?: ProviderId) => Promise<void>` — a type gap. | Changing the exported interface affects callers outside the Library scope; behavior-adjacent contract change, not a safe in-place polish. |
| `src/components/LibraryRoute/hooks/useAlbumsSection.ts` + `usePlaylistsSection.ts` | Near-identical filter/pin-exclude logic between the two hooks. | Merging would require a generic or shared abstraction that changes the API shape; deferred for a dedicated refactor. |
| `src/components/LibraryRoute/views/SearchResultsView.tsx:100` | Magic inline style `rgba(255,255,255,0.6)` instead of a theme token. | Visual/styling change; per CLAUDE.md, direct styling edits require explicit instruction. |

Closes #1435