### PR TITLE
chore(claude): add serena-worktree-guard hook + document pinning hazard

### DIFF
--- a/.claude/hooks/serena-worktree-guard.sh
+++ b/.claude/hooks/serena-worktree-guard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# PreToolUse hook: deny Serena write tools when the agent's session cwd is not
+# the Serena MCP project root.
+#
+# Why: Serena MCP launches once with `--project .` relative to Claude Code's
+# initial cwd (the main worktree). All sub-agents share that single MCP
+# connection, so Serena write tools (replace_symbol_body, insert_*_symbol,
+# rename_symbol, safe_delete_symbol, replace_content) silently land in the
+# main worktree's files even when the calling agent works in
+# .claude/worktrees/agent-*.
+#
+# This hook reads the session cwd from the hook payload, compares it against
+# the main worktree (= Serena project root), and denies the call if they
+# differ. Read tools (find_symbol, get_symbols_overview,
+# find_referencing_symbols) remain unaffected.
+
+set -euo pipefail
+
+payload="$(cat)"
+
+cwd_raw="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+tool_name="$(printf '%s' "$payload" | jq -r '.tool_name // empty')"
+
+if [[ -z "$cwd_raw" ]]; then
+  exit 0
+fi
+
+main_worktree="$(git -C "$cwd_raw" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [[ -z "$main_worktree" ]]; then
+  exit 0
+fi
+
+session_canonical="$(cd "$cwd_raw" 2>/dev/null && pwd -P || printf '%s' "$cwd_raw")"
+main_canonical="$(cd "$main_worktree" 2>/dev/null && pwd -P || printf '%s' "$main_worktree")"
+
+if [[ "$session_canonical" == "$main_canonical" ]]; then
+  exit 0
+fi
+
+cat <<EOF >&2
+[serena-worktree-guard] DENIED: $tool_name
+
+Serena MCP is pinned to the main worktree:
+  $main_canonical
+
+Your session cwd is:
+  $session_canonical
+
+Serena write tools (replace_symbol_body, insert_*_symbol, rename_symbol,
+safe_delete_symbol, replace_content) resolve relative paths against Serena's
+project root, so calling them from this worktree would silently edit files in
+the main worktree instead of yours.
+
+Use the Read + Edit tools instead — they respect this worktree's cwd.
+
+Navigation tools (find_symbol, find_referencing_symbols,
+get_symbols_overview, search_for_pattern) are still allowed; just remember
+the absolute paths in their output point to the main worktree.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,18 @@
       "mcp__serena__read_memory",
       "mcp__serena__list_memories"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__serena__(replace_symbol_body|insert_after_symbol|insert_before_symbol|rename_symbol|safe_delete_symbol|replace_content)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/serena-worktree-guard.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,29 @@ for cross-file symbol lookups, especially across the parallel
 `src/providers/{spotify,dropbox,mock}/` trees. Use Read/Edit for
 non-symbol files (CSS, JSON, MD).
 
+### Worktree hazard — Serena edit tools are pinned to the main worktree
+
+Serena MCP launches once with `--project .` relative to the cwd Claude Code
+started in (the main worktree). All sub-agents share that single MCP
+connection, so Serena **write** tools — `replace_symbol_body`,
+`insert_after_symbol`, `insert_before_symbol`, `rename_symbol`,
+`safe_delete_symbol`, `replace_content` — silently land in the main
+worktree's files even when the calling agent works in
+`.claude/worktrees/agent-*`.
+
+In any sub-agent context (anything spawned with `isolation: worktree`):
+
+- **Mutations**: use `Read` + `Edit` only. Never use Serena edit tools.
+- **Navigation**: Serena read tools (`find_symbol`,
+  `find_referencing_symbols`, `get_symbols_overview`, `search_for_pattern`)
+  remain useful, but treat the absolute paths in their output as
+  informational — they point to the main worktree, not yours.
+
+The `.claude/hooks/serena-worktree-guard.sh` PreToolUse hook denies the
+unsafe write tools when the session cwd doesn't match the Serena project
+root (i.e. when an agent in a worktree tries to call one). If you see a
+denial, switch to `Read` + `Edit` for the rest of the task.
+
 ## UI & CSS Guidelines
 
 When modifying CSS layout or styling, avoid making additional 'clever' adjustments beyond what was requested. If the user asks to constrain width or center an element, do exactly that — don't add spacers, override calculated dimensions, or restructure containers unless explicitly asked.


### PR DESCRIPTION
## Summary

Serena MCP launches once with `--project .` relative to Claude Code's initial cwd (the main worktree). All sub-agents share that single MCP connection, so Serena **write** tools (`replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol`, `rename_symbol`, `safe_delete_symbol`, `replace_content`) silently land in the main worktree's files even when the calling agent works in `.claude/worktrees/agent-*`. This bit a `/swarm-plus` builder this session (PR #1489) — first-attempt edits leaked into the main worktree before the agent noticed and reverted.

This PR adds a PreToolUse guard hook + documents the hazard so the same mistake stops happening silently.

## Changes

- **`.claude/hooks/serena-worktree-guard.sh`** — PreToolUse hook script. Reads the session cwd from the hook payload, compares it to the Serena project root (= main worktree, discovered via `git worktree list --porcelain`), and exits 2 with a stderr explanation when they differ. Allows (exit 0) when the session is at the project root.
- **`.claude/settings.json`** — registers the hook as a `PreToolUse` matcher on the six unsafe Serena write tools. Read tools (`find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `search_for_pattern`) are unaffected.
- **`CLAUDE.md`** — adds a "Worktree hazard" subsection under MCP Tooling that documents the structural pinning, lists the unsafe tools, and tells sub-agents to use `Read` + `Edit` for mutations in worktree contexts.

## Test plan

- [x] Hook smoke-tested: `cwd = main worktree` → exit 0 (allow)
- [x] Hook smoke-tested: `cwd = sub-worktree` → exit 2 (deny) with the explanation in stderr
- [ ] Verify in a real `/swarm-plus` run that builder agents are blocked from calling Serena write tools and fall back to `Read` + `Edit` cleanly
- [ ] Confirm main-session Serena write tools still work uninhibited (no false positives when working at the project root)

## Notes

- Hook is intentionally narrow: it covers exactly the six write tools that resolve relative paths against the project root. Memory tools (`write_memory`, `edit_memory`, `delete_memory`, `rename_memory`) are deliberately not blocked — they target `.serena/memories/` and central main-worktree storage is the right behavior.
- Upstream feature request to Serena (per-call `project_root` parameter) is a separate, lower-priority item; this guard makes the failure mode visible in the meantime.