### PR TITLE
chore(deps): add audit:ci script to guard against high-severity regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "capture:desktop": "playwright test --config playwright/capture/capture.config.ts --project desktop",
     "capture:mobile": "playwright test --config playwright/capture/capture.config.ts --project mobile",
     "snapshot:spotify": "tsx scripts/snapshot-spotify.ts",
-    "snapshot:dropbox": "tsx scripts/snapshot-dropbox.ts"
+    "snapshot:dropbox": "tsx scripts/snapshot-dropbox.ts",
+    "audit:ci": "npm audit --audit-level=high"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Closes #1361

## Summary
Issue #1361 reported 7 high + 5 moderate npm audit advisories. PR #1367 already resolved them via `npm audit fix` on the lockfile (no manifest change required, since semver ranges already permitted the patched versions). On develop today, `npm audit --json` reports `0` vulnerabilities — but the issue stayed open because #1367's title referenced #1361 instead of using `Closes #1361`.

This PR finishes the work by:
1. Formally closing the issue.
2. Adding a tiny `audit:ci` npm script (`npm audit --audit-level=high`) so future drift trips a non-zero exit code rather than silently re-introducing high-severity advisories.

No production dependency changes — script-only addition.

## Audit before/after
```
On origin/develop @ HEAD (this PR's base):
  Before: 0 info / 0 low / 0 moderate / 0 high / 0 critical
  After:  0 info / 0 low / 0 moderate / 0 high / 0 critical
```

(The originally reported 7H/5M counts predate PR #1367's lockfile refresh and are no longer reproducible.)

## Verify
- `npx tsc -b --noEmit` ✓
- `npm run build` ✓
- `npm run test:run` ✓ (1923 passed)
- `npm run audit:ci` ✓