### PR TITLE
refactor(error-handling): log swallowed errors at empty-catch sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 - Container queries as primary responsive strategy, media queries as fallback
 - `useLocalStorage` hook for persistence with `'vorbis-player-'` key prefix
 - Strict TypeScript; `import type` when possible; types in `src/types/`
+- Empty `catch` blocks are permitted only when paired with `logCaughtError('<context>', err)` from `src/utils/logCaughtError.ts` so swallowed failures still surface in dev. Existing rationale comments inside the catch should stay; the helper call is additive.
 
 ## Testing
 

--- a/src/components/AppSettingsMenu/ProviderDataSection.tsx
+++ b/src/components/AppSettingsMenu/ProviderDataSection.tsx
@@ -4,6 +4,7 @@ import type { CatalogProvider } from '@/types/providers';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 import {
   ControlGroup,
@@ -49,7 +50,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       a.click();
       URL.revokeObjectURL(url);
       setResultMessage('Exported!');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.exportFn', err);
       setResultMessage('Export failed');
     }
   }, [catalog]);
@@ -61,7 +63,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       if (result.updated > 0) parts.push(`${result.updated} updated`);
       if (result.removed > 0) parts.push(`${result.removed} removed`);
       setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.refreshMetadataFn', err);
       setResultMessage('Refresh failed');
     }
   }, [catalog]);
@@ -80,7 +83,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       const json = await file.text();
       const count = await catalog.importLikes!(json);
       setResultMessage(`Imported ${count} tracks`);
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.handleImport', err);
       setResultMessage('Import failed');
     }
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { theme } from '@/styles/theme';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface LogEntry {
   time: string;
@@ -15,11 +16,11 @@ const TAP_WINDOW_MS = 2000;
 function isDebugEnabled(): boolean {
   if (typeof window === 'undefined') return false;
   if (new URLSearchParams(window.location.search).get('debug') === 'true') return true;
-  try { return localStorage.getItem(STORAGE_KEYS.DEBUG_OVERLAY) === 'true'; } catch { return false; }
+  try { return localStorage.getItem(STORAGE_KEYS.DEBUG_OVERLAY) === 'true'; } catch (err) { logCaughtError('DebugOverlay.isDebugEnabled', err); return false; }
 }
 
 function setDebugEnabled(enabled: boolean) {
-  try { localStorage.setItem(STORAGE_KEYS.DEBUG_OVERLAY, String(enabled)); } catch { /* noop */ }
+  try { localStorage.setItem(STORAGE_KEYS.DEBUG_OVERLAY, String(enabled)); } catch (err) { /* noop */ logCaughtError('DebugOverlay.setDebugEnabled', err); }
 }
 
 export function useDebugActivator() {

--- a/src/components/SettingsV2/sections/ProviderDataBlock.tsx
+++ b/src/components/SettingsV2/sections/ProviderDataBlock.tsx
@@ -4,6 +4,7 @@ import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 import type { CatalogProvider } from '@/types/providers';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -50,7 +51,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       a.click();
       URL.revokeObjectURL(url);
       setResultMessage('Exported!');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.exportFn', err);
       setResultMessage('Export failed');
     }
   }, [catalog]);
@@ -62,7 +64,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       if (result.updated > 0) parts.push(`${result.updated} updated`);
       if (result.removed > 0) parts.push(`${result.removed} removed`);
       setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.refreshMetadataFn', err);
       setResultMessage('Refresh failed');
     }
   }, [catalog]);
@@ -81,7 +84,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       const json = await file.text();
       const count = await catalog.importLikes!(json);
       setResultMessage(`Imported ${count} tracks`);
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.handleImport', err);
       setResultMessage('Import failed');
     }
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/contexts/ProfilingContext.tsx
+++ b/src/contexts/ProfilingContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface RenderStats {
   renderCount: number; mountCount: number; updateCount: number;
@@ -89,7 +90,10 @@ class MetricsCollector {
         }
       });
       this.longTaskObserver.observe({ entryTypes: ['longtask'] });
-    } catch { /* longtask not supported */ }
+    } catch (err) {
+      /* longtask not supported */
+      logCaughtError('ProfilingContext.startLongTaskObserver', err);
+    }
   }
 
   recordRender(

--- a/src/contexts/VisualizerDebugContext.tsx
+++ b/src/contexts/VisualizerDebugContext.tsx
@@ -13,6 +13,7 @@ import {
   type VisualizerDebugOverrides,
 } from '@/constants/visualizerDebugConfig';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const DEBUG_PARAM = 'debug';
 const DEBUG_VALUE = 'visualizer';
@@ -29,7 +30,8 @@ function readStoredOverrides(): VisualizerDebugOverrides | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as VisualizerDebugOverrides;
     return parsed;
-  } catch {
+  } catch (err) {
+    logCaughtError('VisualizerDebugContext.readStoredOverrides', err);
     return null;
   }
 }
