### PR TITLE
feat(settings-v2): port Sources + Advanced sections

### DIFF
--- a/src/components/AppSettingsMenu/styled.ts
+++ b/src/components/AppSettingsMenu/styled.ts
@@ -154,8 +154,8 @@ export const ResetButton = styled.button`
   margin-top: ${({ theme }) => theme.spacing.lg};
 
   &:hover {
-    background: color-mix(in srgb, var(--accent-color) 13%, transparent);
-    border-color: color-mix(in srgb, var(--accent-color) 27%, transparent);
+    background: hsl(var(--muted));
+    border-color: hsl(var(--ring));
     color: ${({ theme }) => theme.colors.foreground};
     transform: translateY(-1px);
   }
@@ -219,8 +219,8 @@ export const CacheCheckbox = styled.input`
   transition: all ${({ theme }) => theme.transitions.fast};
 
   &:checked {
-    background: var(--accent-color);
-    border-color: var(--accent-color);
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
 
   &:checked::after {
@@ -271,9 +271,9 @@ export const CacheCancelButton = styled.button`
 `;
 
 export const OptionButton = styled.button<{ $isActive: boolean }>`
-  background: ${({ $isActive, theme }) => $isActive ? 'var(--accent-color)' : theme.colors.muted.background};
-  border: 1px solid ${({ $isActive, theme }) => $isActive ? 'var(--accent-color)' : theme.colors.border};
-  color: ${({ $isActive, theme }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.muted.foreground};
+  background: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary))' : theme.colors.muted.background};
+  border: 1px solid ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary))' : theme.colors.border};
+  color: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary-foreground))' : theme.colors.muted.foreground};
   padding: 0.375rem 0.75rem;
   border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
@@ -283,9 +283,9 @@ export const OptionButton = styled.button<{ $isActive: boolean }>`
   min-width: 60px;
 
   &:hover {
-    background: ${({ $isActive }) => $isActive ? 'color-mix(in srgb, var(--accent-color) 87%, transparent)' : 'color-mix(in srgb, var(--accent-color) 13%, transparent)'};
-    border-color: var(--accent-color);
-    color: ${({ $isActive, theme }) => $isActive ? 'var(--accent-contrast-color)' : theme.colors.white};
+    background: ${({ $isActive }) => $isActive ? 'hsl(var(--primary) / 0.87)' : 'hsl(var(--muted))'};
+    border-color: hsl(var(--ring));
+    color: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary-foreground))' : theme.colors.white};
     transform: translateY(-1px);
   }
 `;

--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -53,18 +53,22 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
  */
 export const SettingsV2SectionBody: React.FC<{ activeSection: SettingsV2SectionId }> = ({ activeSection }) => {
   switch (activeSection) {
-    case 'sources':
+    case 'sources': {
+      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
       return (
-        <Suspense fallback={null}>
+        <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
           <SourcesSection />
         </Suspense>
       );
-    case 'advanced':
+    }
+    case 'advanced': {
+      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
       return (
-        <Suspense fallback={null}>
+        <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
           <AdvancedSection />
         </Suspense>
       );
+    }
     case 'playback':
     case 'appearance':
     default: {

--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { X } from 'lucide-react';
 import type { SettingsV2SectionId } from './sections';
 import { SETTINGS_V2_SECTIONS } from './sections';
@@ -11,6 +11,16 @@ import {
   SectionTitle,
   SectionPlaceholder,
 } from './styled';
+
+// Lazy-load section bodies so the shell can mount (and unit-test) without
+// eagerly pulling in the provider registry, profiling/visualizer contexts,
+// or the legacy AppSettingsMenu module graph.
+const SourcesSection = lazy(() =>
+  import('./sections/SourcesSection').then((m) => ({ default: m.SourcesSection })),
+);
+const AdvancedSection = lazy(() =>
+  import('./sections/AdvancedSection').then((m) => ({ default: m.AdvancedSection })),
+);
 
 interface SettingsV2ContentProps {
   activeSection: SettingsV2SectionId;
@@ -29,10 +39,42 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
         </IconButton>
       </Header>
       <ContentBody>
-        <SectionTitle>{section.label}</SectionTitle>
-        <SectionPlaceholder>{section.description}</SectionPlaceholder>
+        <SettingsV2SectionBody activeSection={activeSection} />
       </ContentBody>
     </ContentRoot>
   );
 };
 
+/**
+ * Maps a section ID to the live-content component, or to a placeholder for
+ * sections still scheduled for future phases. Phase 2 (#1450) ships
+ * `sources` + `advanced`; `playback` (#1452) and `appearance` (#1451) keep
+ * the placeholder treatment from phase 1.
+ */
+export const SettingsV2SectionBody: React.FC<{ activeSection: SettingsV2SectionId }> = ({ activeSection }) => {
+  switch (activeSection) {
+    case 'sources':
+      return (
+        <Suspense fallback={null}>
+          <SourcesSection />
+        </Suspense>
+      );
+    case 'advanced':
+      return (
+        <Suspense fallback={null}>
+          <AdvancedSection />
+        </Suspense>
+      );
+    case 'playback':
+    case 'appearance':
+    default: {
+      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+      return (
+        <>
+          <SectionTitle>{section.label}</SectionTitle>
+          <SectionPlaceholder>{section.description}</SectionPlaceholder>
+        </>
+      );
+    }
+  }
+};

--- a/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
+++ b/src/components/SettingsV2/SettingsV2MobileTakeover.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { X } from 'lucide-react';
 import type { SettingsV2SectionId } from './sections';
 import { SETTINGS_V2_SECTIONS } from './sections';
+import { SettingsV2SectionBody } from './SettingsV2Content';
 import {
   Header,
   HeaderTitle,
@@ -10,8 +11,6 @@ import {
   MobileSectionRow,
   MobileChevron,
   MobileDetailBody,
-  SectionTitle,
-  SectionPlaceholder,
 } from './styled';
 
 interface SettingsV2MobileTakeoverProps {
@@ -66,8 +65,7 @@ export const SettingsV2MobileTakeover: React.FC<SettingsV2MobileTakeoverProps> =
         </IconButton>
       </Header>
       <MobileDetailBody>
-        <SectionTitle>{section.label}</SectionTitle>
-        <SectionPlaceholder>{section.description}</SectionPlaceholder>
+        <SettingsV2SectionBody activeSection={activeSection} />
       </MobileDetailBody>
     </>
   );

--- a/src/components/SettingsV2/sections/AdvancedSection.styled.ts
+++ b/src/components/SettingsV2/sections/AdvancedSection.styled.ts
@@ -1,0 +1,126 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const ControlBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const ControlLabelText = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: hsl(var(--foreground));
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+`;
+
+export const ControlHelp = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+export const SectionGroupTitle = styled.h4`
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+export const Divider = styled.div`
+  border-top: 1px solid hsl(var(--border));
+`;
+
+export const CacheOptionList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const CacheOptionItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const CacheCheckbox = styled.input`
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid hsl(var(--border));
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  background: hsl(var(--input));
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: all ${({ theme }) => theme.transitions.fast};
+
+  &:checked {
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
+  }
+
+  &:checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 5px;
+    height: 9px;
+    border: 2px solid hsl(var(--primary-foreground));
+    border-top: none;
+    border-left: none;
+    transform: rotate(45deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+`;
+
+export const CacheButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ShortcutHintList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const ShortcutHintRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+export const Kbd = styled.kbd`
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  padding: 0 ${({ theme }) => theme.spacing.xs};
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--foreground));
+`;

--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -1,0 +1,511 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { useProfilingContext } from '@/contexts/ProfilingContext';
+import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
+import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
+import { clearCacheWithOptions } from '@/services/cache/libraryCache';
+import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
+import { STORAGE_KEYS } from '@/constants/storage';
+import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
+import type { CatalogProvider } from '@/types/providers';
+
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion';
+
+/**
+ * SettingsV2 Advanced section — phase 2 port (#1450).
+ *
+ * Ports the legacy AppSettingsMenu controls into v2 chrome (neutral shadcn
+ * palette only — no `var(--accent-color)` references). Each control reads /
+ * writes the same hook + storage key as the v1 surface, so toggling in
+ * either UI reflects in the other immediately:
+ *
+ *   - Quick Access Panel ↔ `useQapEnabled()` ↔ `vorbis-player-qap-enabled`
+ *   - Performance Profiler ↔ `useProfilingContext()` ↔ `STORAGE_KEYS.PROFILING`
+ *   - Visualizer Debug ↔ `useVisualizerDebug()` (in-memory; toggling has no
+ *     localStorage side-effect by design)
+ *   - Clear Library Cache → `clearCacheWithOptions()` + `clearAllPins()` +
+ *     accent-overrides cleanup (mirrors `PlayerControlsSection.handleClearCache`).
+ */
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+const ControlBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const ControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+const ControlLabelText = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: hsl(var(--foreground));
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+`;
+
+const ControlHelp = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+const SectionGroupTitle = styled.h4`
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+const Divider = styled.div`
+  border-top: 1px solid hsl(var(--border));
+`;
+
+const CacheOptionList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const CacheOptionItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const CacheCheckbox = styled.input`
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid hsl(var(--border));
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  background: hsl(var(--input));
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: all ${({ theme }) => theme.transitions.fast};
+
+  &:checked {
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
+  }
+
+  &:checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 5px;
+    height: 9px;
+    border: 2px solid hsl(var(--primary-foreground));
+    border-top: none;
+    border-left: none;
+    transform: rotate(45deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+`;
+
+const CacheButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const ShortcutHintList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+const ShortcutHintRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+const Kbd = styled.kbd`
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  padding: 0 ${({ theme }) => theme.spacing.xs};
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--foreground));
+`;
+
+interface ProviderDataBlockProps {
+  providerName: string;
+  catalog: CatalogProvider;
+}
+
+const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerName, catalog }) => {
+  const [resultMessage, setResultMessage] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const hasArtCache = !!catalog.clearArtCache;
+  const hasRefreshArt = !!catalog.refreshArtCache;
+  const hasLikesManagement = !!catalog.exportLikes && !!catalog.importLikes;
+  const hasMetadataRefresh = !!catalog.refreshLikedMetadata;
+
+  const clearResultMessage = useCallback(() => setResultMessage(''), []);
+
+  const clearArtFn = useCallback(async () => {
+    await catalog.clearArtCache?.();
+  }, [catalog]);
+
+  const refreshArtFn = useCallback(async () => {
+    await catalog.refreshArtCache?.();
+    window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
+  }, [catalog]);
+
+  const exportFn = useCallback(async () => {
+    try {
+      const json = await catalog.exportLikes!();
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `vorbis-liked-songs-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setResultMessage('Exported!');
+    } catch {
+      setResultMessage('Export failed');
+    }
+  }, [catalog]);
+
+  const refreshMetadataFn = useCallback(async () => {
+    try {
+      const result = await catalog.refreshLikedMetadata!();
+      const parts: string[] = [];
+      if (result.updated > 0) parts.push(`${result.updated} updated`);
+      if (result.removed > 0) parts.push(`${result.removed} removed`);
+      setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
+    } catch {
+      setResultMessage('Refresh failed');
+    }
+  }, [catalog]);
+
+  const [clearArtStatus, runClearArt] = useAsyncAction(clearArtFn);
+  const [refreshArtStatus, runRefreshArt] = useAsyncAction(refreshArtFn);
+  const [exportStatus, runExport] = useAsyncAction(exportFn, { onReset: clearResultMessage });
+  const [metadataStatus, runRefreshMetadata] = useAsyncAction(refreshMetadataFn, { onReset: clearResultMessage });
+  const [importStatus, setImportStatus] = useState<'idle' | 'working' | 'done'>('idle');
+
+  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportStatus('working');
+    try {
+      const json = await file.text();
+      const count = await catalog.importLikes!(json);
+      setResultMessage(`Imported ${count} tracks`);
+    } catch {
+      setResultMessage('Import failed');
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setImportStatus('done');
+    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, STATUS_RESET_DELAY_MS);
+  }, [catalog]);
+
+  const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';
+  const likesBusy = exportStatus === 'working' || importStatus === 'working' || metadataStatus === 'working';
+
+  return (
+    <AccordionItem value={`${providerName.toLowerCase()}-data`}>
+      <AccordionTrigger>{`${providerName} Data`}</AccordionTrigger>
+      <AccordionContent>
+        <ControlBlock>
+          {hasArtCache && (
+            <ControlRow>
+              <ControlHelp>Clear cached art so it re-downloads on next library load</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runClearArt} disabled={artBusy}>
+                {clearArtStatus === 'done' ? 'Cleared!' : artBusy ? 'Working…' : 'Clear Art Cache'}
+              </Button>
+            </ControlRow>
+          )}
+          {hasRefreshArt && (
+            <ControlRow>
+              <ControlHelp>Clear and immediately re-fetch fresh art in the background</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runRefreshArt} disabled={artBusy}>
+                {refreshArtStatus === 'done' ? 'Started!' : artBusy ? 'Working…' : 'Refresh Art'}
+              </Button>
+            </ControlRow>
+          )}
+          {hasLikesManagement && (
+            <>
+              <ControlRow>
+                <ControlHelp>Export liked songs to a JSON file for backup</ControlHelp>
+                <Button variant="outline" size="sm" onClick={runExport} disabled={likesBusy}>
+                  {exportStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working…' : 'Export Likes'}
+                </Button>
+              </ControlRow>
+              <ControlRow>
+                <ControlHelp>Import liked songs from a previously exported JSON file</ControlHelp>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  onChange={handleImport}
+                  style={{ display: 'none' }}
+                />
+                <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={likesBusy}>
+                  {importStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working…' : 'Import Likes'}
+                </Button>
+              </ControlRow>
+            </>
+          )}
+          {hasMetadataRefresh && (
+            <ControlRow>
+              <ControlHelp>Re-scan {providerName} to update metadata for liked tracks</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runRefreshMetadata} disabled={likesBusy}>
+                {metadataStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning…' : 'Refresh Metadata'}
+              </Button>
+            </ControlRow>
+          )}
+        </ControlBlock>
+      </AccordionContent>
+    </AccordionItem>
+  );
+};
+
+export const AdvancedSection: React.FC = () => {
+  const { enabledProviderIds, registry } = useProviderContext();
+  const { enabled: profilerEnabled, toggle: profilerToggle } = useProfilingContext();
+  const vizDebugCtx = useVisualizerDebug();
+  const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
+  const [qapEnabled, setQapEnabled] = useQapEnabled();
+
+  const dataProviders = useMemo(() => {
+    return registry.getAll().filter(
+      (p) => enabledProviderIds.includes(p.id) && (p.catalog.clearArtCache || p.catalog.exportLikes),
+    );
+  }, [registry, enabledProviderIds]);
+
+  const [clearState, setClearState] = useState<'idle' | 'confirming' | 'success'>('idle');
+  const [clearLikes, setClearLikes] = useState(false);
+  const [clearPins, setClearPins] = useState(false);
+  const [clearAccentColors, setClearAccentColors] = useState(false);
+
+  const handleClearCacheClick = useCallback(() => {
+    setClearState('confirming');
+  }, []);
+
+  const handleClearCacheCancel = useCallback(() => {
+    setClearState('idle');
+    setClearLikes(false);
+    setClearPins(false);
+    setClearAccentColors(false);
+  }, []);
+
+  const handleClearCacheConfirm = useCallback(async () => {
+    await clearCacheWithOptions({ clearLikes });
+    if (clearPins) {
+      await clearAllPins();
+    }
+    if (clearAccentColors) {
+      localStorage.removeItem(STORAGE_KEYS.ACCENT_COLOR_OVERRIDES);
+      localStorage.removeItem(STORAGE_KEYS.CUSTOM_ACCENT_COLORS);
+    }
+    if (clearPins || clearAccentColors) {
+      const { clearPreferencesSyncTimestamp, getPreferencesSync } =
+        await import('@/providers/dropbox/dropboxPreferencesSync');
+      clearPreferencesSyncTimestamp();
+      getPreferencesSync()?.initialSync();
+    }
+    setClearState('success');
+    setClearLikes(false);
+    setClearPins(false);
+    setClearAccentColors(false);
+    setTimeout(() => setClearState('idle'), STATUS_RESET_DELAY_MS);
+  }, [clearLikes, clearPins, clearAccentColors]);
+
+  const handleProfilerToggle = useCallback(() => {
+    if (!profilerEnabled) {
+      vizDebugCtx?.setIsDebugMode(false);
+    }
+    profilerToggle();
+  }, [profilerEnabled, profilerToggle, vizDebugCtx]);
+
+  const handleVisualizerDebugToggle = useCallback(() => {
+    if (!visualizerDebugEnabled && profilerEnabled) {
+      profilerToggle();
+    }
+    vizDebugCtx?.setIsDebugMode((prev) => !prev);
+  }, [visualizerDebugEnabled, profilerEnabled, profilerToggle, vizDebugCtx]);
+
+  return (
+    <Container>
+      <ControlBlock>
+        <ControlRow>
+          <div>
+            <ControlLabelText htmlFor="settings-v2-qap-toggle">Quick Access Panel</ControlLabelText>
+            <ControlHelp>Show the quick-access overlay on the idle screen.</ControlHelp>
+          </div>
+          <Switch
+            id="settings-v2-qap-toggle"
+            checked={qapEnabled}
+            onCheckedChange={(checked) => setQapEnabled(checked)}
+            aria-label="Toggle Quick Access Panel"
+            variant="neutral"
+          />
+        </ControlRow>
+      </ControlBlock>
+
+      <Divider />
+
+      <ControlBlock>
+        <SectionGroupTitle>Library Cache</SectionGroupTitle>
+        {clearState === 'confirming' ? (
+          <>
+            <CacheOptionList>
+              {dataProviders.length === 0 && (
+                <CacheOptionItem>
+                  <CacheCheckbox
+                    id="settings-v2-clear-likes"
+                    type="checkbox"
+                    checked={clearLikes}
+                    onChange={(e) => setClearLikes(e.target.checked)}
+                  />
+                  <ControlHelp as="label" htmlFor="settings-v2-clear-likes">Also clear Likes</ControlHelp>
+                </CacheOptionItem>
+              )}
+              <CacheOptionItem>
+                <CacheCheckbox
+                  id="settings-v2-clear-pins"
+                  type="checkbox"
+                  checked={clearPins}
+                  onChange={(e) => setClearPins(e.target.checked)}
+                />
+                <ControlHelp as="label" htmlFor="settings-v2-clear-pins">Also clear Pins</ControlHelp>
+              </CacheOptionItem>
+              <CacheOptionItem>
+                <CacheCheckbox
+                  id="settings-v2-clear-accent-colors"
+                  type="checkbox"
+                  checked={clearAccentColors}
+                  onChange={(e) => setClearAccentColors(e.target.checked)}
+                />
+                <ControlHelp as="label" htmlFor="settings-v2-clear-accent-colors">Also clear Accent Colors</ControlHelp>
+              </CacheOptionItem>
+            </CacheOptionList>
+            <CacheButtons>
+              <Button variant="outline" size="sm" onClick={handleClearCacheCancel}>
+                Cancel
+              </Button>
+              <Button variant="default" size="sm" onClick={handleClearCacheConfirm}>
+                Confirm Clear
+              </Button>
+            </CacheButtons>
+          </>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={clearState === 'success' ? undefined : handleClearCacheClick}
+            disabled={clearState === 'success'}
+          >
+            {clearState === 'success' ? 'Cleared!' : 'Clear Cache'}
+          </Button>
+        )}
+      </ControlBlock>
+
+      <Divider />
+
+      <ControlBlock>
+        <SectionGroupTitle>Diagnostics</SectionGroupTitle>
+        <ControlRow>
+          <div>
+            <ControlLabelText htmlFor="settings-v2-profiler-toggle">Performance Profiler</ControlLabelText>
+            <ControlHelp>Capture render and timing metrics for diagnostics.</ControlHelp>
+          </div>
+          <Switch
+            id="settings-v2-profiler-toggle"
+            checked={profilerEnabled}
+            onCheckedChange={handleProfilerToggle}
+            aria-label="Toggle Performance Profiler"
+            variant="neutral"
+          />
+        </ControlRow>
+        <ControlRow>
+          <div>
+            <ControlLabelText htmlFor="settings-v2-viz-debug-toggle">Visualizer Debug</ControlLabelText>
+            <ControlHelp>Show on-screen overlays for visualizer tuning.</ControlHelp>
+          </div>
+          <Switch
+            id="settings-v2-viz-debug-toggle"
+            checked={visualizerDebugEnabled}
+            onCheckedChange={handleVisualizerDebugToggle}
+            aria-label="Toggle Visualizer Debug"
+            variant="neutral"
+          />
+        </ControlRow>
+      </ControlBlock>
+
+      {dataProviders.length > 0 && (
+        <>
+          <Divider />
+          <ControlBlock>
+            <SectionGroupTitle>Provider Data</SectionGroupTitle>
+            <Accordion type="single" collapsible>
+              {dataProviders.map((p) => (
+                <ProviderDataBlock key={p.id} providerName={p.name} catalog={p.catalog} />
+              ))}
+            </Accordion>
+          </ControlBlock>
+        </>
+      )}
+
+      <Divider />
+
+      <ControlBlock>
+        <SectionGroupTitle>About</SectionGroupTitle>
+        <ControlHelp>Vorbis Player — keyboard-first music player.</ControlHelp>
+        <ShortcutHintList>
+          <ShortcutHintRow>
+            <span>Show keyboard shortcuts</span>
+            <Kbd>/</Kbd>
+          </ShortcutHintRow>
+          <ShortcutHintRow>
+            <span>Open settings</span>
+            <Kbd>Shift+S</Kbd>
+          </ShortcutHintRow>
+        </ShortcutHintList>
+      </ControlBlock>
+    </Container>
+  );
+};
+
+AdvancedSection.displayName = 'SettingsV2.AdvancedSection';
+
+export default AdvancedSection;

