### PR TITLE
refactor(dropbox): share content-API auth-retry wrapper and entriesEqual helper

### DIFF
--- a/src/providers/dropbox/__tests__/dropboxContentApiClient.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxContentApiClient.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DropboxAuthAdapter } from '../dropboxAuthAdapter';
+import { contentApiRequest } from '../dropboxContentApiClient';
+
+function createMockAuth(overrides: Partial<DropboxAuthAdapter> = {}): DropboxAuthAdapter {
+  return {
+    providerId: 'dropbox' as const,
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    getAccessToken: vi.fn().mockResolvedValue('initial-token'),
+    beginLogin: vi.fn(),
+    handleCallback: vi.fn(),
+    logout: vi.fn(),
+    ensureValidToken: vi.fn().mockResolvedValue('initial-token'),
+    refreshAccessToken: vi.fn().mockResolvedValue('refreshed-token'),
+    reportUnauthorized: vi.fn(),
+    ...overrides,
+  } satisfies DropboxAuthAdapter;
+}
+
+describe('contentApiRequest', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns response directly when initial call succeeds', async () => {
+    // #given
+    const auth = createMockAuth();
+    const successResponse = new Response('ok', { status: 200 });
+    const requestFn = vi.fn().mockResolvedValue(successResponse);
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBe(successResponse);
+    expect(requestFn).toHaveBeenCalledTimes(1);
+    expect(requestFn).toHaveBeenCalledWith('initial-token');
+    expect(auth.refreshAccessToken).not.toHaveBeenCalled();
+    expect(auth.reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('refreshes token on 401 and returns retry response on success', async () => {
+    // #given
+    const auth = createMockAuth();
+    const unauthorized = new Response(null, { status: 401 });
+    const success = new Response('ok', { status: 200 });
+    const requestFn = vi.fn()
+      .mockResolvedValueOnce(unauthorized)
+      .mockResolvedValueOnce(success);
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBe(success);
+    expect(requestFn).toHaveBeenCalledTimes(2);
+    expect(requestFn).toHaveBeenNthCalledWith(1, 'initial-token');
+    expect(requestFn).toHaveBeenNthCalledWith(2, 'refreshed-token');
+    expect(auth.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(auth.reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('calls reportUnauthorized and returns null when retry also returns 401', async () => {
+    // #given
+    const auth = createMockAuth();
+    const requestFn = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBeNull();
+    expect(requestFn).toHaveBeenCalledTimes(2);
+    expect(auth.reportUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null without invoking requestFn when ensureValidToken returns null', async () => {
+    // #given
+    const auth = createMockAuth({
+      ensureValidToken: vi.fn().mockResolvedValue(null),
+    });
+    const requestFn = vi.fn();
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBeNull();
+    expect(requestFn).not.toHaveBeenCalled();
+    expect(auth.refreshAccessToken).not.toHaveBeenCalled();
+    expect(auth.reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('returns null without calling reportUnauthorized when refreshAccessToken returns null', async () => {
+    // #given
+    const auth = createMockAuth({
+      refreshAccessToken: vi.fn().mockResolvedValue(null),
+    });
+    const requestFn = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBeNull();
+    expect(requestFn).toHaveBeenCalledTimes(1);
+    expect(auth.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(auth.reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('returns non-401 error responses directly without retry', async () => {
+    // #given
+    const auth = createMockAuth();
+    const serverError = new Response('server error', { status: 500 });
+    const requestFn = vi.fn().mockResolvedValue(serverError);
+
+    // #when
+    const result = await contentApiRequest(auth, requestFn);
+
+    // #then
+    expect(result).toBe(serverError);
+    expect(requestFn).toHaveBeenCalledTimes(1);
+    expect(auth.refreshAccessToken).not.toHaveBeenCalled();
+    expect(auth.reportUnauthorized).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/dropbox/__tests__/dropboxLikesSync.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxLikesSync.test.ts
@@ -60,6 +60,7 @@ function createMockAuth(token = 'test-token') {
     logout: vi.fn(),
     ensureValidToken: vi.fn().mockResolvedValue(token),
     refreshAccessToken: vi.fn().mockResolvedValue(token),
+    reportUnauthorized: vi.fn(),
   };
 }
 

--- a/src/providers/dropbox/dropboxContentApiClient.ts
+++ b/src/providers/dropbox/dropboxContentApiClient.ts
@@ -1,9 +1,17 @@
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 
 /**
- * Executes a content-API (or any Dropbox-facing) request with one automatic
- * token refresh on 401.  A second consecutive 401 calls reportUnauthorized and
- * returns null, signalling the caller to abort.
+ * Executes a Dropbox API request with one automatic token refresh on 401.
+ *
+ * Returns null (telling the caller to abort) in three distinct cases:
+ *   1. `ensureValidToken()` returns null — initial auth missing; `requestFn` is never invoked.
+ *   2. Initial 401 + `refreshAccessToken()` returns null — refresh failed; `reportUnauthorized` is **not** called
+ *      (a failed refresh is treated the same as a missing initial token).
+ *   3. Initial 401, refresh succeeds, retry returns 401 — `reportUnauthorized()` is invoked before returning null.
+ *
+ * Any non-401 response (including other 4xx/5xx, 409 path errors, 429 rate limits) is
+ * returned as-is for the caller to handle. Used for both `content.dropboxapi.com`
+ * uploads/downloads and `api.dropboxapi.com` metadata calls.
  *
  * @param auth        - Auth adapter supplying and refreshing tokens.
  * @param requestFn   - Factory that receives an access token and returns a fetch Promise.

--- a/src/providers/dropbox/dropboxContentApiClient.ts
+++ b/src/providers/dropbox/dropboxContentApiClient.ts
@@ -1,0 +1,32 @@
+import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
+
+/**
+ * Executes a content-API (or any Dropbox-facing) request with one automatic
+ * token refresh on 401.  A second consecutive 401 calls reportUnauthorized and
+ * returns null, signalling the caller to abort.
+ *
+ * @param auth        - Auth adapter supplying and refreshing tokens.
+ * @param requestFn   - Factory that receives an access token and returns a fetch Promise.
+ * @returns The Response on any non-401 outcome, or null when auth is unrecoverable.
+ */
+export async function contentApiRequest(
+  auth: DropboxAuthAdapter,
+  requestFn: (token: string) => Promise<Response>,
+): Promise<Response | null> {
+  const token = await auth.ensureValidToken();
+  if (!token) return null;
+
+  let response = await requestFn(token);
+
+  if (response.status === 401) {
+    const refreshed = await auth.refreshAccessToken();
+    if (!refreshed) return null;
+    response = await requestFn(refreshed);
+    if (response.status === 401) {
+      auth.reportUnauthorized();
+      return null;
+    }
+  }
+
+  return response;
+}

--- a/src/providers/dropbox/dropboxLikesSync.ts
+++ b/src/providers/dropbox/dropboxLikesSync.ts
@@ -13,6 +13,7 @@ import {
   setTombstones,
 } from './dropboxLikesCache';
 import { ensureVorbisFolder } from './dropboxSyncFolder';
+import { contentApiRequest } from './dropboxContentApiClient';
 import { logDropboxSync } from '@/lib/debugLog';
 
 export interface RemoteLikesFile {
@@ -26,6 +27,21 @@ const SYNC_FILE_PATH = '/.vorbis/likes.json';
 const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const UPLOAD_DEBOUNCE_MS = 2000;
 
+function entriesEqual<T extends { trackId: string }>(
+  a: T[],
+  b: T[],
+  valuesMatch: (a: T, b: T) => boolean,
+): boolean {
+  if (a.length !== b.length) return false;
+  const mapB = new Map<string, T>();
+  for (const entry of b) mapB.set(entry.trackId, entry);
+  for (const entryA of a) {
+    const entryB = mapB.get(entryA.trackId);
+    if (!entryB || !valuesMatch(entryA, entryB)) return false;
+  }
+  return true;
+}
+
 export class DropboxLikesSyncService {
   private auth: DropboxAuthAdapter;
   private pushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -36,69 +52,29 @@ export class DropboxLikesSyncService {
   }
 
   private likesEqual(a: LikedEntry[], b: LikedEntry[]): boolean {
-    if (a.length !== b.length) return false;
-
-    const mapB = new Map<string, LikedEntry>();
-    for (const entry of b) {
-      mapB.set(entry.trackId, entry);
-    }
-
-    for (const entryA of a) {
-      const entryB = mapB.get(entryA.trackId);
-      if (!entryB) return false;
-      if (entryA.likedAt !== entryB.likedAt) return false;
-      // Track metadata can differ even when IDs match.
-      if (JSON.stringify(entryA.track) !== JSON.stringify(entryB.track)) return false;
-    }
-
-    return true;
+    return entriesEqual(a, b, (ea, eb) =>
+      ea.likedAt === eb.likedAt && JSON.stringify(ea.track) === JSON.stringify(eb.track),
+    );
   }
 
   private tombstonesEqual(a: Tombstone[], b: Tombstone[]): boolean {
-    if (a.length !== b.length) return false;
-
-    const mapB = new Map<string, number>();
-    for (const entry of b) {
-      mapB.set(entry.trackId, entry.deletedAt);
-    }
-
-    for (const entryA of a) {
-      const deletedAtB = mapB.get(entryA.trackId);
-      if (deletedAtB !== entryA.deletedAt) return false;
-    }
-
-    return true;
+    return entriesEqual(a, b, (ea, eb) => ea.deletedAt === eb.deletedAt);
   }
 
   async downloadLikesFile(): Promise<RemoteLikesFile | null> {
-    const token = await this.auth.ensureValidToken();
-    if (!token) return null;
-
     const apiArg = JSON.stringify({ path: SYNC_FILE_PATH });
 
-    let response = await fetch('https://content.dropboxapi.com/2/files/download', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Dropbox-API-Arg': apiArg,
-      },
-    });
-
-    if (response.status === 401) {
-      const refreshed = await this.auth.refreshAccessToken();
-      if (!refreshed) return null;
-      response = await fetch('https://content.dropboxapi.com/2/files/download', {
+    const response = await contentApiRequest(this.auth, (token) =>
+      fetch('https://content.dropboxapi.com/2/files/download', {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${refreshed}`,
+          Authorization: `Bearer ${token}`,
           'Dropbox-API-Arg': apiArg,
         },
-      });
-      if (response.status === 401) {
-        this.auth.reportUnauthorized();
-        return null;
-      }
-    }
+      }),
+    );
+
+    if (!response) return null;
 
     if (response.status === 409) {
       // path/not_found — file doesn't exist yet
@@ -124,9 +100,6 @@ export class DropboxLikesSyncService {
   }
 
   async uploadLikesFile(data: RemoteLikesFile): Promise<boolean> {
-    let token = await this.auth.ensureValidToken();
-    if (!token) return false;
-
     const folderReady = await ensureVorbisFolder(this.auth);
     if (!folderReady) return false;
 
@@ -137,7 +110,7 @@ export class DropboxLikesSyncService {
 
     const body = JSON.stringify(data);
 
-    const upload = (accessToken: string) =>
+    const response = await contentApiRequest(this.auth, (accessToken) =>
       fetch('https://content.dropboxapi.com/2/files/upload', {
         method: 'POST',
         headers: {
@@ -146,20 +119,10 @@ export class DropboxLikesSyncService {
           'Content-Type': 'application/octet-stream',
         },
         body,
-      });
+      }),
+    );
 
-    let response = await upload(token);
-
-    if (response.status === 401) {
-      const refreshed = await this.auth.refreshAccessToken();
-      if (!refreshed) return false;
-      token = refreshed;
-      response = await upload(token);
-      if (response.status === 401) {
-        this.auth.reportUnauthorized();
-        return false;
-      }
-    }
+    if (!response) return false;
 
     if (!response.ok) {
       const errText = await response.text();

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -8,6 +8,7 @@ import type { MediaTrack, MediaCollection, ProviderId, PlaybackItemRef } from '@
 import { toSavedPlaylistId } from '@/constants/playlist';
 import { logLibrary } from '@/lib/debugLog';
 import { buildAlbumCoverMap, selectMosaicCovers } from '@/utils/mosaicSelection';
+import { contentApiRequest } from './dropboxContentApiClient';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -53,31 +54,18 @@ let playlistsFolderConfirmed = false;
 async function ensurePlaylistsFolder(auth: DropboxAuthAdapter): Promise<boolean> {
   if (playlistsFolderConfirmed) return true;
 
-  let token = await auth.ensureValidToken();
-  if (!token) return false;
-
-  const create = async (accessToken: string) =>
+  const response = await contentApiRequest(auth, (token) =>
     fetch('https://api.dropboxapi.com/2/files/create_folder_v2', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ path: PLAYLISTS_FOLDER, autorename: false }),
-    });
+    }),
+  );
 
-  let response = await create(token);
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return false;
-    token = refreshed;
-    response = await create(token);
-    if (response.status === 401) {
-      auth.reportUnauthorized();
-      return false;
-    }
-  }
+  if (!response) return false;
 
   // 409 = folder already exists
   if (response.status === 409 || response.ok) {
@@ -174,36 +162,24 @@ export async function saveQueueAsPlaylist(
     tracks: mediaTracks.map(mediaTrackToSavedTrack),
   };
 
-  const token = await auth.ensureValidToken();
-  if (!token) return null;
-
   const apiArg = jsonToHttpHeader(
     JSON.stringify({ path: filePath, mode: 'overwrite' }),
   );
   const body = JSON.stringify(data);
 
-  const upload = (accessToken: string) =>
+  const response = await contentApiRequest(auth, (token) =>
     fetch('https://content.dropboxapi.com/2/files/upload', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Dropbox-API-Arg': apiArg,
         'Content-Type': 'application/octet-stream',
       },
       body,
-    });
+    }),
+  );
 
-  let response = await upload(token);
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return null;
-    response = await upload(refreshed);
-    if (response.status === 401) {
-      auth.reportUnauthorized();
-      return null;
-    }
-  }
+  if (!response) return null;
 
   if (!response.ok) {
     console.warn('[DropboxPlaylistStorage] Upload failed:', response.status);
@@ -219,37 +195,24 @@ export async function saveQueueAsPlaylist(
 export async function listSavedPlaylists(
   auth: DropboxAuthAdapter,
 ): Promise<MediaCollection[]> {
-  let token = await auth.ensureValidToken();
-  if (!token) return [];
-
   interface ListResult {
     entries: Array<{ '.tag': string; name: string; path_lower: string; path_display: string }>;
     has_more: boolean;
     cursor: string;
   }
 
-  const listFolder = async (accessToken: string) =>
+  const response = await contentApiRequest(auth, (token) =>
     fetch('https://api.dropboxapi.com/2/files/list_folder', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ path: PLAYLISTS_FOLDER, recursive: false }),
-    });
+    }),
+  );
 
-  let response = await listFolder(token);
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return [];
-    token = refreshed;
-    response = await listFolder(token);
-    if (response.status === 401) {
-      auth.reportUnauthorized();
-      return [];
-    }
-  }
+  if (!response) return [];
 
   // 409 = folder doesn't exist yet → no playlists
   if (response.status === 409) return [];
@@ -283,29 +246,19 @@ export async function listSavedPlaylists(
   // Handle pagination
   let cursor = result.cursor;
   let hasMore = result.has_more;
-  const continueFetch = (accessToken: string) =>
-    fetch('https://api.dropboxapi.com/2/files/list_folder/continue', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ cursor }),
-    });
 
   while (hasMore) {
-    let continueResp = await continueFetch(token);
-    if (continueResp.status === 401) {
-      const refreshed = await auth.refreshAccessToken();
-      if (!refreshed) break;
-      token = refreshed;
-      continueResp = await continueFetch(token);
-      if (continueResp.status === 401) {
-        auth.reportUnauthorized();
-        break;
-      }
-    }
-    if (!continueResp.ok) break;
+    const continueResp = await contentApiRequest(auth, (token) =>
+      fetch('https://api.dropboxapi.com/2/files/list_folder/continue', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ cursor }),
+      }),
+    );
+    if (!continueResp || !continueResp.ok) break;
     const cont: ListResult = await continueResp.json();
     collectEntries(cont.entries);
     cursor = cont.cursor;
@@ -347,33 +300,19 @@ async function loadPlaylistFile(
   auth: DropboxAuthAdapter,
   playlistPath: string,
 ): Promise<PlaylistFile | null> {
-  const token = await auth.ensureValidToken();
-  if (!token) return null;
-
   const apiArg = jsonToHttpHeader(JSON.stringify({ path: playlistPath }));
 
-  const download = (accessToken: string) =>
+  const response = await contentApiRequest(auth, (token) =>
     fetch('https://content.dropboxapi.com/2/files/download', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Dropbox-API-Arg': apiArg,
       },
-    });
+    }),
+  );
 
-  let response = await download(token);
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return null;
-    response = await download(refreshed);
-    if (response.status === 401) {
-      auth.reportUnauthorized();
-      return null;
-    }
-  }
-
-  if (!response.ok) return null;
+  if (!response || !response.ok) return null;
 
   try {
     const data: PlaylistFile = await response.json();
@@ -404,30 +343,16 @@ export async function deleteSavedPlaylist(
   auth: DropboxAuthAdapter,
   playlistPath: string,
 ): Promise<boolean> {
-  const token = await auth.ensureValidToken();
-  if (!token) return false;
-
-  const deleteFile = (accessToken: string) =>
+  const response = await contentApiRequest(auth, (token) =>
     fetch('https://api.dropboxapi.com/2/files/delete_v2', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ path: playlistPath }),
-    });
+    }),
+  );
 
-  let response = await deleteFile(token);
-
-  if (response.status === 401) {
-    const refreshed = await auth.refreshAccessToken();
-    if (!refreshed) return false;
-    response = await deleteFile(refreshed);
-    if (response.status === 401) {
-      auth.reportUnauthorized();
-      return false;
-    }
-  }
-
-  return response.ok;
+  return response?.ok ?? false;
 }

--- a/src/providers/dropbox/dropboxPreferencesSync.ts
+++ b/src/providers/dropbox/dropboxPreferencesSync.ts
@@ -6,6 +6,7 @@
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 import { getPins, setPins, UNIFIED_PROVIDER, notifyPinsChanged } from '@/services/settings/pinnedItemsStorage';
 import { ensureVorbisFolder } from './dropboxSyncFolder';
+import { contentApiRequest } from './dropboxContentApiClient';
 import { STORAGE_KEYS } from '@/constants/storage';
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -82,34 +83,19 @@ export class DropboxPreferencesSyncService {
   }
 
   async downloadPreferencesFile(): Promise<RemotePreferencesFile | null> {
-    const token = await this.auth.ensureValidToken();
-    if (!token) return null;
-
     const apiArg = JSON.stringify({ path: PREFERENCES_FILE_PATH });
 
-    let response = await fetch('https://content.dropboxapi.com/2/files/download', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Dropbox-API-Arg': apiArg,
-      },
-    });
-
-    if (response.status === 401) {
-      const refreshed = await this.auth.refreshAccessToken();
-      if (!refreshed) return null;
-      response = await fetch('https://content.dropboxapi.com/2/files/download', {
+    const response = await contentApiRequest(this.auth, (token) =>
+      fetch('https://content.dropboxapi.com/2/files/download', {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${refreshed}`,
+          Authorization: `Bearer ${token}`,
           'Dropbox-API-Arg': apiArg,
         },
-      });
-      if (response.status === 401) {
-        this.auth.reportUnauthorized();
-        return null;
-      }
-    }
+      }),
+    );
+
+    if (!response) return null;
 
     if (response.status === 409) return null; // path/not_found
 
@@ -132,9 +118,6 @@ export class DropboxPreferencesSyncService {
   }
 
   async uploadPreferencesFile(data: RemotePreferencesFile): Promise<boolean> {
-    let token = await this.auth.ensureValidToken();
-    if (!token) return false;
-
     const folderReady = await ensureVorbisFolder(this.auth);
     if (!folderReady) return false;
 
@@ -143,29 +126,21 @@ export class DropboxPreferencesSyncService {
       mode: 'overwrite',
     });
 
-    const upload = (accessToken: string) =>
+    const body = JSON.stringify(data);
+
+    const response = await contentApiRequest(this.auth, (token) =>
       fetch('https://content.dropboxapi.com/2/files/upload', {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${token}`,
           'Dropbox-API-Arg': apiArg,
           'Content-Type': 'application/octet-stream',
         },
-        body: JSON.stringify(data),
-      });
+        body,
+      }),
+    );
 
-    let response = await upload(token);
-
-    if (response.status === 401) {
-      const refreshed = await this.auth.refreshAccessToken();
-      if (!refreshed) return false;
-      token = refreshed;
-      response = await upload(token);
-      if (response.status === 401) {
-        this.auth.reportUnauthorized();
-        return false;
-      }
-    }
+    if (!response) return false;
 
     if (!response.ok) {
       const errText = await response.text();

--- a/src/providers/dropbox/dropboxSyncFolder.ts
+++ b/src/providers/dropbox/dropboxSyncFolder.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
+import { contentApiRequest } from './dropboxContentApiClient';
 
 const FOLDER_PATH = '/.vorbis';
 const RETRY_DELAY_MS = 1500;
@@ -14,32 +15,20 @@ let inflightPromise: Promise<boolean> | null = null;
 const MAX_RATE_LIMIT_RETRIES = 3;
 
 async function doEnsureFolder(auth: DropboxAuthAdapter): Promise<boolean> {
-  let token = await auth.ensureValidToken();
-  if (!token) return false;
-
-  const createFolder = (accessToken: string) =>
+  const createFolder = (token: string) =>
     fetch('https://api.dropboxapi.com/2/files/create_folder_v2', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ path: FOLDER_PATH, autorename: false }),
     });
 
   for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
-    let response = await createFolder(token);
+    const response = await contentApiRequest(auth, createFolder);
 
-    if (response.status === 401) {
-      const refreshed = await auth.refreshAccessToken();
-      if (!refreshed) return false;
-      token = refreshed;
-      response = await createFolder(token);
-      if (response.status === 401) {
-        auth.reportUnauthorized();
-        return false;
-      }
-    }
+    if (!response) return false;
 
     if (response.status === 409) return true;
 


### PR DESCRIPTION
## Summary
- Extracts a shared `contentApiRequest(auth, requestFn)` helper in `dropboxContentApiClient.ts` that encapsulates the `401 → refresh token → retry once → reportUnauthorized on second 401` pattern — all four call sites (`dropboxLikesSync`, `dropboxPreferencesSync`, `dropboxPlaylistStorage`, `dropboxSyncFolder`) migrated.
- Collapses `likesEqual` and `tombstonesEqual` in `dropboxLikesSync.ts` into one-line callers over a shared `entriesEqual<T extends { trackId }>` helper, eliminating the duplicated Map-rebuild on every comparison.
- Public method signatures of `DropboxLikesSyncService` and `DropboxPreferencesSyncService` are unchanged.

## Test plan
- [ ] `npx tsc -b --noEmit`
- [ ] `npm run test:run`

Closes #1419
Closes #1421