@@ -41,8 +43,9 @@ function writeStoredOverrides(overrides: VisualizerDebugOverrides | null): void 
       return;
     }
     localStorage.setItem(STORAGE_KEYS.VISUALIZER_DEBUG_OVERRIDES, JSON.stringify(overrides));
-  } catch {
+  } catch (err) {
     // ignore
+    logCaughtError('VisualizerDebugContext.writeStoredOverrides', err);
   }
 }
 
@@ -128,8 +131,9 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
   const copyExportToClipboard = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(exportAsJson());
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('VisualizerDebugContext.copyExportToClipboard', err);
     }
   }, [exportAsJson]);
 
@@ -143,7 +147,8 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       setOverridesState(overrides);
       writeStoredOverrides(overrides);
       return true;
-    } catch {
+    } catch (err) {
+      logCaughtError('VisualizerDebugContext.loadOverridesFromJson', err);
       return false;
     }
   }, []);

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -15,6 +15,7 @@ import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { useQueueThumbnailLoader } from '@/hooks/useQueueThumbnailLoader';
 import { useQueueDurationLoader } from '@/hooks/useQueueDurationLoader';
 import { trkSummary } from './playerLogicUtils';
@@ -216,8 +217,9 @@ export function usePlayerLogic() {
     if (!drivingDescriptor) return;
     try {
       await drivingDescriptor.playback.resume();
-    } catch {
+    } catch (err) {
       // Autoplay policy or network errors are handled by the playback adapter
+      logCaughtError('usePlayerLogic.ensurePlaybackResumed', err);
     }
   }, [getDrivingProviderDescriptor]);
 
@@ -280,8 +282,9 @@ export function usePlayerLogic() {
       const drivingDescriptor = getDrivingProviderDescriptor();
       if (!drivingDescriptor) return;
       await drivingDescriptor.playback.resume();
-    } catch {
+    } catch (err) {
       // Autoplay policy or network errors are handled by the playback adapter
+      logCaughtError('usePlayerLogic.handlePlay', err);
     }
   }, [playTrack, getDrivingProviderId, getDrivingProviderDescriptor]);
 

--- a/src/hooks/useQueueDurationLoader.ts
+++ b/src/hooks/useQueueDurationLoader.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /** Maximum number of concurrent duration resolution calls per batch. */
 const RESOLVE_CONCURRENCY = 2;
@@ -70,7 +71,8 @@ export function useQueueDurationLoader(
                 batchResults.set(track.id, durationMs);
               }
               if (!controller.signal.aborted) attemptedTrackIds.current.add(track.id);
-            } catch {
+            } catch (err) {
+              logCaughtError('useQueueDurationLoader.resolveDuration', err);
               if (!controller.signal.aborted) attemptedTrackIds.current.add(track.id);
             }
           }),

--- a/src/hooks/useQueueThumbnailLoader.ts
+++ b/src/hooks/useQueueThumbnailLoader.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /** Maximum number of concurrent art resolution calls per batch. */
 const FETCH_CONCURRENCY = 3;
@@ -73,8 +74,9 @@ export function useQueueThumbnailLoader(
               const provider = providerRegistry.get(mt.provider);
               const art = await provider?.catalog.resolveArtwork?.(albumId, controller.signal);
               if (art) batchResults.set(albumId, art);
-            } catch {
+            } catch (err) {
               // Swallow errors for individual album art resolution
+              logCaughtError('useQueueThumbnailLoader.resolveArtwork', err);
             }
           }),
         );

