### PR TITLE
fix: unblock Playwright suite for mock provider

### DIFF
--- a/playwright/fixtures/auth-state.ts
+++ b/playwright/fixtures/auth-state.ts
@@ -1,0 +1,27 @@
+import { test as base, expect } from '@playwright/test';
+
+// Mirrors WELCOME_SEEN_STORAGE_KEY in src/hooks/useWelcomeSeen.ts.
+// useLocalStorage JSON-stringifies its values, so the persisted form is the
+// literal string 'true'.
+const WELCOME_SEEN_STORAGE_KEY = 'vorbis-player-welcome-seen';
+
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    await context.addInitScript((key: string) => {
+      window.localStorage.setItem(key, 'true');
+    }, WELCOME_SEEN_STORAGE_KEY);
+
+    if (process.env.PW_DEBUG_CONSOLE) {
+      context.on('page', (page) => {
+        page.on('console', (msg) => {
+          // eslint-disable-next-line no-console
+          console.log(`[browser:${msg.type()}]`, msg.text());
+        });
+      });
+    }
+
+    await use(context);
+  },
+});
+
+export { expect };

--- a/playwright/specs/player-controls.spec.ts
+++ b/playwright/specs/player-controls.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/auth-state';
 import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type: 'json' };
 
 const hasContent = spotifySnapshot.playlists.length > 0;
@@ -10,11 +10,9 @@ test.describe('Player Controls', () => {
       'Specs require populated snapshots. Run `npm run snapshot:spotify -- --list` to enumerate your library, populate `snapshot.config.json`, then `npm run snapshot:spotify`. See #1372 §10 ("Curating fixtures").',
     );
     await page.goto('/');
-    await page.locator('button[title^="Zen Mode"]').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
 
     if (hasContent) {
-      await page.locator('button[title="Back to Library"]').click();
-      await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 10_000 });
       await page.locator('[data-testid^="library-card-playlist-"]').first().click();
       await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
     }

--- a/playwright/specs/playlist-selection.spec.ts
+++ b/playwright/specs/playlist-selection.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/auth-state';
 import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type: 'json' };
 
 const hasPlaylists = spotifySnapshot.playlists.length > 0;
