### PR TITLE
refactor(librarySyncEngine): rename to SpotifyLibrarySyncEngine and narrow providerId

### DIFF
--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import type { ProviderId } from '@/types/domain';
 import { logLibrary } from '@/lib/debugLog';
-import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 
 export interface UseAlbumSavedStatusResult {
   isSaved: boolean | null;
@@ -64,7 +64,7 @@ export function useAlbumSavedStatus(
       // the pattern when Dropbox (or others) gain one.
       if (descriptor!.id === 'spotify' && !next) {
         try {
-          await librarySyncEngine.optimisticRemoveAlbum(albumId!);
+          await spotifyLibrarySyncEngine.optimisticRemoveAlbum(albumId!);
         } catch (err) {
           logLibrary('optimisticRemoveAlbum failed', err);
         }

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -2,7 +2,7 @@ import { memo, Fragment, useState, useCallback, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom';
 import type { ArtistInfo } from '../../services/spotify';
 import { useProviderContext } from '../../contexts/ProviderContext';
-import { librarySyncEngine } from '../../services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '../../services/cache/librarySyncEngine';
 import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 import TrackInfoPopover, { LibraryIcon, SpotifyIcon, PlayIcon, DiscogsIcon, AddToLibraryIcon, RemoveFromLibraryIcon, ICON_MAP } from './TrackInfoPopover';
 import TrackRadioPopover from './TrackRadioPopover';
@@ -219,9 +219,9 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
                 onClick: () => {
                     catalog.setAlbumSaved!(popover.albumId, !saved).then(() => {
                         if (saved) {
-                            librarySyncEngine.optimisticRemoveAlbum(popover.albumId).catch(() => {});
+                            spotifyLibrarySyncEngine.optimisticRemoveAlbum(popover.albumId).catch(() => {});
                         } else {
-                            librarySyncEngine.optimisticAddAlbum({
+                            spotifyLibrarySyncEngine.optimisticAddAlbum({
                                 id: popover.albumId,
                                 name: popover.albumName,
                                 artists: track?.artists ?? '',

--- a/src/hooks/__tests__/useLibrarySync.test.ts
+++ b/src/hooks/__tests__/useLibrarySync.test.ts
@@ -14,7 +14,7 @@ const { mockSubscribe, mockStart, mockStop, mockSyncNow } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../services/cache/librarySyncEngine', () => ({
-  librarySyncEngine: {
+  spotifyLibrarySyncEngine: {
     providerId: 'spotify',
     subscribe: mockSubscribe,
     start: mockStart,

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -4,7 +4,7 @@ import type { AlbumInfo } from '@/services/spotify';
 import type { MediaCollection, ProviderId } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { providerRegistry } from '@/providers/registry';
-import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logLibrary } from '@/lib/debugLog';
 import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
@@ -131,14 +131,14 @@ export function useLibrarySync(): UseLibrarySyncResult {
     error: null,
   });
 
-  const engineRef = useRef(librarySyncEngine);
+  const engineRef = useRef(spotifyLibrarySyncEngine);
 
   // The sync engine talks directly to the real Spotify Web API. In mock mode,
   // bypass it so the registry-aware catalog path (further down) loads spotify
   // collections via the mock catalog adapter instead.
-  const engineProviderId = shouldUseMockProvider()
+  const engineProviderId: ProviderId | undefined = shouldUseMockProvider()
     ? undefined
-    : (librarySyncEngine.providerId as ProviderId | undefined);
+    : spotifyLibrarySyncEngine.providerId;
 
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,

--- a/src/services/cache/__tests__/librarySyncEngine.test.ts
+++ b/src/services/cache/__tests__/librarySyncEngine.test.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { LibrarySyncEngine } from '../librarySyncEngine';
+import { SpotifyLibrarySyncEngine } from '../librarySyncEngine';
 import * as cache from '../libraryCache';
 import type { CachedPlaylistInfo, SyncState } from '../cacheTypes';
 import type { AlbumInfo, SpotifyImage } from '../../spotify';
@@ -92,14 +92,14 @@ async function seedCacheMeta(opts: {
   });
 }
 
-describe('LibrarySyncEngine', () => {
-  let engine: LibrarySyncEngine;
+describe('SpotifyLibrarySyncEngine', () => {
+  let engine: SpotifyLibrarySyncEngine;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     await cache.initCache();
     await cache.clearAll();
-    engine = new LibrarySyncEngine();
+    engine = new SpotifyLibrarySyncEngine();
   });
 
   afterEach(() => {

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -39,8 +39,8 @@ type SyncListener = (
 
 const OPTIMISTIC_GRACE_MS = 30 * 1000;
 
-export class LibrarySyncEngine {
-  readonly providerId = 'spotify';
+export class SpotifyLibrarySyncEngine {
+  readonly providerId: 'spotify' = 'spotify';
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private listeners = new Set<SyncListener>();
   private abortController: AbortController | null = null;
@@ -352,7 +352,7 @@ export class LibrarySyncEngine {
     if (albums !== undefined) this.lastKnownAlbums = albums;
     if (likedSongsCount !== undefined) {
       this.lastKnownLikedCount = likedSongsCount;
-      writeLikedCountSnapshot(this.providerId as 'spotify', likedSongsCount);
+      writeLikedCountSnapshot(this.providerId, likedSongsCount);
     }
 
     for (const listener of this.listeners) {
@@ -384,4 +384,4 @@ export class LibrarySyncEngine {
 }
 
 /** Singleton instance for app-wide use. */
-export const librarySyncEngine = new LibrarySyncEngine();
+export const spotifyLibrarySyncEngine = new SpotifyLibrarySyncEngine();


### PR DESCRIPTION
## Summary
- Renamed `LibrarySyncEngine` → `SpotifyLibrarySyncEngine` to reflect actual scope (the engine imports Spotify-specific helpers and only ever serves the Spotify provider)
- Narrowed `providerId` from `string` to literal `'spotify'`; the misleading `as 'spotify'` cast in `notifyListeners` is gone, and the `as ProviderId | undefined` cast in `useLibrarySync.ts` is no longer required either
- Renamed the singleton export `librarySyncEngine` → `spotifyLibrarySyncEngine` and updated all four call sites (`useAlbumSavedStatus`, `TrackInfo`, `useLibrarySync`, plus the engine's own test)
- Public surface (`subscribe`/`start`/`stop`/`syncNow`/`optimisticAddAlbum`/`optimisticRemoveAlbum`/`getState`) unchanged in signature
- File path kept as `librarySyncEngine.ts` to stay consistent with the rest of `cache/` (`libraryCache.ts`, `libraryDiffEngine.ts`, `librarySearch.ts`)

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] `npm run test:run` passes (183 files / 1942 tests, including the engine's own suite)
- [x] All importers updated to the new identifier

Closes #1496