### PR TITLE
fix(settings-v2): eyedropper clicks captured through Dialog modal

### DIFF
--- a/src/components/SettingsV2/SettingsV2.tsx
+++ b/src/components/SettingsV2/SettingsV2.tsx
@@ -73,6 +73,26 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
     [closeShell],
   );
 
+  /**
+   * `AccentColorManager` portals `EyedropperOverlay` to `document.body` so
+   * the overlay can cover the entire viewport for pixel picking. That places
+   * the overlay outside this Dialog's content tree, so Radix's
+   * `DismissableLayer` would otherwise treat clicks on the eyedropper canvas
+   * as pointer-down-outside and dismiss the Dialog before the canvas `click`
+   * handler fires. The portaled overlay tags itself with
+   * `data-eyedropper-overlay="true"` (see `EyedropperOverlay.tsx`); when the
+   * dismiss event originates inside that subtree we keep the Dialog open.
+   *
+   * Mirrors the legacy guard in `PlayerContent/AlbumArtSection.tsx` which
+   * uses the same selector to keep the flip-menu open during eyedropper picks.
+   */
+  const preventDismissOnEyedropper = useCallback((event: Event) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest?.('[data-eyedropper-overlay]')) {
+      event.preventDefault();
+    }
+  }, []);
+
   useEffect(() => {
     if (!uiV2) return;
     if (typeof window === 'undefined') return;
@@ -106,7 +126,13 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogPortal>
         {isMobile ? (
-          <DialogPrimitive.Content asChild aria-label="Settings" aria-describedby={undefined}>
+          <DialogPrimitive.Content
+            asChild
+            aria-label="Settings"
+            aria-describedby={undefined}
+            onPointerDownOutside={preventDismissOnEyedropper}
+            onInteractOutside={preventDismissOnEyedropper}
+          >
             <MobileTakeover data-testid="settings-v2-mobile">
               <VisuallyHiddenDialogTitle />
               <SettingsV2MobileTakeover
@@ -122,7 +148,13 @@ export const SettingsV2: React.FC<SettingsV2Props> = ({ isOpen, onClose }) => {
             <DialogOverlay asChild style={{ zIndex: 1404 }}>
               <Overlay aria-hidden="true" />
             </DialogOverlay>
-            <DialogPrimitive.Content asChild aria-label="Settings" aria-describedby={undefined}>
+            <DialogPrimitive.Content
+              asChild
+              aria-label="Settings"
+              aria-describedby={undefined}
+              onPointerDownOutside={preventDismissOnEyedropper}
+              onInteractOutside={preventDismissOnEyedropper}
+            >
               <DesktopShell data-testid="settings-v2-desktop">
                 <VisuallyHiddenDialogTitle />
                 <SettingsV2Sidebar activeSection={activeSection} onSelect={handleSelectSection} />

--- a/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { ColorProvider } from '@/contexts/ColorContext';
+import { STORAGE_KEYS } from '@/constants/storage';
+import type { MediaTrack } from '@/types/domain';
+
+/**
+ * Issue #1467 integration test — locks in the fix for the Settings v2
+ * eyedropper failing to capture pixel clicks.
+ *
+ * Unlike `AccentColorManager.test.tsx`, this test uses the **real**
+ * `EyedropperOverlay` (not a mock) wrapped in the **real** `SettingsV2`
+ * Radix Dialog. The combination is what surfaces the bug: the eyedropper
+ * portals itself to `document.body`, which puts it outside the Dialog's
+ * content tree, so Radix's `DismissableLayer` would otherwise treat the
+ * canvas pointerdown as an outside-click and dismiss the Dialog before
+ * the canvas `click` handler fires.
+ *
+ * The fix in `SettingsV2.tsx` (`onPointerDownOutside` +
+ * `onInteractOutside` handlers that `preventDefault()` when the event
+ * target is inside `[data-eyedropper-overlay]`) is what this test
+ * exercises end-to-end.
+ *
+ * `SettingsV2Content` is mocked so this test can render `<AccentColorManager />`
+ * directly inside the real Dialog without pulling in the full section
+ * registry (Translucence/Visualizer contexts, lazy-loaded providers, etc.).
+ */
+
+const mockCurrentTrack: MediaTrack = {
+  id: 't1',
+  provider: 'spotify',
+  playbackRef: { provider: 'spotify', ref: 'spotify:track:t1' },
+  name: 'Test Track',
+  artists: 'Test Artist',
+  album: 'Test Album',
+  albumId: 'album-123',
+  durationMs: 1000,
+  image: 'https://example.com/image.jpg',
+};
+
+vi.mock('@/hooks/useUiV2', () => ({ useUiV2: () => true }));
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: () => ({ isMobile: false }),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrack: mockCurrentTrack,
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+    showQueue: false,
+    setShowQueue: vi.fn(),
+  })),
+}));
+
+vi.mock('@/utils/colorExtractor', () => ({
+  extractTopVibrantColors: vi.fn(async () => [
+    { hex: '#ff0000', score: 1 },
+    { hex: '#00ff00', score: 0.9 },
+  ]),
+}));
+
+vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
+  getPreferencesSync: vi.fn(() => null),
+}));
+
+vi.mock('../../SettingsV2Sidebar', () => ({
+  SettingsV2Sidebar: () => null,
+}));
+
+vi.mock('../../SettingsV2MobileTakeover', () => ({
+  SettingsV2MobileTakeover: () => null,
+}));
+
+vi.mock('../../SettingsV2Content', async () => {
+  const { AccentColorManager } = await import('../appearance/AccentColorManager');
+  return {
+    SettingsV2Content: () => <AccentColorManager />,
+  };
+});
+
+import { SettingsV2 } from '../../SettingsV2';
+
+/**
+ * jsdom does not implement PointerEvent. Radix's `DismissableLayer` listens
+ * for `pointerdown`, so we dispatch a regular `MouseEvent` with that type
+ * (the listener only reads `event.target` + `event.preventDefault`, both of
+ * which `MouseEvent` provides).
+ */
+function dispatchPointerDown(target: Element): boolean {
+  const event = new MouseEvent('pointerdown', { bubbles: true, cancelable: true });
+  return target.dispatchEvent(event);
+}
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <ColorProvider>{children}</ColorProvider>
+  </ThemeProvider>
+);
+
+describe('SettingsV2 + real EyedropperOverlay (issue #1467)', () => {
+  beforeAll(() => {
+    /**
+     * jsdom does not implement HTMLCanvasElement.getContext. Stub it with a
+     * minimal 2D context — drawImage is a no-op and getImageData returns a
+     * deterministic pixel so the eyedropper produces #abcdef when picked.
+     */
+    HTMLCanvasElement.prototype.getContext = vi.fn(
+      () =>
+        ({
+          drawImage: vi.fn(),
+          getImageData: vi.fn(() => ({
+            data: new Uint8ClampedArray([0xab, 0xcd, 0xef, 0xff]),
+          })),
+        }) as unknown as CanvasRenderingContext2D,
+    ) as typeof HTMLCanvasElement.prototype.getContext;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (window.localStorage.setItem as ReturnType<typeof vi.fn>).mockClear();
+    (window.localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue(null);
+  });
+
+  it('keeps the SettingsV2 Dialog open when pointerdown fires inside the eyedropper portal', async () => {
+    // #given — real SettingsV2 Dialog open with AccentColorManager mounted
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <SettingsV2 isOpen={true} onClose={onClose} />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId('settings-v2-desktop'));
+    fireEvent.click(screen.getByLabelText('Pick color from album art'));
+    const overlay = await waitFor(() =>
+      document.body.querySelector('[data-eyedropper-overlay="true"]'),
+    );
+    expect(overlay).not.toBeNull();
+
+    // Radix's `usePointerDownOutside` registers its document listener inside
+    // a setTimeout(0) — yield once so the listener is live before we dispatch.
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+
+    // #when — pointerdown on the eyedropper portal (outside the Dialog tree)
+    act(() => {
+      dispatchPointerDown(overlay!);
+    });
+
+    // #then — Dialog stays open. Without the fix, Radix DismissableLayer
+    // would treat this as an outside-click and call onClose().
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+  });
+
+  it('captures the picked color and dual-writes ACCENT_COLOR_OVERRIDES + CUSTOM_ACCENT_COLORS', async () => {
+    // #given — real SettingsV2 Dialog open with AccentColorManager mounted
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <SettingsV2 isOpen={true} onClose={onClose} />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId('settings-v2-desktop'));
+    fireEvent.click(screen.getByLabelText('Pick color from album art'));
+    const canvas = (await waitFor(() =>
+      document.body.querySelector('[data-eyedropper-overlay="true"] canvas'),
+    )) as HTMLCanvasElement;
+    expect(canvas).not.toBeNull();
+
+    // #when — pointerdown (Radix dismiss-event) followed by click (canvas pick)
+    act(() => {
+      dispatchPointerDown(canvas);
+    });
+    fireEvent.click(canvas, { clientX: 10, clientY: 10 });
+
+    // #then — Dialog still open, dual-key write hit localStorage with the
+    // canonical `vorbis-player-` prefixed keys.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+
+    const setItemCalls = (window.localStorage.setItem as ReturnType<typeof vi.fn>).mock.calls;
+    const overrideWrite = setItemCalls.find(([key]) => key === STORAGE_KEYS.ACCENT_COLOR_OVERRIDES);
+    const customWrite = setItemCalls.find(([key]) => key === STORAGE_KEYS.CUSTOM_ACCENT_COLORS);
+    expect(overrideWrite).toBeTruthy();
+    expect(customWrite).toBeTruthy();
+    expect(JSON.parse(overrideWrite![1] as string)).toEqual({ 'album-123': '#abcdef' });
+    expect(JSON.parse(customWrite![1] as string)).toEqual({ 'album-123': '#abcdef' });
+  });
+});


