### PR TITLE
docs(dropbox): document dropboxArtworkResolver dual-key cache strategy

### DIFF
--- a/src/providers/dropbox/dropboxArtworkResolver.ts
+++ b/src/providers/dropbox/dropboxArtworkResolver.ts
@@ -78,6 +78,9 @@ export class DropboxArtworkResolver {
           const imageUrl = await this.fetchArtDataUrl(imagePath);
           if (imageUrl) {
             dirToImageUrl.set(dir, imageUrl);
+            // Dual-key cache: fetchArtDataUrl already stored under the file path (fast
+            // per-track lookup); this second write keys on the directory so album-level
+            // lookups (resolveAlbumArt, getAlbumArtForAlbum) can hit without re-scanning.
             await putAlbumArt(dir, imageUrl);
             return;
           }


### PR DESCRIPTION
## Summary
- Add a brief comment explaining why `resolveAlbumArtByDir` writes art twice (per-file via `putArt` and per-album-dir via `putAlbumArt`).

## Test plan
- [ ] npx tsc -b --noEmit
- [ ] npm run test:run

Closes #1420