### PR TITLE
feat(mock-provider): accept persisted-session seed via URL param

### DIFF
--- a/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
+++ b/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
@@ -163,6 +163,55 @@ describe('MockPlaybackAdapter', () => {
     expect(result).toBe(true);
   });
 
+  describe('prepareTrack', () => {
+    it('emits staged state when positionMs is provided', () => {
+      // #given a subscribed listener and no prior track
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs > 0
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: 45000 });
+      // #then listener is notified with the staged state
+      expect(listener).toHaveBeenCalledOnce();
+      const state = listener.mock.calls[0][0];
+      expect(state?.currentTrackId).toBe('seed-track');
+      expect(state?.positionMs).toBe(45000);
+    });
+
+    it('emits staged state when positionMs is 0', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs: 0 (valid start-of-track seed)
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: 0 });
+      // #then listener is notified — positionMs=0 is semantically distinct from
+      // omitting options, matching the Spotify and Dropbox adapter contracts
+      expect(listener).toHaveBeenCalledOnce();
+      const state = listener.mock.calls[0][0];
+      expect(state?.currentTrackId).toBe('seed-track');
+      expect(state?.positionMs).toBe(0);
+    });
+
+    it('does not emit state when options is omitted', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with no options (pre-warm intent)
+      adapter.prepareTrack(makeTrack('seed-track'));
+      // #then listener is not notified
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not emit state when positionMs is undefined', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs explicitly undefined
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: undefined });
+      // #then listener is not notified
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   it('getLastPlayTime returns 0 before first play', () => {
     expect(adapter.getLastPlayTime()).toBe(0);
   });

