### PR TITLE
refactor(useLibrarySync): split engine and catalog paths into focused hooks

### DIFF
--- a/src/hooks/__tests__/useCatalogLibrarySync.test.ts
+++ b/src/hooks/__tests__/useCatalogLibrarySync.test.ts
@@ -1,0 +1,268 @@
+import 'fake-indexeddb/auto';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { MediaCollection, ProviderId } from '@/types/domain';
+
+const mockGetDescriptor = vi.fn();
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => ({
+    enabledProviderIds: [] as ProviderId[],
+    getDescriptor: mockGetDescriptor,
+  }),
+}));
+
+const mockRegistryGet = vi.fn();
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: (...args: unknown[]) => mockRegistryGet(...args),
+    getAll: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('@/utils/libraryFirstSeen', () => ({
+  getOrSetFirstSeenAddedAtIso: vi.fn().mockReturnValue('2024-01-01T00:00:00.000Z'),
+}));
+
+vi.mock('@/services/cache/likedCountSnapshot', () => ({
+  readLikedCountSnapshots: vi.fn().mockReturnValue({}),
+  writeLikedCountSnapshot: vi.fn(),
+}));
+
+import { useCatalogLibrarySync } from '../useCatalogLibrarySync';
+
+function makeCatalogDescriptor(
+  id: ProviderId,
+  collections: MediaCollection[],
+  likedCount = 0,
+  getLikedCount?: () => Promise<number>,
+) {
+  return {
+    id,
+    catalog: {
+      providerId: id,
+      listCollections: vi.fn().mockResolvedValue(collections),
+      listTracks: vi.fn().mockResolvedValue([]),
+      getLikedCount: getLikedCount ?? vi.fn().mockResolvedValue(likedCount),
+    },
+    auth: {
+      providerId: id,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      getAccessToken: vi.fn(),
+      beginLogin: vi.fn(),
+      handleCallback: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+}
+
+function makeCollection(id: string, kind: 'playlist' | 'album' | 'folder' = 'playlist'): MediaCollection {
+  return {
+    id,
+    provider: 'dropbox' as ProviderId,
+    kind,
+    name: `Collection ${id}`,
+    description: null,
+    imageUrl: null,
+    trackCount: 5,
+    ownerName: null,
+    releaseDate: null,
+    revision: null,
+  };
+}
+
+describe('useCatalogLibrarySync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistryGet.mockReturnValue(undefined);
+  });
+
+  it('returns empty state when no provider ids are passed', () => {
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync([] as readonly ProviderId[]));
+
+    // #then
+    expect(result.current.playlists).toEqual([]);
+    expect(result.current.albums).toEqual([]);
+    expect(result.current.totalLikedCount).toBe(0);
+    expect(result.current.allMusicCount).toBe(0);
+    expect(result.current.likedCounts).toEqual([]);
+  });
+
+  it('invokes listCollections for each provided id and exposes the merged result', async () => {
+    // #given
+    const dropboxAlbum = makeCollection('a-1', 'album');
+    const dropboxFolder = makeCollection('f-1', 'folder');
+    const dropboxDescriptor = makeCatalogDescriptor('dropbox', [dropboxAlbum, dropboxFolder], 9);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? dropboxDescriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(dropboxDescriptor.catalog.listCollections).toHaveBeenCalled();
+      expect(result.current.albums.some(a => a.name === 'Collection a-1')).toBe(true);
+      expect(result.current.playlists.some(p => p.name === 'Collection f-1')).toBe(true);
+      expect(result.current.totalLikedCount).toBe(9);
+      expect(result.current.likedCounts).toEqual([{ provider: 'dropbox', count: 9 }]);
+    });
+  });
+
+  it('skips an unauthenticated provider without calling listCollections', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', [], 0);
+    descriptor.auth.isAuthenticated.mockReturnValue(false);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => expect(result.current.playlists).toEqual([]));
+    expect(descriptor.catalog.listCollections).not.toHaveBeenCalled();
+    expect(result.current.syncState.error).toBeNull();
+  });
+
+  it('records syncError when listCollections throws', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', []);
+    descriptor.catalog.listCollections.mockRejectedValue(new Error('Catalog unavailable'));
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.syncState.error).toBe('Catalog unavailable');
+    });
+  });
+
+  it('extracts the Dropbox All-Music aggregate row into allMusicCount', async () => {
+    // #given
+    const allMusicRow: MediaCollection = {
+      ...makeCollection('a-1', 'album'),
+      id: '',
+      trackCount: 1234,
+    };
+    const realPlaylist = makeCollection('f-1', 'folder');
+    const descriptor = makeCatalogDescriptor('dropbox', [allMusicRow, realPlaylist]);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.allMusicCount).toBe(1234);
+      expect(result.current.playlists.some(p => p.id === '')).toBe(false);
+    });
+  });
+
+  it('reacts to the registered likes-changed event by re-fetching the liked count', async () => {
+    // #given
+    const getLikedCount = vi.fn().mockResolvedValue(3);
+    const descriptor = makeCatalogDescriptor('dropbox', [], 3, getLikedCount);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+    mockRegistryGet.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? { likesChangedEvent: 'vorbis-test-likes-changed' } : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => expect(descriptor.catalog.listCollections).toHaveBeenCalled());
+
+    getLikedCount.mockResolvedValue(11);
+
+    // #when
+    act(() => {
+      window.dispatchEvent(new Event('vorbis-test-likes-changed'));
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.totalLikedCount).toBeGreaterThanOrEqual(11);
+    });
+  });
+
+  it('refresh forces listCollections to re-run with forceRefresh', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', [], 4);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => expect(descriptor.catalog.listCollections).toHaveBeenCalledTimes(1));
+
+    // #when
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // #then
+    expect(descriptor.catalog.listCollections).toHaveBeenCalledTimes(2);
+    expect(descriptor.catalog.listCollections.mock.calls[1][1]).toEqual({ forceRefresh: true });
+  });
+
+  it('refresh scoped to one provider does not refetch other providers', async () => {
+    // #given
+    const dropbox = makeCatalogDescriptor('dropbox', [], 4);
+    const apple = makeCatalogDescriptor('apple' as ProviderId, [], 5);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? dropbox : id === ('apple' as ProviderId) ? apple : undefined,
+    );
+
+    const { result } = renderHook(() =>
+      useCatalogLibrarySync(['dropbox', 'apple' as ProviderId] as readonly ProviderId[]),
+    );
+    await waitFor(() => {
+      expect(dropbox.catalog.listCollections).toHaveBeenCalledTimes(1);
+      expect(apple.catalog.listCollections).toHaveBeenCalledTimes(1);
+    });
+
+    // #when
+    await act(async () => {
+      await result.current.refresh('dropbox' as ProviderId);
+    });
+
+    // #then
+    expect(dropbox.catalog.listCollections).toHaveBeenCalledTimes(2);
+    expect(apple.catalog.listCollections).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeCollection drops a collection from the merged output', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor(
+      'dropbox',
+      [makeCollection('keep', 'folder'), makeCollection('drop', 'folder')],
+    );
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => {
+      expect(result.current.playlists.some(p => p.id === 'drop')).toBe(true);
+    });
+
+    // #when
+    act(() => {
+      result.current.removeCollection('drop');
+    });
+
+    // #then
+    expect(result.current.playlists.some(p => p.id === 'drop')).toBe(false);
+    expect(result.current.playlists.some(p => p.id === 'keep')).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useEngineLibrarySync.test.ts
+++ b/src/hooks/__tests__/useEngineLibrarySync.test.ts
@@ -1,0 +1,224 @@
+import 'fake-indexeddb/auto';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { CachedPlaylistInfo, SyncState } from '../../services/cache/cacheTypes';
+import type { AlbumInfo, SpotifyImage } from '../../services/spotify';
+import type { ProviderId } from '@/types/domain';
+
+const { mockSubscribe, mockStart, mockStop, mockSyncNow } = vi.hoisted(() => ({
+  mockSubscribe: vi.fn(),
+  mockStart: vi.fn(),
+  mockStop: vi.fn(),
+  mockSyncNow: vi.fn(),
+}));
+
+vi.mock('../../services/cache/librarySyncEngine', () => ({
+  spotifyLibrarySyncEngine: {
+    providerId: 'spotify',
+    subscribe: mockSubscribe,
+    start: mockStart,
+    stop: mockStop,
+    syncNow: mockSyncNow,
+  },
+}));
+
+import { useEngineLibrarySync } from '../useEngineLibrarySync';
+
+function makePlaylist(id: string, name?: string): CachedPlaylistInfo {
+  return {
+    id,
+    name: name ?? `Playlist ${id}`,
+    description: null,
+    images: [] as SpotifyImage[],
+    tracks: { total: 10 },
+    owner: { display_name: 'TestUser' },
+  };
+}
+
+function makeAlbum(id: string, name?: string): AlbumInfo {
+  return {
+    id,
+    name: name ?? `Album ${id}`,
+    artists: 'Test Artist',
+    images: [] as SpotifyImage[],
+    release_date: '2024-01-01',
+    total_tracks: 12,
+    uri: `spotify:album:${id}`,
+  };
+}
+
+describe('useEngineLibrarySync', () => {
+  let capturedListener: ((state: SyncState, pl?: CachedPlaylistInfo[], al?: AlbumInfo[], lc?: number) => void) | null = null;
+  let unsubscribeFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedListener = null;
+    unsubscribeFn = vi.fn();
+
+    mockSubscribe.mockImplementation((listener: typeof capturedListener) => {
+      capturedListener = listener;
+      listener!({
+        isInitialLoadComplete: false,
+        isSyncing: false,
+        lastSyncTimestamp: null,
+        error: null,
+      });
+      return unsubscribeFn;
+    });
+    mockStart.mockResolvedValue(undefined);
+    mockSyncNow.mockResolvedValue(undefined);
+  });
+
+  it('does not subscribe when engineProviderId is undefined', () => {
+    // #when
+    renderHook(() => useEngineLibrarySync(undefined));
+
+    // #then
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('returns empty data when engineProviderId is undefined', () => {
+    // #when
+    const { result } = renderHook(() => useEngineLibrarySync(undefined));
+
+    // #then
+    expect(result.current.playlists).toEqual([]);
+    expect(result.current.albums).toEqual([]);
+    expect(result.current.likedCount).toBe(0);
+  });
+
+  it('subscribes to the engine and starts on mount when a provider id is given', () => {
+    // #when
+    renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #then
+    expect(mockSubscribe).toHaveBeenCalledOnce();
+    expect(mockStart).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes on unmount but does not stop the engine', () => {
+    // #given
+    const { unmount } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    unmount();
+
+    // #then
+    expect(unsubscribeFn).toHaveBeenCalledOnce();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('updates playlists/albums/likedCount when the engine emits new data', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1', 'My Playlist')],
+        [makeAlbum('a1', 'My Album')],
+        42,
+      );
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.playlists).toHaveLength(1);
+      expect(result.current.playlists[0].name).toBe('My Playlist');
+      expect(result.current.albums[0].name).toBe('My Album');
+      expect(result.current.likedCount).toBe(42);
+      expect(result.current.syncState.isInitialLoadComplete).toBe(true);
+    });
+  });
+
+  it('stamps the engine providerId onto playlists and albums', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1')],
+        [makeAlbum('a1')],
+        0,
+      );
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.playlists[0].provider).toBe('spotify');
+      expect(result.current.albums[0].provider).toBe('spotify');
+    });
+  });
+
+  it('refresh calls syncNow when an engine is active', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    await result.current.refresh();
+
+    // #then
+    expect(mockSyncNow).toHaveBeenCalledOnce();
+  });
+
+  it('refresh is a no-op when no engine provider is active', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync(undefined));
+
+    // #when
+    await result.current.refresh();
+
+    // #then
+    expect(mockSyncNow).not.toHaveBeenCalled();
+  });
+
+  it('keeps initialLoadComplete sticky once the engine emits true', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+      );
+    });
+    await waitFor(() => expect(result.current.syncState.isInitialLoadComplete).toBe(true));
+
+    // #when — engine emits a later state with isInitialLoadComplete: false
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: false, isSyncing: true, lastSyncTimestamp: 1000, error: null },
+      );
+    });
+
+    // #then — sticky stays true
+    await waitFor(() => expect(result.current.syncState.isInitialLoadComplete).toBe(true));
+  });
+
+  it('removeCollection optimistically drops a playlist by id', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1', 'Keep'), makePlaylist('p2', 'Drop')],
+        [],
+        0,
+      );
+    });
+    await waitFor(() => expect(result.current.playlists).toHaveLength(2));
+
+    // #when
+    act(() => {
+      result.current.removeCollection('p2');
+    });
+
+    // #then
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.playlists[0].id).toBe('p1');
+  });
+});

