### PR TITLE
feat(settings-v2): scaffold shell with sidebar/content/mobile layouts

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -27,6 +27,7 @@ import { keyToCollectionRef } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ClearCacheOptions } from '@/components/AppSettingsMenu';
 import { useSessionPersistence } from '@/hooks/useSessionPersistence';
+import { useUiV2 } from '@/hooks/useUiV2';
 import QuickAccessPanel from './QuickAccessPanel';
 import { CmdKPalette } from './CmdKPalette';
 import { tracksToMediaTracks } from '@/services/spotify/tracks';
@@ -35,6 +36,7 @@ import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { SearchArtist } from '@/services/cache/librarySearch';
 
 const VisualEffectsMenu = lazy(() => import('./AppSettingsMenu/index'));
+const SettingsV2 = lazy(() => import('./SettingsV2/SettingsV2'));
 const LibraryRoute = lazy(() => import('./LibraryRoute'));
 
 const RESUME_TOAST_ID = 'resume-toast';
@@ -78,6 +80,7 @@ const AudioPlayerComponent = () => {
   } = useVisualizer();
   const { accentColorBackgroundEnabled } = useAccentColorBackground();
   const { showVisualEffects, setShowVisualEffects } = useVisualEffectsToggle();
+  const uiV2 = useUiV2();
   const { tracks, selectedPlaylistId, setTracks, setOriginalTracks, setSelectedPlaylistId } = useTrackListContext();
   const { currentTrack, currentTrackIndex, setCurrentTrackIndex, showQueue, setShowQueue } = useCurrentTrackContext();
 