--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -1,26 +1,35 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { useProfilingContext } from '@/contexts/ProfilingContext';
 import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
-import { useAsyncAction } from '@/hooks/useAsyncAction';
-import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 import { clearCacheWithOptions } from '@/services/cache/libraryCache';
 import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
-import type { CatalogProvider } from '@/types/providers';
 
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Accordion } from '@/components/ui/accordion';
+
+import { ProviderDataBlock } from './ProviderDataBlock';
 import {
-  Accordion,
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from '@/components/ui/accordion';
+  Container,
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+  Divider,
+  CacheOptionList,
+  CacheOptionItem,
+  CacheCheckbox,
+  CacheButtons,
+  ShortcutHintList,
+  ShortcutHintRow,
+  Kbd,
+} from './AdvancedSection.styled';
 
 /**
  * SettingsV2 Advanced section — phase 2 port (#1450).
@@ -37,267 +46,6 @@ import {
  *   - Clear Library Cache → `clearCacheWithOptions()` + `clearAllPins()` +
  *     accent-overrides cleanup (mirrors `PlayerControlsSection.handleClearCache`).
  */
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.xl};
-`;
-
-const ControlBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.sm};
-`;
-
-const ControlRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${({ theme }) => theme.spacing.md};
-`;
-
-const ControlLabelText = styled.label`
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  color: hsl(var(--foreground));
-  font-weight: ${({ theme }) => theme.fontWeight.medium};
-`;
-
-const ControlHelp = styled.p`
-  margin: 0;
-  font-size: ${({ theme }) => theme.fontSize.xs};
-  color: hsl(var(--muted-foreground));
-`;
-
-const SectionGroupTitle = styled.h4`
-  margin: 0 0 ${({ theme }) => theme.spacing.sm};
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  font-weight: ${({ theme }) => theme.fontWeight.semibold};
-  color: hsl(var(--foreground));
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-`;
-
-const Divider = styled.div`
-  border-top: 1px solid hsl(var(--border));
-`;
-
-const CacheOptionList = styled.ul`
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.sm};
-`;
-
-const CacheOptionItem = styled.li`
-  display: flex;
-  align-items: center;
-  gap: ${({ theme }) => theme.spacing.sm};
-`;
-
-const CacheCheckbox = styled.input`
-  appearance: none;
-  -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
-  border: 1px solid hsl(var(--border));
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  background: hsl(var(--input));
-  cursor: pointer;
-  flex-shrink: 0;
-  position: relative;
-  transition: all ${({ theme }) => theme.transitions.fast};
-
-  &:checked {
-    background: hsl(var(--primary));
-    border-color: hsl(var(--primary));
-  }
-
-  &:checked::after {
-    content: '';
-    position: absolute;
-    left: 4px;
-    top: 1px;
-    width: 5px;
-    height: 9px;
-    border: 2px solid hsl(var(--primary-foreground));
-    border-top: none;
-    border-left: none;
-    transform: rotate(45deg);
-  }
-
-  &:focus-visible {
-    outline: 2px solid hsl(var(--ring));
-    outline-offset: 2px;
-  }
-`;
-
-const CacheButtons = styled.div`
-  display: flex;
-  gap: ${({ theme }) => theme.spacing.sm};
-`;
-
-const ShortcutHintList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.xs};
-`;
-
-const ShortcutHintRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: ${({ theme }) => theme.fontSize.xs};
-  color: hsl(var(--muted-foreground));
-`;
-
-const Kbd = styled.kbd`
-  background: hsl(var(--muted));
-  border: 1px solid hsl(var(--border));
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  padding: 0 ${({ theme }) => theme.spacing.xs};
-  font-family: 'Monaco', 'Menlo', monospace;
-  font-size: ${({ theme }) => theme.fontSize.xs};
-  color: hsl(var(--foreground));
-`;
-
-interface ProviderDataBlockProps {
-  providerName: string;
-  catalog: CatalogProvider;
-}
-
-const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerName, catalog }) => {
-  const [resultMessage, setResultMessage] = useState('');
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const hasArtCache = !!catalog.clearArtCache;
-  const hasRefreshArt = !!catalog.refreshArtCache;
-  const hasLikesManagement = !!catalog.exportLikes && !!catalog.importLikes;
-  const hasMetadataRefresh = !!catalog.refreshLikedMetadata;
-
-  const clearResultMessage = useCallback(() => setResultMessage(''), []);
-
-  const clearArtFn = useCallback(async () => {
-    await catalog.clearArtCache?.();
-  }, [catalog]);
-
-  const refreshArtFn = useCallback(async () => {
-    await catalog.refreshArtCache?.();
-    window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
-  }, [catalog]);
-
-  const exportFn = useCallback(async () => {
-    try {
-      const json = await catalog.exportLikes!();
-      const blob = new Blob([json], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `vorbis-liked-songs-${new Date().toISOString().slice(0, 10)}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      setResultMessage('Exported!');
-    } catch {
-      setResultMessage('Export failed');
-    }
-  }, [catalog]);
-
-  const refreshMetadataFn = useCallback(async () => {
-    try {
-      const result = await catalog.refreshLikedMetadata!();
-      const parts: string[] = [];
-      if (result.updated > 0) parts.push(`${result.updated} updated`);
-      if (result.removed > 0) parts.push(`${result.removed} removed`);
-      setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
-    } catch {
-      setResultMessage('Refresh failed');
-    }
-  }, [catalog]);
-
-  const [clearArtStatus, runClearArt] = useAsyncAction(clearArtFn);
-  const [refreshArtStatus, runRefreshArt] = useAsyncAction(refreshArtFn);
-  const [exportStatus, runExport] = useAsyncAction(exportFn, { onReset: clearResultMessage });
-  const [metadataStatus, runRefreshMetadata] = useAsyncAction(refreshMetadataFn, { onReset: clearResultMessage });
-  const [importStatus, setImportStatus] = useState<'idle' | 'working' | 'done'>('idle');
-
-  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setImportStatus('working');
-    try {
-      const json = await file.text();
-      const count = await catalog.importLikes!(json);
-      setResultMessage(`Imported ${count} tracks`);
-    } catch {
-      setResultMessage('Import failed');
-    }
-    if (fileInputRef.current) fileInputRef.current.value = '';
-    setImportStatus('done');
-    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, STATUS_RESET_DELAY_MS);
-  }, [catalog]);
-
-  const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';
-  const likesBusy = exportStatus === 'working' || importStatus === 'working' || metadataStatus === 'working';
-
-  return (
-    <AccordionItem value={`${providerName.toLowerCase()}-data`}>
-      <AccordionTrigger>{`${providerName} Data`}</AccordionTrigger>
-      <AccordionContent>
-        <ControlBlock>
-          {hasArtCache && (
-            <ControlRow>
-              <ControlHelp>Clear cached art so it re-downloads on next library load</ControlHelp>
-              <Button variant="outline" size="sm" onClick={runClearArt} disabled={artBusy}>
-                {clearArtStatus === 'done' ? 'Cleared!' : artBusy ? 'Working…' : 'Clear Art Cache'}
-              </Button>
-            </ControlRow>
-          )}
-          {hasRefreshArt && (
-            <ControlRow>
-              <ControlHelp>Clear and immediately re-fetch fresh art in the background</ControlHelp>
-              <Button variant="outline" size="sm" onClick={runRefreshArt} disabled={artBusy}>
-                {refreshArtStatus === 'done' ? 'Started!' : artBusy ? 'Working…' : 'Refresh Art'}
-              </Button>
-            </ControlRow>
-          )}
-          {hasLikesManagement && (
-            <>
-              <ControlRow>
-                <ControlHelp>Export liked songs to a JSON file for backup</ControlHelp>
-                <Button variant="outline" size="sm" onClick={runExport} disabled={likesBusy}>
-                  {exportStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working…' : 'Export Likes'}
-                </Button>
-              </ControlRow>
-              <ControlRow>
-                <ControlHelp>Import liked songs from a previously exported JSON file</ControlHelp>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".json"
-                  onChange={handleImport}
-                  style={{ display: 'none' }}
-                />
-                <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={likesBusy}>
-                  {importStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working…' : 'Import Likes'}
-                </Button>
-              </ControlRow>
-            </>
-          )}
-          {hasMetadataRefresh && (
-            <ControlRow>
-              <ControlHelp>Re-scan {providerName} to update metadata for liked tracks</ControlHelp>
-              <Button variant="outline" size="sm" onClick={runRefreshMetadata} disabled={likesBusy}>
-                {metadataStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning…' : 'Refresh Metadata'}
-              </Button>
-            </ControlRow>
-          )}
-        </ControlBlock>
-      </AccordionContent>
-    </AccordionItem>
-  );
-};
 
 export const AdvancedSection: React.FC = () => {
   const { enabledProviderIds, registry } = useProviderContext();
@@ -490,6 +238,7 @@ export const AdvancedSection: React.FC = () => {
 
       <ControlBlock>
         <SectionGroupTitle>About</SectionGroupTitle>
+        {/* TODO(#1462): surface app version once a build-time constant is wired */}
         <ControlHelp>Vorbis Player — keyboard-first music player.</ControlHelp>
         <ShortcutHintList>
           <ShortcutHintRow>

--- a/src/components/SettingsV2/sections/ProviderDataBlock.tsx
+++ b/src/components/SettingsV2/sections/ProviderDataBlock.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useRef, useState } from 'react';
+
+import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
+import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
+import type { CatalogProvider } from '@/types/providers';
+
+import { Button } from '@/components/ui/button';
+import {
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion';
+
+import { ControlBlock, ControlRow, ControlHelp } from './AdvancedSection.styled';
+
+interface ProviderDataBlockProps {
+  providerName: string;
+  catalog: CatalogProvider;
+}
+
+export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerName, catalog }) => {
+  const [resultMessage, setResultMessage] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const hasArtCache = !!catalog.clearArtCache;
+  const hasRefreshArt = !!catalog.refreshArtCache;
+  const hasLikesManagement = !!catalog.exportLikes && !!catalog.importLikes;
+  const hasMetadataRefresh = !!catalog.refreshLikedMetadata;
+
+  const clearResultMessage = useCallback(() => setResultMessage(''), []);
+
+  const clearArtFn = useCallback(async () => {
+    await catalog.clearArtCache?.();
+  }, [catalog]);
+
+  const refreshArtFn = useCallback(async () => {
+    await catalog.refreshArtCache?.();
+    window.dispatchEvent(new CustomEvent(ART_REFRESHED_EVENT));
+  }, [catalog]);
+
+  const exportFn = useCallback(async () => {
+    try {
+      const json = await catalog.exportLikes!();
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `vorbis-liked-songs-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setResultMessage('Exported!');
+    } catch {
+      setResultMessage('Export failed');
+    }
+  }, [catalog]);
+
+  const refreshMetadataFn = useCallback(async () => {
+    try {
+      const result = await catalog.refreshLikedMetadata!();
+      const parts: string[] = [];
+      if (result.updated > 0) parts.push(`${result.updated} updated`);
+      if (result.removed > 0) parts.push(`${result.removed} removed`);
+      setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
+    } catch {
+      setResultMessage('Refresh failed');
+    }
+  }, [catalog]);
+
+  const [clearArtStatus, runClearArt] = useAsyncAction(clearArtFn);
+  const [refreshArtStatus, runRefreshArt] = useAsyncAction(refreshArtFn);
+  const [exportStatus, runExport] = useAsyncAction(exportFn, { onReset: clearResultMessage });
+  const [metadataStatus, runRefreshMetadata] = useAsyncAction(refreshMetadataFn, { onReset: clearResultMessage });
+  const [importStatus, setImportStatus] = useState<'idle' | 'working' | 'done'>('idle');
+
+  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportStatus('working');
+    try {
+      const json = await file.text();
+      const count = await catalog.importLikes!(json);
+      setResultMessage(`Imported ${count} tracks`);
+    } catch {
+      setResultMessage('Import failed');
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setImportStatus('done');
+    setTimeout(() => { setImportStatus('idle'); setResultMessage(''); }, STATUS_RESET_DELAY_MS);
+  }, [catalog]);
+
+  const artBusy = clearArtStatus === 'working' || refreshArtStatus === 'working';
+  const likesBusy = exportStatus === 'working' || importStatus === 'working' || metadataStatus === 'working';
+
+  return (
+    <AccordionItem value={`${providerName.toLowerCase()}-data`}>
+      <AccordionTrigger>{`${providerName} Data`}</AccordionTrigger>
+      <AccordionContent>
+        <ControlBlock>
+          {hasArtCache && (
+            <ControlRow>
+              <ControlHelp>Clear cached art so it re-downloads on next library load</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runClearArt} disabled={artBusy}>
+                {clearArtStatus === 'done' ? 'Cleared!' : artBusy ? 'Working…' : 'Clear Art Cache'}
+              </Button>
+            </ControlRow>
+          )}
+          {hasRefreshArt && (
+            <ControlRow>
+              <ControlHelp>Clear and immediately re-fetch fresh art in the background</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runRefreshArt} disabled={artBusy}>
+                {refreshArtStatus === 'done' ? 'Started!' : artBusy ? 'Working…' : 'Refresh Art'}
+              </Button>
+            </ControlRow>
+          )}
+          {hasLikesManagement && (
+            <>
+              <ControlRow>
+                <ControlHelp>Export liked songs to a JSON file for backup</ControlHelp>
+                <Button variant="outline" size="sm" onClick={runExport} disabled={likesBusy}>
+                  {exportStatus === 'done' && resultMessage === 'Exported!' ? 'Exported!' : likesBusy ? 'Working…' : 'Export Likes'}
+                </Button>
+              </ControlRow>
+              <ControlRow>
+                <ControlHelp>Import liked songs from a previously exported JSON file</ControlHelp>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  onChange={handleImport}
+                  style={{ display: 'none' }}
+                />
+                <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={likesBusy}>
+                  {importStatus === 'done' && resultMessage.startsWith('Imported') ? resultMessage : likesBusy ? 'Working…' : 'Import Likes'}
+                </Button>
+              </ControlRow>
+            </>
+          )}
+          {hasMetadataRefresh && (
+            <ControlRow>
+              <ControlHelp>Re-scan {providerName} to update metadata for liked tracks</ControlHelp>
+              <Button variant="outline" size="sm" onClick={runRefreshMetadata} disabled={likesBusy}>
+                {metadataStatus === 'done' ? resultMessage || 'Done!' : likesBusy ? 'Scanning…' : 'Refresh Metadata'}
+              </Button>
+            </ControlRow>
+          )}
+        </ControlBlock>
+      </AccordionContent>
+    </AccordionItem>
+  );
+};

--- a/src/components/SettingsV2/sections/SourcesSection.tsx
+++ b/src/components/SettingsV2/sections/SourcesSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { MusicSourcesSection, NativeQueueSyncSection } from '@/components/AppSettingsMenu/SourcesSections';
+
+/**
+ * SettingsV2 Sources section — phase 2 port (#1450).
+ *
+ * Reuses the legacy `MusicSourcesSection` + `NativeQueueSyncSection` directly
+ * so v2 reads the same hooks (`useProviderContext`, `useTrackListContext`) and
+ * writes the same `STORAGE_KEYS.SPOTIFY_QUEUE_SYNC` /
+ * `STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER` keys. Both legacy components
+ * self-gate (Music Sources requires ≥2 providers; Native Queue Sync requires
+ * `capabilities.hasNativeQueueSync` on a connected provider) and return
+ * `null` when their conditions aren't met — the v2 section then renders
+ * empty, matching v1 behaviour.
+ */
+
+const SourcesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const SourcesSection: React.FC = () => {
+  return (
+    <SourcesContainer>
+      <MusicSourcesSection />
+      <NativeQueueSyncSection />
+    </SourcesContainer>
+  );
+};
+
+SourcesSection.displayName = 'SettingsV2.SourcesSection';
+
+export default SourcesSection;

--- a/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
@@ -1,0 +1,406 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+import { makeProviderDescriptor } from '@/test/fixtures';
+import type { ProviderDescriptor } from '@/types/providers';
+
+// ── Hook + service mocks ────────────────────────────────────────────────────
+
+const mockProfilerToggle = vi.fn();
+const mockSetVisualizerDebug = vi.fn();
+const mockClearCacheWithOptions = vi.fn().mockResolvedValue(undefined);
+const mockClearAllPins = vi.fn().mockResolvedValue(undefined);
+const mockClearPreferencesSyncTimestamp = vi.fn();
+const mockInitialSync = vi.fn();
+const mockGetPreferencesSync = vi.fn(() => ({ initialSync: mockInitialSync }));
+const mockSetQapEnabled = vi.fn();
+
+let mockProfilerEnabled = false;
+let mockVisualizerDebugEnabled = false;
+let mockQapEnabled = false;
+let mockEnabledProviderIds: string[] = [];
+let mockProviders: ProviderDescriptor[] = [];
+
+// In-memory localStorage shim — the global setup.ts mocks localStorage with
+// vi.fn() returning undefined, which prevents this section's accent-color
+// cleanup branch from being asserted. Override per-test with a real Map.
+const memoryStorage = new Map<string, string>();
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  useProfilingContext: vi.fn(() => ({
+    enabled: mockProfilerEnabled,
+    collector: null,
+    toggle: mockProfilerToggle,
+  })),
+}));
+
+vi.mock('@/contexts/VisualizerDebugContext', () => ({
+  useVisualizerDebug: vi.fn(() => ({
+    isDebugMode: mockVisualizerDebugEnabled,
+    setIsDebugMode: mockSetVisualizerDebug,
+  })),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    registry: {
+      getAll: () => mockProviders,
+      get: (id: string) => mockProviders.find((p) => p.id === id),
+    },
+    enabledProviderIds: mockEnabledProviderIds,
+  })),
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  clearCacheWithOptions: (...args: unknown[]) => mockClearCacheWithOptions(...args),
+}));
+
+vi.mock('@/services/settings/pinnedItemsStorage', () => ({
+  clearAllPins: () => mockClearAllPins(),
+}));
+
+vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
+  clearPreferencesSyncTimestamp: () => mockClearPreferencesSyncTimestamp(),
+  getPreferencesSync: () => mockGetPreferencesSync(),
+}));
+
+vi.mock('@/hooks/useAsyncAction', () => ({
+  useAsyncAction: (fn: () => Promise<void>) => {
+    return ['idle', fn];
+  },
+}));
+
+vi.mock('@/hooks/useLibrarySync', () => ({
+  ART_REFRESHED_EVENT: 'art-refreshed',
+}));
+
+vi.mock('@/hooks/useQapEnabled', () => ({
+  useQapEnabled: vi.fn(() => [
+    mockQapEnabled,
+    (next: boolean) => {
+      mockQapEnabled = next;
+      mockSetQapEnabled(next);
+      memoryStorage.set('vorbis-player-qap-enabled', JSON.stringify(next));
+    },
+  ]),
+}));
+
+import { AdvancedSection } from '../AdvancedSection';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+const QAP_STORAGE_KEY = 'vorbis-player-qap-enabled';
+
+describe('SettingsV2 AdvancedSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProfilerEnabled = false;
+    mockVisualizerDebugEnabled = false;
+    mockQapEnabled = false;
+    mockEnabledProviderIds = [];
+    mockProviders = [];
+    memoryStorage.clear();
+    // Override global localStorage mock with an in-memory shim so writes are
+    // observable. setup.ts replaces localStorage with vi.fn()s that return
+    // undefined; we restore real behaviour for this suite.
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => memoryStorage.get(key) ?? null,
+        setItem: (key: string, value: string) => memoryStorage.set(key, value),
+        removeItem: (key: string) => memoryStorage.delete(key),
+        clear: () => memoryStorage.clear(),
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    memoryStorage.clear();
+  });
+
+  describe('Quick Access Panel toggle', () => {
+    it('writes the QAP-enabled storage key when toggled on', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      const qapToggle = screen.getByLabelText('Toggle Quick Access Panel');
+      fireEvent.click(qapToggle);
+
+      // #then — the hook's setter persists JSON-encoded `true` under the canonical key
+      expect(mockSetQapEnabled).toHaveBeenCalledWith(true);
+      expect(memoryStorage.get(QAP_STORAGE_KEY)).toBe('true');
+    });
+
+    it('reflects the persisted QAP-enabled value on mount', () => {
+      // #given
+      mockQapEnabled = true;
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      const qapToggle = screen.getByLabelText('Toggle Quick Access Panel');
+      expect(qapToggle).toHaveAttribute('data-state', 'checked');
+    });
+  });
+
+  describe('Performance Profiler toggle', () => {
+    it('routes through useProfilingContext().toggle', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Toggle Performance Profiler'));
+
+      // #then
+      expect(mockProfilerToggle).toHaveBeenCalledOnce();
+    });
+
+    it('shows checked when profiler is enabled', () => {
+      // #given
+      mockProfilerEnabled = true;
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByLabelText('Toggle Performance Profiler')).toHaveAttribute('data-state', 'checked');
+    });
+  });
+
+  describe('Visualizer Debug toggle', () => {
+    it('routes through useVisualizerDebug().setIsDebugMode', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Toggle Visualizer Debug'));
+
+      // #then
+      expect(mockSetVisualizerDebug).toHaveBeenCalledOnce();
+    });
+
+    it('disables profiler when enabling visualizer debug while profiler is on', () => {
+      // #given
+      mockProfilerEnabled = true;
+      mockVisualizerDebugEnabled = false;
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Toggle Visualizer Debug'));
+
+      // #then
+      expect(mockProfilerToggle).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Clear Library Cache', () => {
+    it('shows confirm flow with the three option checkboxes when "Clear Cache" is pressed', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #then
+      expect(screen.getByText('Also clear Likes')).toBeInTheDocument();
+      expect(screen.getByText('Also clear Pins')).toBeInTheDocument();
+      expect(screen.getByText('Also clear Accent Colors')).toBeInTheDocument();
+    });
+
+    it('hides the "Also clear Likes" checkbox when a data provider is enabled', () => {
+      // #given — a provider exposing exportLikes lives in `dataProviders`
+      const spotify: ProviderDescriptor = {
+        ...makeProviderDescriptor(),
+        catalog: {
+          ...makeProviderDescriptor().catalog,
+          clearArtCache: vi.fn(),
+          exportLikes: vi.fn(),
+          importLikes: vi.fn(),
+        },
+      };
+      mockProviders = [spotify];
+      mockEnabledProviderIds = ['spotify'];
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #then
+      expect(screen.queryByText('Also clear Likes')).not.toBeInTheDocument();
+    });
+
+    it('forwards the selected options to clearCacheWithOptions and clearAllPins', async () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('Clear Cache'));
+      fireEvent.click(screen.getByLabelText('Also clear Pins'));
+
+      // #when
+      fireEvent.click(screen.getByText('Confirm Clear'));
+
+      // #then
+      await waitFor(() => {
+        expect(mockClearCacheWithOptions).toHaveBeenCalledWith({ clearLikes: false });
+      });
+      expect(mockClearAllPins).toHaveBeenCalledOnce();
+    });
+
+    it('removes the accent-color storage keys when "Also clear Accent Colors" is checked', async () => {
+      // #given
+      memoryStorage.set(STORAGE_KEYS.ACCENT_COLOR_OVERRIDES, '{}');
+      memoryStorage.set(STORAGE_KEYS.CUSTOM_ACCENT_COLORS, '{}');
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('Clear Cache'));
+      fireEvent.click(screen.getByLabelText('Also clear Accent Colors'));
+
+      // #when
+      fireEvent.click(screen.getByText('Confirm Clear'));
+
+      // #then
+      await waitFor(() => {
+        expect(memoryStorage.has(STORAGE_KEYS.ACCENT_COLOR_OVERRIDES)).toBe(false);
+      });
+      expect(memoryStorage.has(STORAGE_KEYS.CUSTOM_ACCENT_COLORS)).toBe(false);
+    });
+
+    it('returns to idle when Cancel is pressed during confirm', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByText('Clear Cache'));
+
+      // #when
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // #then
+      expect(screen.queryByText('Confirm Clear')).not.toBeInTheDocument();
+      expect(screen.getByText('Clear Cache')).toBeInTheDocument();
+    });
+  });
+
+  describe('Provider Data accordion', () => {
+    it('renders one accordion entry per data-capable provider', () => {
+      // #given
+      const spotify: ProviderDescriptor = {
+        ...makeProviderDescriptor(),
+        id: 'spotify',
+        name: 'Spotify',
+        catalog: {
+          ...makeProviderDescriptor().catalog,
+          clearArtCache: vi.fn(),
+        },
+      };
+      const dropbox: ProviderDescriptor = {
+        ...makeProviderDescriptor(),
+        id: 'dropbox' as 'spotify',
+        name: 'Dropbox',
+        catalog: {
+          ...makeProviderDescriptor().catalog,
+          clearArtCache: vi.fn(),
+        },
+      };
+      mockProviders = [spotify, dropbox];
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByText('Spotify Data')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox Data')).toBeInTheDocument();
+    });
+
+    it('hides the Provider Data block when no enabled provider exposes data ops', () => {
+      // #given — provider enabled but its catalog has neither clearArtCache nor exportLikes
+      const dropbox: ProviderDescriptor = {
+        ...makeProviderDescriptor(),
+        id: 'dropbox' as 'spotify',
+        name: 'Dropbox',
+      };
+      mockProviders = [dropbox];
+      mockEnabledProviderIds = ['dropbox'];
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByText('Provider Data')).not.toBeInTheDocument();
+      expect(screen.queryByText('Dropbox Data')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('About section', () => {
+    it('renders the keyboard-shortcut hints', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByText('About')).toBeInTheDocument();
+      expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument();
+      expect(screen.getByText('Open settings')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeProviderDescriptor } from '@/test/fixtures';
+import type { ProviderDescriptor } from '@/types/providers';
+
+// ── Context mocks ──────────────────────────────────────────────────────────
+
+const mockToggleProvider = vi.fn();
+
+const mockRegistry = {
+  getAll: vi.fn<[], ProviderDescriptor[]>(() => []),
+  get: vi.fn<[string], ProviderDescriptor | undefined>(() => undefined),
+  has: vi.fn(() => true),
+};
+
+let mockEnabledProviderIds: string[] = ['spotify', 'dropbox'];
+let mockConnectedProviderIds: string[] = ['spotify'];
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    registry: mockRegistry,
+    enabledProviderIds: mockEnabledProviderIds,
+    connectedProviderIds: mockConnectedProviderIds,
+    toggleProvider: mockToggleProvider,
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: vi.fn(() => ({
+    tracks: [],
+    setTracks: vi.fn(),
+    setOriginalTracks: vi.fn(),
+  })),
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: vi.fn((_key: string, defaultValue: unknown) => [defaultValue, vi.fn()]),
+}));
+
+import { SourcesSection } from '../SourcesSection';
+import { Toaster } from '@/components/ui/sonner';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <Toaster />
+    {children}
+  </ThemeProvider>
+);
+
+function makeDescriptor(
+  id: string,
+  name: string,
+  options: { hasNativeQueueSync?: boolean; isAuthenticated?: boolean } = {},
+): ProviderDescriptor {
+  const base = makeProviderDescriptor();
+  return {
+    ...base,
+    id: id as ProviderDescriptor['id'],
+    name,
+    auth: {
+      ...base.auth,
+      isAuthenticated: vi.fn().mockReturnValue(options.isAuthenticated ?? true),
+    },
+    capabilities: {
+      ...base.capabilities,
+      hasNativeQueueSync: options.hasNativeQueueSync ?? false,
+    },
+  };
+}
+
+describe('SettingsV2 SourcesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnabledProviderIds = ['spotify', 'dropbox'];
+    mockConnectedProviderIds = ['spotify'];
+    mockRegistry.getAll.mockReturnValue([]);
+    mockRegistry.get.mockReturnValue(undefined);
+  });
+
+  describe('MusicSourcesSection gating', () => {
+    it('renders the music-sources rows when ≥2 providers are registered', () => {
+      // #given
+      const spotify = makeDescriptor('spotify', 'Spotify');
+      const dropbox = makeDescriptor('dropbox', 'Dropbox');
+      mockRegistry.getAll.mockReturnValue([spotify, dropbox]);
+      mockRegistry.get.mockImplementation((id) => (id === 'spotify' ? spotify : dropbox));
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByText('Music Sources')).toBeInTheDocument();
+      expect(screen.getByText('Spotify')).toBeInTheDocument();
+      expect(screen.getByText('Dropbox')).toBeInTheDocument();
+    });
+
+    it('hides the music-sources block when only one provider is registered', () => {
+      // #given
+      const spotify = makeDescriptor('spotify', 'Spotify');
+      mockRegistry.getAll.mockReturnValue([spotify]);
+      mockRegistry.get.mockReturnValue(spotify);
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByText('Music Sources')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('NativeQueueSyncSection gating', () => {
+    it('renders the queue-sync block when a connected provider exposes hasNativeQueueSync', () => {
+      // #given
+      const spotify = makeDescriptor('spotify', 'Spotify', { hasNativeQueueSync: true });
+      const dropbox = makeDescriptor('dropbox', 'Dropbox');
+      mockRegistry.getAll.mockReturnValue([spotify, dropbox]);
+      mockConnectedProviderIds = ['spotify'];
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then — the section title interpolates the provider name
+      expect(screen.getByText('Spotify Queue')).toBeInTheDocument();
+    });
+
+    it('hides the queue-sync block when no connected provider exposes hasNativeQueueSync', () => {
+      // #given
+      const dropbox = makeDescriptor('dropbox', 'Dropbox', { hasNativeQueueSync: false });
+      mockRegistry.getAll.mockReturnValue([dropbox]);
+      mockConnectedProviderIds = ['dropbox'];
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByText(/Queue$/)).not.toBeInTheDocument();
+    });
+
+    it('hides the queue-sync block when the capable provider is not connected', () => {
+      // #given
+      const spotify = makeDescriptor('spotify', 'Spotify', { hasNativeQueueSync: true });
+      const dropbox = makeDescriptor('dropbox', 'Dropbox');
+      mockRegistry.getAll.mockReturnValue([spotify, dropbox]);
+      mockConnectedProviderIds = ['dropbox'];
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByText('Spotify Queue')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('renders nothing inside the section when both children gate-out', () => {
+      // #given — single provider, no native queue sync
+      const dropbox = makeDescriptor('dropbox', 'Dropbox');
+      mockRegistry.getAll.mockReturnValue([dropbox]);
+      mockConnectedProviderIds = ['dropbox'];
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByText('Music Sources')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Queue$/)).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Port Music Sources, Native Queue Sync, Quick Access Panel toggle, Provider Data accordion, Clear Library Cache, Performance Profiler, Visualizer Debug, and About into `SettingsV2/sections/SourcesSection.tsx` + `AdvancedSection.tsx`. Mounted via `SettingsV2Content.tsx` (and re-used by the mobile takeover).
- Same hooks, same storage keys — v2 and v1 are parallel surfaces; toggling in either reflects immediately in the other (`useQapEnabled`, `useProfilingContext`, `useVisualizerDebug`, `STORAGE_KEYS.SPOTIFY_QUEUE_*`, `clearCacheWithOptions` + `clearAllPins`).
- Section bodies are lazy-loaded so the shell test stays isolated and the bundle code-splits (`SourcesSection` 0.46 kB, `AdvancedSection` 9.78 kB).
- Theme-bridge cleanup: migrated the three accent-color escape hatches in `AppSettingsMenu/styled.ts` to neutral shadcn defaults (`ResetButton` hover, `CacheCheckbox` checked, `OptionButton` active + hover) so the legacy panel chrome no longer retints per track. `controls/QuickEffectsRow.tsx` stays on the accent variant — that's player chrome.

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — 1866 passed (added section tests verify storage-key parity with legacy controls)
- `npm run build` — clean, sections code-split correctly
- Manual: toggle a setting in v1 (`?ui=v1`), open v2 (`?ui=v2&settings=open`), confirm state reflects without reload. Vice versa.

Closes #1450. Phase 2 of epic #1262 — Sources + Advanced delivered; Appearance (#1451) and Playback (#1452) follow.