### PR TITLE
fix(hooks): resolve exhaustive-deps drift in playback orchestration hooks

### DIFF
--- a/src/hooks/__tests__/useAutoAdvance.test.ts
+++ b/src/hooks/__tests__/useAutoAdvance.test.ts
@@ -235,6 +235,33 @@ describe('useAutoAdvance', () => {
     expect(playTrack).not.toHaveBeenCalled();
   });
 
+  it('does not re-subscribe across re-renders when ref deps are unchanged', () => {
+    // #given — drivingProviderRef has stable identity across renders
+    const drivingProviderRef = { current: 'spotify' as const };
+
+    const { rerender } = renderHook(
+      (props: { tracks: typeof tracks; currentTrackIndex: number }) =>
+        useAutoAdvance({
+          tracks: props.tracks,
+          currentTrackIndex: props.currentTrackIndex,
+          playTrack,
+          currentPlaybackProviderRef: drivingProviderRef,
+        }),
+      { ...opts, initialProps: { tracks, currentTrackIndex: 0 } },
+    );
+
+    const callsAfterInitialMount = mockSubscribe.mock.calls.length;
+    expect(callsAfterInitialMount).toBeGreaterThan(0);
+
+    // #when — re-render multiple times with the same logical inputs
+    rerender({ tracks, currentTrackIndex: 0 });
+    rerender({ tracks, currentTrackIndex: 0 });
+    rerender({ tracks, currentTrackIndex: 0 });
+
+    // #then — subscribe is not called again because the effect's deps are stable
+    expect(mockSubscribe).toHaveBeenCalledTimes(callsAfterInitialMount);
+  });
+
   it('stops at the end of the queue instead of wrapping', () => {
     // #given
     renderHook(() =>

--- a/src/hooks/__tests__/useLibrarySync.test.ts
+++ b/src/hooks/__tests__/useLibrarySync.test.ts
@@ -599,6 +599,37 @@ describe('useLibrarySync', () => {
     });
   });
 
+  describe('catalogProviderIds stabilization', () => {
+    it('does not re-fire catalog load effect across re-renders when the enabled-provider set is unchanged', async () => {
+      // #given
+      mockEnabledProviderIds.length = 0;
+      mockEnabledProviderIds.push('spotify', 'dropbox');
+
+      const dropboxDescriptor = makeCatalogDescriptor('dropbox', [], 0);
+      mockGetDescriptor.mockImplementation((id: ProviderId) =>
+        id === 'dropbox' ? dropboxDescriptor : undefined,
+      );
+
+      const { rerender } = renderHook(() => useLibrarySync());
+
+      await waitFor(() => {
+        expect(dropboxDescriptor.catalog.listCollections).toHaveBeenCalledTimes(1);
+      });
+
+      const callsBeforeRerender = dropboxDescriptor.catalog.listCollections.mock.calls.length;
+
+      // #when — force several re-renders without changing the provider set
+      rerender();
+      rerender();
+      rerender();
+
+      await new Promise(r => setTimeout(r, 20));
+
+      // #then — the catalog load effect should NOT have re-fired
+      expect(dropboxDescriptor.catalog.listCollections).toHaveBeenCalledTimes(callsBeforeRerender);
+    });
+  });
+
   describe('removeCollection', () => {
     it('removes a collection from engine playlist data and re-merges', async () => {
       // #given

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -606,6 +606,48 @@ describe('useQueueManagement', () => {
     errorSpy.mockRestore();
   });
 
+  it('keeps callback identities stable across re-renders when inputs are unchanged', () => {
+    // #given — identical input references on every render
+    const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' }), makeTrack({ id: '3' })];
+    mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2'), makeMediaTrack('3')];
+
+    const props = {
+      tracks,
+      currentTrackIndex: 0,
+      shuffleEnabled: false,
+      trackOps: {
+        setTracks: mockSetTracks,
+        setOriginalTracks: mockSetOriginalTracks,
+        setCurrentTrackIndex: mockSetCurrentTrackIndex,
+        mediaTracksRef,
+      },
+      loadCollection: mockHandlePlaylistSelect,
+      handleBackToLibrary: mockHandleBackToLibrary,
+      activeDescriptor: mockActiveDescriptor,
+      getDescriptor: mockGetDescriptor,
+    };
+
+    const { result, rerender } = renderHook((p: typeof props) => useQueueManagement(p), {
+      initialProps: props,
+    });
+
+    const initialRemove = result.current.handleRemoveFromQueue;
+    const initialReorder = result.current.handleReorderQueue;
+    const initialAdd = result.current.handleAddToQueue;
+
+    // #when — re-render with identical references (mediaTracksRef identity is stable
+    // even as its `.current` array contents mutate; this test guards against the
+    // exhaustive-deps fix re-introducing callback churn).
+    rerender(props);
+    rerender(props);
+    rerender(props);
+
+    // #then
+    expect(result.current.handleRemoveFromQueue).toBe(initialRemove);
+    expect(result.current.handleReorderQueue).toBe(initialReorder);
+    expect(result.current.handleAddToQueue).toBe(initialAdd);
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/useAutoAdvance.ts
+++ b/src/hooks/useAutoAdvance.ts
@@ -156,5 +156,6 @@ export const useAutoAdvance = ({
     }
 
     return () => unsubscribes.forEach((unsub) => unsub());
+    // drivingProviderRef included for exhaustive-deps; ref identity is stable so it does not cause extra re-subscriptions.
   }, [enabled, tracks.length, endThreshold, activeDescriptor, activeProviderId, drivingProviderRef]);
 };

--- a/src/hooks/useAutoAdvance.ts
+++ b/src/hooks/useAutoAdvance.ts
@@ -156,5 +156,5 @@ export const useAutoAdvance = ({
     }
 
     return () => unsubscribes.forEach((unsub) => unsub());
-  }, [enabled, tracks.length, endThreshold, activeDescriptor, activeProviderId]);
+  }, [enabled, tracks.length, endThreshold, activeDescriptor, activeProviderId, drivingProviderRef]);
 };

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -139,7 +139,14 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
 
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
-  const catalogProviderIds = enabledProviderIds.filter(id => id !== engineProviderId);
+  const catalogProviderIdsKey = useMemo(
+    () => enabledProviderIds.filter(id => id !== engineProviderId).sort().join(','),
+    [enabledProviderIds, engineProviderId],
+  );
+  const catalogProviderIds = useMemo(
+    () => (catalogProviderIdsKey ? catalogProviderIdsKey.split(',') as ProviderId[] : []),
+    [catalogProviderIdsKey],
+  );
 
   const mergeAndSetData = useCallback(() => {
     const allPlaylists: CachedPlaylistInfo[] = [];
@@ -281,7 +288,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       cancelled = true;
       controller.abort();
     };
-  }, [[...catalogProviderIds].sort().join(','), getDescriptor, mergeAndSetData]);
+  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
 
   useEffect(() => {
     const cleanups: Array<() => void> = [];
@@ -308,7 +315,7 @@ export function useLibrarySync(): UseLibrarySyncResult {
       cleanups.push(() => window.removeEventListener(eventName, handleLikesChanged));
     }
     return () => cleanups.forEach(cleanup => cleanup());
-  }, [[...catalogProviderIds].sort().join(','), getDescriptor, mergeAndSetData]);
+  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
 
   const refreshNow = useCallback(async (scopeProviderId?: ProviderId) => {
     if (!scopeProviderId || scopeProviderId === engineProviderId) {

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -139,14 +139,23 @@ export function useLibrarySync(): UseLibrarySyncResult {
   const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
 
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
-  const catalogProviderIdsKey = useMemo(
-    () => enabledProviderIds.filter(id => id !== engineProviderId).sort().join(','),
-    [enabledProviderIds, engineProviderId],
-  );
-  const catalogProviderIds = useMemo(
-    () => (catalogProviderIdsKey ? catalogProviderIdsKey.split(',') as ProviderId[] : []),
-    [catalogProviderIdsKey],
-  );
+  // Stabilize catalogProviderIds so downstream effects don't re-fire when the
+  // parent renders with a new array reference for the same logical set. The
+  // ref holds the previously-returned array; we return that same reference
+  // whenever the next computed contents are equal as a sorted set.
+  const catalogProviderIdsRef = useRef<ProviderId[]>([]);
+  const catalogProviderIds = useMemo(() => {
+    const next = enabledProviderIds.filter(id => id !== engineProviderId);
+    const prev = catalogProviderIdsRef.current;
+    if (prev.length === next.length) {
+      const prevSet = new Set(prev);
+      if (next.every(id => prevSet.has(id))) {
+        return prev;
+      }
+    }
+    catalogProviderIdsRef.current = next;
+    return next;
+  }, [enabledProviderIds, engineProviderId]);
 
   const mergeAndSetData = useCallback(() => {
     const allPlaylists: CachedPlaylistInfo[] = [];

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -8,6 +8,7 @@ import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { logLibrary } from '@/lib/debugLog';
 import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
 import { readLikedCountSnapshots, writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { useStableSet } from '@/hooks/useStableSet';
 
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
@@ -140,22 +141,10 @@ export function useLibrarySync(): UseLibrarySyncResult {
 
   const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
   // Stabilize catalogProviderIds so downstream effects don't re-fire when the
-  // parent renders with a new array reference for the same logical set. The
-  // ref holds the previously-returned array; we return that same reference
-  // whenever the next computed contents are equal as a sorted set.
-  const catalogProviderIdsRef = useRef<ProviderId[]>([]);
-  const catalogProviderIds = useMemo(() => {
-    const next = enabledProviderIds.filter(id => id !== engineProviderId);
-    const prev = catalogProviderIdsRef.current;
-    if (prev.length === next.length) {
-      const prevSet = new Set(prev);
-      if (next.every(id => prevSet.has(id))) {
-        return prev;
-      }
-    }
-    catalogProviderIdsRef.current = next;
-    return next;
-  }, [enabledProviderIds, engineProviderId]);
+  // parent renders with a new array reference for the same logical set.
+  const catalogProviderIds = useStableSet(
+    enabledProviderIds.filter((id) => id !== engineProviderId),
+  );
 
   const mergeAndSetData = useCallback(() => {
     const allPlaylists: CachedPlaylistInfo[] = [];

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -135,7 +135,7 @@ export const useProviderPlayback = ({
         setTimeout(() => playTrack(index + 1, skipOnError), SKIP_ON_ERROR_DELAY_MS);
       }
     }
-  }, [setCurrentTrackIndex, pausePreviousProvider, resolveTrackProvider, onAuthExpired, expectedTrackIdRef]);
+  }, [setCurrentTrackIndex, pausePreviousProvider, resolveTrackProvider, onAuthExpired, expectedTrackIdRef, mediaTracksRef]);
 
   const resumePlayback = useCallback(async () => {
     const currentProvider = currentPlaybackProviderRef.current;

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -135,6 +135,7 @@ export const useProviderPlayback = ({
         setTimeout(() => playTrack(index + 1, skipOnError), SKIP_ON_ERROR_DELAY_MS);
       }
     }
+    // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
   }, [setCurrentTrackIndex, pausePreviousProvider, resolveTrackProvider, onAuthExpired, expectedTrackIdRef, mediaTracksRef]);
 
   const resumePlayback = useCallback(async () => {

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -130,7 +130,7 @@ export function useQueueManagement({
         return null;
       }
     },
-    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef]
   );
 
   const handleRemoveFromQueue = useCallback(
@@ -161,7 +161,7 @@ export function useQueueManagement({
 
       logQueue('handleRemoveFromQueue — done, new queueLen=%d', tracks.length - 1);
     },
-    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex]
+    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
   );
 
   const handleReorderQueue = useCallback(
@@ -202,7 +202,7 @@ export function useQueueManagement({
 
       logQueue('handleReorderQueue — done, currentIndex=%d', newCurrentIndex);
     },
-    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex]
+    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
   );
 
   const queueTracksDirectly = useCallback(

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -130,6 +130,7 @@ export function useQueueManagement({
         return null;
       }
     },
+    // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
     [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef]
   );
 
@@ -161,6 +162,7 @@ export function useQueueManagement({
 
       logQueue('handleRemoveFromQueue — done, new queueLen=%d', tracks.length - 1);
     },
+    // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
     [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
   );
 
@@ -202,6 +204,7 @@ export function useQueueManagement({
 
       logQueue('handleReorderQueue — done, currentIndex=%d', newCurrentIndex);
     },
+    // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
     [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
   );
 

--- a/src/hooks/useStableSet.ts
+++ b/src/hooks/useStableSet.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+/**
+ * Returns the previously-returned array reference when the *set* of values
+ * is unchanged, even if the caller passes a fresh array on each render.
+ *
+ * Useful as a dep stabilizer: passing the result into a downstream effect's
+ * dependency array prevents the effect from re-firing when the parent
+ * re-renders with a new array literal whose contents are equivalent.
+ *
+ * The in-render ref mutation is idempotent — given the same logical input,
+ * the function always returns the same reference and never triggers a render.
+ * This makes it StrictMode-safe (double-invocation produces identical output).
+ */
+export function useStableSet<T extends string>(values: readonly T[]): readonly T[] {
+  const ref = useRef<readonly T[]>(values);
+  const prev = ref.current;
+  if (prev.length === values.length) {
+    const prevSet = new Set(prev);
+    if (values.every((v) => prevSet.has(v))) {
+      return prev;
+    }
+  }
+  ref.current = values;
+  return values;
+}


### PR DESCRIPTION
## Summary
- Resolve missing-dep warnings in `useAutoAdvance`, `useProviderPlayback`, `useQueueManagement`, `useLibrarySync`
- Extract complex expressions into `useMemo`/local vars where flagged
- Add stable refs to dep arrays where intent is preserved

## Test plan
- [x] `npm run lint` clears the listed warnings
- [x] `npx tsc -b --noEmit`
- [x] `npm run test:run` (no integration regressions)

Closes #1362