--- a/src/providers/mock/__tests__/sessionSeed.test.ts
+++ b/src/providers/mock/__tests__/sessionSeed.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseMockSessionParam, seedSessionFromUrlParam } from '../sessionSeed';
+import { MockCatalogAdapter } from '../mockCatalogAdapter';
+import type { ProviderSnapshot } from '../../../../playwright/fixtures/data/snapshot.types';
+
+const SNAPSHOT_SCHEMA_VERSION = 1;
+
+function makeSnapshot(provider: 'spotify' | 'dropbox' = 'spotify'): ProviderSnapshot {
+  return {
+    meta: {
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      generatorVersion: '0.1.0',
+      provider,
+      anonymizationSeed: 'aabbccdd',
+    },
+    user: { displayName: 'Anonymous User', hashedId: 'user_00000000' },
+    tracks: {
+      'track-abc': {
+        id: 'track-abc',
+        name: 'Test Track',
+        artists: [{ name: 'Test Artist' }],
+        artistsDisplay: 'Test Artist',
+        album: { id: 'album-1', name: 'Test Album' },
+        durationMs: 240000,
+        trackNumber: 1,
+        ref: 'spotify:track:track-abc',
+        image: { url: '/art/track-abc.jpg' },
+      },
+    },
+    playlists: [],
+    albums: [],
+    likedTrackIds: [],
+    pins: [],
+  };
+}
+
+function encodeBase64(obj: unknown): string {
+  return btoa(JSON.stringify(obj));
+}
+
+function encodeBase64UrlSafe(obj: unknown): string {
+  return btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+describe('parseMockSessionParam', () => {
+  it('returns null when param is absent', () => {
+    // #given a search string with no mock-session param
+    // #when parsed
+    // #then returns null
+    expect(parseMockSessionParam('')).toBeNull();
+    expect(parseMockSessionParam('?foo=bar')).toBeNull();
+  });
+
+  it('decodes a valid base64-encoded JSON payload', () => {
+    // #given a valid payload with trackId and positionMs
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the decoded seed
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 45000 });
+  });
+
+  it('decodes a URL-safe base64 payload (- and _ variants)', () => {
+    // #given a URL-safe encoded payload
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64UrlSafe(payload);
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the decoded seed
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 45000 });
+  });
+
+  it('returns null for invalid base64', () => {
+    // #given a non-base64 value
+    // #when parsed
+    const result = parseMockSessionParam('?mock-session=!!!not-base64!!!');
+    // #then returns null without throwing
+    expect(result).toBeNull();
+  });
+
+  it('returns null for valid base64 that decodes to invalid JSON', () => {
+    // #given valid base64 of a non-JSON string
+    const encoded = btoa('not json at all');
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null without throwing
+    expect(result).toBeNull();
+  });
+
+  it('returns null when trackId is missing', () => {
+    // #given a payload without trackId
+    const encoded = encodeBase64({ positionMs: 45000 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is missing', () => {
+    // #given a payload without positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc' });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is negative', () => {
+    // #given a payload with negative positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: -1 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is not a number', () => {
+    // #given a payload with a string positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: '45000' });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('accepts positionMs of zero', () => {
+    // #given a payload with positionMs=0
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: 0 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the seed (zero is a valid non-negative position)
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 0 });
+  });
+});
+
+describe('seedSessionFromUrlParam', () => {
+  let spotifyCatalog: MockCatalogAdapter;
+  let dropboxCatalog: MockCatalogAdapter;
+  let savedItems: Record<string, string>;
+
+  beforeEach(() => {
+    spotifyCatalog = new MockCatalogAdapter(makeSnapshot('spotify'));
+    dropboxCatalog = new MockCatalogAdapter(makeSnapshot('dropbox'));
+    savedItems = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => savedItems[key] ?? null,
+      setItem: (key: string, value: string) => { savedItems[key] = value; },
+      removeItem: (key: string) => { delete savedItems[key]; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes a SessionSnapshot to localStorage for a known Spotify track', () => {
+    // #given a valid mock-session param for a known Spotify track
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then a SessionSnapshot is written to localStorage
+    const stored = savedItems['vorbis-player-last-session'];
+    expect(stored).toBeTruthy();
+    const session = JSON.parse(stored) as Record<string, unknown>;
+    expect(session.trackId).toBe('track-abc');
+    expect(session.playbackPosition).toBe(45000);
+    expect(Array.isArray(session.queueTracks)).toBe(true);
+  });
+
+  it('writes a SessionSnapshot to localStorage for a known Dropbox track', () => {
+    // #given a valid mock-session param for a known Dropbox track
+    const payload = { trackId: 'track-abc', positionMs: 10000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called (Spotify catalog has no match for this test,
+    // so we pass an empty Spotify catalog and the Dropbox catalog with the track)
+    const emptySpotify = new MockCatalogAdapter({
+      ...makeSnapshot('spotify'),
+      tracks: {},
+    });
+    seedSessionFromUrlParam(emptySpotify, dropboxCatalog);
+
+    // #then the Dropbox track is found and stored
+    const stored = savedItems['vorbis-player-last-session'];
+    expect(stored).toBeTruthy();
+    const session = JSON.parse(stored) as Record<string, unknown>;
+    expect(session.trackId).toBe('track-abc');
+    expect(session.playbackPosition).toBe(10000);
+  });
+
+  it('does not write to localStorage when param is absent', () => {
+    // #given no mock-session param
+    vi.stubGlobal('location', { search: '' });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then nothing is written
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+
+  it('does not write to localStorage for an unknown track id', () => {
+    // #given a valid param but referencing a track not in either catalog
+    const payload = { trackId: 'track-unknown-xyz', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then nothing is written
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+
+  it('does not throw on malformed base64 input', () => {
+    // #given a malformed param
+    vi.stubGlobal('location', { search: '?mock-session=!!!bad!!!' });
+
+    // #when / #then no throw
+    expect(() => seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog)).not.toThrow();
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+});

--- a/src/providers/mock/mockPlaybackAdapter.ts
+++ b/src/providers/mock/mockPlaybackAdapter.ts
@@ -165,10 +165,17 @@ export class MockPlaybackAdapter implements PlaybackProvider {
     return () => this.listeners.delete(listener);
   }
 
-  prepareTrack(track: MediaTrack): void {
+  prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     const audio = this.ensureAudio();
     audio.src = clipUrlForTrack(track.id);
     audio.load();
+
+    if (options?.positionMs !== undefined && options.positionMs > 0) {
+      this.currentTrack = track;
+      this.startedAtPositionMs = options.positionMs;
+      this.startedAtMs = Date.now();
+      this.notifyListeners();
+    }
   }
 
   probePlayable(track: MediaTrack): Promise<boolean> {

--- a/src/providers/mock/mockPlaybackAdapter.ts
+++ b/src/providers/mock/mockPlaybackAdapter.ts
@@ -170,7 +170,7 @@ export class MockPlaybackAdapter implements PlaybackProvider {
     audio.src = clipUrlForTrack(track.id);
     audio.load();
 
-    if (options?.positionMs !== undefined && options.positionMs > 0) {
+    if (options?.positionMs !== undefined) {
       this.currentTrack = track;
       this.startedAtPositionMs = options.positionMs;
       this.startedAtMs = Date.now();

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -8,6 +8,7 @@ import { MockPlaybackAdapter } from './mockPlaybackAdapter';
 import { seedPinsFromSnapshots } from './pinSeeder';
 import { shouldUseMockProvider } from './shouldUseMockProvider';
 import { installMockTestApi } from './test-control';
+import { seedSessionFromUrlParam } from './sessionSeed';
 import { assertProviderSnapshot } from '../../../playwright/fixtures/data/snapshot.types';
 import spotifySnapshotJson from '../../../playwright/fixtures/data/spotify-snapshot.json' with { type: 'json' };
 import dropboxSnapshotJson from '../../../playwright/fixtures/data/dropbox-snapshot.json' with { type: 'json' };
@@ -81,6 +82,11 @@ if (shouldUseMockProvider()) {
   providerRegistry.register(dropboxDescriptor);
 
   void seedPinsFromSnapshots(spotifySnapshotJson.pins, dropboxSnapshotJson.pins);
+
+  seedSessionFromUrlParam(
+    spotifyDescriptor.catalog as MockCatalogAdapter,
+    dropboxDescriptor.catalog as MockCatalogAdapter,
+  );
 
   installMockTestApi({
     spotifyCatalog: spotifyDescriptor.catalog as MockCatalogAdapter,

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -1,0 +1,86 @@
+import { saveSession } from '@/services/sessionPersistence';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import type { MockCatalogAdapter } from './mockCatalogAdapter';
+
+const PARAM_NAME = 'mock-session';
+
+export interface MockSessionSeed {
+  trackId: string;
+  positionMs: number;
+}
+
+/**
+ * Parses the `?mock-session=<base64-json>` URL param and returns the decoded
+ * seed, or null if the param is absent, malformed, or missing required fields.
+ * Never throws.
+ */
+export function parseMockSessionParam(search: string): MockSessionSeed | null {
+  try {
+    const params = new URLSearchParams(search);
+    const raw = params.get(PARAM_NAME);
+    if (!raw) return null;
+
+    const urlSafe = raw.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = atob(urlSafe);
+    const parsed: unknown = JSON.parse(decoded);
+
+    if (typeof parsed !== 'object' || parsed === null) return null;
+
+    const candidate = parsed as Record<string, unknown>;
+    const { trackId, positionMs } = candidate;
+
+    if (
+      typeof trackId !== 'string' ||
+      typeof positionMs !== 'number' ||
+      positionMs < 0
+    ) {
+      return null;
+    }
+
+    return { trackId, positionMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads `?mock-session` from the current URL, resolves the track against the
+ * provided catalogs (Spotify then Dropbox), and writes a full SessionSnapshot
+ * into localStorage so the normal hydrate flow picks it up on first render.
+ *
+ * Falls back silently when the param is absent, malformed, or references an
+ * unknown track id. Never throws.
+ */
+export function seedSessionFromUrlParam(
+  spotifyCatalog: MockCatalogAdapter,
+  dropboxCatalog: MockCatalogAdapter,
+): void {
+  try {
+    const seed = parseMockSessionParam(window.location.search);
+    if (!seed) return;
+
+    const track =
+      spotifyCatalog.getTrackById(seed.trackId) ??
+      dropboxCatalog.getTrackById(seed.trackId);
+
+    if (!track) return;
+
+    const snapshot: SessionSnapshot = {
+      collectionId: track.albumId ?? track.provider,
+      collectionName: track.album,
+      collectionProvider: track.provider,
+      trackIndex: 0,
+      trackId: track.id,
+      queueTracks: [track],
+      trackTitle: track.name,
+      trackArtist: track.artists,
+      trackImage: track.image,
+      playbackPosition: seed.positionMs,
+      savedAt: Date.now(),
+    };
+
+    saveSession(snapshot);
+  } catch {
+    // Fail closed — log nothing, let the app start in default state.
+  }
+}

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -69,6 +69,8 @@ export function seedSessionFromUrlParam(
       collectionId: track.albumId ?? track.provider,
       collectionName: track.album,
       collectionProvider: track.provider,
+      // trackIndex: 0 — single-element queue; handleHydrate resolves by trackId first so
+      // this is benign. Multi-track reload scenarios are a known limitation of the seed.
       trackIndex: 0,
       trackId: track.id,
       queueTracks: [track],


### PR DESCRIPTION
## Summary
- Mock auth/playback adapters now read `?mock-session=<base64-json>` from the URL and seed the active track + `positionMs` before the first hydrate emit, matching the production hydrate-payload shape.
- Decode path validates shape (track id, non-negative positionMs) and falls back silently on missing/malformed input.
- `MockPlaybackAdapter.prepareTrack` extended to emit a synthesized state immediately when `positionMs` is supplied (mirrors the Dropbox adapter pattern, eliminating the 0:00/0:00 flicker window for the mock).
- Vitest coverage added for happy path, invalid base64, invalid JSON, missing fields, negative positionMs, and unknown track id (15 new tests, all passing).

## Test plan
- `npx tsc -b --noEmit` passes.
- `npm run test:run` passes — 183 test files, 1938 tests (15 new in `sessionSeed.test.ts`).
- Manual smoke (optional, follow-up spec lands separately): load the app with `VITE_MOCK_PROVIDER=true` and `?mock-session=<btoa(JSON.stringify({trackId:"...",positionMs:45000}))>` — the seek bar should render the saved position and non-zero duration before any user interaction.

Closes #1477