### PR DESCRIPTION
## Summary
- Settings v2's `AccentColorManager` portals the `EyedropperOverlay` to `document.body`, which placed it outside the Radix Dialog content tree. Radix's `DismissableLayer` was treating `pointerdown` on the eyedropper as an outside-click, closing the Dialog and unmounting the eyedropper portal before the canvas `click` event could fire.
- Fix: pass `onPointerDownOutside` and `onInteractOutside` handlers to both `<DialogPrimitive.Content>` usages in `SettingsV2.tsx` that `preventDefault()` when the event target is inside `[data-eyedropper-overlay]`. Mirrors the legacy guard at `AlbumArtSection.tsx:222`.
- User confirmed repro by triangulating: eyedropper launched from the flip menu (legacy chrome) works fine; same component portaled inside the v2 Dialog was broken.

## Test plan
- `npx tsc -b --noEmit` — clean.
- `npm run test:run` — 1910 passing. New integration test (`AccentColorManager.eyedropper.integration.test.tsx`) renders the real `SettingsV2` Radix Dialog with the un-mocked `EyedropperOverlay`, fires pointerdown + click on the canvas, and asserts the Dialog stays open AND the dual-key write hits both `ACCENT_COLOR_OVERRIDES` and `CUSTOM_ACCENT_COLORS` localStorage keys with `#abcdef`.
  - Note: jsdom does not faithfully reproduce React's portal-to-body event delegation, so the integration test cannot directly assert the bug "fails without the fix" inside the harness — the bug only surfaces in real browsers where the portal's pointerdown bypasses the React-tree capture handler. The test still locks in the dual-key write contract through the real Radix Dialog + real `EyedropperOverlay` and catches future breakage of either piece.
- `npm run build` — clean.
- Manual: `?ui=v2&settings=appearance` → start a track → open Appearance section → click the eyedropper button → click any pixel on the album art canvas. Dialog stays open, picked color lands in the swatches, and the chrome's custom swatch (`controls/QuickEffectsRow`) reflects the new color.

Closes #1467