### PR TITLE
refactor(LibraryContextMenu): extract useMenuItems hook from 19-dep useMemo

### DIFF
--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -1,31 +1,11 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
-import { usePinnedItems } from '@/hooks/usePinnedItems';
-import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
-import { useLikedSection } from '../hooks';
 import type { ContextMenuRequest } from '../types';
 import type { ProviderId, MediaTrack } from '@/types/domain';
-import { useLikedTracksForProvider } from './useLikedTracksForProvider';
-import { useAlbumSavedStatus } from './useAlbumSavedStatus';
-import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
-import { toAlbumPlaylistId } from '@/constants/playlist';
-import {
-  buildMenuItems,
-  isMenuActionError,
-  type MenuActions,
-  type MenuItem,
-} from './menuItemsForKind';
+import { isMenuActionError } from './menuItemsForKind';
+import { useMenuItems, type UseMenuItemsCallbacks } from './useMenuItems';
 import { MenuItemButton, MenuRoot, VirtualAnchor } from './LibraryContextMenu.styled';
-
-const PROVIDER_LABEL: Record<string, string> = {
-  spotify: 'Spotify',
-  dropbox: 'Dropbox',
-};
-
-function providerLabel(provider: ProviderId): string {
-  return PROVIDER_LABEL[provider] ?? provider;
-}
 
 export interface LibraryContextMenuProps {
   request: ContextMenuRequest | null;
@@ -69,29 +49,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
   onPlayLikedTracks,
   onQueueLikedTracks,
 }) => {
-  const {
-    isPlaylistPinned,
-    isAlbumPinned,
-    togglePinPlaylist,
-    togglePinAlbum,
-  } = usePinnedItems();
-  const { remove: removeRecent } = useRecentlyPlayedCollections();
-  const { perProvider } = useLikedSection();
-  const { loadLikedTracks } = useLikedTracksForProvider();
-  const { queueLikedFromCollection } = useQueueLikedFromCollection(onQueueLikedTracks);
-
   const closeReasonRef = useRef<'return' | null>(null);
-
-  const albumIdForSaveStatus =
-    request?.kind === 'album'
-      ? request.id
-      : request?.kind === 'recently-played' && request.originalKind === 'album'
-        ? request.id
-        : null;
-  const { isSaved, toggleSaved, canToggle: canToggleSaved } = useAlbumSavedStatus(
-    albumIdForSaveStatus,
-    request?.provider,
-  );
 
   const closeAfter = useCallback(
     (label: string, fn: () => void | Promise<unknown>): (() => void) =>
@@ -137,126 +95,28 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     }
   }, []);
 
-  const playNextDisabled = !onPlayNext;
-  const startRadioDisabled = !onStartRadioForCollection;
+  const callbacks = useMemo<UseMenuItemsCallbacks>(
+    () => ({
+      closeAfter,
+      onPlayCollection,
+      onAddToQueue,
+      onPlayNext,
+      onStartRadioForCollection,
+      onPlayLikedTracks,
+      onQueueLikedTracks,
+    }),
+    [
+      closeAfter,
+      onPlayCollection,
+      onAddToQueue,
+      onPlayNext,
+      onStartRadioForCollection,
+      onPlayLikedTracks,
+      onQueueLikedTracks,
+    ],
+  );
 
