### PR TITLE
refactor(library): unify UseAlbumsSectionParams and UsePlaylistsSectionParams

### DIFF
--- a/src/components/LibraryRoute/hooks/index.ts
+++ b/src/components/LibraryRoute/hooks/index.ts
@@ -16,4 +16,4 @@ export { useLikedSection } from './useLikedSection';
 
 export { fetchLikedForProvider } from './likedAccessors';
 
-export type { SectionState, LikedSummary } from '../types';
+export type { SectionState, LikedSummary, UseCollectionSectionParams } from '../types';

--- a/src/components/LibraryRoute/hooks/useAlbumsSection.ts
+++ b/src/components/LibraryRoute/hooks/useAlbumsSection.ts
@@ -3,12 +3,9 @@ import { useLibrarySync } from '@/hooks/useLibrarySync';
 import { usePinnedItems } from '@/hooks/usePinnedItems';
 import type { AlbumInfo } from '@/services/spotify';
 import type { ProviderId } from '@/types/domain';
-import type { SectionState } from '../types';
+import type { SectionState, UseCollectionSectionParams } from '../types';
 
-export interface UseAlbumsSectionParams {
-  providerFilter?: ProviderId[];
-  excludePinned?: boolean;
-}
+export type UseAlbumsSectionParams = UseCollectionSectionParams;
 
 export function useAlbumsSection(
   { providerFilter, excludePinned = true }: UseAlbumsSectionParams = {},

--- a/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
+++ b/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
@@ -3,12 +3,9 @@ import { useLibrarySync } from '@/hooks/useLibrarySync';
 import { usePinnedItems } from '@/hooks/usePinnedItems';
 import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { ProviderId } from '@/types/domain';
-import type { SectionState } from '../types';
+import type { SectionState, UseCollectionSectionParams } from '../types';
 
-export interface UsePlaylistsSectionParams {
-  providerFilter?: ProviderId[];
-  excludePinned?: boolean;
-}
+export type UsePlaylistsSectionParams = UseCollectionSectionParams;
 
 export function usePlaylistsSection(
   { providerFilter, excludePinned = true }: UsePlaylistsSectionParams = {},

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -4,6 +4,11 @@ import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
+export interface UseCollectionSectionParams {
+  providerFilter?: ProviderId[];
+  excludePinned?: boolean;
+}
+
 export interface SectionState<T> {
   items: T[];
   isLoading: boolean;


### PR DESCRIPTION
## Summary
- Adds `UseCollectionSectionParams` to `src/components/LibraryRoute/types.ts` as the single source of truth for the shared `{ providerFilter?, excludePinned? }` shape
- `UseAlbumsSectionParams` and `UsePlaylistsSectionParams` are now type aliases for `UseCollectionSectionParams`; existing re-exports in `hooks/index.ts` are preserved for backward compatibility
- `UseCollectionSectionParams` is re-exported from the hooks barrel so consumers can opt into the canonical name

## Test plan
- [x] `npx tsc -b --noEmit` — passes clean
- [x] `npm run test:run` — 1627/1629 pass; 2 pre-existing `SeeAllView` timeouts unrelated to this change

Closes #1429