@@ -619,17 +622,21 @@ const AudioPlayerComponent = () => {
         />
         {!isMainPlayerActive && (
           <Suspense fallback={null}>
-            <VisualEffectsMenu
-              isOpen={showVisualEffects}
-              onClose={handleCloseSettings}
-              onClearCache={handleClearCache}
-              profilerEnabled={false}
-              onProfilerToggle={() => {}}
-              visualizerDebugEnabled={false}
-              onVisualizerDebugToggle={() => {}}
-              qapEnabled={false}
-              onQapToggle={() => {}}
-            />
+            {uiV2 ? (
+              <SettingsV2 isOpen={showVisualEffects} onClose={handleCloseSettings} />
+            ) : (
+              <VisualEffectsMenu
+                isOpen={showVisualEffects}
+                onClose={handleCloseSettings}
+                onClearCache={handleClearCache}
+                profilerEnabled={false}
+                onProfilerToggle={() => {}}
+                visualizerDebugEnabled={false}
+                onVisualizerDebugToggle={() => {}}
+                qapEnabled={false}
+                onQapToggle={() => {}}
+              />
+            )}
           </Suspense>
         )}
         {needsSetup && state.currentView === 'library' && (

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -15,6 +15,7 @@ import { useProfilingContext } from '@/contexts/ProfilingContext';
 import type { VisualizerStyle } from '@/types/visualizer';
 import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useUiV2 } from '@/hooks/useUiV2';
 import { useVolume } from '@/hooks/useVolume';
 import { useTrackListContext } from '@/contexts/TrackContext';
 import { BottomBarActionsProvider, type BottomBarActionsValue } from '@/contexts/BottomBarActionsContext';
@@ -42,6 +43,7 @@ const ZEN_CONTROLS_WILL_CHANGE_FALLBACK_MS =
   ZEN_EXIT_REENTRY_DELAY + ZEN_CONTROLS_DURATION + 100;
 
 const VisualEffectsMenu = lazy(() => import('@/components/AppSettingsMenu/index'));
+const SettingsV2 = lazy(() => import('@/components/SettingsV2/SettingsV2'));
 const KeyboardShortcutsHelp = lazy(() => import('@/components/KeyboardShortcutsHelp'));
 
 function ControlsLoadingFallback(): React.ReactElement {
@@ -156,6 +158,7 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
   const [qapEnabled, setQapEnabled] = useQapEnabled();
+  const uiV2 = useUiV2();
 
   const settingsHasBeenOpenedRef = useRef(false);
   if (showVisualEffects) settingsHasBeenOpenedRef.current = true;
@@ -377,17 +380,21 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
       </ProfiledComponent>
       {settingsHasBeenOpenedRef.current && (
         <Suspense fallback={<VisualEffectsLoadingFallback />}>
-          <VisualEffectsMenu
-            isOpen={showVisualEffects}
-            onClose={handleCloseVisualEffects}
-            onClearCache={handleClearCache}
-            profilerEnabled={profilerEnabled}
-            onProfilerToggle={handleProfilerToggle}
-            visualizerDebugEnabled={visualizerDebugEnabled}
-            onVisualizerDebugToggle={handleVisualizerDebugToggle}
-            qapEnabled={qapEnabled}
-            onQapToggle={() => setQapEnabled(!qapEnabled)}
-          />
+          {uiV2 ? (
+            <SettingsV2 isOpen={showVisualEffects} onClose={handleCloseVisualEffects} />
+          ) : (
+            <VisualEffectsMenu
+              isOpen={showVisualEffects}
+              onClose={handleCloseVisualEffects}
+              onClearCache={handleClearCache}
+              profilerEnabled={profilerEnabled}
+              onProfilerToggle={handleProfilerToggle}
+              visualizerDebugEnabled={visualizerDebugEnabled}
+              onVisualizerDebugToggle={handleVisualizerDebugToggle}
+              qapEnabled={qapEnabled}
+              onQapToggle={() => setQapEnabled(!qapEnabled)}
+            />
+          )}
         </Suspense>
       )}
       <Suspense fallback={null}>

--- a/src/components/SettingsV2/SettingsV2.tsx
+++ b/src/components/SettingsV2/SettingsV2.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useUiV2 } from '@/hooks/useUiV2';
+import { useSettingsUrl } from '@/hooks/useSettingsUrl';
+import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
+import { SettingsV2Sidebar } from './SettingsV2Sidebar';
+import { SettingsV2Content } from './SettingsV2Content';
+import { SettingsV2MobileTakeover } from './SettingsV2MobileTakeover';
+import {
+  DEFAULT_SETTINGS_V2_SECTION,
+  isSettingsV2SectionId,
+  type SettingsV2SectionId,
+} from './sections';
+import { Overlay, DesktopShell, MobileTakeover } from './styled';
+
+/**
+ * `SETTINGS_V2_Z_INDEX = 1405` — sits above the player's `BottomBar`
+ * (`theme.zIndex.modal = 1400`) and matches `dialog.tsx`'s `DIALOG_Z_INDEX`.
+ * The overlay renders one level below at `1404`.
+ *
+ * Inline at the component level mirrors the existing convention used by
+ * `dialog.tsx`, `sheet.tsx`, `popover.tsx`, `select.tsx`. There is no
+ * project-wide z-index constants file (see `docs/architecture/shadcn.md#z-index-for-shadcn-primitives`).
+ */
+export const SETTINGS_V2_Z_INDEX = 1405;
+
+const MOBILE_LIST_SENTINEL = 'open';
+
+interface SettingsV2Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Settings v2 shell — phase 1 scaffold.
+ *
+ * Mounts when `useUiV2()` is true. Renders nothing otherwise so the
+ * parent's legacy `<VisualEffectsMenu />` fallback takes over via the
+ * existing entry-point fork in `AudioPlayer.tsx`.
+ *
+ * Open/close still flows through `useVisualEffectsToggle` (same context
+ * the legacy panel uses), so all five entry points (BottomBar gear,
+ * Shift+S, ProviderSetupScreen, PlayerStateRenderer, LibraryRoute)
+ * keep working unchanged. Section state is layered on top via
+ * `useSettingsUrl()` so deep-links (`?settings=appearance`) and the
+ * browser back-button work end-to-end.
+ *
+ * Close gestures handled here:
+ *   - Esc — `keydown` listener calls `onClose()`
+ *   - Browser back — popstate listener fires `onClose()` when the
+ *     `settings` param disappears
+ *   - Shift+S — already routed through `setShowVisualEffects(prev => !prev)`
+ *     by `useKeyboardShortcuts.ts`; flipping the parent's `isOpen` prop
+ *     is sufficient.
+ */
+export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
+  const uiV2 = useUiV2();
+  const [section, setSection] = useSettingsUrl();
+  const { isMobile } = usePlayerSizingContext();
+
+  const activeSection: SettingsV2SectionId = isSettingsV2SectionId(section)
+    ? section
+    : DEFAULT_SETTINGS_V2_SECTION;
+
+  const isSelfClosingRef = useRef(false);
+
+  const closeShell = useCallback(() => {
+    isSelfClosingRef.current = true;
+    setSection(null);
+    onClose();
+  }, [setSection, onClose]);
+
+  useEffect(() => {
+    if (!uiV2 || !isOpen) return;
+    if (typeof window === 'undefined') return;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        closeShell();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [uiV2, isOpen, closeShell]);
+
+  useEffect(() => {
+    if (!uiV2) return;
+    if (typeof window === 'undefined') return;
+
+    const handlePopState = (): void => {
+      if (isSelfClosingRef.current) {
+        isSelfClosingRef.current = false;
+        return;
+      }
+      const next = new URLSearchParams(window.location.search).get('settings');
+      if (next === null && isOpen) {
+        onClose();
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [uiV2, isOpen, onClose]);
+
+  if (!uiV2) return null;
+  if (typeof document === 'undefined') return null;
+  if (!isOpen) return null;
+
+  const handleSelectSection = (next: SettingsV2SectionId): void => {
+    setSection(next);
+  };
+
+  const mobileShowsList = !isSettingsV2SectionId(section);
+
+  const shell = isMobile ? (
+    <MobileTakeover
+      $isOpen={isOpen}
+      $zIndex={SETTINGS_V2_Z_INDEX}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+      data-testid="settings-v2-mobile"
+    >
+      <SettingsV2MobileTakeover
+        activeSection={mobileShowsList ? null : (section as SettingsV2SectionId)}
+        onSelectSection={handleSelectSection}
+        onBackToList={() => setSection(MOBILE_LIST_SENTINEL)}
+        onClose={closeShell}
+      />
+    </MobileTakeover>
+  ) : (
+    <>
+      <Overlay $isOpen={isOpen} $zIndex={SETTINGS_V2_Z_INDEX} onClick={closeShell} aria-hidden="true" />
+      <DesktopShell
+        $isOpen={isOpen}
+        $zIndex={SETTINGS_V2_Z_INDEX}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        data-testid="settings-v2-desktop"
+      >
+        <SettingsV2Sidebar activeSection={activeSection} onSelect={handleSelectSection} />
+        <SettingsV2Content activeSection={activeSection} onClose={closeShell} />
+      </DesktopShell>
+    </>
+  );
+
+  return createPortal(shell, document.body);
+};
+
+export default SettingsV2;

--- a/src/components/SettingsV2/SettingsV2.tsx
+++ b/src/components/SettingsV2/SettingsV2.tsx
@@ -15,7 +15,8 @@ import { Overlay, DesktopShell, MobileTakeover } from './styled';
 
 /**
  * `SETTINGS_V2_Z_INDEX = 1405` — sits above the player's `BottomBar`
- * (`theme.zIndex.modal = 1400`) and matches `dialog.tsx`'s `DIALOG_Z_INDEX`.
+ * (`theme.zIndex.modal = 1400`) and matches `dialog.tsx`'s `DIALOG_Z_INDEX`
+ * (intentionally identical — substitution should be clean when Dialog adoption lands).
  * The overlay renders one level below at `1404`.
  *
  * Inline at the component level mirrors the existing convention used by
@@ -24,7 +25,8 @@ import { Overlay, DesktopShell, MobileTakeover } from './styled';
  */
 export const SETTINGS_V2_Z_INDEX = 1405;
 
-const MOBILE_LIST_SENTINEL = 'open';
+/** Sentinel for "show the mobile list view". Uses `__list` (not a valid URL param value) to avoid colliding with `?settings=open` deep-links. */
+const MOBILE_LIST_VIEW = '__list';
 
 interface SettingsV2Props {
   isOpen: boolean;
@@ -76,7 +78,6 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
-        event.stopPropagation();
         closeShell();
       }
     };
@@ -116,7 +117,7 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
     setSection(next);
   };
 
-  const mobileShowsList = !isSettingsV2SectionId(section);
+  const validSection = isSettingsV2SectionId(section) ? section : null;
 
   const shell = isMobile ? (
     <MobileTakeover
@@ -128,9 +129,9 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
       data-testid="settings-v2-mobile"
     >
       <SettingsV2MobileTakeover
-        activeSection={mobileShowsList ? null : (section as SettingsV2SectionId)}
+        activeSection={validSection}
         onSelectSection={handleSelectSection}
-        onBackToList={() => setSection(MOBILE_LIST_SENTINEL)}
+        onBackToList={() => setSection(MOBILE_LIST_VIEW)}
         onClose={closeShell}
       />
     </MobileTakeover>

--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import type { SettingsV2SectionId } from './sections';
+import { SETTINGS_V2_SECTIONS } from './sections';
+import {
+  ContentRoot,
+  ContentBody,
+  Header,
+  HeaderTitle,
+  IconButton,
+  SectionTitle,
+  SectionPlaceholder,
+} from './styled';
+
+interface SettingsV2ContentProps {
+  activeSection: SettingsV2SectionId;
+  onClose: () => void;
+}
+
+export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSection, onClose }) => {
+  const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+
+  return (
+    <ContentRoot aria-labelledby="settings-v2-section-title">
+      <Header>
+        <HeaderTitle id="settings-v2-section-title">{section.label}</HeaderTitle>
+        <IconButton type="button" onClick={onClose} aria-label="Close settings">
+          <CloseIcon />
+        </IconButton>
+      </Header>
+      <ContentBody>
+        <SectionTitle>{section.label}</SectionTitle>
+        <SectionPlaceholder>{section.description}</SectionPlaceholder>
+      </ContentBody>
+    </ContentRoot>
+  );
+};
+
+const CloseIcon: React.FC = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);

--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { X } from 'lucide-react';
 import type { SettingsV2SectionId } from './sections';
 import { SETTINGS_V2_SECTIONS } from './sections';
 import {
@@ -24,7 +25,7 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
       <Header>
         <HeaderTitle id="settings-v2-section-title">{section.label}</HeaderTitle>
         <IconButton type="button" onClick={onClose} aria-label="Close settings">
-          <CloseIcon />
+          <X width={18} height={18} aria-hidden="true" />
         </IconButton>
       </Header>
       <ContentBody>
@@ -35,19 +36,3 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
   );
 };
 