--- a/src/hooks/useCatalogLibrarySync.ts
+++ b/src/hooks/useCatalogLibrarySync.ts
@@ -1,0 +1,307 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { MediaCollection, ProviderId } from '@/types/domain';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { providerRegistry } from '@/providers/registry';
+import { logLibrary } from '@/lib/debugLog';
+import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
+import { writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { useStableSet } from '@/hooks/useStableSet';
+
+export interface PerProviderLikedCount {
+  provider: ProviderId;
+  count: number;
+}
+
+export interface CatalogLibrarySyncResult {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCounts: PerProviderLikedCount[];
+  totalLikedCount: number;
+  allMusicCount: number;
+  syncState: SyncState;
+  refresh: (scopeProviderId?: ProviderId) => Promise<void>;
+  removeCollection: (collectionId: string) => void;
+}
+
+interface PerProviderData {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCount: number;
+  allMusicCount: number;
+}
+
+const INITIAL_SYNC_STATE: SyncState = {
+  isInitialLoadComplete: false,
+  isSyncing: false,
+  lastSyncTimestamp: null,
+  error: null,
+};
+
+function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
+  const images: { url: string; height: number | null; width: number | null }[] = c.imageUrl
+    ? [{ url: c.imageUrl, height: null, width: null }]
+    : [];
+
+  return {
+    id: c.id,
+    name: c.name,
+    description: c.description ?? null,
+    images,
+    tracks: c.trackCount != null ? { total: c.trackCount } : null,
+    owner: c.ownerName ? { display_name: c.ownerName } : null,
+    snapshot_id: c.revision ?? undefined,
+    provider: c.provider,
+    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `playlist:${c.id}`, ordinal),
+    mosaicAlbumPaths: c.mosaicAlbumPaths,
+  };
+}
+
+function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
+  return {
+    id: c.id,
+    name: c.name,
+    artists: c.ownerName ?? '',
+    images: c.imageUrl ? [{ url: c.imageUrl, height: null, width: null }] : [],
+    release_date: c.releaseDate ?? '',
+    total_tracks: c.trackCount ?? 0,
+    uri: '',
+    album_type: c.kind === 'folder' ? 'folder' : 'album',
+    provider: c.provider,
+    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `album:${c.id}`, ordinal),
+  };
+}
+
+/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
+function isAllMusicCollection(c: MediaCollection): boolean {
+  return c.provider === 'dropbox' && c.id === '';
+}
+
+function splitCollections(collections: MediaCollection[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  allMusicCount: number;
+} {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  let playlistOrdinal = 0;
+  let albumOrdinal = 0;
+  let allMusicCount = 0;
+  for (const c of collections) {
+    if (isAllMusicCollection(c)) {
+      allMusicCount = c.trackCount ?? 0;
+      continue;
+    }
+    if (c.kind === 'album') {
+      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
+    } else {
+      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
+    }
+  }
+  return { playlists, albums, allMusicCount };
+}
+
+function aggregate(map: Map<ProviderId, PerProviderData>, enabled: readonly ProviderId[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCounts: PerProviderLikedCount[];
+  totalLikedCount: number;
+  allMusicCount: number;
+} {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  const likedCounts: PerProviderLikedCount[] = [];
+  let totalLikedCount = 0;
+  let allMusicCount = 0;
+  for (const [providerId, data] of map) {
+    if (!enabled.includes(providerId)) continue;
+    playlists.push(...data.playlists);
+    albums.push(...data.albums);
+    totalLikedCount += data.likedCount;
+    allMusicCount += data.allMusicCount;
+    if (data.likedCount > 0) {
+      likedCounts.push({ provider: providerId, count: data.likedCount });
+    }
+  }
+  return { playlists, albums, likedCounts, totalLikedCount, allMusicCount };
+}
+
+/**
+ * Hook for the catalog-adapter path (any provider that exposes
+ * `descriptor.catalog.listCollections`).
+ *
+ * Owns the per-provider listCollections effect, the likes-changed event
+ * listeners, and the in-memory data store.
+ *
+ * The input array is stabilized internally via `useStableSet`, so callers
+ * may pass a fresh array each render without re-firing the load effect.
+ */
+export function useCatalogLibrarySync(catalogProviderIdsInput: readonly ProviderId[]): CatalogLibrarySyncResult {
+  const catalogProviderIds = useStableSet(catalogProviderIdsInput);
+  const { getDescriptor } = useProviderContext();
+  const [aggregated, setAggregated] = useState<{
+    playlists: CachedPlaylistInfo[];
+    albums: AlbumInfo[];
+    likedCounts: PerProviderLikedCount[];
+    totalLikedCount: number;
+    allMusicCount: number;
+  }>(() => ({ playlists: [], albums: [], likedCounts: [], totalLikedCount: 0, allMusicCount: 0 }));
+  const [syncState, setSyncState] = useState<SyncState>(INITIAL_SYNC_STATE);
+
+  const dataRef = useRef<Map<ProviderId, PerProviderData>>(new Map());
+  const enabledRef = useRef<readonly ProviderId[]>(catalogProviderIds);
+  enabledRef.current = catalogProviderIds;
+
+  const recomputeAggregate = useCallback(() => {
+    setAggregated(aggregate(dataRef.current, enabledRef.current));
+  }, []);
+
+  useEffect(() => {
+    if (catalogProviderIds.length === 0) {
+      dataRef.current.clear();
+      recomputeAggregate();
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function loadProviderCollections(providerId: ProviderId) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      const auth = descriptor?.auth;
+      if (!catalog || !auth || !auth.isAuthenticated()) {
+        dataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
+        return;
+      }
+
+      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
+
+      try {
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(controller.signal),
+          catalog.getLikedCount ? catalog.getLikedCount(controller.signal) : Promise.resolve(0),
+        ]);
+        if (cancelled) return;
+
+        logLibrary('[%s] raw collections from catalog: %o', providerId,
+          collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
+
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        logLibrary('[%s] after splitCollections — playlists: %o', providerId,
+          playlists.map(p => ({ name: p.name, tracks: p.tracks })));
+        logLibrary('[%s] after splitCollections — albums: %o', providerId,
+          albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
+        dataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
+        writeLikedCountSnapshot(providerId, likedCount);
+        recomputeAggregate();
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          lastSyncTimestamp: Date.now(),
+        }));
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.error(`[useCatalogLibrarySync] Failed to load collections for ${providerId}:`, err);
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          error: err instanceof Error ? err.message : 'Failed to load library',
+        }));
+      }
+    }
+
+    Promise.all(catalogProviderIds.map(loadProviderCollections)).catch(() => {});
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  useEffect(() => {
+    const cleanups: Array<() => void> = [];
+    for (const providerId of catalogProviderIds) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      if (!catalog?.getLikedCount) continue;
+
+      const registryDescriptor = providerRegistry.get(providerId);
+      const eventName = registryDescriptor?.likesChangedEvent;
+      if (!eventName) continue;
+
+      const handleLikesChanged = () => {
+        catalog.getLikedCount!().then(count => {
+          const data = dataRef.current.get(providerId);
+          if (data) {
+            data.likedCount = count;
+            recomputeAggregate();
+          }
+        }).catch(() => {});
+      };
+
+      window.addEventListener(eventName, handleLikesChanged);
+      cleanups.push(() => window.removeEventListener(eventName, handleLikesChanged));
+    }
+    return () => cleanups.forEach(cleanup => cleanup());
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  const refresh = useCallback(async (scopeProviderId?: ProviderId) => {
+    const providerIdsToRefresh = scopeProviderId
+      ? catalogProviderIds.filter(id => id === scopeProviderId)
+      : catalogProviderIds;
+
+    for (const providerId of providerIdsToRefresh) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      if (!catalog) continue;
+
+      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
+      try {
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(undefined, { forceRefresh: true }),
+          catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
+        ]);
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        dataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
+        writeLikedCountSnapshot(providerId, likedCount);
+        recomputeAggregate();
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          lastSyncTimestamp: Date.now(),
+        }));
+      } catch (err) {
+        setSyncState(prev => ({
+          ...prev,
+          isSyncing: false,
+          error: err instanceof Error ? err.message : 'Refresh failed',
+        }));
+      }
+    }
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  const removeCollection = useCallback((collectionId: string) => {
+    for (const [, data] of dataRef.current) {
+      data.playlists = data.playlists.filter(p => p.id !== collectionId);
+      data.albums = data.albums.filter(a => a.id !== collectionId);
+    }
+    recomputeAggregate();
+  }, [recomputeAggregate]);
+
+  return {
+    playlists: aggregated.playlists,
+    albums: aggregated.albums,
+    likedCounts: aggregated.likedCounts,
+    totalLikedCount: aggregated.totalLikedCount,
+    allMusicCount: aggregated.allMusicCount,
+    syncState,
+    refresh,
+    removeCollection,
+  };
+}