--- a/src/hooks/useUiV2.ts
+++ b/src/hooks/useUiV2.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /**
  * `?ui=v2` flag — opt-in mechanism for whole-screen redesigns shipped behind
@@ -63,7 +64,8 @@ function readPersistedFlag(): boolean {
     const raw = window.localStorage.getItem(STORAGE_KEYS.SETTINGS_V2_ENABLED);
     if (raw === null) return false;
     return JSON.parse(raw) === true;
-  } catch {
+  } catch (err) {
+    logCaughtError('useUiV2.readPersistedFlag', err);
     return false;
   }
 }

--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -2,6 +2,7 @@ import type { DropboxFileEntry, DropboxListFolderResult, CachedLink } from './dr
 import { TEMP_LINK_TTL_MS } from './dropboxCatalogHelpers';
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 import { AuthExpiredError } from '@/providers/errors';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const DEFAULT_RETRY_AFTER_SECONDS = 5;
 const MAX_RETRY_AFTER_SECONDS = 30;
@@ -15,8 +16,9 @@ async function parseRetryAfterSeconds(response: Response): Promise<number> {
   try {
     const body = await response.clone().json() as { retry_after?: number };
     if (typeof body?.retry_after === 'number' && body.retry_after > 0) return body.retry_after;
-  } catch {
+  } catch (err) {
     // 429 body wasn't JSON; fall through to default.
+    logCaughtError('dropboxApiClient.parseRetryAfterSeconds', err);
   }
   return DEFAULT_RETRY_AFTER_SECONDS;
 }

--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -4,6 +4,8 @@
  * without hitting the Dropbox API.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
+
 const DB_NAME = 'vorbis-dropbox-art';
 const DB_VERSION = 7;
 const STORE = 'art';
@@ -76,7 +78,8 @@ export async function getArt(path: string): Promise<string | null> {
         resolve(entry && Date.now() - entry.cachedAt < ART_TTL_MS ? entry.dataUrl : null);
       };
       req.onerror = () => resolve(null);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.getArt', err);
       resolve(null);
     }
   });
@@ -92,7 +95,8 @@ export async function putArt(path: string, dataUrl: string): Promise<void> {
       tx.objectStore(STORE).put(entry);
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.putArt', err);
       resolve();
     }
   });
@@ -121,7 +125,8 @@ export async function clearArt(): Promise<void> {
       tx.objectStore(STORE).clear();
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.clearArt', err);
       resolve();
     }
   });
@@ -133,8 +138,9 @@ export async function putDurationMs(trackId: string, durationMs: number): Promis
   try {
     const tx = database.transaction('durations', 'readwrite');
     tx.objectStore('durations').put({ trackId, durationMs });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putDurationMs', err);
   }
 }
 
@@ -151,8 +157,9 @@ export async function putTagMetadata(trackId: string, tags: Omit<CachedTagMetada
   try {
     const tx = database.transaction('tags', 'readwrite');
     tx.objectStore('tags').put({ trackId, ...tags });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putTagMetadata', err);
   }
 }
 
@@ -173,7 +180,8 @@ function batchGetFromStore<T>(database: IDBDatabase, storeName: string, ids: str
           if (--pending === 0) resolve(result);
         };
       }
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.batchGetFromStore', err);
       resolve(result);
     }
   });
@@ -211,8 +219,9 @@ export async function putTrackDate(albumId: string, releaseYear: number): Promis
   try {
     const tx = database.transaction('trackDates', 'readwrite');
     tx.objectStore('trackDates').put({ albumId, releaseYear });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putTrackDate', err);
   }
 }
 

--- a/src/providers/dropbox/dropboxArtworkResolver.ts
+++ b/src/providers/dropbox/dropboxArtworkResolver.ts
@@ -9,6 +9,7 @@ import {
   putAlbumArt,
 } from './dropboxArtCache';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class DropboxArtworkResolver {
   private apiClient: DropboxApiClient;
@@ -46,7 +47,8 @@ export class DropboxArtworkResolver {
 
       await putArt(path, dataUrl);
       return dataUrl;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtworkResolver.doFetchArtDataUrl', err);
       return null;
     }
   }
@@ -120,7 +122,8 @@ export class DropboxArtworkResolver {
         await putAlbumArt(albumDir, imageUrl);
       }
       return imageUrl;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtworkResolver.resolveAlbumArt', err);
       return null;
     }
   }

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -51,6 +51,7 @@ import {
 import { DropboxApiClient } from './dropboxApiClient';
 import { DropboxArtworkResolver } from './dropboxArtworkResolver';
 import { scanAlbumDatesInBackground } from './dropboxDateScanner';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class DropboxCatalogAdapter implements CatalogProvider {
   readonly providerId: ProviderId = 'dropbox';
@@ -190,8 +191,9 @@ export class DropboxCatalogAdapter implements CatalogProvider {
       let savedPlaylists: MediaCollection[] = [];
       try {
         savedPlaylists = await listSavedPlaylists(this.auth);
-      } catch {
+      } catch (err) {
         // Silently ignore -- saved playlists are optional
+        logCaughtError('dropboxCatalogAdapter.listSavedPlaylists', err);
       }
 
       const collections = [allMusic, ...savedPlaylists, ...albums];
@@ -368,7 +370,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         putDurationMs(track.id, durationMs).catch(() => {});
       }
       return durationMs;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogAdapter.fetchTrackDuration', err);
       return null;
     }
   }

--- a/src/providers/dropbox/dropboxCatalogCache.ts
+++ b/src/providers/dropbox/dropboxCatalogCache.ts
@@ -1,4 +1,5 @@
 import type { MediaCollection } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { getDb } from './dropboxArtCache';
 
 const STORE = 'catalog';
@@ -35,7 +36,8 @@ export async function getCachedCatalog(): Promise<{
         });
       };
       req.onerror = () => resolve(null);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogCache.getCachedCatalog', err);
       resolve(null);
     }
   });
@@ -48,8 +50,9 @@ export async function putCatalogCache(collections: MediaCollection[]): Promise<v
     const entry: CachedCatalog = { key: KEY, collections, cachedAt: Date.now() };
     const tx = database.transaction(STORE, 'readwrite');
     tx.objectStore(STORE).put(entry);
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxCatalogCache.putCatalogCache', err);
   }
 }
 
@@ -62,7 +65,8 @@ export async function clearCatalogCache(): Promise<void> {
       tx.objectStore(STORE).clear();
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogCache.clearCatalogCache', err);
       resolve();
     }
   });

--- a/src/providers/dropbox/dropboxDateScanner.ts
+++ b/src/providers/dropbox/dropboxDateScanner.ts
@@ -2,6 +2,7 @@ import type { MediaCollection } from '@/types/domain';
 import type { DropboxApiClient } from './dropboxApiClient';
 import { getTrackDatesMap, putTrackDate } from './dropboxArtCache';
 import { parseID3 } from '@/utils/id3Parser';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 200;
@@ -34,8 +35,9 @@ export async function scanAlbumDatesInBackground(
             await putTrackDate(album.id, meta.releaseYear);
             album.releaseDate = String(meta.releaseYear);
           }
-        } catch {
+        } catch (err) {
           // Silently skip -- will retry on next catalog refresh
+          logCaughtError('dropboxDateScanner.scanAlbumDatesInBackground', err);
         }
       }),
     );

--- a/src/providers/dropbox/dropboxLikesCache.ts
+++ b/src/providers/dropbox/dropboxLikesCache.ts
@@ -1,4 +1,5 @@
 import type { MediaTrack } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { getDb } from './dropboxArtCache';
 
 const STORE = 'likes';
@@ -38,7 +39,8 @@ async function withIdbStore<T>(
       const store = tx.objectStore(storeName);
       fn(store, resolve);
       tx.onerror = () => resolve(fallback);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxLikesCache.withIdbStore', err);
       resolve(fallback);
     }
   });
@@ -129,7 +131,8 @@ export async function importLikes(json: string): Promise<number> {
   try {
     entries = JSON.parse(json);
     if (!Array.isArray(entries)) return 0;
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxLikesCache.importLikes', err);
     return 0;
   }
 

--- a/src/providers/dropbox/dropboxLikesSync.ts
+++ b/src/providers/dropbox/dropboxLikesSync.ts
@@ -15,6 +15,7 @@ import {
 import { ensureVorbisFolder } from './dropboxSyncFolder';
 import { contentApiRequest } from './dropboxContentApiClient';
 import { logDropboxSync } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export interface RemoteLikesFile {
   version: 1;
@@ -93,7 +94,8 @@ export class DropboxLikesSyncService {
         return null;
       }
       return data;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxLikesSync.downloadLikesFile', err);
       console.warn('[DropboxLikesSync] Failed to parse remote likes file');
       return null;
     }
@@ -130,7 +132,8 @@ export class DropboxLikesSyncService {
       try {
         const errJson = JSON.parse(errText);
         errMsg = (errJson?.error_summary ?? errJson?.error ?? errText) || response.statusText;
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxLikesSync.uploadLikesFile.parseError', err);
         errMsg = errText || response.statusText;
       }
       console.warn('[DropboxLikesSync] Upload failed:', response.status, errMsg);

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -11,6 +11,7 @@ import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import { putDurationMs, putTagMetadata } from './dropboxArtCache';
 import { logArtRace } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const PLAYBACK_POLL_INTERVAL_MS = 250;
 const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
@@ -136,7 +137,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       let res: Response;
       try {
         res = await fetch(streamUrl, { headers: { Range: `bytes=0-${FETCH_LIMIT - 1}` } });
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxPlaybackAdapter.enrichMetadataInBackground', err);
         return;
       }
 

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -8,6 +8,7 @@ import type { MediaTrack, MediaCollection, ProviderId, PlaybackItemRef } from '@
 import { toSavedPlaylistId } from '@/constants/playlist';
 import { logLibrary } from '@/lib/debugLog';
 import { buildAlbumCoverMap, selectMosaicCovers } from '@/utils/mosaicSelection';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { contentApiRequest } from './dropboxContentApiClient';
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -150,8 +151,9 @@ export async function saveQueueAsPlaylist(
   try {
     const existing = await loadPlaylistFile(auth, filePath);
     if (existing?.createdAt) createdAt = existing.createdAt;
-  } catch {
+  } catch (err) {
     // New file — use current time
+    logCaughtError('dropboxPlaylistStorage.savePlaylist.loadExisting', err);
   }
 
   const data: PlaylistFile = {
@@ -317,7 +319,8 @@ async function loadPlaylistFile(
   try {
     const data: PlaylistFile = await response.json();
     return data.version === 1 ? data : null;
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxPlaylistStorage.loadPlaylistFile', err);
     return null;
   }
 }

--- a/src/providers/dropbox/dropboxPreferencesSync.ts
+++ b/src/providers/dropbox/dropboxPreferencesSync.ts
@@ -8,6 +8,7 @@ import { getPins, setPins, UNIFIED_PROVIDER, notifyPinsChanged } from '@/service
 import { ensureVorbisFolder } from './dropboxSyncFolder';
 import { contentApiRequest } from './dropboxContentApiClient';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -32,7 +33,8 @@ function parseJsonObject(raw: string | null): Record<string, string> {
   try {
     const parsed: unknown = JSON.parse(raw);
     return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {};
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxPreferencesSync.parseJsonObject', err);
     return {};
   }
 }
@@ -111,7 +113,8 @@ export class DropboxPreferencesSyncService {
         return null;
       }
       return data;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxPreferencesSync.downloadPreferencesFile', err);
       console.warn('[DropboxPreferencesSync] Failed to parse remote preferences file');
       return null;
     }
@@ -148,7 +151,8 @@ export class DropboxPreferencesSyncService {
       try {
         const errJson = JSON.parse(errText);
         errMsg = (errJson?.error_summary ?? errJson?.error ?? errText) || response.statusText;
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxPreferencesSync.uploadPreferencesFile.parseError', err);
         errMsg = errText || response.statusText;
       }
       console.warn('[DropboxPreferencesSync] Upload failed:', response.status, errMsg);

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -1,5 +1,6 @@
 import { saveSession } from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { logCaughtError } from '@/utils/logCaughtError';
 import type { MockCatalogAdapter } from './mockCatalogAdapter';
 
 const PARAM_NAME = 'mock-session';
@@ -38,7 +39,8 @@ export function parseMockSessionParam(search: string): MockSessionSeed | null {
     }
 
     return { trackId, positionMs };
-  } catch {
+  } catch (err) {
+    logCaughtError('mock.sessionSeed.parseMockSessionParam', err);
     return null;
   }
 }
@@ -82,7 +84,8 @@ export function seedSessionFromUrlParam(
     };
 
     saveSession(snapshot);
-  } catch {
+  } catch (err) {
     // Fail closed — log nothing, let the app start in default state.
+    logCaughtError('mock.sessionSeed.seedSessionFromUrlParam', err);
   }
 }

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -7,6 +7,7 @@ import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { spotifyAuth } from '@/services/spotify';
 import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class SpotifyAuthAdapter implements AuthProvider {
   readonly providerId: ProviderId = 'spotify';
@@ -18,7 +19,8 @@ export class SpotifyAuthAdapter implements AuthProvider {
   async getAccessToken(): Promise<string | null> {
     try {
       return await spotifyAuth.ensureValidToken();
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyAuthAdapter.getAccessToken', err);
       return spotifyAuth.getAccessToken();
     }
   }

--- a/src/providers/spotify/spotifyQueueSync.ts
+++ b/src/providers/spotify/spotifyQueueSync.ts
@@ -10,6 +10,7 @@ import { searchTrack, spotifyAuth } from '@/services/spotify';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { MediaTrack } from '@/types/domain';
 import { SPOTIFY_QUEUE_SYNC_DELAY_MS } from '@/constants/timing';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const QUEUE_URI_LIMIT = 200;
 const MAX_CONCURRENT_SEARCHES = 3;
@@ -25,7 +26,8 @@ class SpotifyQueueSyncService {
       const stored = localStorage.getItem(STORAGE_KEYS.SPOTIFY_QUEUE_SYNC);
       if (stored === null) return true; // default on
       return JSON.parse(stored);
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyQueueSync.isSyncEnabled', err);
       return true;
     }
   }
@@ -36,7 +38,8 @@ class SpotifyQueueSyncService {
       const stored = localStorage.getItem(STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER);
       if (stored === null) return true; // default on
       return JSON.parse(stored);
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyQueueSync.isResolveEnabled', err);
       return true;
     }
   }
@@ -101,8 +104,9 @@ class SpotifyQueueSyncService {
           try {
             const result = await searchTrack(track.artists, track.name);
             this.resolutionCache.set(track.id, result?.uri ?? null);
-          } catch {
+          } catch (err) {
             // Network errors — don't cache, might succeed later
+            logCaughtError('spotifyQueueSync.resolveTracksInBackground', err);
           } finally {
             this.pendingResolutions.delete(track.id);
           }

--- a/src/services/cache/libraryCacheStorage.ts
+++ b/src/services/cache/libraryCacheStorage.ts
@@ -6,6 +6,7 @@
  * Consumers don't see the branching.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
 import {
   fallbackStores,
   getDb,
@@ -118,7 +119,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       if (isFallback()) return fallback().get(key);
       try {
         return await idbGet<T>(storeName, key);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.get`, err);
         return fallback().get(key);
       }
     },
@@ -128,7 +130,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       if (isFallback()) return Array.from(fallback().values());
       try {
         return await idbGetAll<T>(storeName);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.getAll`, err);
         return Array.from(fallback().values());
       }
     },
@@ -141,7 +144,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbPut(storeName, value);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.put`, err);
         fallback().set(key, value);
       }
     },
@@ -156,7 +160,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbPutAll(storeName, items);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.putAll`, err);
         const map = fallback();
         for (const [key, value] of entries) map.set(key, value);
       }
@@ -170,7 +175,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbDelete(storeName, key);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.remove`, err);
         fallback().delete(key);
       }
     },
@@ -186,7 +192,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbReplaceAll(storeName, items);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.replaceAll`, err);
         const map = fallback();
         map.clear();
         for (const [key, value] of entries) map.set(key, value);
@@ -201,7 +208,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbClear(storeName);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.clear`, err);
         fallback().clear();
       }
     },

--- a/src/services/cache/likedCountSnapshot.ts
+++ b/src/services/cache/likedCountSnapshot.ts
@@ -1,5 +1,6 @@
 import type { ProviderId } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface SnapshotEntry {
   count: number;
@@ -13,7 +14,8 @@ export function readLikedCountSnapshots(): LikedCountSnapshots {
     const raw = localStorage.getItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS);
     if (!raw) return {};
     return JSON.parse(raw) as LikedCountSnapshots;
-  } catch {
+  } catch (err) {
+    logCaughtError('likedCountSnapshot.readLikedCountSnapshots', err);
     return {};
   }
 }
@@ -23,7 +25,10 @@ export function writeLikedCountSnapshot(providerId: ProviderId, count: number): 
     const snapshots = readLikedCountSnapshots();
     snapshots[providerId] = { count, cachedAt: Date.now() };
     localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
-  } catch { /* quota exceeded — silent */ }
+  } catch (err) {
+    /* quota exceeded — silent */
+    logCaughtError('likedCountSnapshot.writeLikedCountSnapshot', err);
+  }
 }
 
 export function clearLikedCountSnapshot(providerId: ProviderId): void {
@@ -31,5 +36,8 @@ export function clearLikedCountSnapshot(providerId: ProviderId): void {
     const snapshots = readLikedCountSnapshots();
     delete snapshots[providerId];
     localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
-  } catch { /* silent */ }
+  } catch (err) {
+    /* silent */
+    logCaughtError('likedCountSnapshot.clearLikedCountSnapshot', err);
+  }
 }