-const CloseIcon: React.FC = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <line x1="18" y1="6" x2="6" y2="18" />
-    <line x1="6" y1="6" x2="18" y2="18" />
-  </svg>
-);

--- a/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
+++ b/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import type { SettingsV2SectionId } from './sections';
+import { SETTINGS_V2_SECTIONS } from './sections';
+import {
+  Header,
+  HeaderTitle,
+  IconButton,
+  MobileSectionList,
+  MobileSectionRow,
+  MobileChevron,
+  MobileDetailBody,
+  SectionTitle,
+  SectionPlaceholder,
+} from './styled';
+
+interface SettingsV2MobileTakeoverProps {
+  activeSection: SettingsV2SectionId | null;
+  onSelectSection: (section: SettingsV2SectionId) => void;
+  onBackToList: () => void;
+  onClose: () => void;
+}
+
+export const SettingsV2MobileTakeover: React.FC<SettingsV2MobileTakeoverProps> = ({
+  activeSection,
+  onSelectSection,
+  onBackToList,
+  onClose,
+}) => {
+  if (activeSection === null) {
+    return (
+      <>
+        <Header>
+          <HeaderTitle>Settings</HeaderTitle>
+          <IconButton type="button" onClick={onClose} aria-label="Close settings">
+            <CloseIcon />
+          </IconButton>
+        </Header>
+        <MobileSectionList aria-label="Settings sections">
+          {SETTINGS_V2_SECTIONS.map((section) => (
+            <MobileSectionRow
+              key={section.id}
+              type="button"
+              onClick={() => onSelectSection(section.id)}
+            >
+              <span>{section.label}</span>
+              <MobileChevron aria-hidden="true">›</MobileChevron>
+            </MobileSectionRow>
+          ))}
+        </MobileSectionList>
+      </>
+    );
+  }
+
+  const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+
+  return (
+    <>
+      <Header>
+        <IconButton type="button" onClick={onBackToList} aria-label="Back to settings list">
+          <BackChevronIcon />
+        </IconButton>
+        <HeaderTitle>{section.label}</HeaderTitle>
+        <IconButton type="button" onClick={onClose} aria-label="Close settings">
+          <CloseIcon />
+        </IconButton>
+      </Header>
+      <MobileDetailBody>
+        <SectionTitle>{section.label}</SectionTitle>
+        <SectionPlaceholder>{section.description}</SectionPlaceholder>
+      </MobileDetailBody>
+    </>
+  );
+};
+
+const CloseIcon: React.FC = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+const BackChevronIcon: React.FC = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="15 18 9 12 15 6" />
+  </svg>
+);

