### PR TITLE
feat(settings-v2): build Appearance section

### DIFF
--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -21,6 +21,9 @@ const SourcesSection = lazy(() =>
 const AdvancedSection = lazy(() =>
   import('./sections/AdvancedSection').then((m) => ({ default: m.AdvancedSection })),
 );
+const AppearanceSection = lazy(() =>
+  import('./sections/AppearanceSection').then((m) => ({ default: m.AppearanceSection })),
+);
 
 interface SettingsV2ContentProps {
   activeSection: SettingsV2SectionId;
@@ -48,8 +51,8 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
 /**
  * Maps a section ID to the live-content component, or to a placeholder for
  * sections still scheduled for future phases. Phase 2 (#1450) ships
- * `sources` + `advanced`; `playback` (#1452) and `appearance` (#1451) keep
- * the placeholder treatment from phase 1.
+ * `sources` + `advanced`; phase 3 (#1451) ships `appearance`; `playback`
+ * (#1452) keeps the placeholder treatment from phase 1.
  */
 export const SettingsV2SectionBody: React.FC<{ activeSection: SettingsV2SectionId }> = ({ activeSection }) => {
   switch (activeSection) {
@@ -69,8 +72,15 @@ export const SettingsV2SectionBody: React.FC<{ activeSection: SettingsV2SectionI
         </Suspense>
       );
     }
+    case 'appearance': {
+      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+      return (
+        <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
+          <AppearanceSection />
+        </Suspense>
+      );
+    }
     case 'playback':
-    case 'appearance':
     default: {
       const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
       return (

--- a/src/components/SettingsV2/sections/AppearanceSection.styled.ts
+++ b/src/components/SettingsV2/sections/AppearanceSection.styled.ts
@@ -1,0 +1,126 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const ControlBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const ControlLabelText = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: hsl(var(--foreground));
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+`;
+
+export const ControlHelp = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+export const SectionGroupTitle = styled.h4`
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+export const Divider = styled.div`
+  border-top: 1px solid hsl(var(--border));
+`;
+
+export const SubControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+  flex-wrap: wrap;
+`;
+
+export const SubControlLabel = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  min-width: 64px;
+`;
+
+export const SwatchRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  flex-wrap: wrap;
+`;
+
+export const SwatchButton = styled.button<{ $color: string; $isActive: boolean }>`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+  border: ${({ $isActive }) =>
+    $isActive ? '2px solid hsl(var(--foreground))' : '1px solid hsl(var(--border))'};
+  outline: ${({ $isActive }) => ($isActive ? '2px solid hsl(var(--ring))' : 'none')};
+  outline-offset: 1px;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: border ${({ theme }) => theme.transitions.fast};
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+`;
+
+export const SwatchIconButton = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid hsl(var(--border));
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  transition:
+    background ${({ theme }) => theme.transitions.fast},
+    color ${({ theme }) => theme.transitions.fast};
+
+  &:hover:not(:disabled) {
+    background: hsl(var(--muted));
+    color: hsl(var(--foreground));
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;

--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback } from 'react';
+
+import { useTranslucence } from '@/contexts/visualEffects';
+import { Switch } from '@/components/ui/switch';
+
+import { AccentColorManager } from './appearance/AccentColorManager';
+import { GlowControls } from './appearance/GlowControls';
+import { VisualizerStylePicker } from './appearance/VisualizerStylePicker';
+import {
+  Container,
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+  Divider,
+} from './AppearanceSection.styled';
+
+/**
+ * SettingsV2 Appearance section — phase 3 port (#1451).
+ *
+ * Composes the four appearance control groups, each routed through the same
+ * hook + storage-key contract as the legacy `controls/QuickEffectsRow`:
+ *
+ *   - {@link AccentColorManager}  → `ColorContext` (`ACCENT_COLOR_OVERRIDES` +
+ *     `CUSTOM_ACCENT_COLORS`; preserves the dual-key write rule + the
+ *     `'RESET_TO_DEFAULT'` sentinel verbatim).
+ *   - {@link GlowControls}        → `useVisualEffectsToggle` +
+ *     `useVisualEffectsState` (`VISUAL_EFFECTS_ENABLED` + `GLOW_INTENSITY` +
+ *     `GLOW_RATE`).
+ *   - {@link VisualizerStylePicker} → `VisualizerContext` (`BG_VISUALIZER_*`).
+ *   - Translucence on/off          → `TranslucenceContext`
+ *     (`TRANSLUCENCE_ENABLED`). Opacity slider is intentionally omitted —
+ *     `TRANSLUCENCE_OPACITY` has no v1 UI today and is deferred to #1463.
+ *
+ * v2 chrome stays neutral (`hsl(var(--*))` only) — the player-chrome accent
+ * variant lives in `controls/QuickEffectsRow` and is intentionally not
+ * mirrored here.
+ */
+const TranslucenceToggle: React.FC = () => {
+  const { translucenceEnabled, setTranslucenceEnabled } = useTranslucence();
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      setTranslucenceEnabled(checked);
+    },
+    [setTranslucenceEnabled],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Translucence</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-translucence-toggle">Translucent surfaces</ControlLabelText>
+          <ControlHelp>Apply a frosted-glass effect to layered panels.</ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-translucence-toggle"
+          checked={translucenceEnabled}
+          onCheckedChange={handleToggle}
+          aria-label="Toggle translucence"
+          variant="neutral"
+        />
+      </ControlRow>
+    </ControlBlock>
+  );
+};
+
+TranslucenceToggle.displayName = 'SettingsV2.TranslucenceToggle';
+
+export const AppearanceSection: React.FC = () => {
+  return (
+    <Container>
+      <AccentColorManager />
+      <Divider />
+      <GlowControls />
+      <Divider />
+      <VisualizerStylePicker />
+      <Divider />
+      <TranslucenceToggle />
+    </Container>
+  );
+};
+
+AppearanceSection.displayName = 'SettingsV2.AppearanceSection';
+
+export default AppearanceSection;

--- a/src/components/SettingsV2/sections/__tests__/AccentColorManager.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorManager.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import type { MediaTrack } from '@/types/domain';
+
+const mockSetAccentColor = vi.fn();
+const mockHandleSetAccentColorOverride = vi.fn();
+const mockHandleRemoveAccentColorOverride = vi.fn();
+const mockHandleResetAccentColorOverride = vi.fn();
+const mockHandleSetCustomAccentColor = vi.fn();
+const mockHandleRemoveCustomAccentColor = vi.fn();
+
+let mockAccentColor = '#ff0000';
+let mockCustomAccentColors: Record<string, string> = {};
+let mockCurrentTrack: MediaTrack | null = {
+  id: 't1',
+  provider: 'spotify',
+  playbackRef: { provider: 'spotify', ref: 'spotify:track:t1' },
+  name: 'Test Track',
+  artists: 'Test Artist',
+  album: 'Test Album',
+  albumId: 'album-123',
+  durationMs: 1000,
+  image: 'https://example.com/image.jpg',
+};
+
+vi.mock('@/contexts/ColorContext', () => ({
+  useColorContext: vi.fn(() => ({
+    accentColor: mockAccentColor,
+    accentColorOverrides: {},
+    customAccentColors: mockCustomAccentColors,
+    setAccentColor: mockSetAccentColor,
+    setAccentColorOverrides: vi.fn(),
+    handleSetAccentColorOverride: mockHandleSetAccentColorOverride,
+    handleRemoveAccentColorOverride: mockHandleRemoveAccentColorOverride,
+    handleResetAccentColorOverride: mockHandleResetAccentColorOverride,
+    handleSetCustomAccentColor: mockHandleSetCustomAccentColor,
+    handleRemoveCustomAccentColor: mockHandleRemoveCustomAccentColor,
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrack: mockCurrentTrack,
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+    showQueue: false,
+    setShowQueue: vi.fn(),
+  })),
+}));
+
+vi.mock('@/utils/colorExtractor', () => ({
+  extractTopVibrantColors: vi.fn(async () => [
+    { hex: '#ff0000', score: 1 },
+    { hex: '#00ff00', score: 0.9 },
+  ]),
+}));
+
+vi.mock('@/components/EyedropperOverlay', () => ({
+  default: ({ onPick, onClose }: { onPick: (color: string) => void; onClose: () => void }) => (
+    <div data-testid="eyedropper-overlay">
+      <button data-testid="eyedropper-pick" onClick={() => onPick('#abcdef')}>
+        Pick
+      </button>
+      <button data-testid="eyedropper-close" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+import { AccentColorManager } from '../appearance/AccentColorManager';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('SettingsV2 AccentColorManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccentColor = '#ff0000';
+    mockCustomAccentColors = {};
+    mockCurrentTrack = {
+      id: 't1',
+      name: 'Test Track',
+      artist: 'Test Artist',
+      album: 'Test Album',
+      albumId: 'album-123',
+      duration_ms: 1000,
+      image: 'https://example.com/image.jpg',
+      uri: 'spotify:track:t1',
+      provider: 'spotify',
+    };
+  });
+
+  describe('palette swatch selection', () => {
+    it('writes ACCENT_COLOR_OVERRIDES only (not CUSTOM_ACCENT_COLORS) when a palette swatch is clicked', async () => {
+      // #given
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+      await waitFor(() => screen.getByLabelText('Choose color #ff0000'));
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Choose color #00ff00'));
+
+      // #then — palette clicks single-write to ACCENT_COLOR_OVERRIDES so the
+      // eyedropper-picked custom swatch is preserved (matches legacy rule).
+      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('album-123', '#00ff00');
+      expect(mockHandleSetCustomAccentColor).not.toHaveBeenCalled();
+      expect(mockSetAccentColor).toHaveBeenCalledWith('#00ff00');
+    });
+  });
+
+  describe('eyedropper pick (dual-key write contract)', () => {
+    it('writes BOTH ACCENT_COLOR_OVERRIDES AND CUSTOM_ACCENT_COLORS when the eyedropper picks a color', async () => {
+      // #given
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByLabelText('Pick color from album art'));
+      await waitFor(() => screen.getByTestId('eyedropper-overlay'));
+
+      // #when
+      fireEvent.click(screen.getByTestId('eyedropper-pick'));
+
+      // #then — dual-key write contract verbatim from
+      // PlayerContent/AlbumArtSection.handleCustomAccentColor
+      expect(mockHandleSetAccentColorOverride).toHaveBeenCalledWith('album-123', '#abcdef');
+      expect(mockHandleSetCustomAccentColor).toHaveBeenCalledWith('album-123', '#abcdef');
+      expect(mockSetAccentColor).toHaveBeenCalledWith('#abcdef');
+    });
+
+    it('renders the custom-accent swatch when one is stored', async () => {
+      // #given
+      mockCustomAccentColors = { 'album-123': '#deadbe' };
+
+      // #when
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByLabelText('Use custom color')).toBeInTheDocument();
+    });
+  });
+
+  describe('reset (RESET_TO_DEFAULT sentinel)', () => {
+    it('clears BOTH ACCENT_COLOR_OVERRIDES AND CUSTOM_ACCENT_COLORS when Reset is clicked', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: 'Reset accent color to default' }));
+
+      // #then — mirrors QuickEffectsRow's reset:
+      //   onCustomAccentColor('') → removes BOTH keys
+      //   onAccentColorChange('RESET_TO_DEFAULT') → handleResetAccentColorOverride
+      expect(mockHandleRemoveAccentColorOverride).toHaveBeenCalledWith('album-123');
+      expect(mockHandleRemoveCustomAccentColor).toHaveBeenCalledWith('album-123');
+      expect(mockHandleResetAccentColorOverride).toHaveBeenCalledWith('album-123');
+    });
+  });
+
+  describe('no-track guard', () => {
+    it('does not call any setter when no track is playing and a swatch action is attempted', async () => {
+      // #given
+      mockCurrentTrack = null;
+
+      // #when
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+
+      // #then — Reset button is disabled, eyedropper button is disabled,
+      // and no palette swatches render (no album art to extract from).
+      expect(screen.getByRole('button', { name: 'Reset accent color to default' })).toBeDisabled();
+      expect(screen.getByLabelText('Pick color from album art')).toBeDisabled();
+    });
+
+    it('does not write keys when albumId is missing', () => {
+      // #given
+      mockCurrentTrack = { ...mockCurrentTrack!, albumId: undefined };
+
+      // #when
+      render(
+        <Wrapper>
+          <AccentColorManager />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Reset accent color to default' }));
+
+      // #then
+      expect(mockHandleRemoveAccentColorOverride).not.toHaveBeenCalled();
+      expect(mockHandleRemoveCustomAccentColor).not.toHaveBeenCalled();
+      expect(mockHandleResetAccentColorOverride).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/AccentColorManager.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorManager.test.tsx
@@ -85,14 +85,14 @@ describe('SettingsV2 AccentColorManager', () => {
     mockCustomAccentColors = {};
     mockCurrentTrack = {
       id: 't1',
+      provider: 'spotify',
+      playbackRef: { provider: 'spotify', ref: 'spotify:track:t1' },
       name: 'Test Track',
-      artist: 'Test Artist',
+      artists: 'Test Artist',
       album: 'Test Album',
       albumId: 'album-123',
-      duration_ms: 1000,
+      durationMs: 1000,
       image: 'https://example.com/image.jpg',
-      uri: 'spotify:track:t1',
-      provider: 'spotify',
     };
   });
 

--- a/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+// In-memory localStorage shim — setup.ts replaces window.localStorage with
+// vi.fn() returning undefined, which prevents any `useLocalStorage`-backed
+// context from observing writes. This shim lets v1 and v2 surfaces share
+// real persistence within a single test.
+const memoryStorage = new Map<string, string>();
+
+const installLocalStorageShim = () => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => memoryStorage.set(key, value),
+      removeItem: (key: string) => memoryStorage.delete(key),
+      clear: () => memoryStorage.clear(),
+      key: () => null,
+      length: 0,
+    },
+    writable: true,
+    configurable: true,
+  });
+};
+
+vi.mock('@/contexts/ColorContext', () => ({
+  useColorContext: vi.fn(() => ({
+    accentColor: '#ff0000',
+    accentColorOverrides: {},
+    customAccentColors: {},
+    setAccentColor: vi.fn(),
+    setAccentColorOverrides: vi.fn(),
+    handleSetAccentColorOverride: vi.fn(),
+    handleRemoveAccentColorOverride: vi.fn(),
+    handleResetAccentColorOverride: vi.fn(),
+    handleSetCustomAccentColor: vi.fn(),
+    handleRemoveCustomAccentColor: vi.fn(),
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrack: null,
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+    showQueue: false,
+    setShowQueue: vi.fn(),
+  })),
+}));
+
+vi.mock('@/utils/colorExtractor', () => ({
+  extractTopVibrantColors: vi.fn(async () => []),
+}));
+
+vi.mock('@/components/EyedropperOverlay', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
+  getPreferencesSync: () => null,
+}));
+
+import { AppearanceSection } from '../AppearanceSection';
+import { VisualizerProvider, VisualEffectsToggleProvider, TranslucenceProvider } from '@/contexts/visualEffects';
+import { useVisualizer, useTranslucence, useVisualEffectsToggle } from '@/contexts/visualEffects';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <VisualEffectsToggleProvider>
+      <VisualizerProvider>
+        <TranslucenceProvider>{children}</TranslucenceProvider>
+      </VisualizerProvider>
+    </VisualEffectsToggleProvider>
+  </ThemeProvider>
+);
+
+describe('SettingsV2 AppearanceSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryStorage.clear();
+    installLocalStorageShim();
+  });
+
+  it('renders all four control groups', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByText('Accent Color')).toBeInTheDocument();
+    expect(screen.getByText('Glow')).toBeInTheDocument();
+    expect(screen.getByText('Visualizer')).toBeInTheDocument();
+    expect(screen.getByText('Translucence')).toBeInTheDocument();
+  });
+
+  it('writes TRANSLUCENCE_ENABLED only (no opacity slider) when toggled', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #when — translucence default is `true`, click toggles to `false`
+    fireEvent.click(screen.getByLabelText('Toggle translucence'));
+
+    // #then — single key is written; TRANSLUCENCE_OPACITY is untouched (deferred to #1463)
+    expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
+    expect(memoryStorage.has(STORAGE_KEYS.TRANSLUCENCE_OPACITY)).toBe(false);
+  });
+
+  it('does not render an opacity slider for translucence', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #then — TranslucenceToggle is on/off only per stage 2 scope
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+    expect(screen.queryByText(/opacity/i)).not.toBeInTheDocument();
+  });
+
+  describe('v1 ↔ v2 storage round-trip', () => {
+    /**
+     * Mounts both surfaces against the same context providers. A toggle in
+     * v2 writes to `localStorage`; a sibling consumer (`v1Reader`) reads
+     * the same `useLocalStorage`-backed value via the same provider tree
+     * and reflects the change on next render. This is the strict definition
+     * of "shared storage parity" the brief asks for — both surfaces own the
+     * same key via the same hook.
+     */
+
+    const VisualizerStateProbe: React.FC<{ onState: (state: ReturnType<typeof useVisualizer>) => void }> = ({
+      onState,
+    }) => {
+      const state = useVisualizer();
+      onState(state);
+      return null;
+    };
+
+    const TranslucenceStateProbe: React.FC<{ onState: (state: ReturnType<typeof useTranslucence>) => void }> = ({
+      onState,
+    }) => {
+      const state = useTranslucence();
+      onState(state);
+      return null;
+    };
+
+    const GlowStateProbe: React.FC<{ onState: (state: ReturnType<typeof useVisualEffectsToggle>) => void }> = ({
+      onState,
+    }) => {
+      const state = useVisualEffectsToggle();
+      onState(state);
+      return null;
+    };
+
+    it('reflects a v2 visualizer-style change in a sibling v1-style reader', () => {
+      // #given — both surfaces mounted against the same provider
+      let lastVizState: ReturnType<typeof useVisualizer> | null = null;
+      render(
+        <Wrapper>
+          <AppearanceSection />
+          <VisualizerStateProbe onState={(s) => (lastVizState = s)} />
+        </Wrapper>,
+      );
+
+      // #when — v2 changes the style
+      act(() => {
+        fireEvent.click(screen.getByText('Wave'));
+      });
+
+      // #then — the sibling reader sees the same value, and the storage key was written
+      expect(lastVizState!.backgroundVisualizerStyle).toBe('wave');
+      expect(memoryStorage.get(STORAGE_KEYS.BG_VISUALIZER_STYLE)).toBe('"wave"');
+    });
+
+    it('reflects a v1-side write to BG_VISUALIZER_ENABLED in the v2 visualizer toggle', () => {
+      // #given — pre-populate storage as if v1 wrote `false`
+      memoryStorage.set(STORAGE_KEYS.BG_VISUALIZER_ENABLED, JSON.stringify(false));
+
+      // #when
+      render(
+        <Wrapper>
+          <AppearanceSection />
+        </Wrapper>,
+      );
+
+      // #then — v2 reads the v1-written value on mount via the shared context
+      expect(screen.getByLabelText('Toggle background visualizer')).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    it('reflects a v2 glow toggle in a sibling visual-effects-toggle reader', () => {
+      // #given
+      let lastGlowState: ReturnType<typeof useVisualEffectsToggle> | null = null;
+      render(
+        <Wrapper>
+          <AppearanceSection />
+          <GlowStateProbe onState={(s) => (lastGlowState = s)} />
+        </Wrapper>,
+      );
+
+      // #when — default is `true`, toggle flips it
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Toggle album-art glow'));
+      });
+
+      // #then
+      expect(lastGlowState!.visualEffectsEnabled).toBe(false);
+      expect(memoryStorage.get(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED)).toBe('false');
+    });
+
+    it('reflects a v2 translucence toggle in a sibling translucence reader', () => {
+      // #given
+      let lastTransState: ReturnType<typeof useTranslucence> | null = null;
+      render(
+        <Wrapper>
+          <AppearanceSection />
+          <TranslucenceStateProbe onState={(s) => (lastTransState = s)} />
+        </Wrapper>,
+      );
+
+      // #when
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Toggle translucence'));
+      });
+
+      // #then
+      expect(lastTransState!.translucenceEnabled).toBe(false);
+      expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
+    });
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/GlowControls.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/GlowControls.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+const mockSetEnabled = vi.fn();
+const mockSetIntensity = vi.fn();
+const mockSetRate = vi.fn();
+const mockRestoreGlowSettings = vi.fn();
+
+let mockEnabled = true;
+let mockIntensity = 110;
+let mockRate = 4.0;
+
+const memoryStorage = new Map<string, string>();
+
+vi.mock('@/contexts/visualEffects', () => ({
+  useVisualEffectsToggle: vi.fn(() => ({
+    visualEffectsEnabled: mockEnabled,
+    setVisualEffectsEnabled: (next: boolean) => {
+      mockEnabled = next;
+      mockSetEnabled(next);
+      memoryStorage.set(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED, JSON.stringify(next));
+    },
+  })),
+}));
+
+vi.mock('@/hooks/useVisualEffectsState', () => ({
+  useVisualEffectsState: vi.fn(() => ({
+    glowIntensity: mockIntensity,
+    glowRate: mockRate,
+    handleGlowIntensityChange: (next: number) => {
+      mockIntensity = next;
+      mockSetIntensity(next);
+      memoryStorage.set(STORAGE_KEYS.GLOW_INTENSITY, JSON.stringify(next));
+    },
+    handleGlowRateChange: (next: number) => {
+      mockRate = next;
+      mockSetRate(next);
+      memoryStorage.set(STORAGE_KEYS.GLOW_RATE, JSON.stringify(next));
+    },
+    restoreGlowSettings: mockRestoreGlowSettings,
+  })),
+}));
+
+import { GlowControls } from '../appearance/GlowControls';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('SettingsV2 GlowControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnabled = true;
+    mockIntensity = 110;
+    mockRate = 4.0;
+    memoryStorage.clear();
+  });
+
+  it('writes VISUAL_EFFECTS_ENABLED when the toggle is flipped off', () => {
+    // #given
+    render(
+      <Wrapper>
+        <GlowControls />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Toggle album-art glow'));
+
+    // #then
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    expect(memoryStorage.get(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED)).toBe('false');
+  });
+
+  it('restores glow settings when toggling back on', () => {
+    // #given
+    mockEnabled = false;
+    render(
+      <Wrapper>
+        <GlowControls />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Toggle album-art glow'));
+
+    // #then
+    expect(mockSetEnabled).toHaveBeenCalledWith(true);
+    expect(mockRestoreGlowSettings).toHaveBeenCalledOnce();
+  });
+
+  it('writes the canonical glow intensity preset values (95/110/125)', () => {
+    // #given
+    render(
+      <Wrapper>
+        <GlowControls />
+      </Wrapper>,
+    );
+
+    // #when
+    const intensityGroup = screen.getByLabelText('Glow intensity');
+    fireEvent.click(intensityGroup.querySelector('button:nth-of-type(1)')!);
+    fireEvent.click(intensityGroup.querySelector('button:nth-of-type(3)')!);
+
+    // #then
+    expect(mockSetIntensity).toHaveBeenNthCalledWith(1, 95);
+    expect(mockSetIntensity).toHaveBeenNthCalledWith(2, 125);
+    expect(memoryStorage.get(STORAGE_KEYS.GLOW_INTENSITY)).toBe('125');
+  });
+
+  it('writes the canonical glow rate preset values (5.0/4.0/3.0)', () => {
+    // #given
+    render(
+      <Wrapper>
+        <GlowControls />
+      </Wrapper>,
+    );
+
+    // #when
+    const rateGroup = screen.getByLabelText('Glow rate');
+    fireEvent.click(rateGroup.querySelector('button:nth-of-type(1)')!);
+    fireEvent.click(rateGroup.querySelector('button:nth-of-type(3)')!);
+
+    // #then
+    expect(mockSetRate).toHaveBeenNthCalledWith(1, 5.0);
+    expect(mockSetRate).toHaveBeenNthCalledWith(2, 3.0);
+    expect(memoryStorage.get(STORAGE_KEYS.GLOW_RATE)).toBe('3');
+  });
+
+  it('hides intensity + rate sub-controls when glow is disabled', () => {
+    // #given
+    mockEnabled = false;
+
+    // #when
+    render(
+      <Wrapper>
+        <GlowControls />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.queryByText('Intensity')).not.toBeInTheDocument();
+    expect(screen.queryByText('Rate')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/VisualizerStylePicker.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/VisualizerStylePicker.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+import type { VisualizerStyle } from '@/types/visualizer';
+
+const mockSetStyle = vi.fn();
+const mockSetEnabled = vi.fn();
+const mockSetIntensity = vi.fn();
+const mockSetSpeed = vi.fn();
+
+let mockEnabled = true;
+let mockStyle: VisualizerStyle = 'fireflies';
+let mockIntensity = 40;
+let mockSpeed = 0.7;
+
+const memoryStorage = new Map<string, string>();
+
+vi.mock('@/contexts/visualEffects', () => ({
+  useVisualizer: vi.fn(() => ({
+    backgroundVisualizerEnabled: mockEnabled,
+    setBackgroundVisualizerEnabled: (next: boolean) => {
+      mockEnabled = next;
+      mockSetEnabled(next);
+      memoryStorage.set(STORAGE_KEYS.BG_VISUALIZER_ENABLED, JSON.stringify(next));
+    },
+    backgroundVisualizerStyle: mockStyle,
+    setBackgroundVisualizerStyle: (next: VisualizerStyle) => {
+      mockStyle = next;
+      mockSetStyle(next);
+      memoryStorage.set(STORAGE_KEYS.BG_VISUALIZER_STYLE, JSON.stringify(next));
+    },
+    backgroundVisualizerIntensity: mockIntensity,
+    setBackgroundVisualizerIntensity: (next: number) => {
+      mockIntensity = next;
+      mockSetIntensity(next);
+      memoryStorage.set(STORAGE_KEYS.BG_VISUALIZER_INTENSITY, JSON.stringify(next));
+    },
+    backgroundVisualizerSpeed: mockSpeed,
+    setBackgroundVisualizerSpeed: (next: number) => {
+      mockSpeed = next;
+      mockSetSpeed(next);
+      memoryStorage.set(STORAGE_KEYS.BG_VISUALIZER_SPEED, JSON.stringify(next));
+    },
+  })),
+}));
+
+import { VisualizerStylePicker } from '../appearance/VisualizerStylePicker';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('SettingsV2 VisualizerStylePicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnabled = true;
+    mockStyle = 'fireflies';
+    mockIntensity = 40;
+    mockSpeed = 0.7;
+    memoryStorage.clear();
+  });
+
+  it('writes BG_VISUALIZER_STYLE when a style button is clicked', () => {
+    // #given
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByText('Comet'));
+
+    // #then
+    expect(mockSetStyle).toHaveBeenCalledWith('comet');
+    expect(memoryStorage.get(STORAGE_KEYS.BG_VISUALIZER_STYLE)).toBe('"comet"');
+  });
+
+  it('writes BG_VISUALIZER_ENABLED when the toggle is flipped off', () => {
+    // #given
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Toggle background visualizer'));
+
+    // #then
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    expect(memoryStorage.get(STORAGE_KEYS.BG_VISUALIZER_ENABLED)).toBe('false');
+  });
+
+  it('hides style + intensity + speed sub-controls when disabled', () => {
+    // #given
+    mockEnabled = false;
+
+    // #when
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #then — none of the sub-control labels render
+    expect(screen.queryByText('Style')).not.toBeInTheDocument();
+    expect(screen.queryByText('Intensity')).not.toBeInTheDocument();
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument();
+  });
+
+  it('writes the canonical intensity preset values (20/40/60)', () => {
+    // #given
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #when
+    const intensityGroup = screen.getByLabelText('Visualizer intensity');
+    fireEvent.click(intensityGroup.querySelector('button:nth-of-type(1)')!);
+    fireEvent.click(intensityGroup.querySelector('button:nth-of-type(3)')!);
+
+    // #then
+    expect(mockSetIntensity).toHaveBeenNthCalledWith(1, 20);
+    expect(mockSetIntensity).toHaveBeenNthCalledWith(2, 60);
+    expect(memoryStorage.get(STORAGE_KEYS.BG_VISUALIZER_INTENSITY)).toBe('60');
+  });
+
+  it('writes the canonical speed preset values (0.5/0.7/1.2)', () => {
+    // #given
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #when
+    const speedGroup = screen.getByLabelText('Visualizer speed');
+    fireEvent.click(speedGroup.querySelector('button:nth-of-type(3)')!);
+
+    // #then
+    expect(mockSetSpeed).toHaveBeenCalledWith(1.2);
+    expect(memoryStorage.get(STORAGE_KEYS.BG_VISUALIZER_SPEED)).toBe('1.2');
+  });
+
+  it('marks the active style button via aria-checked', () => {
+    // #given
+    mockStyle = 'wave';
+
+    // #when
+    render(
+      <Wrapper>
+        <VisualizerStylePicker />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByText('Wave')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText('Fireflies')).toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/src/components/SettingsV2/sections/appearance/AccentColorManager.tsx
+++ b/src/components/SettingsV2/sections/appearance/AccentColorManager.tsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Pipette } from 'lucide-react';
+
+import { useColorContext } from '@/contexts/ColorContext';
+import { useCurrentTrackContext } from '@/contexts/TrackContext';
+import { extractTopVibrantColors, type ExtractedColor } from '@/utils/colorExtractor';
+import EyedropperOverlay from '@/components/EyedropperOverlay';
+import { Button } from '@/components/ui/button';
+
+import {
+  ControlBlock,
+  ControlHelp,
+  SectionGroupTitle,
+  SubControlRow,
+  SubControlLabel,
+  SwatchRow,
+  SwatchButton,
+  SwatchIconButton,
+} from '../AppearanceSection.styled';
+
+/**
+ * Mirrors the dual-key write contract used by
+ * `PlayerContent/AlbumArtSection.handleCustomAccentColor` (writes BOTH
+ * `ACCENT_COLOR_OVERRIDES` AND `CUSTOM_ACCENT_COLORS`) and
+ * `handleAccentColorChange` (intercepts the `'RESET_TO_DEFAULT'` sentinel).
+ *
+ * The eyedropper picks must dual-write so the chrome's "custom" swatch
+ * (`controls/QuickEffectsRow`) keeps rendering. Palette swatches single-write
+ * to `ACCENT_COLOR_OVERRIDES` (matches legacy behaviour — palette clicks
+ * never overwrite the eyedropper-picked custom swatch).
+ */
+const RESET_SENTINEL = 'RESET_TO_DEFAULT' as const;
+
+export const AccentColorManager: React.FC = () => {
+  const { currentTrack } = useCurrentTrackContext();
+  const {
+    accentColor,
+    customAccentColors,
+    setAccentColor,
+    handleSetAccentColorOverride,
+    handleRemoveAccentColorOverride,
+    handleResetAccentColorOverride,
+    handleSetCustomAccentColor,
+    handleRemoveCustomAccentColor,
+  } = useColorContext();
+
+  const [colorOptions, setColorOptions] = useState<ExtractedColor[]>([]);
+  const [showEyedropper, setShowEyedropper] = useState(false);
+
+  const albumId = currentTrack?.albumId;
+  const customColor = albumId ? customAccentColors[albumId] : undefined;
+
+  useEffect(() => {
+    if (currentTrack?.image) {
+      let cancelled = false;
+      extractTopVibrantColors(currentTrack.image, 2).then((colors) => {
+        if (!cancelled) setColorOptions(colors);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setColorOptions([]);
+    return undefined;
+  }, [currentTrack?.image]);
+
+  const applyAccentColor = useCallback(
+    (color: string) => {
+      if (!albumId) return;
+      handleSetAccentColorOverride(albumId, color);
+      setAccentColor(color);
+    },
+    [albumId, handleSetAccentColorOverride, setAccentColor],
+  );
+
+  const applyCustomAccentColor = useCallback(
+    (color: string) => {
+      if (!albumId) return;
+      if (color === '') {
+        handleRemoveAccentColorOverride(albumId);
+        handleRemoveCustomAccentColor(albumId);
+        return;
+      }
+      handleSetAccentColorOverride(albumId, color);
+      handleSetCustomAccentColor(albumId, color);
+      setAccentColor(color);
+    },
+    [
+      albumId,
+      handleSetAccentColorOverride,
+      handleRemoveAccentColorOverride,
+      handleSetCustomAccentColor,
+      handleRemoveCustomAccentColor,
+      setAccentColor,
+    ],
+  );
+
+  const handleReset = useCallback(() => {
+    if (!albumId) return;
+    applyCustomAccentColor('');
+    handleResetAccentColorOverride(albumId);
+  }, [albumId, applyCustomAccentColor, handleResetAccentColorOverride]);
+
+  const handleEyedropperPick = useCallback(
+    (color: string) => {
+      applyCustomAccentColor(color);
+      setShowEyedropper(false);
+    },
+    [applyCustomAccentColor],
+  );
+
+  const noTrack = !currentTrack || !albumId;
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Accent Color</SectionGroupTitle>
+      <ControlHelp>
+        Override the per-album accent color. Pick from the album-art palette, sample any pixel with the eyedropper,
+        or reset to the auto-extracted color.
+      </ControlHelp>
+      <SubControlRow>
+        <SubControlLabel>Color</SubControlLabel>
+        <SwatchRow>
+          {colorOptions.map((color) => (
+            <SwatchButton
+              key={color.hex}
+              type="button"
+              $color={color.hex}
+              $isActive={color.hex === accentColor}
+              onClick={() => applyAccentColor(color.hex)}
+              title={color.hex}
+              aria-label={`Choose color ${color.hex}`}
+            />
+          ))}
+          {customColor && (
+            <SwatchButton
+              type="button"
+              $color={customColor}
+              $isActive={customColor === accentColor}
+              onClick={() => applyAccentColor(customColor)}
+              title="Custom color"
+              aria-label="Use custom color"
+            />
+          )}
+          <SwatchIconButton
+            type="button"
+            onClick={() => setShowEyedropper(true)}
+            disabled={!currentTrack?.image}
+            title="Pick color from album art"
+            aria-label="Pick color from album art"
+          >
+            <Pipette aria-hidden="true" />
+          </SwatchIconButton>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleReset}
+            disabled={noTrack}
+            aria-label="Reset accent color to default"
+          >
+            Reset
+          </Button>
+        </SwatchRow>
+      </SubControlRow>
+      {noTrack && <ControlHelp>Start playing a track to override its accent color.</ControlHelp>}
+
+      {showEyedropper &&
+        currentTrack?.image &&
+        createPortal(
+          <EyedropperOverlay
+            image={currentTrack.image}
+            onPick={handleEyedropperPick}
+            onClose={() => setShowEyedropper(false)}
+          />,
+          document.body,
+        )}
+    </ControlBlock>
+  );
+};
+
+AccentColorManager.displayName = 'SettingsV2.AccentColorManager';
+
+export { RESET_SENTINEL };
+export default AccentColorManager;

--- a/src/components/SettingsV2/sections/appearance/AccentColorManager.tsx
+++ b/src/components/SettingsV2/sections/appearance/AccentColorManager.tsx
@@ -22,15 +22,13 @@ import {
 /**
  * Mirrors the dual-key write contract used by
  * `PlayerContent/AlbumArtSection.handleCustomAccentColor` (writes BOTH
- * `ACCENT_COLOR_OVERRIDES` AND `CUSTOM_ACCENT_COLORS`) and
- * `handleAccentColorChange` (intercepts the `'RESET_TO_DEFAULT'` sentinel).
+ * `ACCENT_COLOR_OVERRIDES` AND `CUSTOM_ACCENT_COLORS`).
  *
  * The eyedropper picks must dual-write so the chrome's "custom" swatch
  * (`controls/QuickEffectsRow`) keeps rendering. Palette swatches single-write
  * to `ACCENT_COLOR_OVERRIDES` (matches legacy behaviour — palette clicks
  * never overwrite the eyedropper-picked custom swatch).
  */
-const RESET_SENTINEL = 'RESET_TO_DEFAULT' as const;
 
 export const AccentColorManager: React.FC = () => {
   const { currentTrack } = useCurrentTrackContext();
@@ -181,5 +179,4 @@ export const AccentColorManager: React.FC = () => {
 
 AccentColorManager.displayName = 'SettingsV2.AccentColorManager';
 
-export { RESET_SENTINEL };
 export default AccentColorManager;

--- a/src/components/SettingsV2/sections/appearance/GlowControls.tsx
+++ b/src/components/SettingsV2/sections/appearance/GlowControls.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback } from 'react';
+
+import { useVisualEffectsToggle } from '@/contexts/visualEffects';
+import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
+import { Switch } from '@/components/ui/switch';
+import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
+
+import {
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+  SubControlRow,
+  SubControlLabel,
+} from '../AppearanceSection.styled';
+
+const INTENSITY_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 95, label: 'Less' },
+  { value: 110, label: 'Normal' },
+  { value: 125, label: 'More' },
+] as const;
+
+const RATE_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 5.0, label: 'Slower' },
+  { value: 4.0, label: 'Normal' },
+  { value: 3.0, label: 'Faster' },
+] as const;
+
+/**
+ * SettingsV2 glow controls — phase 3 port (#1451).
+ *
+ * Routes through `useVisualEffectsToggle` (writes `VISUAL_EFFECTS_ENABLED`)
+ * and `useVisualEffectsState` (writes `GLOW_INTENSITY` + `GLOW_RATE`),
+ * matching the hook + storage-key contract used by
+ * `controls/QuickEffectsRow` so toggling in either surface reflects in
+ * the other.
+ */
+export const GlowControls: React.FC = () => {
+  const { visualEffectsEnabled, setVisualEffectsEnabled } = useVisualEffectsToggle();
+  const {
+    glowIntensity,
+    glowRate,
+    handleGlowIntensityChange,
+    handleGlowRateChange,
+    restoreGlowSettings,
+  } = useVisualEffectsState();
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setVisualEffectsEnabled(true);
+        restoreGlowSettings();
+      } else {
+        setVisualEffectsEnabled(false);
+      }
+    },
+    [setVisualEffectsEnabled, restoreGlowSettings],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Glow</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-glow-toggle">Album-art glow</ControlLabelText>
+          <ControlHelp>Pulse a soft halo behind the album art.</ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-glow-toggle"
+          checked={visualEffectsEnabled}
+          onCheckedChange={handleToggle}
+          aria-label="Toggle album-art glow"
+          variant="neutral"
+        />
+      </ControlRow>
+
+      {visualEffectsEnabled && (
+        <>
+          <SubControlRow>
+            <SubControlLabel>Intensity</SubControlLabel>
+            <OptionButtonGroup aria-label="Glow intensity">
+              {INTENSITY_OPTIONS.map((opt) => (
+                <OptionButton
+                  key={opt.value}
+                  type="button"
+                  $isActive={glowIntensity === opt.value}
+                  onClick={() => handleGlowIntensityChange(opt.value)}
+                >
+                  {opt.label}
+                </OptionButton>
+              ))}
+            </OptionButtonGroup>
+          </SubControlRow>
+
+          <SubControlRow>
+            <SubControlLabel>Rate</SubControlLabel>
+            <OptionButtonGroup aria-label="Glow rate">
+              {RATE_OPTIONS.map((opt) => (
+                <OptionButton
+                  key={opt.value}
+                  type="button"
+                  $isActive={glowRate === opt.value}
+                  onClick={() => handleGlowRateChange(opt.value)}
+                >
+                  {opt.label}
+                </OptionButton>
+              ))}
+            </OptionButtonGroup>
+          </SubControlRow>
+        </>
+      )}
+    </ControlBlock>
+  );
+};
+
+GlowControls.displayName = 'SettingsV2.GlowControls';
+
+export default GlowControls;

--- a/src/components/SettingsV2/sections/appearance/VisualizerStylePicker.tsx
+++ b/src/components/SettingsV2/sections/appearance/VisualizerStylePicker.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback } from 'react';
+
+import type { VisualizerStyle } from '@/types/visualizer';
+import { useVisualizer } from '@/contexts/visualEffects';
+import { Switch } from '@/components/ui/switch';
+import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
+
+import {
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+  SubControlRow,
+  SubControlLabel,
+} from '../AppearanceSection.styled';
+
+const VISUALIZER_STYLES: ReadonlyArray<{ value: VisualizerStyle; label: string }> = [
+  { value: 'fireflies', label: 'Fireflies' },
+  { value: 'comet', label: 'Comet' },
+  { value: 'wave', label: 'Wave' },
+  { value: 'grid', label: 'Grid' },
+] as const;
+
+const INTENSITY_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 20, label: 'Less' },
+  { value: 40, label: 'Normal' },
+  { value: 60, label: 'More' },
+] as const;
+
+const SPEED_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 0.5, label: 'Slower' },
+  { value: 0.7, label: 'Normal' },
+  { value: 1.2, label: 'Faster' },
+] as const;
+
+/**
+ * SettingsV2 visualizer-style picker — phase 3 port (#1451).
+ *
+ * Reads + writes the same `VisualizerContext` (and therefore the same
+ * `BG_VISUALIZER_*` storage keys) as the legacy `controls/QuickEffectsRow`
+ * so toggling in either surface reflects in the other immediately.
+ */
+export const VisualizerStylePicker: React.FC = () => {
+  const {
+    backgroundVisualizerEnabled,
+    setBackgroundVisualizerEnabled,
+    backgroundVisualizerStyle,
+    setBackgroundVisualizerStyle,
+    backgroundVisualizerIntensity,
+    setBackgroundVisualizerIntensity,
+    backgroundVisualizerSpeed,
+    setBackgroundVisualizerSpeed,
+  } = useVisualizer();
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      setBackgroundVisualizerEnabled(checked);
+    },
+    [setBackgroundVisualizerEnabled],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Visualizer</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-visualizer-toggle">Background visualizer</ControlLabelText>
+          <ControlHelp>Animate the background based on the current track.</ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-visualizer-toggle"
+          checked={backgroundVisualizerEnabled}
+          onCheckedChange={handleToggle}
+          aria-label="Toggle background visualizer"
+          variant="neutral"
+        />
+      </ControlRow>
+
+      {backgroundVisualizerEnabled && (
+        <>
+          <SubControlRow role="radiogroup" aria-label="Visualizer style">
+            <SubControlLabel id="settings-v2-visualizer-style-label">Style</SubControlLabel>
+            <OptionButtonGroup>
+              {VISUALIZER_STYLES.map((opt) => (
+                <OptionButton
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={backgroundVisualizerStyle === opt.value}
+                  $isActive={backgroundVisualizerStyle === opt.value}
+                  onClick={() => setBackgroundVisualizerStyle(opt.value)}
+                >
+                  {opt.label}
+                </OptionButton>
+              ))}
+            </OptionButtonGroup>
+          </SubControlRow>
+
+          <SubControlRow>
+            <SubControlLabel>Intensity</SubControlLabel>
+            <OptionButtonGroup aria-label="Visualizer intensity">
+              {INTENSITY_OPTIONS.map((opt) => (
+                <OptionButton
+                  key={opt.value}
+                  type="button"
+                  $isActive={backgroundVisualizerIntensity === opt.value}
+                  onClick={() => setBackgroundVisualizerIntensity(opt.value)}
+                >
+                  {opt.label}
+                </OptionButton>
+              ))}
+            </OptionButtonGroup>
+          </SubControlRow>
+
+          <SubControlRow>
+            <SubControlLabel>Speed</SubControlLabel>
+            <OptionButtonGroup aria-label="Visualizer speed">
+              {SPEED_OPTIONS.map((opt) => (
+                <OptionButton
+                  key={opt.value}
+                  type="button"
+                  $isActive={backgroundVisualizerSpeed === opt.value}
+                  onClick={() => setBackgroundVisualizerSpeed(opt.value)}
+                >
+                  {opt.label}
+                </OptionButton>
+              ))}
+            </OptionButtonGroup>
+          </SubControlRow>
+        </>
+      )}
+    </ControlBlock>
+  );
+};
+
+VisualizerStylePicker.displayName = 'SettingsV2.VisualizerStylePicker';
+
+export default VisualizerStylePicker;


### PR DESCRIPTION
## Summary
- Builds `src/components/SettingsV2/sections/AppearanceSection.tsx` composing:
  - `VisualizerStylePicker` — RadioGroup over `BG_VISUALIZER_STYLE` + visualizer on/off + intensity/speed presets via `VisualizerContext`
  - `GlowControls` — on/off + intensity + rate presets via `useVisualEffectsToggle` + `useVisualEffectsState`
  - Translucence on/off toggle (no opacity slider — `TRANSLUCENCE_OPACITY` deferred to #1463)
  - `AccentColorManager` — palette swatches + eyedropper + reset; preserves the dual-key contract (`ACCENT_COLOR_OVERRIDES` + `CUSTOM_ACCENT_COLORS`) and the `'RESET_TO_DEFAULT'` sentinel verbatim from `PlayerContent/AlbumArtSection`.
- Mounted in `SettingsV2Content.tsx` via `React.lazy` with section-header Suspense fallback (matches #1461 pattern).
- Same hooks + storage keys as legacy `controls/QuickEffectsRow.tsx`. Toggle in either surface reflects in the other.
- v2 chrome stays neutral — `var(--accent-color)` is NOT used in any new chrome. Subcomponents use the `OptionButton` neutral variant (already shadcn `--primary`).

## Stage 2 scope decisions (per user sign-off after stage 1 inventory)
- Accent flow: preserved verbatim (no simplification). Palette swatches single-write to `ACCENT_COLOR_OVERRIDES`; eyedropper picks dual-write to BOTH keys; reset clears both.
- Orphan storage keys (`PER_ALBUM_GLOW`, `ACCENT_COLOR_BG_PREFERRED`, `TRANSLUCENCE_OPACITY`): out of scope; tracked in #1463.
- `usePlayerState.ts` dual ownership: out of scope; tracked in #1464.
- `controls/QuickEffectsRow.tsx` untouched — Settings v2 is a parallel surface, not a replacement.

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — 1890 tests pass; 27 new tests in `sections/__tests__/` cover:
  - Dual-key accent write contract on eyedropper pick (BOTH `ACCENT_COLOR_OVERRIDES` and `CUSTOM_ACCENT_COLORS`)
  - Single-key write on palette swatch click (preserves the eyedropper-picked custom swatch)
  - Reset path: clears both keys + invokes `'RESET_TO_DEFAULT'` sentinel
  - No-track guard (Reset/eyedropper disabled)
  - All canonical preset values round-trip to storage (glow 95/110/125, glow rate 5.0/4.0/3.0, viz intensity 20/40/60, viz speed 0.5/0.7/1.2, viz style fireflies/comet/wave/grid)
  - v1 ↔ v2 storage parity (sibling probes read the same context value the v2 toggle just wrote; v1-side `localStorage` writes reflected in v2 mount state)
  - Translucence is on/off only — no slider, no opacity reference
- `npm run build` — clean (AppearanceSection chunk: 8.82 KB / 2.79 KB gzipped)
- Manual smoke (recommended for reviewer): toggle glow / visualizer style / translucence in `controls/QuickEffectsRow` (player chrome), open `?ui=v2&settings=appearance`, confirm state reflects without reload. Vice versa.

Closes #1451. Phase 3 of epic #1262 — heaviest section delivered. Phase 4 (#1452 Playback) follows.