### PR TITLE
refactor(settings-v2): adopt shadcn Dialog primitive for shell

### DIFF
--- a/src/components/SettingsV2/SettingsV2.tsx
+++ b/src/components/SettingsV2/SettingsV2.tsx
@@ -119,7 +119,7 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
           </DialogPrimitive.Content>
         ) : (
           <>
-            <DialogOverlay asChild>
+            <DialogOverlay asChild style={{ zIndex: 1404 }}>
               <Overlay aria-hidden="true" />
             </DialogOverlay>
             <DialogPrimitive.Content asChild aria-label="Settings" aria-describedby={undefined}>

--- a/src/components/SettingsV2/SettingsV2.tsx
+++ b/src/components/SettingsV2/SettingsV2.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { Dialog, DialogPortal, DialogOverlay } from '@/components/ui/dialog';
 import { useUiV2 } from '@/hooks/useUiV2';
 import { useSettingsUrl } from '@/hooks/useSettingsUrl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
@@ -12,18 +13,6 @@ import {
   type SettingsV2SectionId,
 } from './sections';
 import { Overlay, DesktopShell, MobileTakeover } from './styled';
-
-/**
- * `SETTINGS_V2_Z_INDEX = 1405` — sits above the player's `BottomBar`
- * (`theme.zIndex.modal = 1400`) and matches `dialog.tsx`'s `DIALOG_Z_INDEX`
- * (intentionally identical — substitution should be clean when Dialog adoption lands).
- * The overlay renders one level below at `1404`.
- *
- * Inline at the component level mirrors the existing convention used by
- * `dialog.tsx`, `sheet.tsx`, `popover.tsx`, `select.tsx`. There is no
- * project-wide z-index constants file (see `docs/architecture/shadcn.md#z-index-for-shadcn-primitives`).
- */
-export const SETTINGS_V2_Z_INDEX = 1405;
 
 /** Sentinel for "show the mobile list view". Uses `__list` (not a valid URL param value) to avoid colliding with `?settings=open` deep-links. */
 const MOBILE_LIST_VIEW = '__list';
@@ -47,10 +36,15 @@ interface SettingsV2Props {
  * `useSettingsUrl()` so deep-links (`?settings=appearance`) and the
  * browser back-button work end-to-end.
  *
- * Close gestures handled here:
- *   - Esc — `keydown` listener calls `onClose()`
- *   - Browser back — popstate listener fires `onClose()` when the
- *     `settings` param disappears
+ * Close gestures handled by Radix `Dialog`:
+ *   - Esc — Radix emits `onOpenChange(false)` natively
+ *   - Overlay click — Radix emits `onOpenChange(false)` natively
+ *   - Focus trap + return-to-trigger on close — handled by Radix
+ *
+ * Close gestures handled by this component:
+ *   - Browser back — popstate listener mirrors URL changes from outside
+ *     into `onClose()` (Dialog only handles its own internal close, not
+ *     the URL state owned by `useSettingsUrl()`).
  *   - Shift+S — already routed through `setShowVisualEffects(prev => !prev)`
  *     by `useKeyboardShortcuts.ts`; flipping the parent's `isOpen` prop
  *     is sufficient.
@@ -72,21 +66,12 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
     onClose();
   }, [setSection, onClose]);
 
-  useEffect(() => {
-    if (!uiV2 || !isOpen) return;
-    if (typeof window === 'undefined') return;
-
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') {
-        closeShell();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [uiV2, isOpen, closeShell]);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) closeShell();
+    },
+    [closeShell],
+  );
 
   useEffect(() => {
     if (!uiV2) return;
@@ -110,8 +95,6 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
   }, [uiV2, isOpen, onClose]);
 
   if (!uiV2) return null;