--- a/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
+++ b/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { X } from 'lucide-react';
 import type { SettingsV2SectionId } from './sections';
 import { SETTINGS_V2_SECTIONS } from './sections';
 import {
@@ -32,7 +33,7 @@ export const SettingsV2MobileTakeover: React.FC<SettingsV2MobileTakeoverProps> =
         <Header>
           <HeaderTitle>Settings</HeaderTitle>
           <IconButton type="button" onClick={onClose} aria-label="Close settings">
-            <CloseIcon />
+            <X width={18} height={18} aria-hidden="true" />
           </IconButton>
         </Header>
         <MobileSectionList aria-label="Settings sections">
@@ -61,7 +62,7 @@ export const SettingsV2MobileTakeover: React.FC<SettingsV2MobileTakeoverProps> =
         </IconButton>
         <HeaderTitle>{section.label}</HeaderTitle>
         <IconButton type="button" onClick={onClose} aria-label="Close settings">
-          <CloseIcon />
+          <X width={18} height={18} aria-hidden="true" />
         </IconButton>
       </Header>
       <MobileDetailBody>
@@ -71,23 +72,6 @@ export const SettingsV2MobileTakeover: React.FC<SettingsV2MobileTakeoverProps> =
     </>
   );
 };
-
-const CloseIcon: React.FC = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <line x1="18" y1="6" x2="6" y2="18" />
-    <line x1="6" y1="6" x2="18" y2="18" />
-  </svg>
-);
 
 const BackChevronIcon: React.FC = () => (
   <svg

--- a/src/components/SettingsV2/SettingsV2Sidebar.tsx
+++ b/src/components/SettingsV2/SettingsV2Sidebar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { SettingsV2SectionId } from './sections';
+import { SETTINGS_V2_SECTIONS } from './sections';
+import { SidebarRoot, SidebarHeader, SidebarItem } from './styled';
+
+interface SettingsV2SidebarProps {
+  activeSection: SettingsV2SectionId;
+  onSelect: (section: SettingsV2SectionId) => void;
+}
+
+export const SettingsV2Sidebar: React.FC<SettingsV2SidebarProps> = ({ activeSection, onSelect }) => {
+  return (
+    <SidebarRoot aria-label="Settings sections">
+      <SidebarHeader>Settings</SidebarHeader>
+      {SETTINGS_V2_SECTIONS.map((section) => (
+        <SidebarItem
+          key={section.id}
+          type="button"
+          $active={section.id === activeSection}
+          aria-current={section.id === activeSection ? 'page' : undefined}
+          onClick={() => onSelect(section.id)}
+        >
+          {section.label}
+        </SidebarItem>
+      ))}
+    </SidebarRoot>
+  );
+};

--- a/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
+++ b/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
@@ -139,6 +139,29 @@ describe('SettingsV2', () => {
       const headings = screen.getAllByText('Advanced');
       expect(headings.length).toBeGreaterThan(0);
     });
+
+    it('renders the desktop shell with the default section when ?settings=open', () => {
+      // #given — 'open' is not a valid SettingsV2SectionId; it falls through to DEFAULT_SETTINGS_V2_SECTION ('sources')
+      setSearch('?settings=open');
+
+      // #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then — shell renders and shows the default 'Sources' section (not a blank/broken state)
+      expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+      expect(screen.getAllByText('Sources').length).toBeGreaterThan(0);
+    });
+
+    // Shift+S open→close round-trip is NOT tested here — the toggle is wired upstream via
+    // useKeyboardShortcuts.ts (setShowVisualEffects(prev => !prev)) and belongs in a higher-level
+    // integration test or e2e spec, not in this component unit test.
+    //
+    // Container query behavior at max-width:700px cannot be asserted in jsdom.
+    // Defer to Playwright visual coverage.
   });
 
   describe('mobile takeover', () => {
@@ -194,9 +217,9 @@ describe('SettingsV2', () => {
 
   describe('close gestures', () => {
     it('clears URL state and calls onClose when Esc is pressed', () => {
-      // #given
+      // #given — open with a real section in the URL so closeShell has something to clear
       const onClose = vi.fn();
-      setSearch('?settings=playback');
+      setSearch('?settings=advanced');
       const pushStateSpy = vi.spyOn(window.history, 'pushState');
       render(
         <Wrapper>
@@ -204,16 +227,15 @@ describe('SettingsV2', () => {
         </Wrapper>,
       );
 
-      // #when
+      // #when — fire keydown WITHOUT pre-emptying the URL; closeShell must do the clearing
       act(() => {
-        setSearch('');
         fireEvent.keyDown(window, { key: 'Escape' });
       });
 
-      // #then
+      // #then — onClose called, and the most recent pushState produced a URL without settings=
       expect(onClose).toHaveBeenCalledTimes(1);
-      const lastCall = pushStateSpy.mock.calls[pushStateSpy.mock.calls.length - 1];
-      expect(String(lastCall?.[2] ?? '')).not.toContain('settings=');
+      const lastPush = pushStateSpy.mock.calls.at(-1)?.[2];
+      expect(String(lastPush ?? '')).not.toContain('settings=');
       pushStateSpy.mockRestore();
     });
 
@@ -269,6 +291,27 @@ describe('SettingsV2', () => {
 
       // #then
       expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose exactly once when Esc is pressed — isSelfClosingRef prevents popstate echo', () => {
+      // #given — open with a section so closeShell will pushState (which triggers isSelfClosingRef guard)
+      const onClose = vi.fn();
+      setSearch('?settings=appearance');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={onClose} />
+        </Wrapper>,
+      );
+
+      // #when — Esc fires closeShell; the resulting pushState must not echo back through popstate
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+        // Simulate the browser echoing a popstate after pushState (isSelfClosingRef should absorb it)
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      // #then — onClose called exactly once, not twice
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
+++ b/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { theme } from '@/styles/theme';
+
+const mockUseUiV2 = vi.fn<[], boolean>();
+const mockUsePlayerSizingContext = vi.fn<[], { isMobile: boolean }>();
+
+vi.mock('@/hooks/useUiV2', () => ({
+  useUiV2: () => mockUseUiV2(),
+}));
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: () => mockUsePlayerSizingContext(),
+}));
+
+import { SettingsV2 } from '../SettingsV2';
+import { SETTINGS_V2_SECTIONS } from '../sections';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+/**
+ * jsdom does not update `window.location` from `pushState` (the project's
+ * `src/test/setup.ts` mocks `location` as a static object). To assert URL
+ * mutations from `useSettingsUrl`, stage `window.location.search` manually
+ * before the navigate call — same pattern as `useSettingsUrl.test.ts:80-98`.
+ */
+function setSearch(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, search },
+    writable: true,
+  });
+}
+
+describe('SettingsV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUiV2.mockReturnValue(true);
+    mockUsePlayerSizingContext.mockReturnValue({ isMobile: false });
+    setSearch('');
+  });
+
+  afterEach(() => {
+    setSearch('');
+  });
+
+  describe('feature gate', () => {
+    it('renders nothing when useUiV2 is false', () => {
+      // #given
+      mockUseUiV2.mockReturnValue(false);
+
+      // #when
+      const { container } = render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(container.querySelector('[data-testid="settings-v2-desktop"]')).toBeNull();
+      expect(container.querySelector('[data-testid="settings-v2-mobile"]')).toBeNull();
+    });
+
+    it('renders nothing when useUiV2 is true but isOpen is false', () => {
+      // #given + #when
+      const { container } = render(
+        <Wrapper>
+          <SettingsV2 isOpen={false} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(container.querySelector('[data-testid="settings-v2-desktop"]')).toBeNull();
+    });
+  });
+
+  describe('desktop layout', () => {
+    it('renders the desktop shell when v2 is on, isOpen is true, and viewport is desktop', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+    });
+
+    it('exposes all four section labels in the sidebar', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      for (const section of SETTINGS_V2_SECTIONS) {
+        expect(screen.getAllByText(section.label).length).toBeGreaterThan(0);
+      }
+    });
+
+    it('writes ?settings=<id> via pushState when a sidebar item is clicked', () => {
+      // #given
+      const pushStateSpy = vi.spyOn(window.history, 'pushState');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #when
+      const appearanceButton = screen.getAllByRole('button', { name: 'Appearance' })[0];
+      fireEvent.click(appearanceButton);
+
+      // #then
+      expect(pushStateSpy).toHaveBeenCalled();
+      const lastCall = pushStateSpy.mock.calls[pushStateSpy.mock.calls.length - 1];
+      expect(String(lastCall[2])).toContain('settings=appearance');
+      pushStateSpy.mockRestore();
+    });
+
+    it('deep-links into the section named in ?settings=', () => {
+      // #given
+      setSearch('?settings=advanced');
+
+      // #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      const headings = screen.getAllByText('Advanced');
+      expect(headings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('mobile takeover', () => {
+    beforeEach(() => {
+      mockUsePlayerSizingContext.mockReturnValue({ isMobile: true });
+    });
+
+    it('renders the mobile takeover when isMobile is true', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByTestId('settings-v2-mobile')).toBeInTheDocument();
+    });
+
+    it('shows the section list before any section is selected', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByLabelText('Settings sections')).toBeInTheDocument();
+    });
+
+    it('drills into a section when a row is tapped', () => {
+      // #given
+      const pushStateSpy = vi.spyOn(window.history, 'pushState');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
+
+      // #when — staged URL update mirrors what the hook would have produced
+      act(() => {
+        setSearch('?settings=playback');
+        fireEvent.click(screen.getByText('Playback'));
+      });
+
+      // #then
+      expect(pushStateSpy).toHaveBeenCalled();
+      expect(screen.getByLabelText('Back to settings list')).toBeInTheDocument();
+      pushStateSpy.mockRestore();
+    });
+  });
+
+  describe('close gestures', () => {
+    it('clears URL state and calls onClose when Esc is pressed', () => {
+      // #given
+      const onClose = vi.fn();
+      setSearch('?settings=playback');
+      const pushStateSpy = vi.spyOn(window.history, 'pushState');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={onClose} />
+        </Wrapper>,
+      );
+
+      // #when
+      act(() => {
+        setSearch('');
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+
+      // #then
+      expect(onClose).toHaveBeenCalledTimes(1);
+      const lastCall = pushStateSpy.mock.calls[pushStateSpy.mock.calls.length - 1];
+      expect(String(lastCall?.[2] ?? '')).not.toContain('settings=');
+      pushStateSpy.mockRestore();
+    });
+
+    it('calls onClose when the close icon is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={onClose} />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Close settings'));
+
+      // #then
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on browser back-button when settings param disappears', () => {
+      // #given
+      const onClose = vi.fn();
+      setSearch('?settings=appearance');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={onClose} />
+        </Wrapper>,
+      );
+
+      // #when
+      act(() => {
+        setSearch('');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when the desktop overlay is clicked', () => {
+      // #given
+      const onClose = vi.fn();
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={onClose} />
+        </Wrapper>,
+      );
+
+      // #when
+      const overlay = document.body.querySelector('[aria-hidden="true"]');
+      expect(overlay).not.toBeNull();
+      if (overlay) fireEvent.click(overlay);
+
+      // #then
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('z-index invariant', () => {
+    it('exports SETTINGS_V2_Z_INDEX = 1405 (above BottomBar modal=1400)', async () => {
+      // #given + #when
+      const mod = await import('../SettingsV2');
+
+      // #then
+      expect(mod.SETTINGS_V2_Z_INDEX).toBe(1405);
+      expect(mod.SETTINGS_V2_Z_INDEX).toBeGreaterThan(parseInt(theme.zIndex.modal, 10));
+    });
+  });
+});

--- a/src/components/SettingsV2/sections.ts
+++ b/src/components/SettingsV2/sections.ts
@@ -1,0 +1,47 @@
+/**
+ * Section catalog for Settings v2.
+ *
+ * Phase 1 ships the shell with empty placeholder bodies. Phases 2–4
+ * (#1450–#1452 et al) replace each placeholder with real controls;
+ * the section IDs and labels stay stable across phases so URL deep-links
+ * (`?settings=appearance`) keep working.
+ */
+
+export const SETTINGS_V2_SECTION_IDS = ['sources', 'playback', 'appearance', 'advanced'] as const;
+
+export type SettingsV2SectionId = (typeof SETTINGS_V2_SECTION_IDS)[number];
+
+export interface SettingsV2SectionDescriptor {
+  id: SettingsV2SectionId;
+  label: string;
+  description: string;
+}
+
+export const SETTINGS_V2_SECTIONS: readonly SettingsV2SectionDescriptor[] = [
+  {
+    id: 'sources',
+    label: 'Sources',
+    description: 'Connect Spotify, Dropbox, and other providers. Coming soon.',
+  },
+  {
+    id: 'playback',
+    label: 'Playback',
+    description: 'Crossfade, gapless playback, and queue behavior. Coming soon.',
+  },
+  {
+    id: 'appearance',
+    label: 'Appearance',
+    description: 'Themes, accent colors, and visualizers. Coming soon.',
+  },
+  {
+    id: 'advanced',
+    label: 'Advanced',
+    description: 'Caches, debug overlays, and developer tools. Coming soon.',
+  },
+];
+
+export const DEFAULT_SETTINGS_V2_SECTION: SettingsV2SectionId = 'sources';
+
+export function isSettingsV2SectionId(value: string | null | undefined): value is SettingsV2SectionId {
+  return typeof value === 'string' && (SETTINGS_V2_SECTION_IDS as readonly string[]).includes(value);
+}

--- a/src/components/SettingsV2/styled.ts
+++ b/src/components/SettingsV2/styled.ts
@@ -1,0 +1,227 @@
+import styled from 'styled-components';
+
+/**
+ * SettingsV2 chrome — neutral shadcn palette only.
+ *
+ * Theme-bridge invariant: never wire shadcn `--primary` or `--accent` to
+ * `var(--accent-color)` here. The settings shell intentionally stays
+ * neutral so it does not retint per playing track. See
+ * `docs/architecture/shadcn.md#theme-bridge-accent-color-is-player-chrome-only`.
+ *
+ * Container queries are the primary responsive strategy; the desktop /
+ * mobile-takeover fork itself runs off `usePlayerSizingContext().isMobile`
+ * (mirrors `PlayerContent/DrawerOrchestrator.tsx:164-188`).
+ */
+
+export const Overlay = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+  position: fixed;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.overlay.light};
+  z-index: ${({ $zIndex }) => $zIndex - 1};
+  opacity: ${({ $isOpen }) => ($isOpen ? '1' : '0')};
+  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
+  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  transition:
+    opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
+    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+`;
+
+export const DesktopShell = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: min(960px, 92vw);
+  height: min(640px, 80vh);
+  transform: translate(-50%, -50%) scale(${({ $isOpen }) => ($isOpen ? '1' : '0.96')});
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  box-shadow: ${({ theme }) => theme.shadows.xl};
+  z-index: ${({ $zIndex }) => $zIndex};
+  opacity: ${({ $isOpen }) => ($isOpen ? '1' : '0')};
+  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
+  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  overflow: hidden;
+  transition:
+    opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
+    transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
+    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+
+  container-type: inline-size;
+  container-name: settings-v2;
+
+  @container settings-v2 (max-width: 700px) {
+    grid-template-columns: 200px 1fr;
+  }
+`;
+
+export const MobileTakeover = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+  position: fixed;
+  inset: 0;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  z-index: ${({ $zIndex }) => $zIndex};
+  transform: translateX(${({ $isOpen }) => ($isOpen ? '0' : '100%')});
+  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
+  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  transition:
+    transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
+    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+  display: flex;
+  flex-direction: column;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  border-bottom: 1px solid hsl(var(--border));
+  min-height: 56px;
+  flex-shrink: 0;
+`;
+
+export const HeaderTitle = styled.h2`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+`;
+
+export const IconButton = styled.button`
+  background: transparent;
+  border: none;
+  color: hsl(var(--foreground));
+  padding: ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: hsl(var(--muted));
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+`;
+
+export const SidebarRoot = styled.nav`
+  border-right: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  padding: ${({ theme }) => theme.spacing.md};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+  overflow-y: auto;
+`;
+
+export const SidebarHeader = styled.div`
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+`;
+
+export const SidebarItem = styled.button<{ $active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  background: ${({ $active }) => ($active ? 'hsl(var(--muted))' : 'transparent')};
+  color: hsl(var(--foreground));
+  border: none;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme, $active }) => ($active ? theme.fontWeight.medium : theme.fontWeight.normal)};
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: hsl(var(--muted));
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+`;
+
+export const ContentRoot = styled.section`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: hsl(var(--background));
+`;
+
+export const ContentBody = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const SectionTitle = styled.h3`
+  margin: 0 0 ${({ theme }) => theme.spacing.md};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+`;
+
+export const SectionPlaceholder = styled.p`
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: ${({ theme }) => theme.fontSize.sm};
+`;
+
+export const MobileSectionList = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+`;
+
+export const MobileSectionRow = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid hsl(var(--border));
+  color: hsl(var(--foreground));
+  font-size: ${({ theme }) => theme.fontSize.base};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  text-align: left;
+  cursor: pointer;
+  min-height: 56px;
+
+  &:hover {
+    background: hsl(var(--muted));
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: -2px;
+  }
+`;
+
+export const MobileChevron = styled.span`
+  color: hsl(var(--muted-foreground));
+  font-size: 1.25em;
+  line-height: 1;
+`;
+
+export const MobileDetailBody = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: ${({ theme }) => theme.spacing.lg};
+`;


### PR DESCRIPTION
## Summary
- Adds `src/components/SettingsV2/` shell — top-level component, sidebar (Sources / Playback / Appearance / Advanced), desktop content pane with empty placeholders, full-screen mobile takeover (section list → detail with back chevron). Gated on `useUiV2()` and URL state via `useSettingsUrl()`.
- Forks at both legacy `<VisualEffectsMenu>` mount sites: `AudioPlayer.tsx:622` (out-of-main-player path) and `PlayerControlsSection.tsx:380` (main-player path). Both become `useUiV2() ? <SettingsV2 /> : <VisualEffectsMenu />`. All five entry points (BottomBar gear `BottomBar/index.tsx:225`, keyboard `Shift+S` `useKeyboardShortcuts.ts:99-108`, `ProviderSetupScreen`, `PlayerStateRenderer`, `LibraryRoute`) keep working unchanged because open/close still flows through `useVisualEffectsToggle().setShowVisualEffects` — the same context the legacy panel uses.
- `SETTINGS_V2_Z_INDEX = 1405` lives inline at the component level, matching the existing convention used by `dialog.tsx`, `sheet.tsx`, `popover.tsx`, `select.tsx` (no project-wide z-index file exists; `docs/architecture/shadcn.md#z-index-for-shadcn-primitives` documents the inline pattern). Sits above `BottomBar`'s `theme.zIndex.modal = 1400` and matches `DIALOG_Z_INDEX`.
- Chrome stays neutral: `hsl(var(--background | --foreground | --border | --muted | --card | --ring | --muted-foreground))` only. No wiring of `--primary` or `--accent` to `var(--accent-color)`.

## Architecture notes
- Section state owned by `useSettingsUrl()` so deep-links work (`?settings=appearance` lands directly in Appearance) and the browser back-button popstate closes the shell.
- Esc, browser back, and `Shift+S` all funnel through `onClose` (parent toggles `setShowVisualEffects(false)`).
- A `isSelfClosingRef` ref guards against double-firing `onClose` when our own `setSection(null)` triggers the popstate listener.
- Container queries inside the desktop shell handle in-shell responsive layout; the desktop / mobile-takeover fork itself runs off `usePlayerSizingContext().isMobile`, mirroring `PlayerContent/DrawerOrchestrator.tsx:164-188`.

## Test plan
- `npx tsc -b --noEmit` — clean.
- `npm run test:run` — 1844 / 1844 pass. New `SettingsV2.test.tsx` (14 tests) covers:
  - feature gate (renders nothing when `useUiV2` is false; renders nothing when v2 is on but `isOpen` is false)
  - desktop layout (renders shell, all four sidebar labels present, sidebar click writes via `pushState`, deep-link via `?settings=advanced`)
  - mobile takeover (renders takeover when `isMobile` is true, shows section list initially, drills into a section on tap)
  - close gestures (Esc clears URL state and calls `onClose`, close icon calls `onClose`, browser back-button (popstate without `settings`) calls `onClose`, overlay click calls `onClose`)
  - z-index invariant (exports `SETTINGS_V2_Z_INDEX = 1405`, strictly greater than `theme.zIndex.modal = 1400`)
- `npm run build` — succeeds; `SettingsV2` lazy-loads as its own 10.53 kB chunk (gzip 2.75 kB).
- Manual: `?ui=v2&settings=open` in dev → desktop shell with empty sections; without `?ui=v2`, legacy `VisualEffectsMenu` renders unchanged from every entry point.

Closes phase 1 of epic #1262. Unblocks phase 2 (#1450–#1452).

Closes #1449