### PR TITLE
refactor(library): stabilize useAlbumSavedStatus.toggleSaved inner async

### DIFF
--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -47,13 +47,8 @@ export function useAlbumSavedStatus(
     };
   }, [albumId, descriptor]);
 
-  const toggleSaved = useCallback(() => {
-    if (!canToggle || !albumId || isSaved === null) return;
-    const next = !isSaved;
-    setIsSaved(next);
-    setSaveError(null);
-
-    async function run() {
+  const commitToggle = useCallback(
+    async (next: boolean) => {
       try {
         await descriptor!.catalog.setAlbumSaved!(albumId!, next);
       } catch (err) {
@@ -74,10 +69,17 @@ export function useAlbumSavedStatus(
           logLibrary('optimisticRemoveAlbum failed', err);
         }
       }
-    }
+    },
+    [albumId, descriptor],
+  );
 
-    run().catch((err) => logLibrary('toggleSaved unexpected error', err));
-  }, [canToggle, albumId, isSaved, descriptor]);
+  const toggleSaved = useCallback(() => {
+    if (!canToggle || !albumId || isSaved === null) return;
+    const next = !isSaved;
+    setIsSaved(next);
+    setSaveError(null);
+    commitToggle(next).catch((err) => logLibrary('toggleSaved unexpected error', err));
+  }, [canToggle, albumId, isSaved, commitToggle]);
 
   const clearSaveError = useCallback(() => setSaveError(null), []);
 


### PR DESCRIPTION
## Summary
- Extracted the `run()` inner async function from inside `toggleSaved` into a named `commitToggle` `useCallback` helper that receives `next` as a parameter
- `commitToggle` closes over `albumId` and `descriptor` with its own dep array — the function is now stable across invocations of `toggleSaved` and only recreated when those deps change
- `toggleSaved` dep array updated to depend on `commitToggle` instead of `descriptor` directly (same effective stability)

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1625 passed, 4 pre-existing timeout failures in unrelated test files (`ResumeToast`, `LibraryRoute.nav`, `LibraryContextMenu.edges`); none in `useAlbumSavedStatus`

Closes #1432