### PR TITLE
Add structured error handling to context menu actions

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -216,7 +216,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     };
 
     if (isAlbumKind && canToggleSaved && isSaved !== null) {
-      actions.onToggleSave = closeAfter('Unlike', toggleSaved);
+      actions.onToggleSave = closeAfter(isSaved ? 'Unlike' : 'Like', toggleSaved);
     }
 
     if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -12,6 +12,7 @@ import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
 import { toAlbumPlaylistId } from '@/constants/playlist';
 import {
   buildMenuItems,
+  isMenuActionError,
   type MenuActions,
   type MenuItem,
 } from './menuItemsForKind';
@@ -93,11 +94,22 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
   );
 
   const closeAfter = useCallback(
-    (fn: () => void | Promise<unknown>): (() => void) =>
+    (label: string, fn: () => void | Promise<unknown>): (() => void) =>
       () => {
         onReturnFocusClose();
-        Promise.resolve(fn()).catch(() => {
-          toast("Couldn't complete that action. Try again.");
+        Promise.resolve(fn()).catch((err: unknown) => {
+          const actionLabel = isMenuActionError(err) ? err.label : label;
+          const cause = isMenuActionError(err) ? err.cause : err;
+          const causeMessage =
+            cause instanceof Error
+              ? cause.message
+              : typeof cause === 'string'
+                ? cause
+                : null;
+          const message = causeMessage
+            ? `Couldn't ${actionLabel.toLowerCase()}: ${causeMessage}. Try again.`
+            : `Couldn't ${actionLabel.toLowerCase()}. Try again.`;
+          toast(message);
         });
       },
     [onReturnFocusClose],
@@ -157,15 +169,18 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     };
 
     const likedProviderActions = isLikedKind
-      ? perProvider.map((entry) => ({
-          provider: entry.provider,
-          label: `Play (${providerLabel(entry.provider)})`,
-          onPlay: closeAfter(() => playLikedFor(entry.provider)),
-        }))
+      ? perProvider.map((entry) => {
+          const entryLabel = `Play (${providerLabel(entry.provider)})`;
+          return {
+            provider: entry.provider,
+            label: entryLabel,
+            onPlay: closeAfter(entryLabel, () => playLikedFor(entry.provider)),
+          };
+        })
       : undefined;
 
     const actions: MenuActions = {
-      onPlay: closeAfter(() => {
+      onPlay: closeAfter('Play', () => {
         if (isLikedKind) {
           // "Play All" routes through the library's own liked-handler via the parent.
           const inferred = perProvider[0]?.provider;
@@ -176,20 +191,20 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
           onPlayCollection(effectiveKind, request.id, request.name, request.provider);
         }
       }),
-      onAddToQueue: closeAfter(() => {
+      onAddToQueue: closeAfter('Add to Queue', () => {
         if (onAddToQueue) {
           const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
           onAddToQueue(id, request.name, request.provider);
         }
       }),
-      onPlayNext: closeAfter(() => {
+      onPlayNext: closeAfter('Play Next', () => {
         if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
           const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
           onPlayNext(effectiveKind, id, request.name, request.provider);
         }
       }),
-      onTogglePin: closeAfter(togglePin),
-      onStartRadio: closeAfter(() => {
+      onTogglePin: closeAfter(isPinned ? 'Unpin' : 'Pin', togglePin),
+      onStartRadio: closeAfter('Start Radio', () => {
         if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
           onStartRadioForCollection(effectiveKind, request.id, request.provider);
         }
@@ -201,21 +216,21 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     };
 
     if (isAlbumKind && canToggleSaved && isSaved !== null) {
-      actions.onToggleSave = closeAfter(toggleSaved);
+      actions.onToggleSave = closeAfter('Unlike', toggleSaved);
     }
 
     if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
       const collectionId = request.id;
       const collectionName = request.name;
       const provider = request.provider;
-      actions.onQueueLikedFromCollection = closeAfter(() =>
+      actions.onQueueLikedFromCollection = closeAfter('Queue Liked Songs', () =>
         queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
       );
     }
 
     if (request.kind === 'recently-played' && request.recentRef) {
       const recentRef = request.recentRef;
-      actions.onRemoveFromHistory = closeAfter(() => removeRecent(recentRef));
+      actions.onRemoveFromHistory = closeAfter('Remove from history', () => removeRecent(recentRef));
     }
 
     return buildMenuItems(request, actions);

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
@@ -9,15 +9,20 @@
  *  - Remove-from-history with recentRef.kind='album' calls remove with album shape
  *  - Remove-from-history with recentRef.kind='liked' calls remove with liked shape
  *  - When no recentRef on a recently-played request, no Remove item is rendered
+ *  - closeAfter error handling: label + cause surfaced in toast
  */
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import type { ContextMenuRequest } from '../../types';
 import type { ProviderId } from '@/types/domain';
+import { createMenuActionError } from '../menuItemsForKind';
+
+const mockToast = vi.fn();
+vi.mock('sonner', () => ({ toast: (...args: unknown[]) => mockToast(...args) }));
 
 const { mockPinned, mockLikedSection, mockRecent, mockLoadLiked } = vi.hoisted(() => ({
   mockPinned: vi.fn(),
@@ -240,6 +245,81 @@ describe('LibraryContextMenu edges', () => {
       // #then
       expect(onReturnFocusClose).toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closeAfter structured error handling', () => {
+    // Tests use the liked-provider play path because playLikedFor is async and
+    // properly propagates loadLikedTracks rejections through closeAfter's .catch.
+    beforeEach(() => {
+      mockToast.mockClear();
+      mockLikedSection.mockReturnValue({
+        perProvider: [{ provider: 'spotify' as ProviderId, count: 10 }],
+      });
+    });
+
+    it('shows label + Error.message in toast when the action rejects with a plain Error', async () => {
+      // #given
+      mockLoadLiked.mockRejectedValue(new Error('network timeout'));
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }) });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('menu-play-liked-spotify'));
+      });
+
+      // #then — label is the per-provider entry label "Play (Spotify)"
+      expect(mockToast).toHaveBeenCalledWith(
+        "Couldn't play (spotify): network timeout. Try again.",
+      );
+    });
+
+    it('shows label without cause detail when the rejection is a non-Error non-string', async () => {
+      // #given
+      mockLoadLiked.mockRejectedValue({ code: 42 });
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }) });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('menu-play-liked-spotify'));
+      });
+
+      // #then
+      expect(mockToast).toHaveBeenCalledWith("Couldn't play (spotify). Try again.");
+    });
+
+    it('uses MenuActionError label and cause when the action throws createMenuActionError', async () => {
+      // #given — loadLikedTracks itself throws a structured error with a custom label
+      mockLoadLiked.mockRejectedValue(
+        createMenuActionError('Load Liked Tracks', new Error('quota exceeded')),
+      );
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }) });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('menu-play-liked-spotify'));
+      });
+
+      // #then — MenuActionError overrides both label and cause
+      expect(mockToast).toHaveBeenCalledWith(
+        "Couldn't load liked tracks: quota exceeded. Try again.",
+      );
+    });
+
+    it('surfaces a string rejection as the cause message in the toast', async () => {
+      // #given
+      mockLoadLiked.mockRejectedValue('service unavailable');
+
+      // #when
+      renderMenu({ request: makeRequest({ kind: 'liked', id: 'liked', provider: undefined }) });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('menu-play-liked-spotify'));
+      });
+
+      // #then
+      expect(mockToast).toHaveBeenCalledWith(
+        "Couldn't play (spotify): service unavailable. Try again.",
+      );
     });
   });
 });

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -1,6 +1,24 @@
 import type { ProviderId } from '@/types/domain';
 import type { ContextMenuRequest } from '../types';
 
