### PR TITLE
refactor(library): share toggleInArray util for search filters

### DIFF
--- a/src/components/LibraryRoute/search/useLibrarySearch.ts
+++ b/src/components/LibraryRoute/search/useLibrarySearch.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import type { ProviderId } from '@/types/domain';
+import { toggleInArray } from '@/utils/toggleInArray';
 
 export type LibraryKindFilter = 'playlist' | 'album';
 export type LibrarySort = 'recent' | 'name-asc' | 'name-desc';
@@ -45,20 +46,14 @@ export function useLibrarySearch(): LibrarySearchState {
 
   const toggleProvider = useCallback(
     (id: ProviderId) => {
-      setProviderFilter(
-        providerFilter.includes(id)
-          ? providerFilter.filter((p) => p !== id)
-          : [...providerFilter, id],
-      );
+      setProviderFilter(toggleInArray(providerFilter, id));
     },
     [providerFilter, setProviderFilter],
   );
 
   const toggleKind = useCallback(
     (kind: LibraryKindFilter) => {
-      setKindFilter(
-        kindFilter.includes(kind) ? kindFilter.filter((k) => k !== kind) : [...kindFilter, kind],
-      );
+      setKindFilter(toggleInArray(kindFilter, kind));
     },
     [kindFilter, setKindFilter],
   );

--- a/src/utils/__tests__/toggleInArray.test.ts
+++ b/src/utils/__tests__/toggleInArray.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { toggleInArray } from '../toggleInArray';
+
+describe('toggleInArray', () => {
+  it('adds an item when the array is empty', () => {
+    // #given
+    const arr: string[] = [];
+
+    // #when
+    const result = toggleInArray(arr, 'a');
+
+    // #then
+    expect(result).toEqual(['a']);
+  });
+
+  it('appends an item when not present in a non-empty array', () => {
+    // #given
+    const arr = ['a', 'b'];
+
+    // #when
+    const result = toggleInArray(arr, 'c');
+
+    // #then
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('removes an item that already exists', () => {
+    // #given
+    const arr = ['a', 'b', 'c'];
+
+    // #when
+    const result = toggleInArray(arr, 'b');
+
+    // #then
+    expect(result).toEqual(['a', 'c']);
+  });
+
+  it('removes every occurrence when the item appears multiple times', () => {
+    // #given
+    const arr = ['a', 'b', 'a', 'c', 'a'];
+
+    // #when
+    const result = toggleInArray(arr, 'a');
+
+    // #then
+    expect(result).toEqual(['b', 'c']);
+  });
+
+  it('does not mutate the input array', () => {
+    // #given
+    const arr = ['a', 'b'];
+    const snapshot = [...arr];
+
+    // #when
+    toggleInArray(arr, 'a');
+    toggleInArray(arr, 'c');
+
+    // #then
+    expect(arr).toEqual(snapshot);
+  });
+
+  it('uses identity (===) for object items', () => {
+    // #given
+    const a = { id: 1 };
+    const b = { id: 2 };
+    const aClone = { id: 1 };
+    const arr = [a, b];
+
+    // #when — clone has same shape but different identity, so it gets appended
+    const result = toggleInArray(arr, aClone);
+
+    // #then
+    expect(result).toEqual([a, b, aClone]);
+    expect(result).toHaveLength(3);
+  });
+});

--- a/src/utils/toggleInArray.ts
+++ b/src/utils/toggleInArray.ts
@@ -1,0 +1,3 @@
+export function toggleInArray<T>(arr: T[], item: T): T[] {
+  return arr.includes(item) ? arr.filter((x) => x !== item) : [...arr, item];
+}


### PR DESCRIPTION
## Summary
- Extract a generic `toggleInArray<T>(arr, item): T[]` util to `src/utils/toggleInArray.ts`
- Replace duplicated toggle-in-array logic in `toggleProvider` and `toggleKind` callbacks with the shared util
- No behavior changes; all existing tests pass

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 151 files / 1629 tests passed

Closes #1431