--- a/src/services/devbug/consoleCapture.ts
+++ b/src/services/devbug/consoleCapture.ts
@@ -1,5 +1,6 @@
 import createDebug from 'debug';
 import { CircularBuffer } from './circularBuffer';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const log = createDebug('vorbis:devbug');
 
@@ -74,7 +75,8 @@ function safeStringify(value: unknown, seen = new Set<unknown>()): string {
     seen.delete(value);
     const result = `{${entries.join(', ')}}`;
     return result.length > MAX_STRING_LENGTH ? result.slice(0, MAX_STRING_LENGTH) + '...[truncated]' : result;
-  } catch {
+  } catch (err) {
+    logCaughtError('consoleCapture.safeStringify', err);
     seen.delete(value);
     return '[Unserializable]';
   }

--- a/src/services/devbug/githubService.ts
+++ b/src/services/devbug/githubService.ts
@@ -1,5 +1,6 @@
 import type { BugReport } from '@/types/devbug';
 import { formatIssueBody, formatIssueTitle } from './issueFormatter';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const SCREENSHOT_PATH_PREFIX = 'docs/bug-screenshots';
@@ -85,8 +86,9 @@ export function createGitHubService(config: GitHubServiceConfig): GitHubService 
       const filename = `${report.id}.png`;
       try {
         screenshotUrl = await uploadScreenshot(report.screenshotDataUrl, filename);
-      } catch {
+      } catch (err) {
         // Continue without screenshot — don't block issue creation
+        logCaughtError('githubService.createIssue.uploadScreenshot', err);
       }
     }
 