--- a/src/hooks/useEngineLibrarySync.ts
+++ b/src/hooks/useEngineLibrarySync.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { ProviderId } from '@/types/domain';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { logLibrary } from '@/lib/debugLog';
+
+export interface EngineLibrarySyncResult {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCount: number;
+  syncState: SyncState;
+  refresh: () => Promise<void>;
+  removeCollection: (collectionId: string) => void;
+}
+
+const INITIAL_SYNC_STATE: SyncState = {
+  isInitialLoadComplete: false,
+  isSyncing: false,
+  lastSyncTimestamp: null,
+  error: null,
+};
+
+/**
+ * Hook for the library-sync-engine path (currently Spotify only).
+ *
+ * Owns the `spotifyLibrarySyncEngine.subscribe(...)` lifecycle and exposes the most
+ * recent playlists/albums/likedCount snapshot the engine has emitted.
+ *
+ * When `engineProviderId` is undefined or disabled, the hook returns empty
+ * data and does not subscribe.
+ */
+export function useEngineLibrarySync(engineProviderId: ProviderId | undefined): EngineLibrarySyncResult {
+  const [playlists, setPlaylists] = useState<CachedPlaylistInfo[]>([]);
+  const [albums, setAlbums] = useState<AlbumInfo[]>([]);
+  const [likedCount, setLikedCount] = useState(0);
+  const [syncState, setSyncState] = useState<SyncState>(INITIAL_SYNC_STATE);
+
+  const engineRef = useRef(spotifyLibrarySyncEngine);
+
+  useEffect(() => {
+    if (!engineProviderId) {
+      setPlaylists([]);
+      setAlbums([]);
+      setLikedCount(0);
+      return;
+    }
+
+    const engine = engineRef.current;
+    const epId = engineProviderId;
+
+    const unsubscribe = engine.subscribe((state, newPlaylists, newAlbums, newLikedCount) => {
+      setSyncState(prev => ({
+        ...prev,
+        ...state,
+        isInitialLoadComplete: prev.isInitialLoadComplete || state.isInitialLoadComplete,
+      }));
+      if (newPlaylists !== undefined) {
+        logLibrary('[%s] sync engine playlists: %o', epId,
+          newPlaylists.map(p => ({ name: p.name, tracks: p.tracks })));
+        setPlaylists(newPlaylists.map(p => ({ ...p, provider: epId })));
+      }
+      if (newAlbums !== undefined) {
+        setAlbums(newAlbums.map(a => ({ ...a, provider: epId })));
+      }
+      if (newLikedCount !== undefined) {
+        setLikedCount(newLikedCount);
+      }
+    });
+
+    engine.start().catch((err) => {
+      console.error('[useEngineLibrarySync] Failed to start sync engine:', err);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [engineProviderId]);
+
+  const refresh = useCallback(async () => {
+    if (!engineProviderId) return;
+    await engineRef.current.syncNow(true);
+  }, [engineProviderId]);
+
+  const removeCollection = useCallback((collectionId: string) => {
+    setPlaylists(prev => prev.filter(p => p.id !== collectionId));
+    setAlbums(prev => prev.filter(a => a.id !== collectionId));
+  }, []);
+
+  return {
+    playlists,
+    albums,
+    likedCount,
+    syncState,
+    refresh,
+    removeCollection,
+  };
+}

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -1,24 +1,16 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { AlbumInfo } from '@/services/spotify';
-import type { MediaCollection, ProviderId } from '@/types/domain';
+import type { ProviderId } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
-import { providerRegistry } from '@/providers/registry';
 import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
-import { logLibrary } from '@/lib/debugLog';
-import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
-import { readLikedCountSnapshots, writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
-import { useStableSet } from '@/hooks/useStableSet';
+import { readLikedCountSnapshots } from '@/services/cache/likedCountSnapshot';
+import { useEngineLibrarySync } from '@/hooks/useEngineLibrarySync';
+import { useCatalogLibrarySync, type PerProviderLikedCount } from '@/hooks/useCatalogLibrarySync';
 
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
-
-/** Per-provider liked songs count for rendering separate cards. */
-interface PerProviderLikedCount {
-  provider: ProviderId;
-  count: number;
-}
 
 interface UseLibrarySyncResult {
   playlists: CachedPlaylistInfo[];
@@ -40,328 +32,91 @@ interface UseLibrarySyncResult {
   removeCollection: (collectionId: string) => void;
 }
 
-function initLikedCountsFromSnapshot(): { total: number; perProvider: PerProviderLikedCount[] } {
+function initialLikedTotalFromSnapshot(): number {
   const snapshots = readLikedCountSnapshots();
-  const perProvider: PerProviderLikedCount[] = [];
   let total = 0;
-  for (const [provider, entry] of Object.entries(snapshots)) {
-    if (entry.count > 0) {
-      perProvider.push({ provider: provider as ProviderId, count: entry.count });
-      total += entry.count;
-    }
+  for (const entry of Object.values(snapshots)) {
+    if (entry.count > 0) total += entry.count;
   }
-  return { total, perProvider };
-}
-
-function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
-  const images: { url: string; height: number | null; width: number | null }[] = c.imageUrl
-    ? [{ url: c.imageUrl, height: null, width: null }]
-    : [];
-
-  return {
-    id: c.id,
-    name: c.name,
-    description: c.description ?? null,
-    images,
-    tracks: c.trackCount != null ? { total: c.trackCount } : null,
-    owner: c.ownerName ? { display_name: c.ownerName } : null,
-    snapshot_id: c.revision ?? undefined,
-    provider: c.provider,
-    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `playlist:${c.id}`, ordinal),
-    mosaicAlbumPaths: c.mosaicAlbumPaths,
-  };
-}
-
-function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
-  return {
-    id: c.id,
-    name: c.name,
-    artists: c.ownerName ?? '',
-    images: c.imageUrl ? [{ url: c.imageUrl, height: null, width: null }] : [],
-    release_date: c.releaseDate ?? '',
-    total_tracks: c.trackCount ?? 0,
-    uri: '',
-    album_type: c.kind === 'folder' ? 'folder' : 'album',
-    provider: c.provider,
-    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `album:${c.id}`, ordinal),
-  };
-}
-
-/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
-function isAllMusicCollection(c: MediaCollection): boolean {
-  return c.provider === 'dropbox' && c.id === '';
-}
-
-function splitCollections(collections: MediaCollection[]): {
-  playlists: CachedPlaylistInfo[];
-  albums: AlbumInfo[];
-  allMusicCount: number;
-} {
-  const playlists: CachedPlaylistInfo[] = [];
-  const albums: AlbumInfo[] = [];
-  let playlistOrdinal = 0;
-  let albumOrdinal = 0;
-  let allMusicCount = 0;
-  for (const c of collections) {
-    if (isAllMusicCollection(c)) {
-      allMusicCount = c.trackCount ?? 0;
-      continue;
-    }
-    if (c.kind === 'album') {
-      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
-    } else {
-      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
-    }
-  }
-  return { playlists, albums, allMusicCount };
+  return total;
 }
 
 export function useLibrarySync(): UseLibrarySyncResult {
-  const { enabledProviderIds, getDescriptor } = useProviderContext();
-  const initialSnapshot = useMemo(() => initLikedCountsFromSnapshot(), []);
-  const [playlists, setPlaylists] = useState<CachedPlaylistInfo[]>([]);
-  const [albums, setAlbums] = useState<AlbumInfo[]>([]);
-  const [likedSongsCount, setLikedSongsCount] = useState(() => initialSnapshot.total);
-  const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>(() => initialSnapshot.perProvider);
-  const [allMusicCount, setAllMusicCount] = useState(0);
-  const [syncState, setSyncState] = useState<SyncState>({
-    isInitialLoadComplete: false,
-    isSyncing: false,
-    lastSyncTimestamp: null,
-    error: null,
-  });
-
-  const engineRef = useRef(spotifyLibrarySyncEngine);
+  const { enabledProviderIds } = useProviderContext();
+  const initialLikedSnapshotTotal = useMemo(() => initialLikedTotalFromSnapshot(), []);
 
   // The sync engine talks directly to the real Spotify Web API. In mock mode,
-  // bypass it so the registry-aware catalog path (further down) loads spotify
-  // collections via the mock catalog adapter instead.
-  const engineProviderId: ProviderId | undefined = shouldUseMockProvider()
+  // bypass it so the registry-aware catalog path loads spotify collections
+  // via the mock catalog adapter instead.
+  const rawEngineProviderId: ProviderId | undefined = shouldUseMockProvider()
     ? undefined
     : spotifyLibrarySyncEngine.providerId;
+  const engineProviderId = rawEngineProviderId && enabledProviderIds.includes(rawEngineProviderId)
+    ? rawEngineProviderId
+    : undefined;
 
-  const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
-    playlists: [], albums: [], likedCount: 0,
-  });
-  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
+  const catalogProviderIds = enabledProviderIds.filter((id) => id !== rawEngineProviderId);
 
-  const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
-  // Stabilize catalogProviderIds so downstream effects don't re-fire when the
-  // parent renders with a new array reference for the same logical set.
-  const catalogProviderIds = useStableSet(
-    enabledProviderIds.filter((id) => id !== engineProviderId),
-  );
+  const engine = useEngineLibrarySync(engineProviderId);
+  const catalog = useCatalogLibrarySync(catalogProviderIds);
 
-  const mergeAndSetData = useCallback(() => {
-    const allPlaylists: CachedPlaylistInfo[] = [];
-    const allAlbums: AlbumInfo[] = [];
-    let totalLikedCount = 0;
-    let totalAllMusicCount = 0;
-    const perProvider: PerProviderLikedCount[] = [];
+  const merged = useMemo(() => {
+    const playlists: CachedPlaylistInfo[] = [];
+    const albums: AlbumInfo[] = [];
+    const likedSongsPerProvider: PerProviderLikedCount[] = [];
+    let likedSongsCount = 0;
 
-    if (isEngineProviderEnabled && engineProviderId) {
-      allPlaylists.push(...engineDataRef.current.playlists);
-      allAlbums.push(...engineDataRef.current.albums);
-      totalLikedCount += engineDataRef.current.likedCount;
-      if (engineDataRef.current.likedCount > 0) {
-        perProvider.push({ provider: engineProviderId, count: engineDataRef.current.likedCount });
+    if (engineProviderId) {
+      playlists.push(...engine.playlists);
+      albums.push(...engine.albums);
+      likedSongsCount += engine.likedCount;
+      if (engine.likedCount > 0) {
+        likedSongsPerProvider.push({ provider: engineProviderId, count: engine.likedCount });
       }
     }
 
-    for (const [providerId, data] of catalogDataRef.current) {
-      if (enabledProviderIds.includes(providerId)) {
-        allPlaylists.push(...data.playlists);
-        allAlbums.push(...data.albums);
-        totalLikedCount += data.likedCount;
-        totalAllMusicCount += data.allMusicCount;
-        if (data.likedCount > 0) {
-          perProvider.push({ provider: providerId, count: data.likedCount });
-        }
-      }
-    }
+    playlists.push(...catalog.playlists);
+    albums.push(...catalog.albums);
+    likedSongsCount += catalog.totalLikedCount;
+    likedSongsPerProvider.push(...catalog.likedCounts);
 
-    setPlaylists(allPlaylists);
-    setAlbums(allAlbums);
-    setLikedSongsCount(totalLikedCount);
-    setLikedSongsPerProvider(perProvider);
-    setAllMusicCount(totalAllMusicCount);
-  }, [isEngineProviderEnabled, engineProviderId, enabledProviderIds]);
+    return { playlists, albums, likedSongsCount, likedSongsPerProvider };
+  }, [
+    engineProviderId,
+    engine.playlists,
+    engine.albums,
+    engine.likedCount,
+    catalog.playlists,
+    catalog.albums,
+    catalog.totalLikedCount,
+    catalog.likedCounts,
+  ]);
 
-  useEffect(() => {
-    if (!isEngineProviderEnabled || !engineProviderId) {
-      engineDataRef.current = { playlists: [], albums: [], likedCount: 0 };
-      mergeAndSetData();
-      return;
-    }
+  const stickyInitialLoadRef = useRef(false);
+  const isInitialLoadComplete = stickyInitialLoadRef.current
+    || engine.syncState.isInitialLoadComplete
+    || catalog.syncState.isInitialLoadComplete;
+  if (isInitialLoadComplete) {
+    stickyInitialLoadRef.current = true;
+  }
 
-    const engine = engineRef.current;
-    const epId = engineProviderId;
+  const isSyncing = engine.syncState.isSyncing || catalog.syncState.isSyncing;
+  const lastSyncTimestamp = Math.max(
+    engine.syncState.lastSyncTimestamp ?? 0,
+    catalog.syncState.lastSyncTimestamp ?? 0,
+  ) || null;
+  const syncError = catalog.syncState.error ?? engine.syncState.error;
 
-    const unsubscribe = engine.subscribe((state, newPlaylists, newAlbums, newLikedCount) => {
-      setSyncState(prev => ({
-        ...prev,
-        ...state,
-        isInitialLoadComplete: prev.isInitialLoadComplete || state.isInitialLoadComplete,
-      }));
-      if (newPlaylists !== undefined) {
-        logLibrary('[%s] sync engine playlists: %o', epId,
-          newPlaylists.map(p => ({ name: p.name, tracks: p.tracks })));
-        engineDataRef.current.playlists = newPlaylists.map(p => ({ ...p, provider: epId }));
-      }
-      if (newAlbums !== undefined) {
-        engineDataRef.current.albums = newAlbums.map(a => ({ ...a, provider: epId }));
-      }
-      if (newLikedCount !== undefined) {
-        engineDataRef.current.likedCount = newLikedCount;
-      }
-      if (newPlaylists !== undefined || newAlbums !== undefined || newLikedCount !== undefined) {
-        mergeAndSetData();
-      }
-    });
-
-    engine.start().catch((err) => {
-      console.error('[useLibrarySync] Failed to start sync engine:', err);
-    });
-
-    return () => {
-      unsubscribe();
-    };
-  }, [isEngineProviderEnabled, engineProviderId, mergeAndSetData]);
-
-  useEffect(() => {
-    if (catalogProviderIds.length === 0) {
-      catalogDataRef.current.clear();
-      mergeAndSetData();
-      return;
-    }
-
-    let cancelled = false;
-    const controller = new AbortController();
-
-    async function loadProviderCollections(providerId: ProviderId) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      const auth = descriptor?.auth;
-      if (!catalog || !auth || !auth.isAuthenticated()) {
-        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
-        return;
-      }
-
-      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
-
-      try {
-        const [collections, likedCount] = await Promise.all([
-          catalog.listCollections(controller.signal),
-          catalog.getLikedCount ? catalog.getLikedCount(controller.signal) : Promise.resolve(0),
-        ]);
-        if (cancelled) return;
-
-        logLibrary('[%s] raw collections from catalog: %o', providerId,
-          collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
-
-        const { playlists, albums, allMusicCount } = splitCollections(collections);
-        logLibrary('[%s] after splitCollections — playlists: %o', providerId,
-          playlists.map(p => ({ name: p.name, tracks: p.tracks })));
-        logLibrary('[%s] after splitCollections — albums: %o', providerId,
-          albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
-        writeLikedCountSnapshot(providerId, likedCount);
-        mergeAndSetData();
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          lastSyncTimestamp: Date.now(),
-        }));
-      } catch (err) {
-        if (cancelled) return;
-        if (err instanceof DOMException && err.name === 'AbortError') return;
-        console.error(`[useLibrarySync] Failed to load collections for ${providerId}:`, err);
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          error: err instanceof Error ? err.message : 'Failed to load library',
-        }));
-      }
-    }
-
-    Promise.all(catalogProviderIds.map(loadProviderCollections)).catch(() => {});
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
-
-  useEffect(() => {
-    const cleanups: Array<() => void> = [];
-    for (const providerId of catalogProviderIds) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      if (!catalog?.getLikedCount) continue;
-
-      const registryDescriptor = providerRegistry.get(providerId);
-      const eventName = registryDescriptor?.likesChangedEvent;
-      if (!eventName) continue;
-
-      const handleLikesChanged = () => {
-        catalog.getLikedCount!().then(count => {
-          const data = catalogDataRef.current.get(providerId);
-          if (data) {
-            data.likedCount = count;
-            mergeAndSetData();
-          }
-        }).catch(() => {});
-      };
-
-      window.addEventListener(eventName, handleLikesChanged);
-      cleanups.push(() => window.removeEventListener(eventName, handleLikesChanged));
-    }
-    return () => cleanups.forEach(cleanup => cleanup());
-  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
-
+  const engineRefresh = engine.refresh;
+  const catalogRefresh = catalog.refresh;
   const refreshNow = useCallback(async (scopeProviderId?: ProviderId) => {
     if (!scopeProviderId || scopeProviderId === engineProviderId) {
-      if (isEngineProviderEnabled) {
-        await engineRef.current.syncNow(true);
-      }
+      await engineRefresh();
     }
-
-    const providerIdsToRefresh = scopeProviderId
-      ? catalogProviderIds.filter(id => id === scopeProviderId)
-      : catalogProviderIds;
-
-    for (const providerId of providerIdsToRefresh) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      if (!catalog) continue;
-
-      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
-      try {
-        const [collections, likedCount] = await Promise.all([
-          catalog.listCollections(undefined, { forceRefresh: true }),
-          catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
-        ]);
-        const { playlists, albums, allMusicCount } = splitCollections(collections);
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
-        writeLikedCountSnapshot(providerId, likedCount);
-        mergeAndSetData();
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          lastSyncTimestamp: Date.now(),
-        }));
-      } catch (err) {
-        setSyncState(prev => ({
-          ...prev,
-          isSyncing: false,
-          error: err instanceof Error ? err.message : 'Refresh failed',
-        }));
-      }
+    if (!scopeProviderId || scopeProviderId !== engineProviderId) {
+      await catalogRefresh(scopeProviderId);
     }
-  }, [isEngineProviderEnabled, engineProviderId, catalogProviderIds, getDescriptor, mergeAndSetData]);
+  }, [engineProviderId, engineRefresh, catalogRefresh]);
 
   useEffect(() => {
     const handleArtRefresh = () => { refreshNow().catch(() => {}); };
@@ -377,33 +132,28 @@ export function useLibrarySync(): UseLibrarySyncResult {
     };
   }, [refreshNow]);
 
