### PR TITLE
release: 2026-05-06

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,10 +1,138 @@
-language: typescript
+
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths:
-  - dist
-  - dist-electron
-  - node_modules
-  - playwright/capture/output
-  - public/playwright-fixtures/art
-  - "*.snapshot.json"
+- dist
+- dist-electron
+- node_modules
+- playwright/capture/output
+- public/playwright-fixtures/art
+- "*.snapshot.json"
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
 read_only: false
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ''
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: utf-8
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+# the name by which the project can be referenced within Serena
+project_name: vorbis-player

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "capture:desktop": "playwright test --config playwright/capture/capture.config.ts --project desktop",
     "capture:mobile": "playwright test --config playwright/capture/capture.config.ts --project mobile",
     "snapshot:spotify": "tsx scripts/snapshot-spotify.ts",
-    "snapshot:dropbox": "tsx scripts/snapshot-dropbox.ts"
+    "snapshot:dropbox": "tsx scripts/snapshot-dropbox.ts",
+    "audit:ci": "npm audit --audit-level=high"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/components/WelcomeScreen/index.tsx
+++ b/src/components/WelcomeScreen/index.tsx
@@ -113,4 +113,3 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 };
 
 export default WelcomeScreen;
-export { WelcomeScreen };

--- a/src/constants/playlist.ts
+++ b/src/constants/playlist.ts
@@ -24,12 +24,6 @@ export function isAllMusicRef(ref: CollectionRef): boolean {
   return ref.provider === 'dropbox' && ref.kind === 'folder' && 'id' in ref && ref.id === '';
 }
 