+export interface MenuActionError {
+  readonly type: 'menu-action-error';
+  readonly label: string;
+  readonly cause: unknown;
+}
+
+export function isMenuActionError(err: unknown): err is MenuActionError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as Record<string, unknown>)['type'] === 'menu-action-error'
+  );
+}
+
+export function createMenuActionError(label: string, cause: unknown): MenuActionError {
+  return { type: 'menu-action-error', label, cause };
+}
+
 export interface MenuItem {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary
Improved error handling in the library context menu by adding structured error messages that surface both action labels and error causes to users via toast notifications.

## Key Changes
- **Structured Error Type**: Introduced `MenuActionError` interface with `createMenuActionError()` factory and `isMenuActionError()` type guard to allow actions to throw errors with custom labels and causes
- **Enhanced `closeAfter` Callback**: Modified to accept an action label parameter and extract error details from rejections:
  - Extracts `MenuActionError` label/cause when available
  - Falls back to provided label and raw error for standard errors
  - Handles Error objects, strings, and other rejection types gracefully
  - Constructs user-friendly messages: `"Couldn't {action}: {cause}. Try again."` or `"Couldn't {action}. Try again."`
- **Action Label Propagation**: Updated all menu action handlers to pass descriptive labels to `closeAfter()` (e.g., "Play", "Add to Queue", "Pin", "Unlike")
- **Per-Provider Actions**: Extracted entry labels for liked-provider actions to enable proper error messaging with provider context (e.g., "Play (Spotify)")
- **Toast Integration**: Mocked `sonner` toast in tests to verify error messages are properly formatted and displayed

## Implementation Details
- Error cause extraction prioritizes `MenuActionError.cause` over raw rejection value
- Message formatting handles three cause types: Error (uses `.message`), string (uses directly), and other (omits cause detail)
- All async action handlers now have appropriate labels for better user feedback on failures

https://claude.ai/code/session_01KFusE1jCdwBRzDrVVitgGo