### PR TITLE
refactor(library): dedupe CollectionRef discrimination in LibraryContextMenu.removeRecent

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -215,23 +215,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
 
     if (request.kind === 'recently-played' && request.recentRef) {
       const recentRef = request.recentRef;
-      actions.onRemoveFromHistory = closeAfter(() => {
-        if (recentRef.kind === 'liked') {
-          removeRecent({ provider: recentRef.provider as ProviderId, kind: 'liked' });
-        } else if (recentRef.kind === 'album') {
-          removeRecent({
-            provider: recentRef.provider as ProviderId,
-            kind: 'album',
-            id: recentRef.id,
-          });
-        } else {
-          removeRecent({
-            provider: recentRef.provider as ProviderId,
-            kind: 'playlist',
-            id: recentRef.id,
-          });
-        }
-      });
+      actions.onRemoveFromHistory = closeAfter(() => removeRecent(recentRef));
     }
 
     return buildMenuItems(request, actions);

--- a/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
+++ b/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ProviderId } from '@/types/domain';
+import type { CollectionRef, ProviderId } from '@/types/domain';
 import { useRecentlyPlayedSection } from '../hooks';
 import type { ContextMenuRequest, LibraryItemKind } from '../types';
 import Section from './Section';
@@ -54,13 +54,17 @@ const RecentlyPlayedSection: React.FC<RecentlyPlayedSectionProps> = ({
           }
           const refOriginalKind: 'playlist' | 'album' | 'liked' =
             ref.kind === 'liked' ? 'liked' : ref.kind === 'album' ? 'album' : 'playlist';
+          const recentRef: CollectionRef =
+            refOriginalKind === 'liked'
+              ? { provider: ref.provider, kind: 'liked' }
+              : { provider: ref.provider, kind: refOriginalKind, id: cardId };
           const wrappedContextMenu = onContextMenuRequest
             ? (req: ContextMenuRequest) => {
                 onContextMenuRequest({
                   ...req,
                   kind: 'recently-played',
                   originalKind: refOriginalKind,
-                  recentRef: { kind: refOriginalKind, id: cardId, provider: ref.provider },
+                  recentRef,
                 });
               }
             : undefined;

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -1,6 +1,6 @@
 import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { AlbumInfo } from '@/services/spotify';
-import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
 
@@ -39,7 +39,7 @@ export interface ContextMenuRequest {
   /** When kind === 'recently-played', the underlying collection kind so the menu can dispatch the right schema. */
   originalKind?: 'playlist' | 'album' | 'liked';
   /** When kind === 'recently-played', back-pointer used by the "Remove from history" action. */
-  recentRef?: { kind: 'playlist' | 'album' | 'liked'; id: string; provider?: ProviderId };
+  recentRef?: CollectionRef;
 }
 
 export type {


### PR DESCRIPTION
## Summary

- Typed `ContextMenuRequest.recentRef` as `CollectionRef` (from `@/types/domain`) instead of the looser inline shape `{ kind, id, provider? }`, eliminating the structural mismatch that forced the caller to discriminate and cast
- `RecentlyPlayedSection` now builds a typed `CollectionRef` at the construction site (no `id` for `liked`, guaranteed `ProviderId` for all variants)
- `LibraryContextMenu.onRemoveFromHistory` collapses from a 15-line three-branch `if/else if/else` to a single `removeRecent(recentRef)` call — no discrimination, no `as ProviderId` casts

No public-API change to `useRecentlyPlayedCollections`. The `ContextMenuRequest` shape is intentionally reshaped: the old inline type was a looser approximation of `CollectionRef`; tightening it removes the need for any discrimination at the call site.

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run` — 1629 tests passed (151 files)

Closes #1434