-  if (typeof document === 'undefined') return null;
-  if (!isOpen) return null;
 
   const handleSelectSection = (next: SettingsV2SectionId): void => {
     setSection(next);
@@ -119,40 +102,62 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
 
   const validSection = isSettingsV2SectionId(section) ? section : null;
 
-  const shell = isMobile ? (
-    <MobileTakeover
-      $isOpen={isOpen}
-      $zIndex={SETTINGS_V2_Z_INDEX}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Settings"
-      data-testid="settings-v2-mobile"
-    >
-      <SettingsV2MobileTakeover
-        activeSection={validSection}
-        onSelectSection={handleSelectSection}
-        onBackToList={() => setSection(MOBILE_LIST_VIEW)}
-        onClose={closeShell}
-      />
-    </MobileTakeover>
-  ) : (
-    <>
-      <Overlay $isOpen={isOpen} $zIndex={SETTINGS_V2_Z_INDEX} onClick={closeShell} aria-hidden="true" />
-      <DesktopShell
-        $isOpen={isOpen}
-        $zIndex={SETTINGS_V2_Z_INDEX}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Settings"
-        data-testid="settings-v2-desktop"
-      >
-        <SettingsV2Sidebar activeSection={activeSection} onSelect={handleSelectSection} />
-        <SettingsV2Content activeSection={activeSection} onClose={closeShell} />
-      </DesktopShell>
-    </>
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        {isMobile ? (
+          <DialogPrimitive.Content asChild aria-label="Settings" aria-describedby={undefined}>
+            <MobileTakeover data-testid="settings-v2-mobile">
+              <VisuallyHiddenDialogTitle />
+              <SettingsV2MobileTakeover
+                activeSection={validSection}
+                onSelectSection={handleSelectSection}
+                onBackToList={() => setSection(MOBILE_LIST_VIEW)}
+                onClose={closeShell}
+              />
+            </MobileTakeover>
+          </DialogPrimitive.Content>
+        ) : (
+          <>
+            <DialogOverlay asChild>
+              <Overlay aria-hidden="true" />
+            </DialogOverlay>
+            <DialogPrimitive.Content asChild aria-label="Settings" aria-describedby={undefined}>
+              <DesktopShell data-testid="settings-v2-desktop">
+                <VisuallyHiddenDialogTitle />
+                <SettingsV2Sidebar activeSection={activeSection} onSelect={handleSelectSection} />
+                <SettingsV2Content activeSection={activeSection} onClose={closeShell} />
+              </DesktopShell>
+            </DialogPrimitive.Content>
+          </>
+        )}
+      </DialogPortal>
+    </Dialog>
   );
-
-  return createPortal(shell, document.body);
 };
+
+/**
+ * Radix `Dialog` requires a `Title` for screen readers and warns in dev when
+ * one is missing. The visible heading lives inside `SettingsV2Content` /
+ * `SettingsV2MobileTakeover`, so render an SR-only title to satisfy the
+ * primitive without disturbing the layout.
+ */
+const VisuallyHiddenDialogTitle: React.FC = () => (
+  <DialogPrimitive.Title
+    style={{
+      position: 'absolute',
+      width: 1,
+      height: 1,
+      padding: 0,
+      margin: -1,
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0,
+    }}
+  >
+    Settings
+  </DialogPrimitive.Title>
+);
 
 export default SettingsV2;