+  const engineRemove = engine.removeCollection;
+  const catalogRemove = catalog.removeCollection;
   const removeCollection = useCallback((collectionId: string) => {
-    engineDataRef.current.playlists = engineDataRef.current.playlists.filter(p => p.id !== collectionId);
-    engineDataRef.current.albums = engineDataRef.current.albums.filter(a => a.id !== collectionId);
-
-    for (const [, data] of catalogDataRef.current) {
-      data.playlists = data.playlists.filter(p => p.id !== collectionId);
-      data.albums = data.albums.filter(a => a.id !== collectionId);
-    }
-
-    mergeAndSetData();
-  }, [mergeAndSetData]);
+    engineRemove(collectionId);
+    catalogRemove(collectionId);
+  }, [engineRemove, catalogRemove]);
 
   const isLikedSongsSyncing = enabledProviderIds.length > 0
-    && !syncState.isInitialLoadComplete
-    && initialSnapshot.total > 0;
+    && !isInitialLoadComplete
+    && initialLikedSnapshotTotal > 0;
 
   return {
-    playlists,
-    albums,
-    likedSongsCount,
-    likedSongsPerProvider,
-    allMusicCount,
-    isInitialLoadComplete: syncState.isInitialLoadComplete,
-    isSyncing: syncState.isSyncing,
+    playlists: merged.playlists,
+    albums: merged.albums,
+    likedSongsCount: merged.likedSongsCount,
+    likedSongsPerProvider: merged.likedSongsPerProvider,
+    allMusicCount: catalog.allMusicCount,
+    isInitialLoadComplete,
+    isSyncing,
     isLikedSongsSyncing,
-    lastSyncTimestamp: syncState.lastSyncTimestamp,
-    syncError: syncState.error,
+    lastSyncTimestamp,
+    syncError,
     refreshNow,
     removeCollection,
   };