--- a/src/services/devbug/perfCapture.ts
+++ b/src/services/devbug/perfCapture.ts
@@ -1,4 +1,5 @@
 import type { PerfData } from '@/types/devbug';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface MemoryInfo {
   usedJSHeapSize: number;
@@ -20,7 +21,8 @@ function readFcp(): number | null {
     const entries = performance.getEntriesByType('paint');
     const fcp = entries.find((e) => e.name === 'first-contentful-paint');
     return fcp ? fcp.startTime : null;
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.readFcp', err);
     return null;
   }
 }
@@ -33,7 +35,8 @@ function readMemory(): Pick<PerfData, 'memoryUsed' | 'memoryTotal'> {
       memoryUsed: mem.usedJSHeapSize,
       memoryTotal: mem.totalJSHeapSize,
     };
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.readMemory', err);
     return { memoryUsed: null, memoryTotal: null };
   }
 }
@@ -61,7 +64,8 @@ export function startPerfCapture(): void {
       }
     });
     lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.startPerfCapture.lcpObserver', err);
     lcpObserver = null;
   }
 
@@ -74,7 +78,8 @@ export function startPerfCapture(): void {
       }
     });
     longTaskObserver.observe({ type: 'longtask', buffered: false });
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.startPerfCapture.longTaskObserver', err);
     longTaskObserver = null;
   }
 }