--- a/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
+++ b/src/components/SettingsV2/__tests__/SettingsV2.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'styled-components';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { theme } from '@/styles/theme';
@@ -216,21 +217,20 @@ describe('SettingsV2', () => {
   });
 
   describe('close gestures', () => {
-    it('clears URL state and calls onClose when Esc is pressed', () => {
+    it('clears URL state and calls onClose when Esc is pressed', async () => {
       // #given — open with a real section in the URL so closeShell has something to clear
       const onClose = vi.fn();
       setSearch('?settings=advanced');
       const pushStateSpy = vi.spyOn(window.history, 'pushState');
+      const user = userEvent.setup();
       render(
         <Wrapper>
           <SettingsV2 isOpen={true} onClose={onClose} />
         </Wrapper>,
       );
 
-      // #when — fire keydown WITHOUT pre-emptying the URL; closeShell must do the clearing
-      act(() => {
-        fireEvent.keyDown(window, { key: 'Escape' });
-      });
+      // #when — Radix Dialog handles Esc natively and emits onOpenChange(false) → closeShell()
+      await user.keyboard('{Escape}');
 
       // #then — onClose called, and the most recent pushState produced a URL without settings=
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -275,28 +275,31 @@ describe('SettingsV2', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
-    it('calls onClose when the desktop overlay is clicked', () => {
+    it('calls onClose when the desktop overlay is clicked', async () => {
       // #given
       const onClose = vi.fn();
+      const user = userEvent.setup();
       render(
         <Wrapper>
           <SettingsV2 isOpen={true} onClose={onClose} />
         </Wrapper>,
       );
 
-      // #when
-      const overlay = document.body.querySelector('[aria-hidden="true"]');
+      // #when — Radix DialogOverlay carries data-testid="dialog-overlay";
+      // clicking it dispatches the pointerdown-outside event Radix listens for.
+      const overlay = document.body.querySelector('[data-testid="dialog-overlay"]');
       expect(overlay).not.toBeNull();
-      if (overlay) fireEvent.click(overlay);
+      if (overlay) await user.click(overlay);
 
       // #then
       expect(onClose).toHaveBeenCalled();
     });
 
-    it('calls onClose exactly once when Esc is pressed — isSelfClosingRef prevents popstate echo', () => {
+    it('calls onClose exactly once when Esc is pressed — isSelfClosingRef prevents popstate echo', async () => {
       // #given — open with a section so closeShell will pushState (which triggers isSelfClosingRef guard)
       const onClose = vi.fn();
       setSearch('?settings=appearance');
+      const user = userEvent.setup();
       render(
         <Wrapper>
           <SettingsV2 isOpen={true} onClose={onClose} />
@@ -304,8 +307,8 @@ describe('SettingsV2', () => {
       );
 
       // #when — Esc fires closeShell; the resulting pushState must not echo back through popstate
+      await user.keyboard('{Escape}');
       act(() => {
-        fireEvent.keyDown(window, { key: 'Escape' });
         // Simulate the browser echoing a popstate after pushState (isSelfClosingRef should absorb it)
         window.dispatchEvent(new PopStateEvent('popstate'));
       });
@@ -315,14 +318,27 @@ describe('SettingsV2', () => {
     });
   });
 
-  describe('z-index invariant', () => {
-    it('exports SETTINGS_V2_Z_INDEX = 1405 (above BottomBar modal=1400)', async () => {
+  describe('focus management (Radix Dialog)', () => {
+    it('moves focus into the dialog when opened', async () => {
       // #given + #when
-      const mod = await import('../SettingsV2');
+      render(
+        <Wrapper>
+          <SettingsV2 isOpen={true} onClose={vi.fn()} />
+        </Wrapper>,
+      );
 
-      // #then
-      expect(mod.SETTINGS_V2_Z_INDEX).toBe(1405);
-      expect(mod.SETTINGS_V2_Z_INDEX).toBeGreaterThan(parseInt(theme.zIndex.modal, 10));
+      // #then — Radix moves focus to the first focusable descendant (or the
+      // Content element itself) after open. Either way, the active element
+      // must live inside the dialog subtree, not on document.body.
+      const dialog = screen.getByTestId('settings-v2-desktop');
+      const active = document.activeElement as HTMLElement | null;
+      expect(active).not.toBe(document.body);
+      expect(dialog.contains(active)).toBe(true);
     });
+
+    // Return-focus-to-trigger on close is delegated to Radix and validated in
+    // the live browser; jsdom's focus model does not faithfully simulate the
+    // synthetic focusin/focusout cascade Radix relies on. Coverage lives in
+    // Playwright e2e specs (see docs/testing.md).
   });
 });

--- a/src/components/SettingsV2/styled.ts
+++ b/src/components/SettingsV2/styled.ts
@@ -11,69 +11,86 @@ import styled from 'styled-components';
  * Container queries are the primary responsive strategy; the desktop /
  * mobile-takeover fork itself runs off `usePlayerSizingContext().isMobile`
  * (mirrors `PlayerContent/DrawerOrchestrator.tsx:164-188`).
+ *
+ * Z-index parity: 1405 matches `DIALOG_Z_INDEX` in `src/components/ui/dialog.tsx`
+ * (above `theme.zIndex.modal = 1400` / `BottomBar` max 1350). The overlay
+ * sits one level below at 1404. These values are coupled to `dialog.tsx` —
+ * the wrappers in `SettingsV2.tsx` are now rendered via Radix Dialog primitives
+ * (`asChild`), so visibility/pointer-events/transitions are driven by Radix
+ * `data-state` rather than the previous `$isOpen` prop wiring.
  */
 
-export const Overlay = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+export const Overlay = styled.div`
   position: fixed;
   inset: 0;
   background: ${({ theme }) => theme.colors.overlay.light};
-  z-index: ${({ $zIndex }) => $zIndex - 1};
-  opacity: ${({ $isOpen }) => ($isOpen ? '1' : '0')};
-  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
-  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
-  transition:
-    opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
-    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+  z-index: 1404;
+  opacity: 0;
+  transition: opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+
+  &[data-state='open'] {
+    opacity: 1;
+  }
 `;
 
-export const DesktopShell = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+export const DesktopShell = styled.div`
   position: fixed;
   top: 50%;
   left: 50%;
   width: min(960px, 92vw);
   height: min(640px, 80vh);
-  transform: translate(-50%, -50%) scale(${({ $isOpen }) => ($isOpen ? '1' : '0.96')});
+  transform: translate(-50%, -50%) scale(0.96);
   background: hsl(var(--background));
   color: hsl(var(--foreground));
   border: 1px solid hsl(var(--border));
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   box-shadow: ${({ theme }) => theme.shadows.xl};
-  z-index: ${({ $zIndex }) => $zIndex};
-  opacity: ${({ $isOpen }) => ($isOpen ? '1' : '0')};
-  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
-  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+  z-index: 1405;
+  opacity: 0;
   display: grid;
   grid-template-columns: 240px 1fr;
   overflow: hidden;
   transition:
     opacity ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
-    transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
-    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+    transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
 
   container-type: inline-size;
   container-name: settings-v2;
+
+  &[data-state='open'] {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+
+  &:focus {
+    outline: none;
+  }
 
   @container settings-v2 (max-width: 700px) {
     grid-template-columns: 200px 1fr;
   }
 `;
 
-export const MobileTakeover = styled.div<{ $isOpen: boolean; $zIndex: number }>`
+export const MobileTakeover = styled.div`
   position: fixed;
   inset: 0;
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  z-index: ${({ $zIndex }) => $zIndex};
-  transform: translateX(${({ $isOpen }) => ($isOpen ? '0' : '100%')});
-  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
-  pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
-  transition:
-    transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing},
-    visibility ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
+  z-index: 1405;
+  transform: translateX(100%);
+  transition: transform ${({ theme }) => theme.drawer.transitionDuration}ms ${({ theme }) => theme.drawer.transitionEasing};
   display: flex;
   flex-direction: column;
   padding-top: env(safe-area-inset-top, 0px);
   padding-bottom: env(safe-area-inset-bottom, 0px);
+
+  &[data-state='open'] {
+    transform: translateX(0);
+  }
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 export const Header = styled.div`

--- a/src/components/SettingsV2/styled.ts
+++ b/src/components/SettingsV2/styled.ts
@@ -31,6 +31,10 @@ export const Overlay = styled.div`
   &[data-state='open'] {
     opacity: 1;
   }
+
+  &[data-state='closed'] {
+    pointer-events: none;
+  }
 `;
 
 export const DesktopShell = styled.div`
@@ -62,6 +66,10 @@ export const DesktopShell = styled.div`
     opacity: 1;
   }
 
+  &[data-state='closed'] {
+    pointer-events: none;
+  }
+
   &:focus {
     outline: none;
   }
@@ -86,6 +94,10 @@ export const MobileTakeover = styled.div`
 
   &[data-state='open'] {
     transform: translateX(0);
+  }
+
+  &[data-state='closed'] {
+    pointer-events: none;
   }
 
   &:focus {


### PR DESCRIPTION
## Summary
- Replace raw `<div role="dialog">` wrappers in `SettingsV2.tsx` (both desktop and mobile takeover) with shadcn `Dialog` from `src/components/ui/dialog.tsx`. Renders our existing `Overlay`/`DesktopShell`/`MobileTakeover` styled components via Radix `asChild`, preserving visual parity exactly.
- `Dialog`'s `onOpenChange(false)` wires to `closeShell()`; Radix handles Esc + overlay-click + focus trap + return-focus-to-trigger natively.
- Bespoke Esc keydown handler and overlay-click handler removed; popstate listener kept for URL-hook integration (browser-back propagation).
- `SETTINGS_V2_Z_INDEX` constant removed — `DIALOG_Z_INDEX = 1405` already handles it (was identical by design). The styled wrappers now hard-code 1405/1404 with a comment noting the parity, and visibility/transitions key off Radix `data-state` instead of the previous `$isOpen` prop wiring.
- Visually-hidden `DialogPrimitive.Title` rendered inside each Content variant to satisfy Radix's a11y requirement (visible heading still lives inside `SettingsV2Content` / `SettingsV2MobileTakeover`).

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — 1846 passed (174 files). `SettingsV2.test.tsx` updated to drive the Dialog open/close path: Esc + overlay-click now exercised through `userEvent` against the Radix-managed listeners. The dropped `SETTINGS_V2_Z_INDEX` test is replaced by a focus-management assertion (focus moves into the dialog on open). Return-focus-to-trigger is deferred to Playwright — jsdom does not faithfully simulate the focus cascade Radix relies on.
- `npm run build` — clean (only pre-existing dynamic-import warnings).
- Manual: `?ui=v2&settings=open` → Dialog mounts; tabbing wraps inside; Esc closes and returns focus to gear button; URL clears.

Closes #1458. Recommended to land before #1450 (phase 2).