### PR TITLE
chore: sweep dead exports flagged by knip

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/src/components/WelcomeScreen/index.tsx
+++ b/src/components/WelcomeScreen/index.tsx
@@ -113,4 +113,3 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 };
 
 export default WelcomeScreen;
-export { WelcomeScreen };

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -24,12 +24,6 @@ export function isAllMusicRef(ref: CollectionRef): boolean {
   return ref.provider === 'dropbox' && ref.kind === 'folder' && 'id' in ref && ref.id === '';
 }
 
-/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row). */
-export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID]);
-
-/** Album IDs that stay in catalog order and are not reordered by library sort. */
-export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set();
-
 /** Check whether a playlist selection ID represents an album */
 export function isAlbumId(playlistId: string): boolean {
   return playlistId.startsWith(ALBUM_ID_PREFIX);

--- a/src/contexts/visualEffects/index.tsx
+++ b/src/contexts/visualEffects/index.tsx
@@ -8,10 +8,9 @@ import { GlowProvider } from './GlowContext';
 
 export { VisualEffectsToggleProvider, useVisualEffectsToggle } from './VisualEffectsToggleContext';
 export { VisualizerProvider, useVisualizer } from './VisualizerContext';
-export { AccentColorBackgroundProvider, useAccentColorBackground } from './AccentColorBackgroundContext';
+export { useAccentColorBackground } from './AccentColorBackgroundContext';
 export { TranslucenceProvider, useTranslucence } from './TranslucenceContext';
-export { ZenModeProvider, useZenMode } from './ZenModeContext';
-export { GlowProvider, useGlow } from './GlowContext';
+export { useZenMode } from './ZenModeContext';
 
 export function VisualEffectsProvider({ children }: { children: React.ReactNode }) {
   return (

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 
-export const FEEDBACK_DISPLAY_MS = STATUS_RESET_DELAY_MS;
+const FEEDBACK_DISPLAY_MS = STATUS_RESET_DELAY_MS;
 
 type AsyncStatus = 'idle' | 'working' | 'done';
 

--- a/src/providers/mock/audioMapping.ts
+++ b/src/providers/mock/audioMapping.ts
@@ -1,5 +1,5 @@
 export const AUDIO_CLIP_COUNT = 10;
-export const AUDIO_CLIP_BASE_PATH = '/playwright-fixtures/audio';
+const AUDIO_CLIP_BASE_PATH = '/playwright-fixtures/audio';
 
 // Blueprint D7 specifies sha256 → mod N. Using inline FNV-1a instead because
 // js-sha256 is not a transitive dependency in this project. For the use case

--- a/src/services/cache/librarySearch.ts
+++ b/src/services/cache/librarySearch.ts
@@ -15,7 +15,6 @@ import {
   getAllAlbums,
   getAllPlaylists,
   getTrackList,
-  _testing as cacheInternals,
 } from './libraryCache';
 
 const DEFAULT_LIMIT_PER_CATEGORY = 10;
@@ -195,8 +194,3 @@ export async function searchLibraryCache(
 export function emptySearchResult(): LibrarySearchResult {
   return EMPTY_RESULT;
 }
-
-/** Internal handle for tests — exposes the underlying cache state. */
-export const _searchTesting = {
-  cacheInternals,
-};

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,5 +1,3 @@
-import type { AlbumInfo } from '@/services/spotify';
-import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import { vi } from 'vitest';
@@ -15,31 +13,6 @@ export function makeTrack(overrides?: Partial<MediaTrack>): MediaTrack {
     albumId: 'album-1',
     durationMs: 210000,
     image: 'https://i.scdn.co/image/test',
-    ...overrides,
-  };
-}
-
-export function makePlaylistInfo(overrides?: Partial<CachedPlaylistInfo>): CachedPlaylistInfo {
-  return {
-    id: 'playlist-1',
-    name: 'Test Playlist',
-    description: 'A test playlist',
-    images: [{ url: 'https://i.scdn.co/image/playlist', height: 300, width: 300 }],
-    tracks: { total: 25 },
-    owner: { display_name: 'Test User' },
-    ...overrides,
-  };
-}
-
-export function makeAlbumInfo(overrides?: Partial<AlbumInfo>): AlbumInfo {
-  return {
-    id: 'album-1',
-    name: 'Test Album',
-    artists: 'Test Artist',
-    images: [{ url: 'https://i.scdn.co/image/album', height: 300, width: 300 }],
-    release_date: '2024-01-15',
-    total_tracks: 12,
-    uri: 'spotify:album:album-1',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Surgical sweep of unambiguously-dead value/function exports flagged by `npm run knip`. Net `-39 lines` across 7 source files. The 74 type-export and 12 dupe-export findings from knip are intentionally **deferred** — they need case-by-case review (some are React Props composed externally) and don't fit a single sweep.

Also commits `.serena/.gitignore` (Serena auto-generates it on session start; ignores `cache/` + `project.local.yml`).

## Changes

**Removed (zero importers):**
- `WelcomeScreen` named export at `src/components/WelcomeScreen/index.tsx:116` — default at line 115 stays (used by `PlayerStateRenderer.tsx`).
- `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` + `LIBRARY_ALBUM_SORT_ANCHOR_IDS` in `src/constants/playlist.ts`.
- `_searchTesting` const + its `cacheInternals` import in `src/services/cache/librarySearch.ts`. The `_` prefix signaled "intentional escape hatch for tests" but no test ever consumed it.
- `makePlaylistInfo` + `makeAlbumInfo` test fixtures in `src/test/fixtures.ts`, plus the now-orphan `AlbumInfo` / `CachedPlaylistInfo` type imports.

**Demoted to non-exported** (used internally, exported needlessly):
- `FEEDBACK_DISPLAY_MS` in `src/hooks/useAsyncAction.ts` (used as default at line 11).
- `AUDIO_CLIP_BASE_PATH` in `src/providers/mock/audioMapping.ts` (used internally at line 23).

**Trimmed barrel re-exports** in `src/contexts/visualEffects/index.tsx`:
- Dropped `AccentColorBackgroundProvider`, `ZenModeProvider` from their shared export lines (siblings `useAccentColorBackground` / `useZenMode` are imported via the barrel and stay).
- Removed the entire `GlowProvider, useGlow` re-export line (both flagged unused via the barrel).
- The source-file imports stay — they still feed the internal `VisualEffectsProvider` composite.

**Added:**
- `.serena/.gitignore` — versions Serena's auto-dropped ignore rules.

## Out of scope (left for follow-ups)

| Item | Why deferred |
|---|---|
| 74 unused exported types (mostly React Props interfaces) | Risk of breaking external type composition; requires per-file judgement. |
| 12 default+named export dupes | Style consolidation, not dead code. |
| `.serena/project.yml` (Serena auto-expansion) | Separate concern; existing branch [chore/commit-serena-runtime-config](https://github.com/smallorbit/vorbis-player/pull/1487) is parked for it. |

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 1923/1923 passing
- [x] Verified each "unused" symbol is truly orphan (zero importers across `src/**`, `playwright/**`, `scripts/**`, including test files) before removal
- [x] Verified each demoted constant is still used internally
- [x] Verified each trimmed barrel re-export's siblings still have consumers