@@ -85,8 +90,9 @@ export function stopPerfCapture(): PerfData {
   if (lcpObserver) {
     try {
       lcpObserver.disconnect();
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('perfCapture.stopPerfCapture.lcpDisconnect', err);
     }
     lcpObserver = null;
   }
@@ -94,8 +100,9 @@ export function stopPerfCapture(): PerfData {
   if (longTaskObserver) {
     try {
       longTaskObserver.disconnect();
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('perfCapture.stopPerfCapture.longTaskDisconnect', err);
     }
     longTaskObserver = null;
   }

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -1,4 +1,5 @@
 import type { MediaTrack, ProviderId } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const SESSION_KEY = 'vorbis-player-last-session';
 
@@ -56,7 +57,8 @@ export function loadSession(): SessionSnapshot | null {
       return parsed as SessionSnapshot;
     }
     return null;
-  } catch {
+  } catch (err) {
+    logCaughtError('sessionPersistence.loadSession', err);
     return null;
   }
 }
@@ -78,7 +80,8 @@ export function isSessionStale(
 export function clearSession(): void {
   try {
     localStorage.removeItem(SESSION_KEY);
-  } catch {
+  } catch (err) {
     // Ignore
+    logCaughtError('sessionPersistence.clearSession', err);
   }
 }

--- a/src/services/settings/settingsDb.ts
+++ b/src/services/settings/settingsDb.ts
@@ -4,6 +4,8 @@
  * Follows the same singleton + initPromise + in-memory fallback pattern as libraryCache.ts.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
+
 export const STORE_NAMES = { PINS: 'pins' } as const;
 
 const DB_NAME = 'vorbis-player-settings';
@@ -64,7 +66,8 @@ export async function settingsGet<T>(store: string, key: string): Promise<T | un
   }
   try {
     return await idbGet<T>(store, key);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsGet', err);
     return fallbackStores[store]?.get(key) as T | undefined;
   }
 }