-  const items = useMemo<MenuItem[]>(() => {
-    if (!request) return [];
-
-    const effectiveKind: 'playlist' | 'album' | 'liked' =
-      request.kind === 'recently-played'
-        ? request.originalKind ?? 'playlist'
-        : (request.kind as 'playlist' | 'album' | 'liked');
-
-    const isPlaylistKind = effectiveKind === 'playlist';
-    const isAlbumKind = effectiveKind === 'album';
-    const isLikedKind = effectiveKind === 'liked';
-
-    const isPinned = isPlaylistKind
-      ? isPlaylistPinned(request.id)
-      : isAlbumKind
-        ? isAlbumPinned(request.id)
-        : false;
-
-    const togglePin = isPlaylistKind
-      ? () => togglePinPlaylist(request.id)
-      : () => togglePinAlbum(request.id);
-
-    const playLikedFor = async (provider: ProviderId) => {
-      const tracks = await loadLikedTracks(provider);
-      if (tracks.length === 0) return;
-      await onPlayLikedTracks(tracks, `liked-${provider}`, 'Liked Songs', provider);
-    };
-
-    const likedProviderActions = isLikedKind
-      ? perProvider.map((entry) => {
-          const entryLabel = `Play (${providerLabel(entry.provider)})`;
-          return {
-            provider: entry.provider,
-            label: entryLabel,
-            onPlay: closeAfter(entryLabel, () => playLikedFor(entry.provider)),
-          };
-        })
-      : undefined;
-
-    const actions: MenuActions = {
-      onPlay: closeAfter('Play', () => {
-        if (isLikedKind) {
-          // "Play All" routes through the library's own liked-handler via the parent.
-          const inferred = perProvider[0]?.provider;
-          if (inferred) void playLikedFor(inferred);
-          return;
-        }
-        if (isPlaylistKind || isAlbumKind) {
-          onPlayCollection(effectiveKind, request.id, request.name, request.provider);
-        }
-      }),
-      onAddToQueue: closeAfter('Add to Queue', () => {
-        if (onAddToQueue) {
-          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
-          onAddToQueue(id, request.name, request.provider);
-        }
-      }),
-      onPlayNext: closeAfter('Play Next', () => {
-        if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
-          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
-          onPlayNext(effectiveKind, id, request.name, request.provider);
-        }
-      }),
-      onTogglePin: closeAfter(isPinned ? 'Unpin' : 'Pin', togglePin),
-      onStartRadio: closeAfter('Start Radio', () => {
-        if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
-          onStartRadioForCollection(effectiveKind, request.id, request.provider);
-        }
-      }),
-      isPinned,
-      startRadioDisabled: startRadioDisabled || isLikedKind,
-      playNextDisabled: playNextDisabled || isLikedKind,
-      likedProviderActions,
-    };
-
-    if (isAlbumKind && canToggleSaved && isSaved !== null) {
-      actions.onToggleSave = closeAfter(isSaved ? 'Unlike' : 'Like', toggleSaved);
-    }
-
-    if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
-      const collectionId = request.id;
-      const collectionName = request.name;
-      const provider = request.provider;
-      actions.onQueueLikedFromCollection = closeAfter('Queue Liked Songs', () =>
-        queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
-      );
-    }
-
-    if (request.kind === 'recently-played' && request.recentRef) {
-      const recentRef = request.recentRef;
-      actions.onRemoveFromHistory = closeAfter('Remove from history', () => removeRecent(recentRef));
-    }
-
-    return buildMenuItems(request, actions);
-  }, [
-    request,
-    isPlaylistPinned,
-    isAlbumPinned,
-    togglePinPlaylist,
-    togglePinAlbum,
-    perProvider,
-    onPlayCollection,
-    onAddToQueue,
-    onPlayNext,
-    onStartRadioForCollection,
-    onPlayLikedTracks,
-    loadLikedTracks,
-    removeRecent,
-    closeAfter,
-    playNextDisabled,
-    startRadioDisabled,
-    canToggleSaved,
-    isSaved,
-    toggleSaved,
-    onQueueLikedTracks,
-    queueLikedFromCollection,
-  ]);
+  const items = useMenuItems(request, callbacks);
 
   if (!request) return null;
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ContextMenuRequest } from '../../types';
+import type { ProviderId } from '@/types/domain';
+
+const { mockPinned, mockLikedSection, mockRecent, mockLoadLiked } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLikedSection: vi.fn(),
+  mockRecent: vi.fn(),
+  mockLoadLiked: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockRecent(),
+}));
+
+vi.mock('../../hooks', () => ({
+  useLikedSection: () => mockLikedSection(),
+}));
+
+vi.mock('../useLikedTracksForProvider', () => ({
+  useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
+}));
+
+const { mockQueueLikedFromCollection, mockUseAlbumSavedStatus } = vi.hoisted(() => ({
+  mockQueueLikedFromCollection: vi.fn(),
+  mockUseAlbumSavedStatus: vi.fn(),
+}));
+
+vi.mock('../useQueueLikedFromCollection', () => ({
+  useQueueLikedFromCollection: () => ({ queueLikedFromCollection: mockQueueLikedFromCollection }),
+}));
+
+vi.mock('../useAlbumSavedStatus', () => ({
+  useAlbumSavedStatus: (...args: unknown[]) => mockUseAlbumSavedStatus(...args),
+}));
+
+import { useMenuItems, type UseMenuItemsCallbacks } from '../useMenuItems';
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'My Playlist',
+    provider: 'spotify' as ProviderId,
+    anchorRect: new DOMRect(10, 10, 100, 40),
+    ...overrides,
+  };
+}
+
+function makeCallbacks(overrides: Partial<UseMenuItemsCallbacks> = {}): UseMenuItemsCallbacks {
+  return {
+    closeAfter: (_label, fn) => () => {
+      void fn();
+    },
+    onPlayCollection: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayLikedTracks: vi.fn(),
+    ...overrides,
+  };
+}
+
+function defaultMocks() {
+  mockPinned.mockReturnValue({
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  });
+  mockLikedSection.mockReturnValue({
+    perProvider: [{ provider: 'spotify' as ProviderId, count: 10 }],
+  });
+  mockRecent.mockReturnValue({ remove: vi.fn() });
+  mockLoadLiked.mockResolvedValue([]);
+  mockUseAlbumSavedStatus.mockReturnValue({
+    isSaved: null,
+    toggleSaved: vi.fn(),
+    canToggle: false,
+    saveError: null,
+    clearSaveError: vi.fn(),
+  });
+}
+
+describe('useMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultMocks();
+  });
+
+  it('returns an empty array when request is null', () => {
+    // #when
+    const { result } = renderHook(() => useMenuItems(null, makeCallbacks()));
+
+    // #then
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns the playlist schema with 5 items', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    expect(result.current.map((i) => i.id)).toEqual([
+      'play',
+      'add-to-queue',
+      'play-next',
+      'toggle-pin',
+      'start-radio',
+    ]);
+  });
+
+  it('disables Play Next and Start Radio when handlers are undefined', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'playlist' }),
+        makeCallbacks({ onPlayNext: undefined, onStartRadioForCollection: undefined }),
+      ),
+    );
+
+    // #then
+    const playNext = result.current.find((i) => i.id === 'play-next');
+    const startRadio = result.current.find((i) => i.id === 'start-radio');
+    expect(playNext?.disabled).toBe(true);
+    expect(startRadio?.disabled).toBe(true);
+  });
+
+  it('labels toggle-pin as "Pin" when not pinned', () => {
+    // #given - default mock has isPlaylistPinned = () => false
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const togglePin = result.current.find((i) => i.id === 'toggle-pin');
+    expect(togglePin?.label).toBe('Pin');
+  });
+
+  it('labels toggle-pin as "Unpin" when playlist is pinned', () => {
+    // #given
+    mockPinned.mockReturnValue({
+      isPlaylistPinned: () => true,
+      isAlbumPinned: () => false,
+      togglePinPlaylist: vi.fn(),
+      togglePinAlbum: vi.fn(),
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const togglePin = result.current.find((i) => i.id === 'toggle-pin');
+    expect(togglePin?.label).toBe('Unpin');
+  });
+
+  it('builds per-provider liked entries from useLikedSection', () => {
+    // #given
+    mockLikedSection.mockReturnValue({
+      perProvider: [
+        { provider: 'spotify', count: 10 },
+        { provider: 'dropbox', count: 5 },
+      ],
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'liked', id: 'liked', provider: undefined }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('play-all');
+    expect(ids).toContain('play-liked-spotify');
+    expect(ids).toContain('play-liked-dropbox');
+  });
+
+  it('appends Remove from history for recently-played requests with recentRef', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({
+          kind: 'recently-played',
+          originalKind: 'playlist',
+          recentRef: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+        }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('remove-from-history');
+  });
+
+  it('omits queue-liked when onQueueLikedTracks is not provided', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).not.toContain('queue-liked');
+  });
+
+  it('includes queue-liked when onQueueLikedTracks is provided and provider exists', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'playlist' }),
+        makeCallbacks({ onQueueLikedTracks: vi.fn() }),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('queue-liked');
+  });
+
+  it('includes Unlike for an album when canToggleSaved and isSaved=true', () => {
+    // #given
+    mockUseAlbumSavedStatus.mockReturnValue({
+      isSaved: true,
+      toggleSaved: vi.fn(),
+      canToggle: true,
+      saveError: null,
+      clearSaveError: vi.fn(),
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const toggleSave = result.current.find((i) => i.id === 'toggle-save');
+    expect(toggleSave?.label).toBe('Unlike');
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/useMenuItems.ts
+++ b/src/components/LibraryRoute/contextMenu/useMenuItems.ts
@@ -1,0 +1,206 @@
+import { useMemo } from 'react';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
+import { useLikedSection } from '../hooks';
+import type { ContextMenuRequest } from '../types';
+import type { ProviderId, MediaTrack } from '@/types/domain';
+import { useLikedTracksForProvider } from './useLikedTracksForProvider';
+import { useAlbumSavedStatus } from './useAlbumSavedStatus';
+import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
+import { toAlbumPlaylistId } from '@/constants/playlist';
+import { buildMenuItems, type MenuActions, type MenuItem } from './menuItemsForKind';
+
+const PROVIDER_LABEL: Record<string, string> = {
+  spotify: 'Spotify',
+  dropbox: 'Dropbox',
+};
+
+function providerLabel(provider: ProviderId): string {
+  return PROVIDER_LABEL[provider] ?? provider;
+}
+
+export interface UseMenuItemsCallbacks {
+  closeAfter: (label: string, fn: () => void | Promise<unknown>) => () => void;
+  onPlayCollection: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onAddToQueue?: (id: string, name: string, provider?: ProviderId) => void | Promise<unknown>;
+  onPlayNext?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onStartRadioForCollection?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    provider?: ProviderId,
+  ) => void;
+  onPlayLikedTracks: (
+    tracks: MediaTrack[],
+    collectionId: string,
+    collectionName: string,
+    provider?: ProviderId,
+  ) => Promise<void> | void;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+}
+
+export function useMenuItems(
+  request: ContextMenuRequest | null,
+  callbacks: UseMenuItemsCallbacks,
+): MenuItem[] {
+  const {
+    closeAfter,
+    onPlayCollection,
+    onAddToQueue,
+    onPlayNext,
+    onStartRadioForCollection,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
+  } = callbacks;
+
+  const {
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+  } = usePinnedItems();
+  const { remove: removeRecent } = useRecentlyPlayedCollections();
+  const { perProvider } = useLikedSection();
+  const { loadLikedTracks } = useLikedTracksForProvider();
+  const { queueLikedFromCollection } = useQueueLikedFromCollection(onQueueLikedTracks);
+
+  const albumIdForSaveStatus =
+    request?.kind === 'album'
+      ? request.id
+      : request?.kind === 'recently-played' && request.originalKind === 'album'
+        ? request.id
+        : null;
+  const { isSaved, toggleSaved, canToggle: canToggleSaved } = useAlbumSavedStatus(
+    albumIdForSaveStatus,
+    request?.provider,
+  );
+
+  const playNextDisabled = !onPlayNext;
+  const startRadioDisabled = !onStartRadioForCollection;
+
+  return useMemo<MenuItem[]>(() => {
+    if (!request) return [];
+
+    const effectiveKind: 'playlist' | 'album' | 'liked' =
+      request.kind === 'recently-played'
+        ? request.originalKind ?? 'playlist'
+        : (request.kind as 'playlist' | 'album' | 'liked');
+
+    const isPlaylistKind = effectiveKind === 'playlist';
+    const isAlbumKind = effectiveKind === 'album';
+    const isLikedKind = effectiveKind === 'liked';
+
+    const isPinned = isPlaylistKind
+      ? isPlaylistPinned(request.id)
+      : isAlbumKind
+        ? isAlbumPinned(request.id)
+        : false;
+
+    const togglePin = isPlaylistKind
+      ? () => togglePinPlaylist(request.id)
+      : () => togglePinAlbum(request.id);
+
+    const playLikedFor = async (provider: ProviderId) => {
+      const tracks = await loadLikedTracks(provider);
+      if (tracks.length === 0) return;
+      await onPlayLikedTracks(tracks, `liked-${provider}`, 'Liked Songs', provider);
+    };
+
+    const likedProviderActions = isLikedKind
+      ? perProvider.map((entry) => {
+          const entryLabel = `Play (${providerLabel(entry.provider)})`;
+          return {
+            provider: entry.provider,
+            label: entryLabel,
+            onPlay: closeAfter(entryLabel, () => playLikedFor(entry.provider)),
+          };
+        })
+      : undefined;
+
+    const actions: MenuActions = {
+      onPlay: closeAfter('Play', () => {
+        if (isLikedKind) {
+          const inferred = perProvider[0]?.provider;
+          if (inferred) void playLikedFor(inferred);
+          return;
+        }
+        if (isPlaylistKind || isAlbumKind) {
+          onPlayCollection(effectiveKind, request.id, request.name, request.provider);
+        }
+      }),
+      onAddToQueue: closeAfter('Add to Queue', () => {
+        if (onAddToQueue) {
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onAddToQueue(id, request.name, request.provider);
+        }
+      }),
+      onPlayNext: closeAfter('Play Next', () => {
+        if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onPlayNext(effectiveKind, id, request.name, request.provider);
+        }
+      }),
+      onTogglePin: closeAfter(isPinned ? 'Unpin' : 'Pin', togglePin),
+      onStartRadio: closeAfter('Start Radio', () => {
+        if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
+          onStartRadioForCollection(effectiveKind, request.id, request.provider);
+        }
+      }),
+      isPinned,
+      startRadioDisabled: startRadioDisabled || isLikedKind,
+      playNextDisabled: playNextDisabled || isLikedKind,
+      likedProviderActions,
+    };
+
+    if (isAlbumKind && canToggleSaved && isSaved !== null) {
+      actions.onToggleSave = closeAfter(isSaved ? 'Unlike' : 'Like', toggleSaved);
+    }
+
+    if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
+      const collectionId = request.id;
+      const collectionName = request.name;
+      const provider = request.provider;
+      actions.onQueueLikedFromCollection = closeAfter('Queue Liked Songs', () =>
+        queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
+      );
+    }
+
+    if (request.kind === 'recently-played' && request.recentRef) {
+      const recentRef = request.recentRef;
+      actions.onRemoveFromHistory = closeAfter('Remove from history', () => removeRecent(recentRef));
+    }
+
+    return buildMenuItems(request, actions);
+  }, [
+    request,
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+    perProvider,
+    onPlayCollection,
+    onAddToQueue,
+    onPlayNext,
+    onStartRadioForCollection,
+    onPlayLikedTracks,
+    loadLikedTracks,
+    removeRecent,
+    closeAfter,
+    playNextDisabled,
+    startRadioDisabled,
+    canToggleSaved,
+    isSaved,
+    toggleSaved,
+    onQueueLikedTracks,
+    queueLikedFromCollection,
+  ]);
+}


### PR DESCRIPTION
## Summary
- Extracted `useMenuItems(request, callbacks)` to a colocated hook that consumes context hooks directly (`usePinnedItems`, `useRecentlyPlayedCollections`, `useLikedSection`, `useLikedTracksForProvider`, `useAlbumSavedStatus`, `useQueueLikedFromCollection`)
- Reduced the inline `useMemo` in `LibraryContextMenu.tsx` to a 7-dep callbacks bundle; component now focuses on popover / focus wiring
- Added a colocated unit test for the new hook

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes (1952 tests across 184 files; a11y and existing context-menu tests stay green)
- No menu-order or action-set changes

Closes #1499