### PR TITLE
fix(lint): scope react-hooks rules off Playwright fixtures and fix empty destructure

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,13 @@ import tseslint from 'typescript-eslint'
 export default tseslint.config(
   { ignores: ['dist'] },
   {
+    files: ['playwright/**/*.{ts,tsx}'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+    },
+  },
+  {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,13 +7,6 @@ import tseslint from 'typescript-eslint'
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    files: ['playwright/**/*.{ts,tsx}'],
-    rules: {
-      'react-hooks/rules-of-hooks': 'off',
-      'react-hooks/exhaustive-deps': 'off',
-    },
-  },
-  {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
@@ -38,6 +31,13 @@ export default tseslint.config(
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+    },
+  },
+  {
+    files: ['playwright/**/*.{ts,tsx}'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-hooks/exhaustive-deps': 'off',
     },
   },
 )

--- a/playwright/capture/fixtures.ts
+++ b/playwright/capture/fixtures.ts
@@ -27,7 +27,7 @@ function hasSnapshotContent(): boolean {
 }
 
 export const test = base.extend<{ capturePage: Page }>({
-  capturePage: async ({}, runFixture, testInfo) => {
+  capturePage: async (_fixtures, runFixture, testInfo) => {
     if (!hasSnapshotContent()) {
       testInfo.skip(
         true,


### PR DESCRIPTION
## Summary
- Add eslint override for `playwright/**` that disables `react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps`. Playwright fixture callbacks conventionally take a parameter named `use`, which the `eslint-plugin-react-hooks` plugin mis-identifies as a React Hook invocation. The override is positional defensive hygiene for any current or future Playwright fixture file that follows this API.
- Fix empty object destructure `{}` -> `_fixtures` at `playwright/capture/fixtures.ts:30`.

## Notes on issue scope

- **#1364** — Reproduced on `develop`: `no-empty-pattern` at `playwright/capture/fixtures.ts:30`. Fixed.
- **#1359** — The cited evidence file `playwright/fixtures/auth.ts:13` was deleted in the Playwright mock provider epic (#1376/#1384), which replaced auth-based fixtures with the mock provider. The original `react-hooks` false-positive fix from PR #1366 was lost in that refactor. No `react-hooks/rules-of-hooks` errors currently surface in `npm run lint`, so this override is **defensive hygiene** that re-establishes the previously-shipped protection for any future Playwright fixture authored with the `use` parameter convention.

## Test plan
- [x] `npm run lint` exits 0 (0 errors, 41 warnings — all pre-existing in `src/`)
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 181 test files, 1901 tests, all passed
- [x] Synthetic verification: a temporary `playwright/_test_override.ts` file containing `use(...)` called inside a conditional was linted with exit 0, confirming the override is positionally correct (later entry wins in flat config).

Closes #1364
Closes #1359