### PR TITLE
feat(settings-v2): expose build-time app version in About

### DIFF
--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -292,8 +292,7 @@ export const AdvancedSection: React.FC = () => {
 
       <ControlBlock>
         <SectionGroupTitle>About</SectionGroupTitle>
-        {/* TODO(#1462): surface app version once a build-time constant is wired */}
-        <ControlHelp>Vorbis Player — keyboard-first music player.</ControlHelp>
+        <ControlHelp>Vorbis Player {__APP_VERSION__} — keyboard-first music player.</ControlHelp>
         <ShortcutHintList>
           <ShortcutHintRow>
             <span>Show keyboard shortcuts</span>

--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -292,7 +292,7 @@ export const AdvancedSection: React.FC = () => {
 
       <ControlBlock>
         <SectionGroupTitle>About</SectionGroupTitle>
-        <ControlHelp>Vorbis Player {__APP_VERSION__} — keyboard-first music player.</ControlHelp>
+        <ControlHelp>{`Vorbis Player${__APP_VERSION__ !== '0.0.0' ? ` ${__APP_VERSION__}` : ''} — keyboard-first music player.`}</ControlHelp>
         <ShortcutHintList>
           <ShortcutHintRow>
             <span>Show keyboard shortcuts</span>

--- a/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
@@ -528,5 +528,19 @@ describe('SettingsV2 AdvancedSection', () => {
       expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument();
       expect(screen.getByText('Open settings')).toBeInTheDocument();
     });
+
+    it('renders the About tagline matching "Vorbis Player … — keyboard-first music player."', () => {
+      // #given + #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then — tagline renders with or without a version prefix; the gate in
+      // AdvancedSection suppresses the placeholder "0.0.0" so the suffix is
+      // optional, but the surrounding copy is invariant.
+      expect(screen.getByText(/Vorbis Player.* — keyboard-first music player\./)).toBeInTheDocument();
+    });
   });
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 interface ImportMetaEnv {
   readonly VITE_DROPBOX_APP_KEY: string
   readonly VITE_SPOTIFY_CLIENT_ID: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,10 +41,16 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const pkg = require('./package.json') as { version: string }
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react()],
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Summary
- Wire `__APP_VERSION__` build-time constant via vite `define`, sourced from package.json
- Add TypeScript declaration for `__APP_VERSION__` in `src/vite-env.d.ts`
- Replace TODO in AdvancedSection About block with the actual version

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run build` succeeds
- [ ] Manual: open Settings v2 → Advanced → About; version is shown

Closes #1462