@@ -78,7 +81,8 @@ export async function settingsPut<T extends { key: string }>(store: string, valu
   }
   try {
     await idbPut(store, value);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsPut', err);
     ensureFallbackStore(store);
     fallbackStores[store].set(value.key, value);
   }
@@ -92,7 +96,8 @@ export async function settingsClearStore(store: string): Promise<void> {
   }
   try {
     await idbClear(store);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsClearStore', err);
     fallbackStores[store]?.clear();
   }
 }

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -7,6 +7,7 @@ import { albumSavedCache, trackListCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSI
 import { formatArtists, transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import * as libraryCache from '../cache/libraryCache';
 import { ALBUM_ID_PREFIX } from '@/constants/playlist';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Shared Helpers
@@ -61,8 +62,9 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
       trackListCache.set(cacheKey, { data: tracks, timestamp: idbCached.timestamp });
       return tracksToMediaTracks(tracks);
     }
-  } catch {
+  } catch (err) {
     // IndexedDB read failed, continue to API fetch
+    logCaughtError('spotify.albums.getAlbumTracks.idbRead', err);
   }
 
   // L3: Fetch from Spotify API

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -1,5 +1,6 @@
 import type { TokenData } from './types';
 import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 
@@ -55,7 +56,8 @@ class SpotifyAuth {
         return;
       }
       this.tokenData = tokenData;
