### PR TITLE
feat(settings-v2): Playback section + persistence graduation

### DIFF
--- a/src/components/SettingsV2/SettingsV2Content.tsx
+++ b/src/components/SettingsV2/SettingsV2Content.tsx
@@ -9,7 +9,6 @@ import {
   HeaderTitle,
   IconButton,
   SectionTitle,
-  SectionPlaceholder,
 } from './styled';
 
 // Lazy-load section bodies so the shell can mount (and unit-test) without
@@ -23,6 +22,9 @@ const AdvancedSection = lazy(() =>
 );
 const AppearanceSection = lazy(() =>
   import('./sections/AppearanceSection').then((m) => ({ default: m.AppearanceSection })),
+);
+const PlaybackSection = lazy(() =>
+  import('./sections/PlaybackSection').then((m) => ({ default: m.PlaybackSection })),
 );
 
 interface SettingsV2ContentProps {
@@ -49,46 +51,37 @@ export const SettingsV2Content: React.FC<SettingsV2ContentProps> = ({ activeSect
 };
 
 /**
- * Maps a section ID to the live-content component, or to a placeholder for
- * sections still scheduled for future phases. Phase 2 (#1450) ships
- * `sources` + `advanced`; phase 3 (#1451) ships `appearance`; `playback`
- * (#1452) keeps the placeholder treatment from phase 1.
+ * Maps a section ID to the live-content component. The Settings v2 taxonomy
+ * is complete as of phase 4 (#1452): Sources / Playback / Appearance / Advanced.
  */
 export const SettingsV2SectionBody: React.FC<{ activeSection: SettingsV2SectionId }> = ({ activeSection }) => {
+  const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+
   switch (activeSection) {
-    case 'sources': {
-      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+    case 'sources':
       return (
         <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
           <SourcesSection />
         </Suspense>
       );
-    }
-    case 'advanced': {
-      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+    case 'advanced':
       return (
         <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
           <AdvancedSection />
         </Suspense>
       );
-    }
-    case 'appearance': {
-      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+    case 'appearance':
       return (
         <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
           <AppearanceSection />
         </Suspense>
       );
-    }
     case 'playback':
-    default: {
-      const section = SETTINGS_V2_SECTIONS.find((entry) => entry.id === activeSection) ?? SETTINGS_V2_SECTIONS[0];
+    default:
       return (
-        <>
-          <SectionTitle>{section.label}</SectionTitle>
-          <SectionPlaceholder>{section.description}</SectionPlaceholder>
-        </>
+        <Suspense fallback={<SectionTitle>{section.label}</SectionTitle>}>
+          <PlaybackSection />
+        </Suspense>
       );
-    }
   }
 };

--- a/src/components/SettingsV2/sections.ts
+++ b/src/components/SettingsV2/sections.ts
@@ -26,7 +26,7 @@ export const SETTINGS_V2_SECTIONS: readonly SettingsV2SectionDescriptor[] = [
   {
     id: 'playback',
     label: 'Playback',
-    description: 'Crossfade, gapless playback, and queue behavior. Coming soon.',
+    description: 'Default volume and shuffle behaviour.',
   },
   {
     id: 'appearance',

--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -4,6 +4,8 @@ import { useProviderContext } from '@/contexts/ProviderContext';
 import { useProfilingContext } from '@/contexts/ProfilingContext';
 import { useVisualizerDebug } from '@/contexts/VisualizerDebugContext';
 import { useQapEnabled } from '@/hooks/useQapEnabled';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useSettingsUrl } from '@/hooks/useSettingsUrl';
 import { clearCacheWithOptions } from '@/services/cache/libraryCache';
 import { clearAllPins } from '@/services/settings/pinnedItemsStorage';
 import { STORAGE_KEYS } from '@/constants/storage';
@@ -53,6 +55,34 @@ export const AdvancedSection: React.FC = () => {
   const vizDebugCtx = useVisualizerDebug();
   const visualizerDebugEnabled = vizDebugCtx?.isDebugMode ?? false;
   const [qapEnabled, setQapEnabled] = useQapEnabled();
+  const [settingsV2Persisted, setSettingsV2Persisted] = useLocalStorage<boolean>(
+    STORAGE_KEYS.SETTINGS_V2_ENABLED,
+    false,
+  );
+  const [, setSettingsSection] = useSettingsUrl();
+
+  const handleSettingsV2PersistenceToggle = useCallback(
+    (checked: boolean) => {
+      setSettingsV2Persisted(checked);
+      if (!checked) {
+        // Toggle-off: clear ?settings=* so the URL doesn't keep deep-linking
+        // back into a v2 section the user has just opted out of.
+        setSettingsSection(null);
+
+        // If the URL no longer carries ?ui=v2 either, useUiV2() will resolve
+        // false on the next render and AudioPlayer.tsx will fork to the
+        // legacy panel. A reload guarantees a clean re-mount even if the
+        // user is mid-interaction.
+        if (typeof window !== 'undefined') {
+          const urlParams = new URLSearchParams(window.location.search);
+          if (urlParams.get('ui') !== 'v2') {
+            window.location.reload();
+          }
+        }
+      }
+    },
+    [setSettingsV2Persisted, setSettingsSection],
+  );
 
   const dataProviders = useMemo(() => {
     return registry.getAll().filter(
@@ -233,6 +263,30 @@ export const AdvancedSection: React.FC = () => {
           </ControlBlock>
         </>
       )}
+
+      <Divider />
+
+      <ControlBlock>
+        <SectionGroupTitle>Settings v2</SectionGroupTitle>
+        <ControlRow>
+          <div>
+            <ControlLabelText htmlFor="settings-v2-persistence-toggle">
+              Keep Settings v2 enabled across sessions
+            </ControlLabelText>
+            <ControlHelp>
+              Remember this UI without the <code>?ui=v2</code> URL flag. Turning this off
+              returns to the legacy settings panel.
+            </ControlHelp>
+          </div>
+          <Switch
+            id="settings-v2-persistence-toggle"
+            checked={settingsV2Persisted}
+            onCheckedChange={handleSettingsV2PersistenceToggle}
+            aria-label="Keep Settings v2 enabled across sessions"
+            variant="neutral"
+          />
+        </ControlRow>
+      </ControlBlock>
 
       <Divider />
 

--- a/src/components/SettingsV2/sections/PlaybackSection.styled.ts
+++ b/src/components/SettingsV2/sections/PlaybackSection.styled.ts
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const ControlBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const ControlLabelText = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: hsl(var(--foreground));
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+`;
+
+export const ControlHelp = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+`;
+
+export const SectionGroupTitle = styled.h4`
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: hsl(var(--foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+export const Divider = styled.div`
+  border-top: 1px solid hsl(var(--border));
+`;
+
+export const SliderRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const SliderValue = styled.span`
+  font-variant-numeric: tabular-nums;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+  min-width: 40px;
+  text-align: right;
+`;

--- a/src/components/SettingsV2/sections/PlaybackSection.tsx
+++ b/src/components/SettingsV2/sections/PlaybackSection.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback } from 'react';
+
+import { Switch } from '@/components/ui/switch';
+import { Slider } from '@/components/ui/slider';
+import { useTrackListContext, useCurrentTrackContext } from '@/contexts/TrackContext';
+import { useVolume } from '@/hooks/useVolume';
+
+import {
+  Container,
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+  Divider,
+  SliderRow,
+  SliderValue,
+} from './PlaybackSection.styled';
+
+/**
+ * SettingsV2 Playback section — phase 4 (#1452).
+ *
+ * Inventory note: the legacy `AppSettingsMenu` exposes zero playback-specific
+ * controls. The genuinely user-facing playback preferences are:
+ *
+ *   - Default volume — `STORAGE_KEYS.VOLUME` (`useVolume()`). The chrome
+ *     `controls/VolumeControl` slider already writes this; the settings UI
+ *     is a second view onto the same hook + storage key.
+ *   - Default shuffle — `STORAGE_KEYS.SHUFFLE_ENABLED` via
+ *     `TrackContext.handleShuffleToggle`. Routing through the context keeps
+ *     the live queue reorder behaviour identical to toggling from BottomBar.
+ *
+ * No crossfade, no gapless, no auto-advance preference exists today
+ * (`useAutoAdvance` is hardcoded `enabled: true` at `usePlayerLogic.ts:167`).
+ * The build matches reality.
+ *
+ * Neutral chrome only — no `var(--accent-color)` references; the `Switch`
+ * uses `variant="neutral"` and the `Slider` uses default shadcn `--primary`.
+ */
+
+const VolumeBlock: React.FC = () => {
+  const { currentTrack } = useCurrentTrackContext();
+  const { volume, setVolumeLevel } = useVolume(currentTrack?.provider);
+
+  const handleVolumeChange = useCallback(
+    (values: number[]) => {
+      const next = values[0];
+      if (typeof next === 'number') {
+        setVolumeLevel(next);
+      }
+    },
+    [setVolumeLevel],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Volume</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-volume-slider">Default volume</ControlLabelText>
+          <ControlHelp>Persisted across sessions and applied to the active player.</ControlHelp>
+        </div>
+        <SliderValue aria-live="polite">{volume}%</SliderValue>
+      </ControlRow>
+      <SliderRow>
+        <Slider
+          id="settings-v2-volume-slider"
+          value={[volume]}
+          min={0}
+          max={100}
+          step={1}
+          onValueChange={handleVolumeChange}
+          aria-label="Default volume"
+        />
+      </SliderRow>
+    </ControlBlock>
+  );
+};
+
+VolumeBlock.displayName = 'SettingsV2.PlaybackSection.VolumeBlock';
+
+const ShuffleBlock: React.FC = () => {
+  const { shuffleEnabled, handleShuffleToggle, originalTracks } = useTrackListContext();
+
+  const canToggle = originalTracks.length > 0;
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Shuffle</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-shuffle-toggle">Shuffle queue</ControlLabelText>
+          <ControlHelp>
+            {canToggle
+              ? 'Reorder the current queue and remember the preference for next time.'
+              : 'Load a playlist or album to enable shuffle.'}
+          </ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-shuffle-toggle"
+          checked={shuffleEnabled}
+          onCheckedChange={() => handleShuffleToggle()}
+          disabled={!canToggle}
+          aria-label="Toggle shuffle"
+          variant="neutral"
+        />
+      </ControlRow>
+    </ControlBlock>
+  );
+};
+
+ShuffleBlock.displayName = 'SettingsV2.PlaybackSection.ShuffleBlock';
+
+export const PlaybackSection: React.FC = () => {
+  return (
+    <Container>
+      <VolumeBlock />
+      <Divider />
+      <ShuffleBlock />
+    </Container>
+  );
+};
+
+PlaybackSection.displayName = 'SettingsV2.PlaybackSection';
+
+export default PlaybackSection;

--- a/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
@@ -495,6 +495,23 @@ describe('SettingsV2 AdvancedSection', () => {
       expect(mockSetSettingsSection).toHaveBeenCalledWith(null);
       expect(reloadSpy).not.toHaveBeenCalled();
     });
+
+    it('never touches the dormant legacy settings key', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+      const toggle = screen.getByLabelText('Keep Settings v2 enabled across sessions');
+
+      // #when — toggle on then off
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+
+      // #then — the dormant 'vorbis-player-settings' key must remain untouched
+      expect(memoryStorage.get(STORAGE_KEYS.SETTINGS)).toBeUndefined();
+    });
   });
 
   describe('About section', () => {

--- a/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
@@ -88,6 +88,11 @@ vi.mock('@/hooks/useQapEnabled', () => ({
   ]),
 }));
 
+const mockSetSettingsSection = vi.fn();
+vi.mock('@/hooks/useSettingsUrl', () => ({
+  useSettingsUrl: vi.fn(() => [null, mockSetSettingsSection]),
+}));
+
 import { AdvancedSection } from '../AdvancedSection';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -385,6 +390,110 @@ describe('SettingsV2 AdvancedSection', () => {
       // #then
       expect(screen.queryByText('Provider Data')).not.toBeInTheDocument();
       expect(screen.queryByText('Dropbox Data')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Settings v2 persistence toggle', () => {
+    const SETTINGS_V2_KEY = 'vorbis-player-settings-v2-enabled';
+
+    let originalLocation: Location;
+    let reloadSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      originalLocation = window.location;
+      reloadSpy = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          search: '',
+          pathname: '/',
+          reload: reloadSpy,
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('writes the persistence storage key as true when toggled on', () => {
+      // #given
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      const toggle = screen.getByLabelText('Keep Settings v2 enabled across sessions');
+      fireEvent.click(toggle);
+
+      // #then
+      expect(memoryStorage.get(SETTINGS_V2_KEY)).toBe('true');
+    });
+
+    it('reflects the persisted value on mount', () => {
+      // #given
+      memoryStorage.set(SETTINGS_V2_KEY, 'true');
+
+      // #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByLabelText('Keep Settings v2 enabled across sessions')).toHaveAttribute(
+        'data-state',
+        'checked',
+      );
+    });
+
+    it('clears the ?settings=* URL state and reloads when toggled off without ?ui=v2', () => {
+      // #given — toggle is currently on, URL has no ui=v2 fallback
+      memoryStorage.set(SETTINGS_V2_KEY, 'true');
+      window.location.search = '?settings=advanced';
+
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Keep Settings v2 enabled across sessions'));
+
+      // #then
+      expect(memoryStorage.get(SETTINGS_V2_KEY)).toBe('false');
+      expect(mockSetSettingsSection).toHaveBeenCalledWith(null);
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not reload when toggled off if ?ui=v2 still in URL', () => {
+      // #given — URL still carries ui=v2, so v2 stays mounted on next render
+      memoryStorage.set(SETTINGS_V2_KEY, 'true');
+      window.location.search = '?ui=v2&settings=advanced';
+
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Keep Settings v2 enabled across sessions'));
+
+      // #then
+      expect(memoryStorage.get(SETTINGS_V2_KEY)).toBe('false');
+      expect(mockSetSettingsSection).toHaveBeenCalledWith(null);
+      expect(reloadSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/SettingsV2/sections/__tests__/PlaybackSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/PlaybackSection.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+// jsdom doesn't implement ResizeObserver; Radix Slider uses it via @radix-ui/react-use-size.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as { ResizeObserver?: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
+
+// ── Hook mocks ─────────────────────────────────────────────────────────────
+
+const mockSetVolumeLevel = vi.fn();
+const mockHandleShuffleToggle = vi.fn();
+
+let mockVolume = 50;
+let mockShuffleEnabled = false;
+let mockOriginalTracks: Array<{ id: string }> = [];
+let mockCurrentTrackProvider: string | undefined;
+
+vi.mock('@/hooks/useVolume', () => ({
+  useVolume: vi.fn(() => ({
+    volume: mockVolume,
+    isMuted: false,
+    handleMuteToggle: vi.fn(),
+    handleVolumeButtonClick: vi.fn(),
+    setVolumeLevel: mockSetVolumeLevel,
+  })),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useTrackListContext: vi.fn(() => ({
+    shuffleEnabled: mockShuffleEnabled,
+    handleShuffleToggle: mockHandleShuffleToggle,
+    originalTracks: mockOriginalTracks,
+  })),
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrack: mockCurrentTrackProvider
+      ? { id: 't1', provider: mockCurrentTrackProvider }
+      : null,
+  })),
+}));
+
+import { PlaybackSection } from '../PlaybackSection';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+describe('SettingsV2 PlaybackSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVolume = 50;
+    mockShuffleEnabled = false;
+    mockOriginalTracks = [];
+    mockCurrentTrackProvider = undefined;
+  });
+
+  describe('Volume control', () => {
+    it('renders the persisted volume value in the readout', () => {
+      // #given
+      mockVolume = 73;
+
+      // #when
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+
+      // #then — Radix Slider thumb carries aria-valuenow; the visible readout is what users see
+      expect(screen.getByText('73%')).toBeInTheDocument();
+      const thumb = document.querySelector('[role="slider"]');
+      expect(thumb).toHaveAttribute('aria-valuenow', '73');
+    });
+
+    it('routes slider changes through useVolume().setVolumeLevel', () => {
+      // #given
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+      const thumb = document.querySelector('[role="slider"]') as HTMLElement;
+
+      // #when — Radix slider responds to keyboard arrows
+      thumb.focus();
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+      // #then
+      expect(mockSetVolumeLevel).toHaveBeenCalled();
+    });
+  });
+
+  describe('Shuffle toggle', () => {
+    it('reflects the persisted shuffle state on mount', () => {
+      // #given
+      mockShuffleEnabled = true;
+      mockOriginalTracks = [{ id: 't1' }];
+
+      // #when
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByLabelText('Toggle shuffle')).toHaveAttribute('data-state', 'checked');
+    });
+
+    it('routes through TrackContext.handleShuffleToggle when toggled', () => {
+      // #given
+      mockOriginalTracks = [{ id: 't1' }];
+
+      // #when
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByLabelText('Toggle shuffle'));
+
+      // #then
+      expect(mockHandleShuffleToggle).toHaveBeenCalledOnce();
+    });
+
+    it('disables the shuffle toggle when no playlist is loaded', () => {
+      // #given — empty originalTracks means no queue to reorder
+      mockOriginalTracks = [];
+
+      // #when
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+
+      // #then
+      const toggle = screen.getByLabelText('Toggle shuffle');
+      expect(toggle).toBeDisabled();
+      expect(screen.getByText(/Load a playlist or album to enable shuffle/i)).toBeInTheDocument();
+    });
+
+    it('shows the active-queue help copy when a playlist is loaded', () => {
+      // #given
+      mockOriginalTracks = [{ id: 't1' }];
+
+      // #when
+      render(
+        <Wrapper>
+          <PlaybackSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(
+        screen.getByText(/Reorder the current queue and remember the preference/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SettingsV2/styled.ts
+++ b/src/components/SettingsV2/styled.ts
@@ -204,12 +204,6 @@ export const SectionTitle = styled.h3`
   color: hsl(var(--foreground));
 `;
 
-export const SectionPlaceholder = styled.p`
-  margin: 0;
-  color: hsl(var(--muted-foreground));
-  font-size: ${({ theme }) => theme.fontSize.sm};
-`;
-
 export const MobileSectionList = styled.div`
   flex: 1;
   display: flex;

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -57,6 +57,9 @@ export const STORAGE_KEYS = {
   LIBRARY: 'vorbis-player-library',
   SETTINGS: 'vorbis-player-settings',
 
+  // Settings v2 — persistence graduation (#1452)
+  SETTINGS_V2_ENABLED: 'vorbis-player-settings-v2-enabled',
+
   // Debug and development
   PROFILING: 'vorbis-player-profiling',
   DEBUG_OVERLAY: 'vorbis-player-debug-overlay',

--- a/src/hooks/__tests__/useUiV2.test.ts
+++ b/src/hooks/__tests__/useUiV2.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '@/constants/storage';
 import { useUiV2 } from '../useUiV2';
 
 function setSearch(search: string): void {
@@ -9,14 +10,35 @@ function setSearch(search: string): void {
   });
 }
 
+const memoryStorage = new Map<string, string>();
+
+function installMemoryLocalStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => memoryStorage.set(key, value),
+      removeItem: (key: string) => memoryStorage.delete(key),
+      clear: () => memoryStorage.clear(),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe('useUiV2', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+    installMemoryLocalStorage();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     setSearch('');
+    memoryStorage.clear();
   });
 
-  it('returns false when neither env nor query param is set', () => {
-    // #given — default test setup leaves search empty and VITE_UI_V2 unset
+  it('returns false when neither env nor query param nor persistence is set', () => {
+    // #given — default test setup leaves all signals unset
 
     // #when
     const { result } = renderHook(() => useUiV2());
@@ -96,7 +118,7 @@ describe('useUiV2', () => {
     expect(result.current).toBe(true);
   });
 
-  it('removes its popstate listener on unmount', () => {
+  it('removes its popstate and storage listeners on unmount', () => {
     // #given
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
 
@@ -106,6 +128,109 @@ describe('useUiV2', () => {
 
     // #then
     expect(removeEventListenerSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
     removeEventListenerSpy.mockRestore();
+  });
+
+  describe('localStorage persistence signal', () => {
+    it('returns true when the persistence key is set, even without ui=v2 in the URL', () => {
+      // #given
+      memoryStorage.set(STORAGE_KEYS.SETTINGS_V2_ENABLED, JSON.stringify(true));
+      setSearch('');
+
+      // #when
+      const { result } = renderHook(() => useUiV2());
+
+      // #then
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when the persistence key is set to false and no other signal is on', () => {
+      // #given
+      memoryStorage.set(STORAGE_KEYS.SETTINGS_V2_ENABLED, JSON.stringify(false));
+      setSearch('');
+
+      // #when
+      const { result } = renderHook(() => useUiV2());
+
+      // #then
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true when persistence is true even if URL lacks ui=v2 (OR semantics)', () => {
+      // #given — URL has no opt-in flag, but persistence is on
+      memoryStorage.set(STORAGE_KEYS.SETTINGS_V2_ENABLED, JSON.stringify(true));
+      setSearch('?other=param');
+
+      // #when
+      const { result } = renderHook(() => useUiV2());
+
+      // #then — there is no URL-based opt-out path; persistence wins
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when persistence is unset (null) and no other signal is on', () => {
+      // #given — key absent from storage
+      setSearch('');
+
+      // #when
+      const { result } = renderHook(() => useUiV2());
+
+      // #then
+      expect(result.current).toBe(false);
+    });
+
+    it('re-evaluates on cross-tab storage events when the persistence key flips', () => {
+      // #given
+      setSearch('');
+      const { result } = renderHook(() => useUiV2());
+      expect(result.current).toBe(false);
+
+      // #when — another tab writes the key and emits a storage event
+      act(() => {
+        memoryStorage.set(STORAGE_KEYS.SETTINGS_V2_ENABLED, JSON.stringify(true));
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: STORAGE_KEYS.SETTINGS_V2_ENABLED,
+            newValue: JSON.stringify(true),
+          }),
+        );
+      });
+
+      // #then
+      expect(result.current).toBe(true);
+    });
+
+    it('ignores storage events for unrelated keys', () => {
+      // #given
+      setSearch('');
+      const { result } = renderHook(() => useUiV2());
+      expect(result.current).toBe(false);
+
+      // #when — an unrelated key changes
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'some-other-key',
+            newValue: 'true',
+          }),
+        );
+      });
+
+      // #then
+      expect(result.current).toBe(false);
+    });
+
+    it('treats malformed JSON in the persistence key as not-enabled', () => {
+      // #given
+      memoryStorage.set(STORAGE_KEYS.SETTINGS_V2_ENABLED, '{not-json');
+      setSearch('');
+
+      // #when
+      const { result } = renderHook(() => useUiV2());
+
+      // #then
+      expect(result.current).toBe(false);
+    });
   });
 });

--- a/src/hooks/useUiV2.ts
+++ b/src/hooks/useUiV2.ts
@@ -1,15 +1,23 @@
 import { useEffect, useState } from 'react';
+import { STORAGE_KEYS } from '@/constants/storage';
 
 /**
  * `?ui=v2` flag — opt-in mechanism for whole-screen redesigns shipped behind
  * a feature gate.
  *
- * Returns `true` when EITHER:
+ * Returns `true` when ANY of these signals is on:
  *   - `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in), OR
- *   - the current URL contains `?ui=v2` (per-session opt-in via query string).
+ *   - the current URL contains `?ui=v2` (per-session opt-in via query string), OR
+ *   - the `vorbis-player-settings-v2-enabled` localStorage key is `true`
+ *     (cross-session persistence — set by the "Keep v2 enabled" toggle in
+ *     `SettingsV2/sections/AdvancedSection.tsx`, #1452).
+ *
+ * The OR is one-way: any signal flips the gate on, and there is no URL-based
+ * opt-out (the persistence toggle owns the off path).
  *
  * Subscribes to `popstate` so SPA navigation that changes the query string
- * re-evaluates the flag without a full page reload.
+ * re-evaluates the flag without a full page reload, and to `storage` so
+ * cross-tab toggles propagate.
  *
  * SSR-safe: returns `false` during a render where `window` is undefined.
  */
@@ -23,12 +31,20 @@ export function useUiV2(): boolean {
       setEnabled(readFlag());
     };
 
+    const handleStorage = (event: StorageEvent): void => {
+      if (event.key === STORAGE_KEYS.SETTINGS_V2_ENABLED) {
+        setEnabled(readFlag());
+      }
+    };
+
     // pushState/replaceState do not fire popstate natively — only browser
     // back/forward navigation triggers this listener. Programmatic URL
     // mutations need window.dispatchEvent(new PopStateEvent('popstate')).
     window.addEventListener('popstate', handlePopState);
+    window.addEventListener('storage', handleStorage);
     return () => {
       window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('storage', handleStorage);
     };
   }, []);
 
@@ -38,5 +54,16 @@ export function useUiV2(): boolean {
 function readFlag(): boolean {
   if (import.meta.env.VITE_UI_V2 === 'true') return true;
   if (typeof window === 'undefined') return false;
-  return new URLSearchParams(window.location.search).get('ui') === 'v2';
+  if (new URLSearchParams(window.location.search).get('ui') === 'v2') return true;
+  return readPersistedFlag();
+}
+
+function readPersistedFlag(): boolean {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEYS.SETTINGS_V2_ENABLED);
+    if (raw === null) return false;
+    return JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- Builds `src/components/SettingsV2/sections/PlaybackSection.tsx` with the playback controls discovered in the inventory pass: default volume slider (`useVolume`) and shuffle persistence toggle (from `TrackContext`).
- Persistence graduation: new `STORAGE_KEYS.SETTINGS_V2_ENABLED` (`'vorbis-player-settings-v2-enabled'`) + extended `useUiV2()` to OR a `useLocalStorage` signal with the existing URL/env signals. Settings v2 now persists across sessions without `?ui=v2`.
- "Keep Settings v2 enabled" Switch added to AdvancedSection. Toggling off clears `?settings=*` and reloads to legacy chrome if `?ui=v2` is also absent.
- Neutral chrome throughout (no `var(--accent-color)`).

## Inventory finding
Legacy `AppSettingsMenu` had zero playback controls. Only two genuinely persisted playback prefs exist: `VOLUME` (via `useVolume`) and `SHUFFLE_ENABLED` (via `TrackContext`). No crossfade/gapless/auto-advance pref exists (`useAutoAdvance` is invoked with hardcoded `enabled: true`). PlaybackSection mirrors only what's real.

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run` — covers Playback controls (volume slider, shuffle toggle), `useUiV2` persistence cases (URL/persistence/env OR semantics, SSR, storage-event), AdvancedSection 'Keep v2 enabled' toggle (storage write, URL clear, conditional reload, dormant key not touched).
- Manual: enable persistence toggle, close tab, reopen without `?ui=v2` → v2 still active. Disable toggle → URL cleared, page reloads to legacy.

Settings v2 taxonomy complete: Sources / Playback / Appearance / Advanced. Legacy `AppSettingsMenu` remains mounted; deletion is a separate epic.

Closes #1452
Closes #1262