### PR TITLE
refactor(providers): replace mock guard in collection loader with capability flag

### DIFF
--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -5,12 +5,6 @@ import { makeTrack } from '@/test/fixtures';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import type { MediaTrack } from '@/types/domain';
 
-vi.mock('@/providers/mock/shouldUseMockProvider', () => ({
-  shouldUseMockProvider: vi.fn(() => false),
-}));
-
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
-
 function makeMediaTrack(id: string, addedAt?: number): MediaTrack {
   return {
     id,
@@ -56,7 +50,7 @@ describe('useCollectionLoader', () => {
     mockRecord = vi.fn();
     mediaTracksRef = { current: [] };
     drivingProviderRef = { current: null };
-    mockActiveDescriptor = { id: 'spotify' };
+    mockActiveDescriptor = { id: 'spotify', capabilities: { hasContextPlaybackFallback: false } };
   });
 
   it('loading a standard provider collection sets tracks and calls playTrack(0)', async () => {
@@ -204,14 +198,14 @@ describe('useCollectionLoader', () => {
     expect(trackCount).toBe(0);
   });
 
-  it('skips the legacy SDK fallback when the mock provider is active even if playCollection is defined', async () => {
-    // #given — mock active, empty catalog, playback advertises playCollection
-    vi.mocked(shouldUseMockProvider).mockReturnValueOnce(true);
+  it('skips the legacy SDK fallback when the descriptor lacks hasContextPlaybackFallback even if playCollection is defined', async () => {
+    // #given — empty catalog, playback advertises playCollection, but capability flag is unset (mock/dropbox shape)
     const mockCatalog = {
       listTracks: vi.fn().mockResolvedValue([]),
     };
     mockActiveDescriptor.catalog = mockCatalog;
     mockActiveDescriptor.playback = { pause: vi.fn(), playCollection: vi.fn() };
+    mockActiveDescriptor.capabilities = { hasContextPlaybackFallback: false };
 
     const { result } = renderHook(() =>
       useCollectionLoader({
@@ -242,7 +236,7 @@ describe('useCollectionLoader', () => {
     expect(trackCount).toBe(0);
   });
 
-  it('the legacy SDK fallback path is invoked when list.length === 0 and playCollection is defined', async () => {
+  it('the legacy SDK fallback path is invoked when list.length === 0 and the descriptor declares hasContextPlaybackFallback', async () => {
     // #given
     mockSpotifyHandlePlaylistSelect.mockResolvedValue([makeTrack('1'), makeTrack('2')]);
 
@@ -251,6 +245,7 @@ describe('useCollectionLoader', () => {
     };
     mockActiveDescriptor.catalog = mockCatalog;
     mockActiveDescriptor.playback = { pause: vi.fn(), playCollection: vi.fn() };
+    mockActiveDescriptor.capabilities = { hasContextPlaybackFallback: true };
 
     const { result } = renderHook(() =>
       useCollectionLoader({

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -5,7 +5,6 @@ import type { TrackOperations } from '@/types/trackOperations';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logQueue } from '@/lib/debugLog';
 import { queueSnapshot } from './playerLogicUtils';
 
@@ -167,7 +166,7 @@ export function useCollectionLoader({
       const collectionRef = { provider: providerId, kind: collectionKind, id: collectionId } as const;
       const list = await targetDescriptor.catalog.listTracks(collectionRef);
 
-      if (list.length === 0 && targetDescriptor.playback.playCollection && !shouldUseMockProvider()) {
+      if (list.length === 0 && targetDescriptor.capabilities.hasContextPlaybackFallback) {
         return loadContextPlayback(playlistId, providerId);
       }
 

--- a/src/providers/spotify/spotifyProvider.ts
+++ b/src/providers/spotify/spotifyProvider.ts
@@ -32,6 +32,7 @@ const spotifyDescriptor: ProviderDescriptor = {
     externalLinkLabel: 'Open in Spotify',
     hasTrackSearch: true,
     hasNativeQueueSync: true,
+    hasContextPlaybackFallback: true,
   },
   auth: new SpotifyAuthAdapter(),
   catalog: new SpotifyCatalogAdapter(),

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -113,6 +113,16 @@ export interface ProviderCapabilities {
   hasTrackSearch?: boolean;
   /** Provider syncs its native queue with the app queue. */
   hasNativeQueueSync?: boolean;
+  /**
+   * Provider's `playback.playCollection` is a true context-playback path that
+   * also populates the queue UI from native SDK state when the catalog returns
+   * no tracks (Spotify only — region-restricted playlists, etc.).
+   *
+   * Other providers (Dropbox, mock) implement `playCollection` as a no-op
+   * because they drive playback track-by-track via the app queue, so this flag
+   * stays false for them.
+   */
+  hasContextPlaybackFallback?: boolean;
 }
 
 export interface ProviderDescriptor {


### PR DESCRIPTION
Closes #1393

## Summary

Removes the last `shouldUseMockProvider()` runtime guard from `useCollectionLoader`, replacing it with a semantic `ProviderCapabilities.hasContextPlaybackFallback` flag. PR [#1476](https://github.com/smallorbit/vorbis-player/pull/1476) already addressed the App.tsx and `useSpotifyPlaylistManager` sites listed in the issue; this PR completes the third bullet by routing the empty-collection fallback on a descriptor capability instead of mock-mode detection.

## Sites updated

- `src/types/providers.ts` — added `hasContextPlaybackFallback?: boolean` to `ProviderCapabilities` with a docstring explaining what the flag means and why it stays unset for Dropbox and mock.
- `src/providers/spotify/spotifyProvider.ts` — set `hasContextPlaybackFallback: true` on the real Spotify descriptor (only adapter whose `playCollection` populates the queue UI from native SDK state).
- `src/hooks/useCollectionLoader.ts` — replaced `targetDescriptor.playback.playCollection && !shouldUseMockProvider()` with `targetDescriptor.capabilities.hasContextPlaybackFallback` and dropped the `shouldUseMockProvider` import.
- `src/hooks/__tests__/useCollectionLoader.test.ts` — dropped the `shouldUseMockProvider` mock; updated the two affected tests to toggle `capabilities.hasContextPlaybackFallback` instead; added a baseline `capabilities` field to `mockActiveDescriptor` so the new code path doesn't NPE on tests with empty catalogs.

## `loadContextPlayback` — deferred (with reason)

Deletion is **not** included in this PR, matching the issue's own guidance ("if not, document the residual gap in the PR body and leave it for follow-up"):

- `MockPlaybackAdapter.playCollection` is a no-op (collection playback is driven by the app's queue).
- `DropboxPlaybackAdapter.playCollection` is a no-op for the same reason.
- `SpotifyPlaybackAdapter.playCollection` calls `spotifyPlayer.playContext` but does **not** populate the queue UI from `track_window`.

`useCollectionLoader.loadContextPlayback` remains the only path that pulls tracks out of the Spotify SDK's `track_window` to populate the queue UI when `getPlaylistTracks()` returns empty (typical for region-restricted playlists). Deleting it would regress that behavior. Closing the gap requires either teaching `SpotifyPlaybackAdapter.playCollection` to return a track list or surfacing `track_window` reads through a different descriptor method — both larger refactors than this issue's scope.

## Verify

- `npx tsc -b --noEmit` clean
- `npm run test:run` — 1923/1923 passing