### PR TITLE
refactor(spotify): consolidate SavedAlbumItem transform and migrate getAllUserPlaylists to fetchAllPaginated

### DIFF
--- a/src/services/spotify/__tests__/getAllUserPlaylists.test.ts
+++ b/src/services/spotify/__tests__/getAllUserPlaylists.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../auth', () => ({
+  spotifyAuth: {
+    ensureValidToken: vi.fn().mockResolvedValue('mock-token'),
+  },
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  getTrackList: vi.fn().mockResolvedValue(null),
+  putTrackList: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getAllUserPlaylists } from '../playlists';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('getAllUserPlaylists — fallback added_at stamping across pages', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('assigns unique fallback added_at stamps that span page boundaries', async () => {
+    // #given two pages of two playlists each, none carrying added_at
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            { id: 'p0', name: 'P0' },
+            { id: 'p1', name: 'P1' },
+          ],
+          next: 'https://api.spotify.com/v1/me/playlists?limit=50&offset=50',
+          total: 4,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            { id: 'p2', name: 'P2' },
+            { id: 'p3', name: 'P3' },
+          ],
+          next: null,
+          total: 4,
+        }),
+      );
+
+    // #when
+    const playlists = await getAllUserPlaylists();
+
+    // #then — four playlists fetched in order
+    expect(playlists.map((p) => p.id)).toEqual(['p0', 'p1', 'p2', 'p3']);
+
+    // #then — every fallback added_at is set, all unique (closure counter survived page boundary)
+    const stamps = playlists.map((p) => p.added_at) as string[];
+    expect(new Set(stamps).size).toBe(4);
+
+    // #then — each subsequent stamp is ~60_000ms earlier than the previous
+    // (uses Date.now() at transform time so absolute spacing has small jitter)
+    const times = stamps.map((s) => new Date(s).getTime());
+    for (let i = 0; i < times.length - 1; i++) {
+      const delta = times[i] - times[i + 1];
+      expect(delta).toBeGreaterThan(59_000);
+      expect(delta).toBeLessThan(61_000);
+    }
+  });
+
+  it('preserves explicit added_at when present and applies fallback only when absent', async () => {
+    // #given an item with explicit added_at and one without
+    const explicit = '2024-06-15T12:00:00.000Z';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { id: 'p0', name: 'P0', added_at: explicit },
+          { id: 'p1', name: 'P1' },
+        ],
+        next: null,
+        total: 2,
+      }),
+    );
+
+    // #when
+    const playlists = await getAllUserPlaylists();
+
+    // #then — explicit stamp preserved
+    expect(playlists[0].added_at).toBe(explicit);
+    // #then — fallback applied to second item
+    expect(playlists[1].added_at).not.toBe(explicit);
+    expect(typeof playlists[1].added_at).toBe('string');
+  });
+});

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -12,12 +12,12 @@ import { ALBUM_ID_PREFIX } from '@/constants/playlist';
 // Shared Helpers
 // =============================================================================
 
