### PR TITLE
refactor(providers): route auth/playlist via descriptors instead of mock guards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,13 @@ function App() {
             <RetryButton
               onClick={() => {
                 setAuthError(null);
+                // This branch renders before <ProviderProvider>, so we read the registry
+                // directly. The Spotify descriptor is available here because
+                // ProviderContext.tsx has a top-level `import '@/providers/spotify/spotifyProvider'`
+                // that self-registers at module evaluation; under mock mode, main.tsx awaits
+                // the mock import before createRoot, so the mock descriptor (whose auth.beginLogin
+                // is a no-op) overwrites it. The defensive `?.` guard surfaces a future regression
+                // if that import side-effect is ever removed or made lazy.
                 const spotifyDescriptor = providerRegistry.get('spotify');
                 if (spotifyDescriptor) {
                   spotifyDescriptor.auth.beginLogin().catch((err) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import AudioPlayerComponent from './components/AudioPlayer';
 import { spotifyAuth } from './services/spotify';
-import { shouldUseMockProvider } from './providers/mock/shouldUseMockProvider';
 import { ThemeProvider } from './styles/ThemeProvider';
 import { flexCenter, buttonPrimary } from './styles/utils';
 import { AuthCallbackPage } from './components/AuthCallbackPage';
@@ -169,8 +168,12 @@ function App() {
             <RetryButton
               onClick={() => {
                 setAuthError(null);
-                if (shouldUseMockProvider()) return;
-                spotifyAuth.redirectToAuth();
+                const spotifyDescriptor = providerRegistry.get('spotify');
+                if (spotifyDescriptor) {
+                  spotifyDescriptor.auth.beginLogin().catch((err) => {
+                    setAuthError(err instanceof Error ? err.message : 'Failed to start login.');
+                  });
+                }
               }}
             >
               Try Again

--- a/src/hooks/__tests__/usePlaylistManager.test.ts
+++ b/src/hooks/__tests__/usePlaylistManager.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { makeTrack } from '@/test/fixtures';
-import type { MediaTrack } from '@/types/domain';
-
-vi.mock('@/providers/mock/shouldUseMockProvider', () => ({
-  shouldUseMockProvider: vi.fn().mockReturnValue(false),
-}));
 
 vi.mock('@/services/spotifyPlayer', () => ({
   spotifyPlayer: {
@@ -35,7 +30,6 @@ vi.mock('@/services/spotify', () => ({
 
 import { useSpotifyPlaylistManager as usePlaylistManager } from '@/providers/spotify/useSpotifyPlaylistManager';
 import { getPlaylistTracks, getAlbumTracks, getLikedSongs, spotifyAuth } from '@/services/spotify';
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 
 describe('usePlaylistManager', () => {
   const setError = vi.fn();
@@ -177,24 +171,5 @@ describe('usePlaylistManager', () => {
 
     // #then
     expect(setIsLoading).toHaveBeenLastCalledWith(false);
-  });
-
-  describe('mock provider short-circuit', () => {
-    it('returns [] without calling spotifyPlayer.initialize when mock provider is active', async () => {
-      // #given — mock provider is active
-      vi.mocked(shouldUseMockProvider).mockReturnValue(true);
-      const { spotifyPlayer } = await import('@/services/spotifyPlayer');
-      const { result } = renderHook(() => usePlaylistManager(defaultProps));
-
-      // #when
-      let tracks: MediaTrack[] = [];
-      await act(async () => {
-        tracks = await result.current.handlePlaylistSelect('playlist-123');
-      });
-
-      // #then
-      expect(tracks).toEqual([]);
-      expect(spotifyPlayer.initialize).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -16,7 +16,6 @@ import { shuffleArray } from '@/utils/shuffleArray';
 import type { ProviderId, MediaTrack } from '@/types/domain';
 import type { TrackOperations } from '@/types/trackOperations';
 import { logQueue } from '@/lib/debugLog';
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { SPOTIFY_RETRY_DELAY_MS, SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
 
 const SPOTIFY_PROVIDER_ID: ProviderId = 'spotify';
@@ -72,15 +71,6 @@ export const useSpotifyPlaylistManager = ({
 
   const handlePlaylistSelect = useCallback(async (playlistId: string): Promise<MediaTrack[]> => {
     logQueue('useSpotifyPlaylistManager.handlePlaylistSelect — playlistId=%s, shuffle=%s', playlistId, String(shuffleEnabled));
-
-    // The mock provider replaces the spotify descriptor at the registry level,
-    // but this hook still calls real Spotify SDK/API helpers directly. Short-
-    // circuit when the mock is active so capture/Playwright runs never hit
-    // accounts.spotify.com or the Web Playback SDK.
-    if (shouldUseMockProvider()) {
-      logQueue('useSpotifyPlaylistManager — mock provider active, skipping real Spotify path');
-      return [];
-    }
 
     try {
       setError(null);


### PR DESCRIPTION
## Summary
- Replace `shouldUseMockProvider()` guard in `App.tsx` auth retry button with descriptor-routed `beginLogin()` via `providerRegistry.get('spotify')?.auth.beginLogin()`. Mock descriptor's auth adapter naturally no-ops, so capture/Playwright runs never hit `accounts.spotify.com`.
- Drop the duplicate mock short-circuit inside `useSpotifyPlaylistManager.handlePlaylistSelect` (~lines 80-83). The upstream gate at `useCollectionLoader.ts:170` (`!shouldUseMockProvider()`) already prevents the legacy SDK path from running under the mock provider, so the inner guard was dead defensive code. Removed the corresponding "mock provider short-circuit" test from `usePlaylistManager.test.ts` — equivalent assertion already exists in `useCollectionLoader.test.ts` ("skips the legacy SDK fallback when the mock provider is active").

## Deferred
- **`loadContextPlayback` deletion is deferred.** The hook still reads tracks out of the Spotify SDK's `track_window` (via `buildTracksFromWindow`) to populate the queue UI when `getPlaylistTracks()` returns 0 (region-locked / Spotify-curated playlists). The descriptor-level `playback.playCollection()` only triggers context playback — it does not return tracks for the queue. Removing `loadContextPlayback` would lose that queue-population behavior. The remaining `shouldUseMockProvider()` guard in `useCollectionLoader.ts:170` stays in place until a follow-up either teaches `playCollection` to return its track list or reworks the queue-from-SDK-state path.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1900 passing
- [x] `npm run lint` — no new errors (1 pre-existing `no-empty-pattern` in `playwright/capture/fixtures.ts`, unrelated)
- [x] `npm run test:e2e` — failures reproduce on `origin/develop` HEAD with the same error (timeout waiting for `button[title^="Zen Mode"]` because welcome screen now intercepts); not caused by this PR

Refs #1393