-    } catch {
+    } catch (err) {
+      logCaughtError('spotify.auth.loadTokenFromStorage', err);
       localStorage.removeItem('spotify_token');
     }
   }

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -6,6 +6,7 @@ import { trackListCache, albumSavedCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSI
 import { transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import { type SavedAlbumItem, transformSavedAlbumItem } from './albums';
 import * as libraryCache from '../cache/libraryCache';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Callback Types
@@ -108,8 +109,9 @@ export async function getPlaylistTracks(playlistId: string): Promise<MediaTrack[
       trackListCache.set(cacheKey, { data: tracks, timestamp: idbCached.timestamp });
       return tracksToMediaTracks(tracks);
     }
-  } catch {
+  } catch (err) {
     // IndexedDB read failed, continue to API fetch
+    logCaughtError('spotify.playlists.getPlaylistTracks.idbRead', err);
   }
 
   // L3: Fetch from Spotify API

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -16,6 +16,7 @@ import {
   setLikedSongsCache,
 } from './cache';
 import * as libraryCache from '../cache/libraryCache';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Shared Utilities
@@ -118,7 +119,10 @@ export async function getLikedSongs(limit?: number): Promise<MediaTrack[]> {
         setLikedSongsCache({ data: idbCached.tracks, limit: Infinity, timestamp: idbCached.timestamp });
         return tracksToMediaTracks(idbCached.tracks);
       }
-    } catch { /* IndexedDB unavailable — fall through to API */ }
+    } catch (err) {
+      /* IndexedDB unavailable — fall through to API */
+      logCaughtError('spotify.tracks.getLikedSongs.idbRead', err);
+    }
   }
 
   const token = await spotifyAuth.ensureValidToken();

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -2,6 +2,7 @@ import { spotifyAuth } from './spotify';
 import { AuthExpiredError } from '@/providers/errors';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logSpotify } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import {
   SPOTIFY_MAX_RETRIES,
   SPOTIFY_INITIAL_RETRY_DELAY_MS,
@@ -178,8 +179,9 @@ class SpotifyPlayerService {
     if (!isIOS) {
       try {
         await this.player.setVolume(volume);
-      } catch {
+      } catch (err) {
         // SDK setVolume failed; fall through to debounced API call
+        logCaughtError('spotifyPlayer.setVolume', err);
       }
     }
 
@@ -299,7 +301,7 @@ class SpotifyPlayerService {
 
       if (state) {
         if (state.paused && state.position === 0) {
-          try { await this.resume(); } catch { /* ignore */ }
+          try { await this.resume(); } catch (err) { /* ignore */ logCaughtError('spotifyPlayer.waitForPlaybackOrResume.onStateChange.resume', err); }
         }
       } else {
         await activateDevice();
@@ -318,7 +320,7 @@ class SpotifyPlayerService {
         const state = await this.getCurrentState();
         if (state) {
           if (state.paused && state.position === 0) {
-            try { await this.resume(); } catch { /* ignore */ }
+            try { await this.resume(); } catch (err) { /* ignore */ logCaughtError('spotifyPlayer.waitForPlaybackOrResume.timeout.resume', err); }
           }
         } else {
           await activateDevice();

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -2,6 +2,7 @@ import { spotifyAuth } from './spotify';
 import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 import { TRANSFER_RETRY_DELAY_MS } from '@/constants/timing';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 async function parsePlayError(response: Response): Promise<string> {
   const errorText = await response.text();
@@ -10,7 +11,8 @@ async function parsePlayError(response: Response): Promise<string> {
     const json = JSON.parse(errorText);
     if (json.error?.message) reason = ` - ${json.error.message}`;
     if (json.error?.reason) reason += ` (${json.error.reason})`;
-  } catch {
+  } catch (err) {
+    logCaughtError('spotifyPlayerPlayback.parsePlayError', err);
     reason = errorText ? ` - ${errorText}` : '';
   }
   if (response.status === 429) {

--- a/src/utils/__tests__/logCaughtError.test.ts
+++ b/src/utils/__tests__/logCaughtError.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logCaughtError } from '../logCaughtError';
+
+describe('logCaughtError', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns with the contextual tag in dev', () => {
+    // #given
+    const err = new Error('boom');
+
+    // #when
+    logCaughtError('test.context', err);
+
+    // #then — vitest runs with import.meta.env.DEV === true
+    expect(warnSpy).toHaveBeenCalledWith('[test.context]', err);
+  });
+
+  it('forwards the error value verbatim', () => {
+    // #given
+    const err = { code: 42, message: 'kapow' };
+
+    // #when
+    logCaughtError('another.context', err);
+
+    // #then
+    expect(warnSpy).toHaveBeenCalledWith('[another.context]', err);
+  });
+});

--- a/src/utils/id3Parser.ts
+++ b/src/utils/id3Parser.ts
@@ -4,6 +4,8 @@
  * Extracts title, artist, album, and embedded cover art (APIC/PIC frames).
  */
 
+import { logCaughtError } from './logCaughtError';
+
 interface AudioMetadata {
   title?: string;
   artist?: string;
@@ -203,8 +205,9 @@ function parseFlac(bytes: Uint8Array): AudioMetadata {
             const dataLen = (picBytes[p] << 24) | (picBytes[p+1] << 16) | (picBytes[p+2] << 8) | picBytes[p+3];
             p += 4;
             result.coverArt = { data: picBytes.slice(p, p + dataLen), mimeType };
-          } catch {
+          } catch (err) {
             // malformed picture block — skip
+            logCaughtError('id3Parser.pictureBlock', err);
           }
         }
       }

--- a/src/utils/libraryFirstSeen.ts
+++ b/src/utils/libraryFirstSeen.ts
@@ -1,4 +1,5 @@
 import type { ProviderId } from '@/types/domain';
+import { logCaughtError } from './logCaughtError';
 
 /**
  * Stable "added to this app" time for catalog-backed collections (e.g. Dropbox)
@@ -20,7 +21,8 @@ export function getOrSetFirstSeenAddedAtIso(
     const now = new Date(Date.now() - ordinalForNew * 60000).toISOString();
     window.localStorage.setItem(key, now);
     return now;
-  } catch {
+  } catch (err) {
+    logCaughtError('libraryFirstSeen.getOrSetFirstSeenAddedAtIso', err);
     return new Date(Date.now() - ordinalForNew * 60000).toISOString();
   }
 }

--- a/src/utils/logCaughtError.ts
+++ b/src/utils/logCaughtError.ts
@@ -1,0 +1,6 @@
+export function logCaughtError(context: string, err: unknown): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(`[${context}]`, err);
+  }
+}


### PR DESCRIPTION
## Summary
- Added `logCaughtError(context, err)` helper for dev-time diagnostics at empty-catch sites
- Converted every previously-empty catch to call the helper with a contextual tag, preserving existing rationale comments
- Updated CLAUDE.md / comments rule to require the helper at empty-catch sites going forward

## Test plan
- `npx tsc -b --noEmit` passes
- `npm run test:run` passes
- Manual: trigger a known silent-failure path (e.g. autoplay rejection) in dev and observe the warning surface

Closes #1483