-/** Playlist IDs that stay in catalog order and are not reordered by library sort (Liked Songs row). */
-export const LIBRARY_PLAYLIST_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set([LIKED_SONGS_ID]);
-
-/** Album IDs that stay in catalog order and are not reordered by library sort. */
-export const LIBRARY_ALBUM_SORT_ANCHOR_IDS: ReadonlySet<string> = new Set();
-
 /** Check whether a playlist selection ID represents an album */
 export function isAlbumId(playlistId: string): boolean {
   return playlistId.startsWith(ALBUM_ID_PREFIX);

--- a/src/contexts/visualEffects/index.tsx
+++ b/src/contexts/visualEffects/index.tsx
@@ -8,10 +8,9 @@ import { GlowProvider } from './GlowContext';
 
 export { VisualEffectsToggleProvider, useVisualEffectsToggle } from './VisualEffectsToggleContext';
 export { VisualizerProvider, useVisualizer } from './VisualizerContext';
-export { AccentColorBackgroundProvider, useAccentColorBackground } from './AccentColorBackgroundContext';
+export { useAccentColorBackground } from './AccentColorBackgroundContext';
 export { TranslucenceProvider, useTranslucence } from './TranslucenceContext';
-export { ZenModeProvider, useZenMode } from './ZenModeContext';
-export { GlowProvider, useGlow } from './GlowContext';
+export { useZenMode } from './ZenModeContext';
 
 export function VisualEffectsProvider({ children }: { children: React.ReactNode }) {
   return (

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -5,12 +5,6 @@ import { makeTrack } from '@/test/fixtures';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME } from '@/constants/playlist';
 import type { MediaTrack } from '@/types/domain';
 
-vi.mock('@/providers/mock/shouldUseMockProvider', () => ({
-  shouldUseMockProvider: vi.fn(() => false),
-}));
-
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
-
 function makeMediaTrack(id: string, addedAt?: number): MediaTrack {
   return {
     id,
@@ -56,7 +50,7 @@ describe('useCollectionLoader', () => {
     mockRecord = vi.fn();
     mediaTracksRef = { current: [] };
     drivingProviderRef = { current: null };
-    mockActiveDescriptor = { id: 'spotify' };
+    mockActiveDescriptor = { id: 'spotify', capabilities: { hasContextPlaybackFallback: false } };
   });
 
   it('loading a standard provider collection sets tracks and calls playTrack(0)', async () => {
@@ -204,14 +198,14 @@ describe('useCollectionLoader', () => {
     expect(trackCount).toBe(0);
   });
 
-  it('skips the legacy SDK fallback when the mock provider is active even if playCollection is defined', async () => {
-    // #given — mock active, empty catalog, playback advertises playCollection
-    vi.mocked(shouldUseMockProvider).mockReturnValueOnce(true);
+  it('skips the legacy SDK fallback when the descriptor lacks hasContextPlaybackFallback even if playCollection is defined', async () => {
+    // #given — empty catalog, playback advertises playCollection, but capability flag is unset (mock/dropbox shape)
     const mockCatalog = {
       listTracks: vi.fn().mockResolvedValue([]),
     };
     mockActiveDescriptor.catalog = mockCatalog;
     mockActiveDescriptor.playback = { pause: vi.fn(), playCollection: vi.fn() };
+    mockActiveDescriptor.capabilities = { hasContextPlaybackFallback: false };
 
     const { result } = renderHook(() =>
       useCollectionLoader({
@@ -242,7 +236,7 @@ describe('useCollectionLoader', () => {
     expect(trackCount).toBe(0);
   });
 
-  it('the legacy SDK fallback path is invoked when list.length === 0 and playCollection is defined', async () => {
+  it('the legacy SDK fallback path is invoked when list.length === 0 and the descriptor declares hasContextPlaybackFallback', async () => {
     // #given
     mockSpotifyHandlePlaylistSelect.mockResolvedValue([makeTrack('1'), makeTrack('2')]);
 
@@ -251,6 +245,7 @@ describe('useCollectionLoader', () => {
     };
     mockActiveDescriptor.catalog = mockCatalog;
     mockActiveDescriptor.playback = { pause: vi.fn(), playCollection: vi.fn() };
+    mockActiveDescriptor.capabilities = { hasContextPlaybackFallback: true };
 
     const { result } = renderHook(() =>
       useCollectionLoader({

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 
-export const FEEDBACK_DISPLAY_MS = STATUS_RESET_DELAY_MS;
+const FEEDBACK_DISPLAY_MS = STATUS_RESET_DELAY_MS;
 
 type AsyncStatus = 'idle' | 'working' | 'done';
 

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -5,7 +5,6 @@ import type { TrackOperations } from '@/types/trackOperations';
 import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } from '@/constants/playlist';
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
-import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logQueue } from '@/lib/debugLog';
 import { queueSnapshot } from './playerLogicUtils';
 
@@ -167,7 +166,7 @@ export function useCollectionLoader({
       const collectionRef = { provider: providerId, kind: collectionKind, id: collectionId } as const;
       const list = await targetDescriptor.catalog.listTracks(collectionRef);
 
-      if (list.length === 0 && targetDescriptor.playback.playCollection && !shouldUseMockProvider()) {
+      if (list.length === 0 && targetDescriptor.capabilities.hasContextPlaybackFallback) {
         return loadContextPlayback(playlistId, providerId);
       }
 

--- a/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
+++ b/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
@@ -163,6 +163,55 @@ describe('MockPlaybackAdapter', () => {
     expect(result).toBe(true);
   });
 
+  describe('prepareTrack', () => {
+    it('emits staged state when positionMs is provided', () => {
+      // #given a subscribed listener and no prior track
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs > 0
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: 45000 });
+      // #then listener is notified with the staged state
+      expect(listener).toHaveBeenCalledOnce();
+      const state = listener.mock.calls[0][0];
+      expect(state?.currentTrackId).toBe('seed-track');
+      expect(state?.positionMs).toBe(45000);
+    });
+
+    it('emits staged state when positionMs is 0', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs: 0 (valid start-of-track seed)
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: 0 });
+      // #then listener is notified — positionMs=0 is semantically distinct from
+      // omitting options, matching the Spotify and Dropbox adapter contracts
+      expect(listener).toHaveBeenCalledOnce();
+      const state = listener.mock.calls[0][0];
+      expect(state?.currentTrackId).toBe('seed-track');
+      expect(state?.positionMs).toBe(0);
+    });
+
+    it('does not emit state when options is omitted', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with no options (pre-warm intent)
+      adapter.prepareTrack(makeTrack('seed-track'));
+      // #then listener is not notified
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not emit state when positionMs is undefined', () => {
+      // #given a subscribed listener
+      const listener = vi.fn();
+      adapter.subscribe(listener);
+      // #when prepareTrack is called with positionMs explicitly undefined
+      adapter.prepareTrack(makeTrack('seed-track'), { positionMs: undefined });
+      // #then listener is not notified
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   it('getLastPlayTime returns 0 before first play', () => {
     expect(adapter.getLastPlayTime()).toBe(0);
   });

--- a/src/providers/mock/__tests__/sessionSeed.test.ts
+++ b/src/providers/mock/__tests__/sessionSeed.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseMockSessionParam, seedSessionFromUrlParam } from '../sessionSeed';
+import { MockCatalogAdapter } from '../mockCatalogAdapter';
+import type { ProviderSnapshot } from '../../../../playwright/fixtures/data/snapshot.types';
+
+const SNAPSHOT_SCHEMA_VERSION = 1;
+
+function makeSnapshot(provider: 'spotify' | 'dropbox' = 'spotify'): ProviderSnapshot {
+  return {
+    meta: {
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      generatorVersion: '0.1.0',
+      provider,
+      anonymizationSeed: 'aabbccdd',
+    },
+    user: { displayName: 'Anonymous User', hashedId: 'user_00000000' },
+    tracks: {
+      'track-abc': {
+        id: 'track-abc',
+        name: 'Test Track',
+        artists: [{ name: 'Test Artist' }],
+        artistsDisplay: 'Test Artist',
+        album: { id: 'album-1', name: 'Test Album' },
+        durationMs: 240000,
+        trackNumber: 1,
+        ref: 'spotify:track:track-abc',
+        image: { url: '/art/track-abc.jpg' },
+      },
+    },
+    playlists: [],
+    albums: [],
+    likedTrackIds: [],
+    pins: [],
+  };
+}
+
+function encodeBase64(obj: unknown): string {
+  return btoa(JSON.stringify(obj));
+}
+
+function encodeBase64UrlSafe(obj: unknown): string {
+  return btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+describe('parseMockSessionParam', () => {
+  it('returns null when param is absent', () => {
+    // #given a search string with no mock-session param
+    // #when parsed
+    // #then returns null
+    expect(parseMockSessionParam('')).toBeNull();
+    expect(parseMockSessionParam('?foo=bar')).toBeNull();
+  });
+
+  it('decodes a valid base64-encoded JSON payload', () => {
+    // #given a valid payload with trackId and positionMs
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the decoded seed
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 45000 });
+  });
+
+  it('decodes a URL-safe base64 payload (- and _ variants)', () => {
+    // #given a URL-safe encoded payload
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64UrlSafe(payload);
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the decoded seed
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 45000 });
+  });
+
+  it('returns null for invalid base64', () => {
+    // #given a non-base64 value
+    // #when parsed
+    const result = parseMockSessionParam('?mock-session=!!!not-base64!!!');
+    // #then returns null without throwing
+    expect(result).toBeNull();
+  });
+
+  it('returns null for valid base64 that decodes to invalid JSON', () => {
+    // #given valid base64 of a non-JSON string
+    const encoded = btoa('not json at all');
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null without throwing
+    expect(result).toBeNull();
+  });
+
+  it('returns null when trackId is missing', () => {
+    // #given a payload without trackId
+    const encoded = encodeBase64({ positionMs: 45000 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is missing', () => {
+    // #given a payload without positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc' });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is negative', () => {
+    // #given a payload with negative positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: -1 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns null when positionMs is not a number', () => {
+    // #given a payload with a string positionMs
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: '45000' });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns null
+    expect(result).toBeNull();
+  });
+
+  it('accepts positionMs of zero', () => {
+    // #given a payload with positionMs=0
+    const encoded = encodeBase64({ trackId: 'track-abc', positionMs: 0 });
+    // #when parsed
+    const result = parseMockSessionParam(`?mock-session=${encoded}`);
+    // #then returns the seed (zero is a valid non-negative position)
+    expect(result).toEqual({ trackId: 'track-abc', positionMs: 0 });
+  });
+});
+
+describe('seedSessionFromUrlParam', () => {
+  let spotifyCatalog: MockCatalogAdapter;
+  let dropboxCatalog: MockCatalogAdapter;
+  let savedItems: Record<string, string>;
+
+  beforeEach(() => {
+    spotifyCatalog = new MockCatalogAdapter(makeSnapshot('spotify'));
+    dropboxCatalog = new MockCatalogAdapter(makeSnapshot('dropbox'));
+    savedItems = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => savedItems[key] ?? null,
+      setItem: (key: string, value: string) => { savedItems[key] = value; },
+      removeItem: (key: string) => { delete savedItems[key]; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes a SessionSnapshot to localStorage for a known Spotify track', () => {
+    // #given a valid mock-session param for a known Spotify track
+    const payload = { trackId: 'track-abc', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then a SessionSnapshot is written to localStorage
+    const stored = savedItems['vorbis-player-last-session'];
+    expect(stored).toBeTruthy();
+    const session = JSON.parse(stored) as Record<string, unknown>;
+    expect(session.trackId).toBe('track-abc');
+    expect(session.playbackPosition).toBe(45000);
+    expect(Array.isArray(session.queueTracks)).toBe(true);
+  });
+
+  it('writes a SessionSnapshot to localStorage for a known Dropbox track', () => {
+    // #given a valid mock-session param for a known Dropbox track
+    const payload = { trackId: 'track-abc', positionMs: 10000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called (Spotify catalog has no match for this test,
+    // so we pass an empty Spotify catalog and the Dropbox catalog with the track)
+    const emptySpotify = new MockCatalogAdapter({
+      ...makeSnapshot('spotify'),
+      tracks: {},
+    });
+    seedSessionFromUrlParam(emptySpotify, dropboxCatalog);
+
+    // #then the Dropbox track is found and stored
+    const stored = savedItems['vorbis-player-last-session'];
+    expect(stored).toBeTruthy();
+    const session = JSON.parse(stored) as Record<string, unknown>;
+    expect(session.trackId).toBe('track-abc');
+    expect(session.playbackPosition).toBe(10000);
+  });
+
+  it('does not write to localStorage when param is absent', () => {
+    // #given no mock-session param
+    vi.stubGlobal('location', { search: '' });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then nothing is written
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+
+  it('does not write to localStorage for an unknown track id', () => {
+    // #given a valid param but referencing a track not in either catalog
+    const payload = { trackId: 'track-unknown-xyz', positionMs: 45000 };
+    const encoded = encodeBase64(payload);
+    vi.stubGlobal('location', { search: `?mock-session=${encoded}` });
+
+    // #when seedSessionFromUrlParam is called
+    seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog);
+
+    // #then nothing is written
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+
+  it('does not throw on malformed base64 input', () => {
+    // #given a malformed param
+    vi.stubGlobal('location', { search: '?mock-session=!!!bad!!!' });
+
+    // #when / #then no throw
+    expect(() => seedSessionFromUrlParam(spotifyCatalog, dropboxCatalog)).not.toThrow();
+    expect(savedItems['vorbis-player-last-session']).toBeUndefined();
+  });
+});

--- a/src/providers/mock/audioMapping.ts
+++ b/src/providers/mock/audioMapping.ts
@@ -1,5 +1,5 @@
 export const AUDIO_CLIP_COUNT = 10;
-export const AUDIO_CLIP_BASE_PATH = '/playwright-fixtures/audio';
+const AUDIO_CLIP_BASE_PATH = '/playwright-fixtures/audio';
 
 // Blueprint D7 specifies sha256 → mod N. Using inline FNV-1a instead because
 // js-sha256 is not a transitive dependency in this project. For the use case

--- a/src/providers/mock/mockPlaybackAdapter.ts
+++ b/src/providers/mock/mockPlaybackAdapter.ts
@@ -165,10 +165,17 @@ export class MockPlaybackAdapter implements PlaybackProvider {
     return () => this.listeners.delete(listener);
   }
 
-  prepareTrack(track: MediaTrack): void {
+  prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     const audio = this.ensureAudio();
     audio.src = clipUrlForTrack(track.id);
     audio.load();
+
+    if (options?.positionMs !== undefined) {
+      this.currentTrack = track;
+      this.startedAtPositionMs = options.positionMs;
+      this.startedAtMs = Date.now();
+      this.notifyListeners();
+    }
   }
 
   probePlayable(track: MediaTrack): Promise<boolean> {

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -8,6 +8,7 @@ import { MockPlaybackAdapter } from './mockPlaybackAdapter';
 import { seedPinsFromSnapshots } from './pinSeeder';
 import { shouldUseMockProvider } from './shouldUseMockProvider';
 import { installMockTestApi } from './test-control';
+import { seedSessionFromUrlParam } from './sessionSeed';
 import { assertProviderSnapshot } from '../../../playwright/fixtures/data/snapshot.types';
 import spotifySnapshotJson from '../../../playwright/fixtures/data/spotify-snapshot.json' with { type: 'json' };
 import dropboxSnapshotJson from '../../../playwright/fixtures/data/dropbox-snapshot.json' with { type: 'json' };
@@ -81,6 +82,11 @@ if (shouldUseMockProvider()) {
   providerRegistry.register(dropboxDescriptor);
 
   void seedPinsFromSnapshots(spotifySnapshotJson.pins, dropboxSnapshotJson.pins);
+
+  seedSessionFromUrlParam(
+    spotifyDescriptor.catalog as MockCatalogAdapter,
+    dropboxDescriptor.catalog as MockCatalogAdapter,
+  );
 
   installMockTestApi({
     spotifyCatalog: spotifyDescriptor.catalog as MockCatalogAdapter,

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -1,0 +1,88 @@
+import { saveSession } from '@/services/sessionPersistence';
+import type { SessionSnapshot } from '@/services/sessionPersistence';
+import type { MockCatalogAdapter } from './mockCatalogAdapter';
+
+const PARAM_NAME = 'mock-session';
+
+export interface MockSessionSeed {
+  trackId: string;
+  positionMs: number;
+}
+
+/**
+ * Parses the `?mock-session=<base64-json>` URL param and returns the decoded
+ * seed, or null if the param is absent, malformed, or missing required fields.
+ * Never throws.
+ */
+export function parseMockSessionParam(search: string): MockSessionSeed | null {
+  try {
+    const params = new URLSearchParams(search);
+    const raw = params.get(PARAM_NAME);
+    if (!raw) return null;
+
+    const urlSafe = raw.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = atob(urlSafe);
+    const parsed: unknown = JSON.parse(decoded);
+
+    if (typeof parsed !== 'object' || parsed === null) return null;
+
+    const candidate = parsed as Record<string, unknown>;
+    const { trackId, positionMs } = candidate;
+
+    if (
+      typeof trackId !== 'string' ||
+      typeof positionMs !== 'number' ||
+      positionMs < 0
+    ) {
+      return null;
+    }
+
+    return { trackId, positionMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads `?mock-session` from the current URL, resolves the track against the
+ * provided catalogs (Spotify then Dropbox), and writes a full SessionSnapshot
+ * into localStorage so the normal hydrate flow picks it up on first render.
+ *
+ * Falls back silently when the param is absent, malformed, or references an
+ * unknown track id. Never throws.
+ */
+export function seedSessionFromUrlParam(
+  spotifyCatalog: MockCatalogAdapter,
+  dropboxCatalog: MockCatalogAdapter,
+): void {
+  try {
+    const seed = parseMockSessionParam(window.location.search);
+    if (!seed) return;
+
+    const track =
+      spotifyCatalog.getTrackById(seed.trackId) ??
+      dropboxCatalog.getTrackById(seed.trackId);
+
+    if (!track) return;
+
+    const snapshot: SessionSnapshot = {
+      collectionId: track.albumId ?? track.provider,
+      collectionName: track.album,
+      collectionProvider: track.provider,
+      // trackIndex: 0 — single-element queue; handleHydrate resolves by trackId first so
+      // this is benign. Multi-track reload scenarios are a known limitation of the seed.
+      trackIndex: 0,
+      trackId: track.id,
+      queueTracks: [track],
+      trackTitle: track.name,
+      trackArtist: track.artists,
+      trackImage: track.image,
+      playbackPosition: seed.positionMs,
+      savedAt: Date.now(),
+    };
+
+    saveSession(snapshot);
+  } catch {
+    // Fail closed — log nothing, let the app start in default state.
+  }
+}

--- a/src/providers/spotify/spotifyProvider.ts
+++ b/src/providers/spotify/spotifyProvider.ts
@@ -32,6 +32,7 @@ const spotifyDescriptor: ProviderDescriptor = {
     externalLinkLabel: 'Open in Spotify',
     hasTrackSearch: true,
     hasNativeQueueSync: true,
+    hasContextPlaybackFallback: true,
   },
   auth: new SpotifyAuthAdapter(),
   catalog: new SpotifyCatalogAdapter(),

--- a/src/services/cache/librarySearch.ts
+++ b/src/services/cache/librarySearch.ts
@@ -15,7 +15,6 @@ import {
   getAllAlbums,
   getAllPlaylists,
   getTrackList,
-  _testing as cacheInternals,
 } from './libraryCache';
 
 const DEFAULT_LIMIT_PER_CATEGORY = 10;
@@ -195,8 +194,3 @@ export async function searchLibraryCache(
 export function emptySearchResult(): LibrarySearchResult {
   return EMPTY_RESULT;
 }
-
-/** Internal handle for tests — exposes the underlying cache state. */
-export const _searchTesting = {
-  cacheInternals,
-};

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,5 +1,3 @@
-import type { AlbumInfo } from '@/services/spotify';
-import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import { vi } from 'vitest';
@@ -15,31 +13,6 @@ export function makeTrack(overrides?: Partial<MediaTrack>): MediaTrack {
     albumId: 'album-1',
     durationMs: 210000,
     image: 'https://i.scdn.co/image/test',
-    ...overrides,
-  };
-}
-
-export function makePlaylistInfo(overrides?: Partial<CachedPlaylistInfo>): CachedPlaylistInfo {
-  return {
-    id: 'playlist-1',
-    name: 'Test Playlist',
-    description: 'A test playlist',
-    images: [{ url: 'https://i.scdn.co/image/playlist', height: 300, width: 300 }],
-    tracks: { total: 25 },
-    owner: { display_name: 'Test User' },
-    ...overrides,
-  };
-}
-
-export function makeAlbumInfo(overrides?: Partial<AlbumInfo>): AlbumInfo {
-  return {
-    id: 'album-1',
-    name: 'Test Album',
-    artists: 'Test Artist',
-    images: [{ url: 'https://i.scdn.co/image/album', height: 300, width: 300 }],
-    release_date: '2024-01-15',
-    total_tracks: 12,
-    uri: 'spotify:album:album-1',
     ...overrides,
   };
 }

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -113,6 +113,16 @@ export interface ProviderCapabilities {
   hasTrackSearch?: boolean;
   /** Provider syncs its native queue with the app queue. */
   hasNativeQueueSync?: boolean;
+  /**
+   * Provider's `playback.playCollection` is a true context-playback path that
+   * also populates the queue UI from native SDK state when the catalog returns
+   * no tracks (Spotify only — region-restricted playlists, etc.).
+   *
+   * Other providers (Dropbox, mock) implement `playCollection` as a no-op
+   * because they drive playback track-by-track via the app queue, so this flag
+   * stays false for them.
+   */
+  hasContextPlaybackFallback?: boolean;
 }
 
 export interface ProviderDescriptor {


### PR DESCRIPTION
## Summary

Provider abstraction hardening, audit-regression guard, persisted-session capture support for Playwright, and a code-hygiene sweep. Plus the runtime-expanded Serena config commit that ends the per-launch `.serena/project.yml` drift.

## Release summary

**Built from**: `rc/2026-05-06.2`

### Release notes

**chore**
- chore(deps): add `audit:ci` script (`npm audit --audit-level=high`) so future drift trips a non-zero exit. (#1488)
- chore: sweep dead exports flagged by knip — 7 unused values removed, 2 demoted to non-exported, 3 barrel re-exports trimmed; net -39 lines. (#1492)
- chore(serena): commit runtime-expanded project.yml + `.serena/.gitignore` so Serena stops rewriting the file on every session. (#1487)

**refactor**
- refactor(providers): replace `shouldUseMockProvider()` guard in `useCollectionLoader` with `ProviderCapabilities.hasContextPlaybackFallback`, removing the last mock-detection guard from the runtime path. (#1489)

**feat**
- feat(mock-provider): accept persisted-session seed via `?mock-session` URL param so Playwright captures can boot directly into post-hydrate state. (#1491)

Closes #1361
Closes #1393
Closes #1477