### PR TITLE
feat: integrate Serena MCP for symbol-aware code navigation (#1481)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,14 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "mcp__serena__find_symbol",
+      "mcp__serena__find_referencing_symbols",
+      "mcp__serena__get_symbols_overview",
+      "mcp__serena__list_dir",
+      "mcp__serena__search_for_pattern",
+      "mcp__serena__read_memory",
+      "mcp__serena__list_memories"
+    ]
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ playwright/capture/.auth-state.json
 
 # Local-only stashes of skills moved out of .claude/skills/ so Claude won't load them
 .skill-backups/
+
+# Serena MCP — commit project.yml + memories, ignore cache/logs
+.serena/cache/
+.serena/logs/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena",
+        "serena", "start-mcp-server",
+        "--context", "claude-code",
+        "--project", "."
+      ]
+    }
+  }
+}

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,10 @@
+language: typescript
+ignore_all_files_in_gitignore: true
+ignored_paths:
+  - dist
+  - dist-electron
+  - node_modules
+  - playwright/capture/output
+  - public/playwright-fixtures/art
+  - "*.snapshot.json"
+read_only: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,18 @@ npm run build             # Full build
 
 Check for dangling references in `vite.config.ts`, `tsconfig.json`, etc.
 
+## MCP Tooling
+
+This repo registers [Serena MCP](https://github.com/oraios/serena) via `.mcp.json`
+for symbol-aware code navigation and editing. Prerequisite: `uv` installed
+(`curl -LsSf https://astral.sh/uv/install.sh | sh`). Claude Code launches it
+automatically; verify with `/mcp` (should show `serena` connected).
+
+Prefer `mcp__serena__find_symbol` / `find_referencing_symbols` over `grep`
+for cross-file symbol lookups, especially across the parallel
+`src/providers/{spotify,dropbox,mock}/` trees. Use Read/Edit for
+non-symbol files (CSS, JSON, MD).
+
 ## UI & CSS Guidelines
 
 When modifying CSS layout or styling, avoid making additional 'clever' adjustments beyond what was requested. If the user asks to constrain width or center an element, do exactly that — don't add spacers, override calculated dimensions, or restructure containers unless explicitly asked.
@@ -52,6 +64,8 @@ cp ../.env.local .env.local
 ```
 
 Worktrees don't inherit `node_modules`. `.env.local` contains Spotify credentials needed for tests. Verify with `npm run test:run`.
+
+`.serena/cache/` rebuilds on first launch in a fresh worktree (~30s) — that's expected.
 
 ## Development Commands
 


### PR DESCRIPTION
Add project-scoped `.mcp.json` registering Serena via `uvx`, committed
`.serena/project.yml` tuned for the TypeScript LSP (excludes dist/node_modules/
fixtures), read-only Serena tool permissions in `.claude/settings.json`, and
`.gitignore` entries keeping cache/logs local. Documents the setup and worktree
cache-rebuild note in `CLAUDE.md`.

https://claude.ai/code/session_01GyTXC5QpgubEobcgkGhJvb