-interface SavedAlbumItem {
+export interface SavedAlbumItem {
   added_at: string;
   album: SpotifyAlbum;
 }
 
-function transformSavedAlbumItem(item: SavedAlbumItem): AlbumInfo {
+export function transformSavedAlbumItem(item: SavedAlbumItem): AlbumInfo {
   const album = item.album;
   return {
     id: album.id ?? '',

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -17,9 +17,13 @@ export interface SavedAlbumItem {
   album: SpotifyAlbum;
 }
 
-export function transformSavedAlbumItem(item: SavedAlbumItem): AlbumInfo {
+export function transformSavedAlbumItem(
+  item: SavedAlbumItem,
+  options: { withGenres?: boolean } = {},
+): AlbumInfo {
+  const { withGenres = true } = options;
   const album = item.album;
-  return {
+  const result: AlbumInfo = {
     id: album.id ?? '',
     name: album.name ?? 'Unknown Album',
     artists: formatArtists(album.artists),
@@ -29,8 +33,11 @@ export function transformSavedAlbumItem(item: SavedAlbumItem): AlbumInfo {
     uri: album.uri ?? '',
     album_type: album.album_type,
     added_at: item.added_at,
-    genres: album.genres,
   };
+  if (withGenres) {
+    result.genres = album.genres;
+  }
+  return result;
 }
 
 // =============================================================================
@@ -159,7 +166,7 @@ export async function getAlbumsPage(
     { signal }
   );
   return {
-    albums: (data.items ?? []).map(transformSavedAlbumItem),
+    albums: (data.items ?? []).map((item) => transformSavedAlbumItem(item)),
     total: data.total ?? 0,
     hasMore: data.next !== null,
   };

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -73,7 +73,7 @@ export async function getUserLibraryInterleaved(
           .then((data) => {
             const now = Date.now();
             for (const item of data.items ?? []) {
-              albumResults.push(transformSavedAlbumItem(item));
+              albumResults.push(transformSavedAlbumItem(item, { withGenres: false }));
               if (item.album.id) {
                 albumSavedCache.set(item.album.id, { value: true, timestamp: now });
               }

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -1,9 +1,10 @@
 import type { MediaTrack } from '@/types/domain';
-import type { Track, PlaylistInfo, AlbumInfo, SpotifyAlbum, SpotifyTrackItem, PaginatedResponse } from './types';
+import type { Track, PlaylistInfo, AlbumInfo, SpotifyTrackItem, PaginatedResponse } from './types';
 import { spotifyApiRequest, fetchAllPaginated } from './api';
 import { spotifyAuth } from './auth';
 import { trackListCache, albumSavedCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSIST_TTL } from './cache';
-import { formatArtists, transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
+import { transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
+import { type SavedAlbumItem, transformSavedAlbumItem } from './albums';
 import * as libraryCache from '../cache/libraryCache';
 
 // =============================================================================
@@ -32,26 +33,6 @@ export async function getUserLibraryInterleaved(
       added_at: playlist.added_at || fetchTimestamp,
       tracks: playlist.tracks ?? { total: 0 },
       owner: playlist.owner ?? { display_name: '' },
-    };
-  }
-
-  interface SavedAlbumItem {
-    added_at: string;
-    album: SpotifyAlbum;
-  }
-
-  function transformAlbum(item: SavedAlbumItem): AlbumInfo {
-    const album = item.album;
-    return {
-      id: album.id ?? '',
-      name: album.name ?? 'Unknown Album',
-      artists: formatArtists(album.artists),
-      images: album.images ?? [],
-      release_date: album.release_date ?? '',
-      total_tracks: album.total_tracks ?? 0,
-      uri: album.uri ?? '',
-      album_type: album.album_type,
-      added_at: item.added_at,
     };
   }
 
@@ -92,7 +73,7 @@ export async function getUserLibraryInterleaved(
           .then((data) => {
             const now = Date.now();
             for (const item of data.items ?? []) {
-              albumResults.push(transformAlbum(item));
+              albumResults.push(transformSavedAlbumItem(item));
               if (item.album.id) {
                 albumSavedCache.set(item.album.id, { value: true, timestamp: now });
               }
@@ -193,23 +174,15 @@ export async function getPlaylistsPage(
 /** Fetch ALL user playlists with full pagination (not capped at 50). */
 export async function getAllUserPlaylists(signal?: AbortSignal): Promise<PlaylistInfo[]> {
   const token = await spotifyAuth.ensureValidToken();
-  const playlists: PlaylistInfo[] = [];
-  let nextUrl: string | null = 'https://api.spotify.com/v1/me/playlists?limit=50';
   let index = 0;
 
-  while (nextUrl) {
-    if (signal?.aborted) throw new DOMException('Request aborted', 'AbortError');
-    const url = nextUrl;
-    const data: PaginatedResponse<PlaylistInfo> = await spotifyApiRequest(url, token, { signal });
-    for (const item of data.items ?? []) {
-      playlists.push({
-        ...item,
-        added_at: item.added_at || new Date(Date.now() - index * 60000).toISOString(),
-      });
-      index++;
-    }
-    nextUrl = data.next;
-  }
-
-  return playlists;
+  return fetchAllPaginated<PlaylistInfo, PlaylistInfo>(
+    'https://api.spotify.com/v1/me/playlists?limit=50',
+    token,
+    (item) => ({
+      ...item,
+      added_at: item.added_at || new Date(Date.now() - index++ * 60000).toISOString(),
+    }),
+    { signal },
+  );
 }


### PR DESCRIPTION
## Summary
- Export `SavedAlbumItem` and `transformSavedAlbumItem` from `albums.ts` so `getUserLibraryInterleaved`, `getAlbumsPage`, and `getAllUserAlbums` all share one source of truth; removes the duplicate inline interface and transform that had lived inside `playlists.ts`.
- Migrate `getAllUserPlaylists` from a hand-rolled `while (nextUrl)` loop to `fetchAllPaginated`, matching the pattern used by `getAllUserAlbums`; the `added_at` fallback stamp (`new Date(Date.now() - index * 60000)`) is preserved via a closure counter in the transform callback.

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 151 files, 1629 tests, all pass

Closes #1422
Closes #1425