@@ -7,9 +7,7 @@ const hasContent = hasPlaylists || hasAlbums;
 
 async function navigateToLibrary(page: import('@playwright/test').Page) {
   await page.goto('/');
-  await page.locator('button[title^="Zen Mode"]').waitFor({ state: 'visible', timeout: 30_000 });
-  await page.locator('button[title="Back to Library"]').click();
-  await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
 }
 
 test.describe('Playlist Selection', () => {

--- a/playwright/specs/zen-mode.spec.ts
+++ b/playwright/specs/zen-mode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/auth-state';
 import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type: 'json' };
 
 const hasContent = spotifySnapshot.playlists.length > 0;
@@ -10,11 +10,9 @@ test.describe('Zen Mode', () => {
       'Specs require populated snapshots. Run `npm run snapshot:spotify -- --list` to enumerate your library, populate `snapshot.config.json`, then `npm run snapshot:spotify`. See #1372 §10 ("Curating fixtures").',
     );
     await page.goto('/');
-    await page.locator('button[title^="Zen Mode"]').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
 
     if (hasContent) {
-      await page.locator('button[title="Back to Library"]').click();
-      await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 10_000 });
       await page.locator('[data-testid^="library-card-playlist-"]').first().click();
       await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
     }

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -5,6 +5,7 @@ import type { MediaCollection, ProviderId } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { providerRegistry } from '@/providers/registry';
 import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logLibrary } from '@/lib/debugLog';
 import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
 import { readLikedCountSnapshots, writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
@@ -131,7 +132,12 @@ export function useLibrarySync(): UseLibrarySyncResult {
 
   const engineRef = useRef(librarySyncEngine);
 
-  const engineProviderId = librarySyncEngine.providerId as ProviderId | undefined;
+  // The sync engine talks directly to the real Spotify Web API. In mock mode,
+  // bypass it so the registry-aware catalog path (further down) loads spotify
+  // collections via the mock catalog adapter instead.
+  const engineProviderId = shouldUseMockProvider()
+    ? undefined
+    : (librarySyncEngine.providerId as ProviderId | undefined);
 
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,

--- a/src/providers/mock/__tests__/mockCatalogAdapter.test.ts
+++ b/src/providers/mock/__tests__/mockCatalogAdapter.test.ts
@@ -79,21 +79,15 @@ describe('MockCatalogAdapter (spotify)', () => {
 
   // #given a snapshot with 1 playlist, 1 album, 2 liked tracks
   // #when listCollections is called
-  // #then returns liked + playlist + album in the right count
-  it('listCollections returns liked + playlist + album', async () => {
+  // #then returns playlist + album only — Liked Songs is exposed via getLikedCount,
+  //  matching the real Spotify catalog's listCollections shape
+  it('listCollections returns playlist + album', async () => {
     const collections = await adapter.listCollections();
     const kinds = collections.map(c => c.kind);
-    expect(kinds).toContain('liked');
     expect(kinds).toContain('playlist');
     expect(kinds).toContain('album');
-    expect(collections).toHaveLength(3);
-  });
-
-  it('listCollections omits liked when likedTrackIds is empty', async () => {
-    const snapshot = makeSnapshot({ likedTrackIds: [] });
-    const emptyAdapter = new MockCatalogAdapter(snapshot);
-    const collections = await emptyAdapter.listCollections();
-    expect(collections.find(c => c.kind === 'liked')).toBeUndefined();
+    expect(kinds).not.toContain('liked');
+    expect(collections).toHaveLength(2);
   });
 
   it('listTracks resolves liked tracks', async () => {

--- a/src/providers/mock/mockCatalogAdapter.ts
+++ b/src/providers/mock/mockCatalogAdapter.ts
@@ -52,16 +52,6 @@ export class MockCatalogAdapter implements CatalogProvider {
       });
     }
 
-    if (this.snapshot.likedTrackIds.length > 0) {
-      collections.push({
-        id: 'liked',
-        provider: this.providerId,
-        kind: 'liked',
-        name: 'Liked Songs',
-        trackCount: this.likedSet.size,
-      });
-    }
-
     for (const playlist of this.snapshot.playlists) {
       collections.push({
         id: playlist.id,


### PR DESCRIPTION
## Summary

Three layered bugs were causing every Playwright spec to time out, all surfacing as "auth hang" symptoms even though the auth gate was correct. Each commit fixes one independently.

- **`fix(library-sync)`** — `librarySyncEngine` is hardcoded to call the real Spotify Web API and check `spotifyAuth.isAuthenticated()`, ignoring the provider registry. With mock active, the engine bailed silently and the mock catalog was never queried for spotify because `useLibrarySync` filters spotify out of `catalogProviderIds` when `engineProviderId === 'spotify'`. Force `engineProviderId = undefined` in mock mode so spotify routes through the registry-aware catalog path.
- **`fix(mock)`** — `MockCatalogAdapter.listCollections` was synthesizing a `{id:'liked', kind:'liked'}` entry that the real `SpotifyCatalogAdapter` doesn't return. `splitCollections` lumps non-album items into playlists, so the leak rendered as a phantom playlist tile, and clicking it routed through `resolvePlaylistRef('liked')` which falls through to a non-existent playlist (because `LIKED_SONGS_ID` is `'liked-songs'`, not `'liked'`). The player then errored "No tracks found in this collection." Removed the leak; Liked Songs is exposed via `getLikedCount()` like the real catalog.
- **`test(playwright)`** — The first-run `WelcomeScreen` is gated by `localStorage['vorbis-player-welcome-seen']` (unrelated to auth); fresh contexts always saw it. New `playwright/fixtures/auth-state.ts` extends `test()` with `addInitScript` to seed the flag. Specs migrated to import from it. Also realigned each spec's `beforeEach` with the actual boot UX — the previous pattern assumed the app boots into the player and waited 30s for `Zen Mode`, but it actually boots into `library-home`.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1900/1900 unit tests pass
- [x] `npm run test:e2e` — 15/15 specs pass (~9s, was 0/15 timing out at 30s each)
- [ ] CI green