### PR DESCRIPTION
## Summary
- Extracted `useEngineLibrarySync(engineProviderId)` for the `librarySyncEngine.subscribe(...)` path. Owns its own playlists/albums/likedCount state and the engine subscription lifecycle.
- Extracted `useCatalogLibrarySync(catalogProviderIds)` for the `descriptor.catalog.listCollections(...)` path. Owns the per-provider load effect, the `likesChangedEvent` listeners, and the in-memory data store.
- Rewrote `useLibrarySync()` as a thin composing hook: ~160 lines (down from 410). It calls the two child hooks, derives merged playlists/albums/liked counts via `useMemo`, and orchestrates `refreshNow` / `removeCollection`.
- The public return shape is byte-for-byte identical to the previous hook — no consumers needed updates.
- The `useStableSet` workaround moved from the parent into `useCatalogLibrarySync` itself. It still exists; it's now defensive at the seam where the array is consumed (the catalog load effect's dep array) instead of at the call-site. This makes the catalog hook robust regardless of how callers shape their input.
- `mergeAndSetData` is gone — there is no longer an imperative merge callback appearing in three dep arrays. Merging is now a derived `useMemo` over the children's outputs.

## Test plan
- `npx tsc -b --noEmit` passes.
- `npm run test:run` passes (1961 tests across 185 files).
- 23 existing tests in `useLibrarySync.test.ts` still pass without modification — confirming the public surface is unchanged.
- New colocated tests:
  - `useEngineLibrarySync.test.ts` — 10 tests covering subscribe/unsubscribe lifecycle, refresh, providerId stamping, sticky `isInitialLoadComplete`, and optimistic removal.
  - `useCatalogLibrarySync.test.ts` — 9 tests covering `listCollections` invocation, unauthenticated provider skip, error capture, All-Music aggregate extraction, likes-changed event handling, scoped refresh, and removal.

Closes #1495