### PR TITLE
release: 2026-05-08

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 - Container queries as primary responsive strategy, media queries as fallback
 - `useLocalStorage` hook for persistence with `'vorbis-player-'` key prefix
 - Strict TypeScript; `import type` when possible; types in `src/types/`
+- Empty `catch` blocks are permitted only when paired with `logCaughtError('<context>', err)` from `src/utils/logCaughtError.ts` so swallowed failures still surface in dev. Existing rationale comments inside the catch should stay; the helper call is additive.
 
 ## Testing
 

--- a/src/components/AppSettingsMenu/ProviderDataSection.tsx
+++ b/src/components/AppSettingsMenu/ProviderDataSection.tsx
@@ -4,6 +4,7 @@ import type { CatalogProvider } from '@/types/providers';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 import {
   ControlGroup,
@@ -49,7 +50,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       a.click();
       URL.revokeObjectURL(url);
       setResultMessage('Exported!');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.exportFn', err);
       setResultMessage('Export failed');
     }
   }, [catalog]);
@@ -61,7 +63,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       if (result.updated > 0) parts.push(`${result.updated} updated`);
       if (result.removed > 0) parts.push(`${result.removed} removed`);
       setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.refreshMetadataFn', err);
       setResultMessage('Refresh failed');
     }
   }, [catalog]);
@@ -80,7 +83,8 @@ export const ProviderDataSection = memo(({ providerName, catalog }: { providerNa
       const json = await file.text();
       const count = await catalog.importLikes!(json);
       setResultMessage(`Imported ${count} tracks`);
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataSection.handleImport', err);
       setResultMessage('Import failed');
     }
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { theme } from '@/styles/theme';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface LogEntry {
   time: string;
@@ -15,11 +16,11 @@ const TAP_WINDOW_MS = 2000;
 function isDebugEnabled(): boolean {
   if (typeof window === 'undefined') return false;
   if (new URLSearchParams(window.location.search).get('debug') === 'true') return true;
-  try { return localStorage.getItem(STORAGE_KEYS.DEBUG_OVERLAY) === 'true'; } catch { return false; }
+  try { return localStorage.getItem(STORAGE_KEYS.DEBUG_OVERLAY) === 'true'; } catch (err) { logCaughtError('DebugOverlay.isDebugEnabled', err); return false; }
 }
 
 function setDebugEnabled(enabled: boolean) {
-  try { localStorage.setItem(STORAGE_KEYS.DEBUG_OVERLAY, String(enabled)); } catch { /* noop */ }
+  try { localStorage.setItem(STORAGE_KEYS.DEBUG_OVERLAY, String(enabled)); } catch (err) { /* noop */ logCaughtError('DebugOverlay.setDebugEnabled', err); }
 }
 
 export function useDebugActivator() {

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -1,31 +1,11 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
-import { usePinnedItems } from '@/hooks/usePinnedItems';
-import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
-import { useLikedSection } from '../hooks';
 import type { ContextMenuRequest } from '../types';
 import type { ProviderId, MediaTrack } from '@/types/domain';
-import { useLikedTracksForProvider } from './useLikedTracksForProvider';
-import { useAlbumSavedStatus } from './useAlbumSavedStatus';
-import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
-import { toAlbumPlaylistId } from '@/constants/playlist';
-import {
-  buildMenuItems,
-  isMenuActionError,
-  type MenuActions,
-  type MenuItem,
-} from './menuItemsForKind';
+import { isMenuActionError } from './menuItemsForKind';
+import { useMenuItems, type UseMenuItemsCallbacks } from './useMenuItems';
 import { MenuItemButton, MenuRoot, VirtualAnchor } from './LibraryContextMenu.styled';
-
-const PROVIDER_LABEL: Record<string, string> = {
-  spotify: 'Spotify',
-  dropbox: 'Dropbox',
-};
-
-function providerLabel(provider: ProviderId): string {
-  return PROVIDER_LABEL[provider] ?? provider;
-}
 
 export interface LibraryContextMenuProps {
   request: ContextMenuRequest | null;
@@ -69,29 +49,7 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
   onPlayLikedTracks,
   onQueueLikedTracks,
 }) => {
-  const {
-    isPlaylistPinned,
-    isAlbumPinned,
-    togglePinPlaylist,
-    togglePinAlbum,
-  } = usePinnedItems();
-  const { remove: removeRecent } = useRecentlyPlayedCollections();
-  const { perProvider } = useLikedSection();
-  const { loadLikedTracks } = useLikedTracksForProvider();
-  const { queueLikedFromCollection } = useQueueLikedFromCollection(onQueueLikedTracks);
-
   const closeReasonRef = useRef<'return' | null>(null);
-
-  const albumIdForSaveStatus =
-    request?.kind === 'album'
-      ? request.id
-      : request?.kind === 'recently-played' && request.originalKind === 'album'
-        ? request.id
-        : null;
-  const { isSaved, toggleSaved, canToggle: canToggleSaved } = useAlbumSavedStatus(
-    albumIdForSaveStatus,
-    request?.provider,
-  );
 
   const closeAfter = useCallback(
     (label: string, fn: () => void | Promise<unknown>): (() => void) =>
@@ -137,126 +95,28 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
     }
   }, []);
 
-  const playNextDisabled = !onPlayNext;
-  const startRadioDisabled = !onStartRadioForCollection;
+  const callbacks = useMemo<UseMenuItemsCallbacks>(
+    () => ({
+      closeAfter,
+      onPlayCollection,
+      onAddToQueue,
+      onPlayNext,
+      onStartRadioForCollection,
+      onPlayLikedTracks,
+      onQueueLikedTracks,
+    }),
+    [
+      closeAfter,
+      onPlayCollection,
+      onAddToQueue,
+      onPlayNext,
+      onStartRadioForCollection,
+      onPlayLikedTracks,
+      onQueueLikedTracks,
+    ],
+  );
 
-  const items = useMemo<MenuItem[]>(() => {
-    if (!request) return [];
-
-    const effectiveKind: 'playlist' | 'album' | 'liked' =
-      request.kind === 'recently-played'
-        ? request.originalKind ?? 'playlist'
-        : (request.kind as 'playlist' | 'album' | 'liked');
-
-    const isPlaylistKind = effectiveKind === 'playlist';
-    const isAlbumKind = effectiveKind === 'album';
-    const isLikedKind = effectiveKind === 'liked';
-
-    const isPinned = isPlaylistKind
-      ? isPlaylistPinned(request.id)
-      : isAlbumKind
-        ? isAlbumPinned(request.id)
-        : false;
-
-    const togglePin = isPlaylistKind
-      ? () => togglePinPlaylist(request.id)
-      : () => togglePinAlbum(request.id);
-
-    const playLikedFor = async (provider: ProviderId) => {
-      const tracks = await loadLikedTracks(provider);
-      if (tracks.length === 0) return;
-      await onPlayLikedTracks(tracks, `liked-${provider}`, 'Liked Songs', provider);
-    };
-
-    const likedProviderActions = isLikedKind
-      ? perProvider.map((entry) => {
-          const entryLabel = `Play (${providerLabel(entry.provider)})`;
-          return {
-            provider: entry.provider,
-            label: entryLabel,
-            onPlay: closeAfter(entryLabel, () => playLikedFor(entry.provider)),
-          };
-        })
-      : undefined;
-
-    const actions: MenuActions = {
-      onPlay: closeAfter('Play', () => {
-        if (isLikedKind) {
-          // "Play All" routes through the library's own liked-handler via the parent.
-          const inferred = perProvider[0]?.provider;
-          if (inferred) void playLikedFor(inferred);
-          return;
-        }
-        if (isPlaylistKind || isAlbumKind) {
-          onPlayCollection(effectiveKind, request.id, request.name, request.provider);
-        }
-      }),
-      onAddToQueue: closeAfter('Add to Queue', () => {
-        if (onAddToQueue) {
-          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
-          onAddToQueue(id, request.name, request.provider);
-        }
-      }),
-      onPlayNext: closeAfter('Play Next', () => {
-        if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
-          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
-          onPlayNext(effectiveKind, id, request.name, request.provider);
-        }
-      }),
-      onTogglePin: closeAfter(isPinned ? 'Unpin' : 'Pin', togglePin),
-      onStartRadio: closeAfter('Start Radio', () => {
-        if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
-          onStartRadioForCollection(effectiveKind, request.id, request.provider);
-        }
-      }),
-      isPinned,
-      startRadioDisabled: startRadioDisabled || isLikedKind,
-      playNextDisabled: playNextDisabled || isLikedKind,
-      likedProviderActions,
-    };
-
-    if (isAlbumKind && canToggleSaved && isSaved !== null) {
-      actions.onToggleSave = closeAfter(isSaved ? 'Unlike' : 'Like', toggleSaved);
-    }
-
-    if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
-      const collectionId = request.id;
-      const collectionName = request.name;
-      const provider = request.provider;
-      actions.onQueueLikedFromCollection = closeAfter('Queue Liked Songs', () =>
-        queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
-      );
-    }
-
-    if (request.kind === 'recently-played' && request.recentRef) {
-      const recentRef = request.recentRef;
-      actions.onRemoveFromHistory = closeAfter('Remove from history', () => removeRecent(recentRef));
-    }
-
-    return buildMenuItems(request, actions);
-  }, [
-    request,
-    isPlaylistPinned,
-    isAlbumPinned,
-    togglePinPlaylist,
-    togglePinAlbum,
-    perProvider,
-    onPlayCollection,
-    onAddToQueue,
-    onPlayNext,
-    onStartRadioForCollection,
-    onPlayLikedTracks,
-    loadLikedTracks,
-    removeRecent,
-    closeAfter,
-    playNextDisabled,
-    startRadioDisabled,
-    canToggleSaved,
-    isSaved,
-    toggleSaved,
-    onQueueLikedTracks,
-    queueLikedFromCollection,
-  ]);
+  const items = useMenuItems(request, callbacks);
 
   if (!request) return null;
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ContextMenuRequest } from '../../types';
+import type { ProviderId } from '@/types/domain';
+
+const { mockPinned, mockLikedSection, mockRecent, mockLoadLiked } = vi.hoisted(() => ({
+  mockPinned: vi.fn(),
+  mockLikedSection: vi.fn(),
+  mockRecent: vi.fn(),
+  mockLoadLiked: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => mockPinned(),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => mockRecent(),
+}));
+
+vi.mock('../../hooks', () => ({
+  useLikedSection: () => mockLikedSection(),
+}));
+
+vi.mock('../useLikedTracksForProvider', () => ({
+  useLikedTracksForProvider: () => ({ loadLikedTracks: mockLoadLiked }),
+}));
+
+const { mockQueueLikedFromCollection, mockUseAlbumSavedStatus } = vi.hoisted(() => ({
+  mockQueueLikedFromCollection: vi.fn(),
+  mockUseAlbumSavedStatus: vi.fn(),
+}));
+
+vi.mock('../useQueueLikedFromCollection', () => ({
+  useQueueLikedFromCollection: () => ({ queueLikedFromCollection: mockQueueLikedFromCollection }),
+}));
+
+vi.mock('../useAlbumSavedStatus', () => ({
+  useAlbumSavedStatus: (...args: unknown[]) => mockUseAlbumSavedStatus(...args),
+}));
+
+import { useMenuItems, type UseMenuItemsCallbacks } from '../useMenuItems';
+
+function makeRequest(overrides: Partial<ContextMenuRequest> = {}): ContextMenuRequest {
+  return {
+    kind: 'playlist',
+    id: 'p1',
+    name: 'My Playlist',
+    provider: 'spotify' as ProviderId,
+    anchorRect: new DOMRect(10, 10, 100, 40),
+    ...overrides,
+  };
+}
+
+function makeCallbacks(overrides: Partial<UseMenuItemsCallbacks> = {}): UseMenuItemsCallbacks {
+  return {
+    closeAfter: (_label, fn) => () => {
+      void fn();
+    },
+    onPlayCollection: vi.fn(),
+    onAddToQueue: vi.fn(),
+    onPlayLikedTracks: vi.fn(),
+    ...overrides,
+  };
+}
+
+function defaultMocks() {
+  mockPinned.mockReturnValue({
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  });
+  mockLikedSection.mockReturnValue({
+    perProvider: [{ provider: 'spotify' as ProviderId, count: 10 }],
+  });
+  mockRecent.mockReturnValue({ remove: vi.fn() });
+  mockLoadLiked.mockResolvedValue([]);
+  mockUseAlbumSavedStatus.mockReturnValue({
+    isSaved: null,
+    toggleSaved: vi.fn(),
+    canToggle: false,
+    saveError: null,
+    clearSaveError: vi.fn(),
+  });
+}
+
+describe('useMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultMocks();
+  });
+
+  it('returns an empty array when request is null', () => {
+    // #when
+    const { result } = renderHook(() => useMenuItems(null, makeCallbacks()));
+
+    // #then
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns the playlist schema with 5 items', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    expect(result.current.map((i) => i.id)).toEqual([
+      'play',
+      'add-to-queue',
+      'play-next',
+      'toggle-pin',
+      'start-radio',
+    ]);
+  });
+
+  it('disables Play Next and Start Radio when handlers are undefined', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'playlist' }),
+        makeCallbacks({ onPlayNext: undefined, onStartRadioForCollection: undefined }),
+      ),
+    );
+
+    // #then
+    const playNext = result.current.find((i) => i.id === 'play-next');
+    const startRadio = result.current.find((i) => i.id === 'start-radio');
+    expect(playNext?.disabled).toBe(true);
+    expect(startRadio?.disabled).toBe(true);
+  });
+
+  it('labels toggle-pin as "Pin" when not pinned', () => {
+    // #given - default mock has isPlaylistPinned = () => false
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const togglePin = result.current.find((i) => i.id === 'toggle-pin');
+    expect(togglePin?.label).toBe('Pin');
+  });
+
+  it('labels toggle-pin as "Unpin" when playlist is pinned', () => {
+    // #given
+    mockPinned.mockReturnValue({
+      isPlaylistPinned: () => true,
+      isAlbumPinned: () => false,
+      togglePinPlaylist: vi.fn(),
+      togglePinAlbum: vi.fn(),
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const togglePin = result.current.find((i) => i.id === 'toggle-pin');
+    expect(togglePin?.label).toBe('Unpin');
+  });
+
+  it('builds per-provider liked entries from useLikedSection', () => {
+    // #given
+    mockLikedSection.mockReturnValue({
+      perProvider: [
+        { provider: 'spotify', count: 10 },
+        { provider: 'dropbox', count: 5 },
+      ],
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'liked', id: 'liked', provider: undefined }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('play-all');
+    expect(ids).toContain('play-liked-spotify');
+    expect(ids).toContain('play-liked-dropbox');
+  });
+
+  it('appends Remove from history for recently-played requests with recentRef', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({
+          kind: 'recently-played',
+          originalKind: 'playlist',
+          recentRef: { kind: 'playlist', id: 'p1', provider: 'spotify' },
+        }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('remove-from-history');
+  });
+
+  it('omits queue-liked when onQueueLikedTracks is not provided', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(makeRequest({ kind: 'playlist' }), makeCallbacks()),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).not.toContain('queue-liked');
+  });
+
+  it('includes queue-liked when onQueueLikedTracks is provided and provider exists', () => {
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'playlist' }),
+        makeCallbacks({ onQueueLikedTracks: vi.fn() }),
+      ),
+    );
+
+    // #then
+    const ids = result.current.map((i) => i.id);
+    expect(ids).toContain('queue-liked');
+  });
+
+  it('includes Unlike for an album when canToggleSaved and isSaved=true', () => {
+    // #given
+    mockUseAlbumSavedStatus.mockReturnValue({
+      isSaved: true,
+      toggleSaved: vi.fn(),
+      canToggle: true,
+      saveError: null,
+      clearSaveError: vi.fn(),
+    });
+
+    // #when
+    const { result } = renderHook(() =>
+      useMenuItems(
+        makeRequest({ kind: 'album', id: 'a1', name: 'My Album' }),
+        makeCallbacks(),
+      ),
+    );
+
+    // #then
+    const toggleSave = result.current.find((i) => i.id === 'toggle-save');
+    expect(toggleSave?.label).toBe('Unlike');
+  });
+});

--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import type { ProviderId } from '@/types/domain';
 import { logLibrary } from '@/lib/debugLog';
-import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 
 export interface UseAlbumSavedStatusResult {
   isSaved: boolean | null;
@@ -64,7 +64,7 @@ export function useAlbumSavedStatus(
       // the pattern when Dropbox (or others) gain one.
       if (descriptor!.id === 'spotify' && !next) {
         try {
-          await librarySyncEngine.optimisticRemoveAlbum(albumId!);
+          await spotifyLibrarySyncEngine.optimisticRemoveAlbum(albumId!);
         } catch (err) {
           logLibrary('optimisticRemoveAlbum failed', err);
         }

--- a/src/components/LibraryRoute/contextMenu/useMenuItems.ts
+++ b/src/components/LibraryRoute/contextMenu/useMenuItems.ts
@@ -1,0 +1,206 @@
+import { useMemo } from 'react';
+import { usePinnedItems } from '@/hooks/usePinnedItems';
+import { useRecentlyPlayedCollections } from '@/hooks/useRecentlyPlayedCollections';
+import { useLikedSection } from '../hooks';
+import type { ContextMenuRequest } from '../types';
+import type { ProviderId, MediaTrack } from '@/types/domain';
+import { useLikedTracksForProvider } from './useLikedTracksForProvider';
+import { useAlbumSavedStatus } from './useAlbumSavedStatus';
+import { useQueueLikedFromCollection } from './useQueueLikedFromCollection';
+import { toAlbumPlaylistId } from '@/constants/playlist';
+import { buildMenuItems, type MenuActions, type MenuItem } from './menuItemsForKind';
+
+const PROVIDER_LABEL: Record<string, string> = {
+  spotify: 'Spotify',
+  dropbox: 'Dropbox',
+};
+
+function providerLabel(provider: ProviderId): string {
+  return PROVIDER_LABEL[provider] ?? provider;
+}
+
+export interface UseMenuItemsCallbacks {
+  closeAfter: (label: string, fn: () => void | Promise<unknown>) => () => void;
+  onPlayCollection: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onAddToQueue?: (id: string, name: string, provider?: ProviderId) => void | Promise<unknown>;
+  onPlayNext?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    name: string,
+    provider?: ProviderId,
+  ) => void;
+  onStartRadioForCollection?: (
+    kind: 'playlist' | 'album',
+    id: string,
+    provider?: ProviderId,
+  ) => void;
+  onPlayLikedTracks: (
+    tracks: MediaTrack[],
+    collectionId: string,
+    collectionName: string,
+    provider?: ProviderId,
+  ) => Promise<void> | void;
+  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+}
+
+export function useMenuItems(
+  request: ContextMenuRequest | null,
+  callbacks: UseMenuItemsCallbacks,
+): MenuItem[] {
+  const {
+    closeAfter,
+    onPlayCollection,
+    onAddToQueue,
+    onPlayNext,
+    onStartRadioForCollection,
+    onPlayLikedTracks,
+    onQueueLikedTracks,
+  } = callbacks;
+
+  const {
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+  } = usePinnedItems();
+  const { remove: removeRecent } = useRecentlyPlayedCollections();
+  const { perProvider } = useLikedSection();
+  const { loadLikedTracks } = useLikedTracksForProvider();
+  const { queueLikedFromCollection } = useQueueLikedFromCollection(onQueueLikedTracks);
+
+  const albumIdForSaveStatus =
+    request?.kind === 'album'
+      ? request.id
+      : request?.kind === 'recently-played' && request.originalKind === 'album'
+        ? request.id
+        : null;
+  const { isSaved, toggleSaved, canToggle: canToggleSaved } = useAlbumSavedStatus(
+    albumIdForSaveStatus,
+    request?.provider,
+  );
+
+  const playNextDisabled = !onPlayNext;
+  const startRadioDisabled = !onStartRadioForCollection;
+
+  return useMemo<MenuItem[]>(() => {
+    if (!request) return [];
+
+    const effectiveKind: 'playlist' | 'album' | 'liked' =
+      request.kind === 'recently-played'
+        ? request.originalKind ?? 'playlist'
+        : (request.kind as 'playlist' | 'album' | 'liked');
+
+    const isPlaylistKind = effectiveKind === 'playlist';
+    const isAlbumKind = effectiveKind === 'album';
+    const isLikedKind = effectiveKind === 'liked';
+
+    const isPinned = isPlaylistKind
+      ? isPlaylistPinned(request.id)
+      : isAlbumKind
+        ? isAlbumPinned(request.id)
+        : false;
+
+    const togglePin = isPlaylistKind
+      ? () => togglePinPlaylist(request.id)
+      : () => togglePinAlbum(request.id);
+
+    const playLikedFor = async (provider: ProviderId) => {
+      const tracks = await loadLikedTracks(provider);
+      if (tracks.length === 0) return;
+      await onPlayLikedTracks(tracks, `liked-${provider}`, 'Liked Songs', provider);
+    };
+
+    const likedProviderActions = isLikedKind
+      ? perProvider.map((entry) => {
+          const entryLabel = `Play (${providerLabel(entry.provider)})`;
+          return {
+            provider: entry.provider,
+            label: entryLabel,
+            onPlay: closeAfter(entryLabel, () => playLikedFor(entry.provider)),
+          };
+        })
+      : undefined;
+
+    const actions: MenuActions = {
+      onPlay: closeAfter('Play', () => {
+        if (isLikedKind) {
+          const inferred = perProvider[0]?.provider;
+          if (inferred) void playLikedFor(inferred);
+          return;
+        }
+        if (isPlaylistKind || isAlbumKind) {
+          onPlayCollection(effectiveKind, request.id, request.name, request.provider);
+        }
+      }),
+      onAddToQueue: closeAfter('Add to Queue', () => {
+        if (onAddToQueue) {
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onAddToQueue(id, request.name, request.provider);
+        }
+      }),
+      onPlayNext: closeAfter('Play Next', () => {
+        if (onPlayNext && (isPlaylistKind || isAlbumKind)) {
+          const id = isAlbumKind ? toAlbumPlaylistId(request.id) : request.id;
+          onPlayNext(effectiveKind, id, request.name, request.provider);
+        }
+      }),
+      onTogglePin: closeAfter(isPinned ? 'Unpin' : 'Pin', togglePin),
+      onStartRadio: closeAfter('Start Radio', () => {
+        if (onStartRadioForCollection && (isPlaylistKind || isAlbumKind)) {
+          onStartRadioForCollection(effectiveKind, request.id, request.provider);
+        }
+      }),
+      isPinned,
+      startRadioDisabled: startRadioDisabled || isLikedKind,
+      playNextDisabled: playNextDisabled || isLikedKind,
+      likedProviderActions,
+    };
+
+    if (isAlbumKind && canToggleSaved && isSaved !== null) {
+      actions.onToggleSave = closeAfter(isSaved ? 'Unlike' : 'Like', toggleSaved);
+    }
+
+    if ((isPlaylistKind || isAlbumKind) && onQueueLikedTracks && request.provider) {
+      const collectionId = request.id;
+      const collectionName = request.name;
+      const provider = request.provider;
+      actions.onQueueLikedFromCollection = closeAfter('Queue Liked Songs', () =>
+        queueLikedFromCollection(collectionId, collectionName, provider, effectiveKind),
+      );
+    }
+
+    if (request.kind === 'recently-played' && request.recentRef) {
+      const recentRef = request.recentRef;
+      actions.onRemoveFromHistory = closeAfter('Remove from history', () => removeRecent(recentRef));
+    }
+
+    return buildMenuItems(request, actions);
+  }, [
+    request,
+    isPlaylistPinned,
+    isAlbumPinned,
+    togglePinPlaylist,
+    togglePinAlbum,
+    perProvider,
+    onPlayCollection,
+    onAddToQueue,
+    onPlayNext,
+    onStartRadioForCollection,
+    onPlayLikedTracks,
+    loadLikedTracks,
+    removeRecent,
+    closeAfter,
+    playNextDisabled,
+    startRadioDisabled,
+    canToggleSaved,
+    isSaved,
+    toggleSaved,
+    onQueueLikedTracks,
+    queueLikedFromCollection,
+  ]);
+}

--- a/src/components/SettingsV2/sections/ProviderDataBlock.tsx
+++ b/src/components/SettingsV2/sections/ProviderDataBlock.tsx
@@ -4,6 +4,7 @@ import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { ART_REFRESHED_EVENT } from '@/hooks/useLibrarySync';
 import { STATUS_RESET_DELAY_MS } from '@/constants/statusTiming';
 import type { CatalogProvider } from '@/types/providers';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -50,7 +51,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       a.click();
       URL.revokeObjectURL(url);
       setResultMessage('Exported!');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.exportFn', err);
       setResultMessage('Export failed');
     }
   }, [catalog]);
@@ -62,7 +64,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       if (result.updated > 0) parts.push(`${result.updated} updated`);
       if (result.removed > 0) parts.push(`${result.removed} removed`);
       setResultMessage(parts.length > 0 ? parts.join(', ') : 'No changes');
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.refreshMetadataFn', err);
       setResultMessage('Refresh failed');
     }
   }, [catalog]);
@@ -81,7 +84,8 @@ export const ProviderDataBlock: React.FC<ProviderDataBlockProps> = ({ providerNa
       const json = await file.text();
       const count = await catalog.importLikes!(json);
       setResultMessage(`Imported ${count} tracks`);
-    } catch {
+    } catch (err) {
+      logCaughtError('ProviderDataBlock.handleImport', err);
       setResultMessage('Import failed');
     }
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -2,7 +2,7 @@ import { memo, Fragment, useState, useCallback, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom';
 import type { ArtistInfo } from '../../services/spotify';
 import { useProviderContext } from '../../contexts/ProviderContext';
-import { librarySyncEngine } from '../../services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '../../services/cache/librarySyncEngine';
 import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
 import TrackInfoPopover, { LibraryIcon, SpotifyIcon, PlayIcon, DiscogsIcon, AddToLibraryIcon, RemoveFromLibraryIcon, ICON_MAP } from './TrackInfoPopover';
 import TrackRadioPopover from './TrackRadioPopover';
@@ -219,9 +219,9 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
                 onClick: () => {
                     catalog.setAlbumSaved!(popover.albumId, !saved).then(() => {
                         if (saved) {
-                            librarySyncEngine.optimisticRemoveAlbum(popover.albumId).catch(() => {});
+                            spotifyLibrarySyncEngine.optimisticRemoveAlbum(popover.albumId).catch(() => {});
                         } else {
-                            librarySyncEngine.optimisticAddAlbum({
+                            spotifyLibrarySyncEngine.optimisticAddAlbum({
                                 id: popover.albumId,
                                 name: popover.albumName,
                                 artists: track?.artists ?? '',

--- a/src/contexts/ProfilingContext.tsx
+++ b/src/contexts/ProfilingContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface RenderStats {
   renderCount: number; mountCount: number; updateCount: number;
@@ -89,7 +90,10 @@ class MetricsCollector {
         }
       });
       this.longTaskObserver.observe({ entryTypes: ['longtask'] });
-    } catch { /* longtask not supported */ }
+    } catch (err) {
+      /* longtask not supported */
+      logCaughtError('ProfilingContext.startLongTaskObserver', err);
+    }
   }
 
   recordRender(

--- a/src/contexts/VisualizerDebugContext.tsx
+++ b/src/contexts/VisualizerDebugContext.tsx
@@ -13,6 +13,7 @@ import {
   type VisualizerDebugOverrides,
 } from '@/constants/visualizerDebugConfig';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const DEBUG_PARAM = 'debug';
 const DEBUG_VALUE = 'visualizer';
@@ -29,7 +30,8 @@ function readStoredOverrides(): VisualizerDebugOverrides | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as VisualizerDebugOverrides;
     return parsed;
-  } catch {
+  } catch (err) {
+    logCaughtError('VisualizerDebugContext.readStoredOverrides', err);
     return null;
   }
 }
@@ -41,8 +43,9 @@ function writeStoredOverrides(overrides: VisualizerDebugOverrides | null): void 
       return;
     }
     localStorage.setItem(STORAGE_KEYS.VISUALIZER_DEBUG_OVERRIDES, JSON.stringify(overrides));
-  } catch {
+  } catch (err) {
     // ignore
+    logCaughtError('VisualizerDebugContext.writeStoredOverrides', err);
   }
 }
 
@@ -128,8 +131,9 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
   const copyExportToClipboard = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(exportAsJson());
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('VisualizerDebugContext.copyExportToClipboard', err);
     }
   }, [exportAsJson]);
 
@@ -143,7 +147,8 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       setOverridesState(overrides);
       writeStoredOverrides(overrides);
       return true;
-    } catch {
+    } catch (err) {
+      logCaughtError('VisualizerDebugContext.loadOverridesFromJson', err);
       return false;
     }
   }, []);

--- a/src/hooks/__tests__/useCatalogLibrarySync.test.ts
+++ b/src/hooks/__tests__/useCatalogLibrarySync.test.ts
@@ -1,0 +1,268 @@
+import 'fake-indexeddb/auto';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { MediaCollection, ProviderId } from '@/types/domain';
+
+const mockGetDescriptor = vi.fn();
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => ({
+    enabledProviderIds: [] as ProviderId[],
+    getDescriptor: mockGetDescriptor,
+  }),
+}));
+
+const mockRegistryGet = vi.fn();
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: (...args: unknown[]) => mockRegistryGet(...args),
+    getAll: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('@/utils/libraryFirstSeen', () => ({
+  getOrSetFirstSeenAddedAtIso: vi.fn().mockReturnValue('2024-01-01T00:00:00.000Z'),
+}));
+
+vi.mock('@/services/cache/likedCountSnapshot', () => ({
+  readLikedCountSnapshots: vi.fn().mockReturnValue({}),
+  writeLikedCountSnapshot: vi.fn(),
+}));
+
+import { useCatalogLibrarySync } from '../useCatalogLibrarySync';
+
+function makeCatalogDescriptor(
+  id: ProviderId,
+  collections: MediaCollection[],
+  likedCount = 0,
+  getLikedCount?: () => Promise<number>,
+) {
+  return {
+    id,
+    catalog: {
+      providerId: id,
+      listCollections: vi.fn().mockResolvedValue(collections),
+      listTracks: vi.fn().mockResolvedValue([]),
+      getLikedCount: getLikedCount ?? vi.fn().mockResolvedValue(likedCount),
+    },
+    auth: {
+      providerId: id,
+      isAuthenticated: vi.fn().mockReturnValue(true),
+      getAccessToken: vi.fn(),
+      beginLogin: vi.fn(),
+      handleCallback: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+}
+
+function makeCollection(id: string, kind: 'playlist' | 'album' | 'folder' = 'playlist'): MediaCollection {
+  return {
+    id,
+    provider: 'dropbox' as ProviderId,
+    kind,
+    name: `Collection ${id}`,
+    description: null,
+    imageUrl: null,
+    trackCount: 5,
+    ownerName: null,
+    releaseDate: null,
+    revision: null,
+  };
+}
+
+describe('useCatalogLibrarySync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistryGet.mockReturnValue(undefined);
+  });
+
+  it('returns empty state when no provider ids are passed', () => {
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync([] as readonly ProviderId[]));
+
+    // #then
+    expect(result.current.playlists).toEqual([]);
+    expect(result.current.albums).toEqual([]);
+    expect(result.current.totalLikedCount).toBe(0);
+    expect(result.current.allMusicCount).toBe(0);
+    expect(result.current.likedCounts).toEqual([]);
+  });
+
+  it('invokes listCollections for each provided id and exposes the merged result', async () => {
+    // #given
+    const dropboxAlbum = makeCollection('a-1', 'album');
+    const dropboxFolder = makeCollection('f-1', 'folder');
+    const dropboxDescriptor = makeCatalogDescriptor('dropbox', [dropboxAlbum, dropboxFolder], 9);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? dropboxDescriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(dropboxDescriptor.catalog.listCollections).toHaveBeenCalled();
+      expect(result.current.albums.some(a => a.name === 'Collection a-1')).toBe(true);
+      expect(result.current.playlists.some(p => p.name === 'Collection f-1')).toBe(true);
+      expect(result.current.totalLikedCount).toBe(9);
+      expect(result.current.likedCounts).toEqual([{ provider: 'dropbox', count: 9 }]);
+    });
+  });
+
+  it('skips an unauthenticated provider without calling listCollections', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', [], 0);
+    descriptor.auth.isAuthenticated.mockReturnValue(false);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => expect(result.current.playlists).toEqual([]));
+    expect(descriptor.catalog.listCollections).not.toHaveBeenCalled();
+    expect(result.current.syncState.error).toBeNull();
+  });
+
+  it('records syncError when listCollections throws', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', []);
+    descriptor.catalog.listCollections.mockRejectedValue(new Error('Catalog unavailable'));
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.syncState.error).toBe('Catalog unavailable');
+    });
+  });
+
+  it('extracts the Dropbox All-Music aggregate row into allMusicCount', async () => {
+    // #given
+    const allMusicRow: MediaCollection = {
+      ...makeCollection('a-1', 'album'),
+      id: '',
+      trackCount: 1234,
+    };
+    const realPlaylist = makeCollection('f-1', 'folder');
+    const descriptor = makeCatalogDescriptor('dropbox', [allMusicRow, realPlaylist]);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    // #when
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.allMusicCount).toBe(1234);
+      expect(result.current.playlists.some(p => p.id === '')).toBe(false);
+    });
+  });
+
+  it('reacts to the registered likes-changed event by re-fetching the liked count', async () => {
+    // #given
+    const getLikedCount = vi.fn().mockResolvedValue(3);
+    const descriptor = makeCatalogDescriptor('dropbox', [], 3, getLikedCount);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+    mockRegistryGet.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? { likesChangedEvent: 'vorbis-test-likes-changed' } : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => expect(descriptor.catalog.listCollections).toHaveBeenCalled());
+
+    getLikedCount.mockResolvedValue(11);
+
+    // #when
+    act(() => {
+      window.dispatchEvent(new Event('vorbis-test-likes-changed'));
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.totalLikedCount).toBeGreaterThanOrEqual(11);
+    });
+  });
+
+  it('refresh forces listCollections to re-run with forceRefresh', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor('dropbox', [], 4);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => expect(descriptor.catalog.listCollections).toHaveBeenCalledTimes(1));
+
+    // #when
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // #then
+    expect(descriptor.catalog.listCollections).toHaveBeenCalledTimes(2);
+    expect(descriptor.catalog.listCollections.mock.calls[1][1]).toEqual({ forceRefresh: true });
+  });
+
+  it('refresh scoped to one provider does not refetch other providers', async () => {
+    // #given
+    const dropbox = makeCatalogDescriptor('dropbox', [], 4);
+    const apple = makeCatalogDescriptor('apple' as ProviderId, [], 5);
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? dropbox : id === ('apple' as ProviderId) ? apple : undefined,
+    );
+
+    const { result } = renderHook(() =>
+      useCatalogLibrarySync(['dropbox', 'apple' as ProviderId] as readonly ProviderId[]),
+    );
+    await waitFor(() => {
+      expect(dropbox.catalog.listCollections).toHaveBeenCalledTimes(1);
+      expect(apple.catalog.listCollections).toHaveBeenCalledTimes(1);
+    });
+
+    // #when
+    await act(async () => {
+      await result.current.refresh('dropbox' as ProviderId);
+    });
+
+    // #then
+    expect(dropbox.catalog.listCollections).toHaveBeenCalledTimes(2);
+    expect(apple.catalog.listCollections).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeCollection drops a collection from the merged output', async () => {
+    // #given
+    const descriptor = makeCatalogDescriptor(
+      'dropbox',
+      [makeCollection('keep', 'folder'), makeCollection('drop', 'folder')],
+    );
+    mockGetDescriptor.mockImplementation((id: ProviderId) =>
+      id === 'dropbox' ? descriptor : undefined,
+    );
+
+    const { result } = renderHook(() => useCatalogLibrarySync(['dropbox'] as readonly ProviderId[]));
+    await waitFor(() => {
+      expect(result.current.playlists.some(p => p.id === 'drop')).toBe(true);
+    });
+
+    // #when
+    act(() => {
+      result.current.removeCollection('drop');
+    });
+
+    // #then
+    expect(result.current.playlists.some(p => p.id === 'drop')).toBe(false);
+    expect(result.current.playlists.some(p => p.id === 'keep')).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useEngineLibrarySync.test.ts
+++ b/src/hooks/__tests__/useEngineLibrarySync.test.ts
@@ -1,0 +1,224 @@
+import 'fake-indexeddb/auto';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { CachedPlaylistInfo, SyncState } from '../../services/cache/cacheTypes';
+import type { AlbumInfo, SpotifyImage } from '../../services/spotify';
+import type { ProviderId } from '@/types/domain';
+
+const { mockSubscribe, mockStart, mockStop, mockSyncNow } = vi.hoisted(() => ({
+  mockSubscribe: vi.fn(),
+  mockStart: vi.fn(),
+  mockStop: vi.fn(),
+  mockSyncNow: vi.fn(),
+}));
+
+vi.mock('../../services/cache/librarySyncEngine', () => ({
+  spotifyLibrarySyncEngine: {
+    providerId: 'spotify',
+    subscribe: mockSubscribe,
+    start: mockStart,
+    stop: mockStop,
+    syncNow: mockSyncNow,
+  },
+}));
+
+import { useEngineLibrarySync } from '../useEngineLibrarySync';
+
+function makePlaylist(id: string, name?: string): CachedPlaylistInfo {
+  return {
+    id,
+    name: name ?? `Playlist ${id}`,
+    description: null,
+    images: [] as SpotifyImage[],
+    tracks: { total: 10 },
+    owner: { display_name: 'TestUser' },
+  };
+}
+
+function makeAlbum(id: string, name?: string): AlbumInfo {
+  return {
+    id,
+    name: name ?? `Album ${id}`,
+    artists: 'Test Artist',
+    images: [] as SpotifyImage[],
+    release_date: '2024-01-01',
+    total_tracks: 12,
+    uri: `spotify:album:${id}`,
+  };
+}
+
+describe('useEngineLibrarySync', () => {
+  let capturedListener: ((state: SyncState, pl?: CachedPlaylistInfo[], al?: AlbumInfo[], lc?: number) => void) | null = null;
+  let unsubscribeFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedListener = null;
+    unsubscribeFn = vi.fn();
+
+    mockSubscribe.mockImplementation((listener: typeof capturedListener) => {
+      capturedListener = listener;
+      listener!({
+        isInitialLoadComplete: false,
+        isSyncing: false,
+        lastSyncTimestamp: null,
+        error: null,
+      });
+      return unsubscribeFn;
+    });
+    mockStart.mockResolvedValue(undefined);
+    mockSyncNow.mockResolvedValue(undefined);
+  });
+
+  it('does not subscribe when engineProviderId is undefined', () => {
+    // #when
+    renderHook(() => useEngineLibrarySync(undefined));
+
+    // #then
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('returns empty data when engineProviderId is undefined', () => {
+    // #when
+    const { result } = renderHook(() => useEngineLibrarySync(undefined));
+
+    // #then
+    expect(result.current.playlists).toEqual([]);
+    expect(result.current.albums).toEqual([]);
+    expect(result.current.likedCount).toBe(0);
+  });
+
+  it('subscribes to the engine and starts on mount when a provider id is given', () => {
+    // #when
+    renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #then
+    expect(mockSubscribe).toHaveBeenCalledOnce();
+    expect(mockStart).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes on unmount but does not stop the engine', () => {
+    // #given
+    const { unmount } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    unmount();
+
+    // #then
+    expect(unsubscribeFn).toHaveBeenCalledOnce();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('updates playlists/albums/likedCount when the engine emits new data', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1', 'My Playlist')],
+        [makeAlbum('a1', 'My Album')],
+        42,
+      );
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.playlists).toHaveLength(1);
+      expect(result.current.playlists[0].name).toBe('My Playlist');
+      expect(result.current.albums[0].name).toBe('My Album');
+      expect(result.current.likedCount).toBe(42);
+      expect(result.current.syncState.isInitialLoadComplete).toBe(true);
+    });
+  });
+
+  it('stamps the engine providerId onto playlists and albums', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1')],
+        [makeAlbum('a1')],
+        0,
+      );
+    });
+
+    // #then
+    await waitFor(() => {
+      expect(result.current.playlists[0].provider).toBe('spotify');
+      expect(result.current.albums[0].provider).toBe('spotify');
+    });
+  });
+
+  it('refresh calls syncNow when an engine is active', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    // #when
+    await result.current.refresh();
+
+    // #then
+    expect(mockSyncNow).toHaveBeenCalledOnce();
+  });
+
+  it('refresh is a no-op when no engine provider is active', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync(undefined));
+
+    // #when
+    await result.current.refresh();
+
+    // #then
+    expect(mockSyncNow).not.toHaveBeenCalled();
+  });
+
+  it('keeps initialLoadComplete sticky once the engine emits true', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+      );
+    });
+    await waitFor(() => expect(result.current.syncState.isInitialLoadComplete).toBe(true));
+
+    // #when — engine emits a later state with isInitialLoadComplete: false
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: false, isSyncing: true, lastSyncTimestamp: 1000, error: null },
+      );
+    });
+
+    // #then — sticky stays true
+    await waitFor(() => expect(result.current.syncState.isInitialLoadComplete).toBe(true));
+  });
+
+  it('removeCollection optimistically drops a playlist by id', async () => {
+    // #given
+    const { result } = renderHook(() => useEngineLibrarySync('spotify' as ProviderId));
+    act(() => {
+      capturedListener!(
+        { isInitialLoadComplete: true, isSyncing: false, lastSyncTimestamp: 1000, error: null },
+        [makePlaylist('p1', 'Keep'), makePlaylist('p2', 'Drop')],
+        [],
+        0,
+      );
+    });
+    await waitFor(() => expect(result.current.playlists).toHaveLength(2));
+
+    // #when
+    act(() => {
+      result.current.removeCollection('p2');
+    });
+
+    // #then
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.playlists[0].id).toBe('p1');
+  });
+});

--- a/src/hooks/__tests__/useLibrarySync.test.ts
+++ b/src/hooks/__tests__/useLibrarySync.test.ts
@@ -14,7 +14,7 @@ const { mockSubscribe, mockStart, mockStop, mockSyncNow } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../services/cache/librarySyncEngine', () => ({
-  librarySyncEngine: {
+  spotifyLibrarySyncEngine: {
     providerId: 'spotify',
     subscribe: mockSubscribe,
     start: mockStart,

--- a/src/hooks/useCatalogLibrarySync.ts
+++ b/src/hooks/useCatalogLibrarySync.ts
@@ -1,0 +1,307 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { MediaCollection, ProviderId } from '@/types/domain';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { providerRegistry } from '@/providers/registry';
+import { logLibrary } from '@/lib/debugLog';
+import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
+import { writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { useStableSet } from '@/hooks/useStableSet';
+
+export interface PerProviderLikedCount {
+  provider: ProviderId;
+  count: number;
+}
+
+export interface CatalogLibrarySyncResult {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCounts: PerProviderLikedCount[];
+  totalLikedCount: number;
+  allMusicCount: number;
+  syncState: SyncState;
+  refresh: (scopeProviderId?: ProviderId) => Promise<void>;
+  removeCollection: (collectionId: string) => void;
+}
+
+interface PerProviderData {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCount: number;
+  allMusicCount: number;
+}
+
+const INITIAL_SYNC_STATE: SyncState = {
+  isInitialLoadComplete: false,
+  isSyncing: false,
+  lastSyncTimestamp: null,
+  error: null,
+};
+
+function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
+  const images: { url: string; height: number | null; width: number | null }[] = c.imageUrl
+    ? [{ url: c.imageUrl, height: null, width: null }]
+    : [];
+
+  return {
+    id: c.id,
+    name: c.name,
+    description: c.description ?? null,
+    images,
+    tracks: c.trackCount != null ? { total: c.trackCount } : null,
+    owner: c.ownerName ? { display_name: c.ownerName } : null,
+    snapshot_id: c.revision ?? undefined,
+    provider: c.provider,
+    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `playlist:${c.id}`, ordinal),
+    mosaicAlbumPaths: c.mosaicAlbumPaths,
+  };
+}
+
+function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
+  return {
+    id: c.id,
+    name: c.name,
+    artists: c.ownerName ?? '',
+    images: c.imageUrl ? [{ url: c.imageUrl, height: null, width: null }] : [],
+    release_date: c.releaseDate ?? '',
+    total_tracks: c.trackCount ?? 0,
+    uri: '',
+    album_type: c.kind === 'folder' ? 'folder' : 'album',
+    provider: c.provider,
+    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `album:${c.id}`, ordinal),
+  };
+}
+
+/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
+function isAllMusicCollection(c: MediaCollection): boolean {
+  return c.provider === 'dropbox' && c.id === '';
+}
+
+function splitCollections(collections: MediaCollection[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  allMusicCount: number;
+} {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  let playlistOrdinal = 0;
+  let albumOrdinal = 0;
+  let allMusicCount = 0;
+  for (const c of collections) {
+    if (isAllMusicCollection(c)) {
+      allMusicCount = c.trackCount ?? 0;
+      continue;
+    }
+    if (c.kind === 'album') {
+      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
+    } else {
+      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
+    }
+  }
+  return { playlists, albums, allMusicCount };
+}
+
+function aggregate(map: Map<ProviderId, PerProviderData>, enabled: readonly ProviderId[]): {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCounts: PerProviderLikedCount[];
+  totalLikedCount: number;
+  allMusicCount: number;
+} {
+  const playlists: CachedPlaylistInfo[] = [];
+  const albums: AlbumInfo[] = [];
+  const likedCounts: PerProviderLikedCount[] = [];
+  let totalLikedCount = 0;
+  let allMusicCount = 0;
+  for (const [providerId, data] of map) {
+    if (!enabled.includes(providerId)) continue;
+    playlists.push(...data.playlists);
+    albums.push(...data.albums);
+    totalLikedCount += data.likedCount;
+    allMusicCount += data.allMusicCount;
+    if (data.likedCount > 0) {
+      likedCounts.push({ provider: providerId, count: data.likedCount });
+    }
+  }
+  return { playlists, albums, likedCounts, totalLikedCount, allMusicCount };
+}
+
+/**
+ * Hook for the catalog-adapter path (any provider that exposes
+ * `descriptor.catalog.listCollections`).
+ *
+ * Owns the per-provider listCollections effect, the likes-changed event
+ * listeners, and the in-memory data store.
+ *
+ * The input array is stabilized internally via `useStableSet`, so callers
+ * may pass a fresh array each render without re-firing the load effect.
+ */
+export function useCatalogLibrarySync(catalogProviderIdsInput: readonly ProviderId[]): CatalogLibrarySyncResult {
+  const catalogProviderIds = useStableSet(catalogProviderIdsInput);
+  const { getDescriptor } = useProviderContext();
+  const [aggregated, setAggregated] = useState<{
+    playlists: CachedPlaylistInfo[];
+    albums: AlbumInfo[];
+    likedCounts: PerProviderLikedCount[];
+    totalLikedCount: number;
+    allMusicCount: number;
+  }>(() => ({ playlists: [], albums: [], likedCounts: [], totalLikedCount: 0, allMusicCount: 0 }));
+  const [syncState, setSyncState] = useState<SyncState>(INITIAL_SYNC_STATE);
+
+  const dataRef = useRef<Map<ProviderId, PerProviderData>>(new Map());
+  const enabledRef = useRef<readonly ProviderId[]>(catalogProviderIds);
+  enabledRef.current = catalogProviderIds;
+
+  const recomputeAggregate = useCallback(() => {
+    setAggregated(aggregate(dataRef.current, enabledRef.current));
+  }, []);
+
+  useEffect(() => {
+    if (catalogProviderIds.length === 0) {
+      dataRef.current.clear();
+      recomputeAggregate();
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function loadProviderCollections(providerId: ProviderId) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      const auth = descriptor?.auth;
+      if (!catalog || !auth || !auth.isAuthenticated()) {
+        dataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
+        return;
+      }
+
+      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
+
+      try {
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(controller.signal),
+          catalog.getLikedCount ? catalog.getLikedCount(controller.signal) : Promise.resolve(0),
+        ]);
+        if (cancelled) return;
+
+        logLibrary('[%s] raw collections from catalog: %o', providerId,
+          collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
+
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        logLibrary('[%s] after splitCollections — playlists: %o', providerId,
+          playlists.map(p => ({ name: p.name, tracks: p.tracks })));
+        logLibrary('[%s] after splitCollections — albums: %o', providerId,
+          albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
+        dataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
+        writeLikedCountSnapshot(providerId, likedCount);
+        recomputeAggregate();
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          lastSyncTimestamp: Date.now(),
+        }));
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.error(`[useCatalogLibrarySync] Failed to load collections for ${providerId}:`, err);
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          error: err instanceof Error ? err.message : 'Failed to load library',
+        }));
+      }
+    }
+
+    Promise.all(catalogProviderIds.map(loadProviderCollections)).catch(() => {});
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  useEffect(() => {
+    const cleanups: Array<() => void> = [];
+    for (const providerId of catalogProviderIds) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      if (!catalog?.getLikedCount) continue;
+
+      const registryDescriptor = providerRegistry.get(providerId);
+      const eventName = registryDescriptor?.likesChangedEvent;
+      if (!eventName) continue;
+
+      const handleLikesChanged = () => {
+        catalog.getLikedCount!().then(count => {
+          const data = dataRef.current.get(providerId);
+          if (data) {
+            data.likedCount = count;
+            recomputeAggregate();
+          }
+        }).catch(() => {});
+      };
+
+      window.addEventListener(eventName, handleLikesChanged);
+      cleanups.push(() => window.removeEventListener(eventName, handleLikesChanged));
+    }
+    return () => cleanups.forEach(cleanup => cleanup());
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  const refresh = useCallback(async (scopeProviderId?: ProviderId) => {
+    const providerIdsToRefresh = scopeProviderId
+      ? catalogProviderIds.filter(id => id === scopeProviderId)
+      : catalogProviderIds;
+
+    for (const providerId of providerIdsToRefresh) {
+      const descriptor = getDescriptor(providerId);
+      const catalog = descriptor?.catalog;
+      if (!catalog) continue;
+
+      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
+      try {
+        const [collections, likedCount] = await Promise.all([
+          catalog.listCollections(undefined, { forceRefresh: true }),
+          catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
+        ]);
+        const { playlists, albums, allMusicCount } = splitCollections(collections);
+        dataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
+        writeLikedCountSnapshot(providerId, likedCount);
+        recomputeAggregate();
+        setSyncState(prev => ({
+          ...prev,
+          isInitialLoadComplete: true,
+          isSyncing: false,
+          lastSyncTimestamp: Date.now(),
+        }));
+      } catch (err) {
+        setSyncState(prev => ({
+          ...prev,
+          isSyncing: false,
+          error: err instanceof Error ? err.message : 'Refresh failed',
+        }));
+      }
+    }
+  }, [catalogProviderIds, getDescriptor, recomputeAggregate]);
+
+  const removeCollection = useCallback((collectionId: string) => {
+    for (const [, data] of dataRef.current) {
+      data.playlists = data.playlists.filter(p => p.id !== collectionId);
+      data.albums = data.albums.filter(a => a.id !== collectionId);
+    }
+    recomputeAggregate();
+  }, [recomputeAggregate]);
+
+  return {
+    playlists: aggregated.playlists,
+    albums: aggregated.albums,
+    likedCounts: aggregated.likedCounts,
+    totalLikedCount: aggregated.totalLikedCount,
+    allMusicCount: aggregated.allMusicCount,
+    syncState,
+    refresh,
+    removeCollection,
+  };
+}

--- a/src/hooks/useEngineLibrarySync.ts
+++ b/src/hooks/useEngineLibrarySync.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import type { AlbumInfo } from '@/services/spotify';
+import type { ProviderId } from '@/types/domain';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { logLibrary } from '@/lib/debugLog';
+
+export interface EngineLibrarySyncResult {
+  playlists: CachedPlaylistInfo[];
+  albums: AlbumInfo[];
+  likedCount: number;
+  syncState: SyncState;
+  refresh: () => Promise<void>;
+  removeCollection: (collectionId: string) => void;
+}
+
+const INITIAL_SYNC_STATE: SyncState = {
+  isInitialLoadComplete: false,
+  isSyncing: false,
+  lastSyncTimestamp: null,
+  error: null,
+};
+
+/**
+ * Hook for the library-sync-engine path (currently Spotify only).
+ *
+ * Owns the `spotifyLibrarySyncEngine.subscribe(...)` lifecycle and exposes the most
+ * recent playlists/albums/likedCount snapshot the engine has emitted.
+ *
+ * When `engineProviderId` is undefined or disabled, the hook returns empty
+ * data and does not subscribe.
+ */
+export function useEngineLibrarySync(engineProviderId: ProviderId | undefined): EngineLibrarySyncResult {
+  const [playlists, setPlaylists] = useState<CachedPlaylistInfo[]>([]);
+  const [albums, setAlbums] = useState<AlbumInfo[]>([]);
+  const [likedCount, setLikedCount] = useState(0);
+  const [syncState, setSyncState] = useState<SyncState>(INITIAL_SYNC_STATE);
+
+  const engineRef = useRef(spotifyLibrarySyncEngine);
+
+  useEffect(() => {
+    if (!engineProviderId) {
+      setPlaylists([]);
+      setAlbums([]);
+      setLikedCount(0);
+      return;
+    }
+
+    const engine = engineRef.current;
+    const epId = engineProviderId;
+
+    const unsubscribe = engine.subscribe((state, newPlaylists, newAlbums, newLikedCount) => {
+      setSyncState(prev => ({
+        ...prev,
+        ...state,
+        isInitialLoadComplete: prev.isInitialLoadComplete || state.isInitialLoadComplete,
+      }));
+      if (newPlaylists !== undefined) {
+        logLibrary('[%s] sync engine playlists: %o', epId,
+          newPlaylists.map(p => ({ name: p.name, tracks: p.tracks })));
+        setPlaylists(newPlaylists.map(p => ({ ...p, provider: epId })));
+      }
+      if (newAlbums !== undefined) {
+        setAlbums(newAlbums.map(a => ({ ...a, provider: epId })));
+      }
+      if (newLikedCount !== undefined) {
+        setLikedCount(newLikedCount);
+      }
+    });
+
+    engine.start().catch((err) => {
+      console.error('[useEngineLibrarySync] Failed to start sync engine:', err);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [engineProviderId]);
+
+  const refresh = useCallback(async () => {
+    if (!engineProviderId) return;
+    await engineRef.current.syncNow(true);
+  }, [engineProviderId]);
+
+  const removeCollection = useCallback((collectionId: string) => {
+    setPlaylists(prev => prev.filter(p => p.id !== collectionId));
+    setAlbums(prev => prev.filter(a => a.id !== collectionId));
+  }, []);
+
+  return {
+    playlists,
+    albums,
+    likedCount,
+    syncState,
+    refresh,
+    removeCollection,
+  };
+}

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -1,24 +1,16 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import type { CachedPlaylistInfo, SyncState } from '@/services/cache/cacheTypes';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
+import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
 import type { AlbumInfo } from '@/services/spotify';
-import type { MediaCollection, ProviderId } from '@/types/domain';
+import type { ProviderId } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
-import { providerRegistry } from '@/providers/registry';
 import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
-import { logLibrary } from '@/lib/debugLog';
-import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
-import { readLikedCountSnapshots, writeLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
-import { useStableSet } from '@/hooks/useStableSet';
+import { readLikedCountSnapshots } from '@/services/cache/likedCountSnapshot';
+import { useEngineLibrarySync } from '@/hooks/useEngineLibrarySync';
+import { useCatalogLibrarySync, type PerProviderLikedCount } from '@/hooks/useCatalogLibrarySync';
 
 export const ART_REFRESHED_EVENT = 'vorbis-art-refreshed';
 export const LIBRARY_REFRESH_EVENT = 'vorbis-library-refresh';
-
-/** Per-provider liked songs count for rendering separate cards. */
-interface PerProviderLikedCount {
-  provider: ProviderId;
-  count: number;
-}
 
 interface UseLibrarySyncResult {
   playlists: CachedPlaylistInfo[];
@@ -40,328 +32,91 @@ interface UseLibrarySyncResult {
   removeCollection: (collectionId: string) => void;
 }
 
-function initLikedCountsFromSnapshot(): { total: number; perProvider: PerProviderLikedCount[] } {
+function initialLikedTotalFromSnapshot(): number {
   const snapshots = readLikedCountSnapshots();
-  const perProvider: PerProviderLikedCount[] = [];
   let total = 0;
-  for (const [provider, entry] of Object.entries(snapshots)) {
-    if (entry.count > 0) {
-      perProvider.push({ provider: provider as ProviderId, count: entry.count });
-      total += entry.count;
-    }
+  for (const entry of Object.values(snapshots)) {
+    if (entry.count > 0) total += entry.count;
   }
-  return { total, perProvider };
-}
-
-function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPlaylistInfo {
-  const images: { url: string; height: number | null; width: number | null }[] = c.imageUrl
-    ? [{ url: c.imageUrl, height: null, width: null }]
-    : [];
-
-  return {
-    id: c.id,
-    name: c.name,
-    description: c.description ?? null,
-    images,
-    tracks: c.trackCount != null ? { total: c.trackCount } : null,
-    owner: c.ownerName ? { display_name: c.ownerName } : null,
-    snapshot_id: c.revision ?? undefined,
-    provider: c.provider,
-    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `playlist:${c.id}`, ordinal),
-    mosaicAlbumPaths: c.mosaicAlbumPaths,
-  };
-}
-
-function collectionToAlbumInfo(c: MediaCollection, ordinal: number): AlbumInfo {
-  return {
-    id: c.id,
-    name: c.name,
-    artists: c.ownerName ?? '',
-    images: c.imageUrl ? [{ url: c.imageUrl, height: null, width: null }] : [],
-    release_date: c.releaseDate ?? '',
-    total_tracks: c.trackCount ?? 0,
-    uri: '',
-    album_type: c.kind === 'folder' ? 'folder' : 'album',
-    provider: c.provider,
-    added_at: getOrSetFirstSeenAddedAtIso(c.provider, `album:${c.id}`, ordinal),
-  };
-}
-
-/** Returns true when the collection is the Dropbox "All Music" aggregate row. */
-function isAllMusicCollection(c: MediaCollection): boolean {
-  return c.provider === 'dropbox' && c.id === '';
-}
-
-function splitCollections(collections: MediaCollection[]): {
-  playlists: CachedPlaylistInfo[];
-  albums: AlbumInfo[];
-  allMusicCount: number;
-} {
-  const playlists: CachedPlaylistInfo[] = [];
-  const albums: AlbumInfo[] = [];
-  let playlistOrdinal = 0;
-  let albumOrdinal = 0;
-  let allMusicCount = 0;
-  for (const c of collections) {
-    if (isAllMusicCollection(c)) {
-      allMusicCount = c.trackCount ?? 0;
-      continue;
-    }
-    if (c.kind === 'album') {
-      albums.push(collectionToAlbumInfo(c, albumOrdinal++));
-    } else {
-      playlists.push(collectionToPlaylistInfo(c, playlistOrdinal++));
-    }
-  }
-  return { playlists, albums, allMusicCount };
+  return total;
 }
 
 export function useLibrarySync(): UseLibrarySyncResult {
-  const { enabledProviderIds, getDescriptor } = useProviderContext();
-  const initialSnapshot = useMemo(() => initLikedCountsFromSnapshot(), []);
-  const [playlists, setPlaylists] = useState<CachedPlaylistInfo[]>([]);
-  const [albums, setAlbums] = useState<AlbumInfo[]>([]);
-  const [likedSongsCount, setLikedSongsCount] = useState(() => initialSnapshot.total);
-  const [likedSongsPerProvider, setLikedSongsPerProvider] = useState<PerProviderLikedCount[]>(() => initialSnapshot.perProvider);
-  const [allMusicCount, setAllMusicCount] = useState(0);
-  const [syncState, setSyncState] = useState<SyncState>({
-    isInitialLoadComplete: false,
-    isSyncing: false,
-    lastSyncTimestamp: null,
-    error: null,
-  });
-
-  const engineRef = useRef(spotifyLibrarySyncEngine);
+  const { enabledProviderIds } = useProviderContext();
+  const initialLikedSnapshotTotal = useMemo(() => initialLikedTotalFromSnapshot(), []);
 
   // The sync engine talks directly to the real Spotify Web API. In mock mode,
-  // bypass it so the registry-aware catalog path (further down) loads spotify
-  // collections via the mock catalog adapter instead.
-  const engineProviderId: ProviderId | undefined = shouldUseMockProvider()
+  // bypass it so the registry-aware catalog path loads spotify collections
+  // via the mock catalog adapter instead.
+  const rawEngineProviderId: ProviderId | undefined = shouldUseMockProvider()
     ? undefined
     : spotifyLibrarySyncEngine.providerId;
+  const engineProviderId = rawEngineProviderId && enabledProviderIds.includes(rawEngineProviderId)
+    ? rawEngineProviderId
+    : undefined;
 
-  const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
-    playlists: [], albums: [], likedCount: 0,
-  });
-  const catalogDataRef = useRef<Map<ProviderId, { playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number; allMusicCount: number }>>(new Map());
+  const catalogProviderIds = enabledProviderIds.filter((id) => id !== rawEngineProviderId);
 
-  const isEngineProviderEnabled = !!engineProviderId && enabledProviderIds.includes(engineProviderId);
-  // Stabilize catalogProviderIds so downstream effects don't re-fire when the
-  // parent renders with a new array reference for the same logical set.
-  const catalogProviderIds = useStableSet(
-    enabledProviderIds.filter((id) => id !== engineProviderId),
-  );
+  const engine = useEngineLibrarySync(engineProviderId);
+  const catalog = useCatalogLibrarySync(catalogProviderIds);
 
-  const mergeAndSetData = useCallback(() => {
-    const allPlaylists: CachedPlaylistInfo[] = [];
-    const allAlbums: AlbumInfo[] = [];
-    let totalLikedCount = 0;
-    let totalAllMusicCount = 0;
-    const perProvider: PerProviderLikedCount[] = [];
+  const merged = useMemo(() => {
+    const playlists: CachedPlaylistInfo[] = [];
+    const albums: AlbumInfo[] = [];
+    const likedSongsPerProvider: PerProviderLikedCount[] = [];
+    let likedSongsCount = 0;
 
-    if (isEngineProviderEnabled && engineProviderId) {
-      allPlaylists.push(...engineDataRef.current.playlists);
-      allAlbums.push(...engineDataRef.current.albums);
-      totalLikedCount += engineDataRef.current.likedCount;
-      if (engineDataRef.current.likedCount > 0) {
-        perProvider.push({ provider: engineProviderId, count: engineDataRef.current.likedCount });
+    if (engineProviderId) {
+      playlists.push(...engine.playlists);
+      albums.push(...engine.albums);
+      likedSongsCount += engine.likedCount;
+      if (engine.likedCount > 0) {
+        likedSongsPerProvider.push({ provider: engineProviderId, count: engine.likedCount });
       }
     }
 
-    for (const [providerId, data] of catalogDataRef.current) {
-      if (enabledProviderIds.includes(providerId)) {
-        allPlaylists.push(...data.playlists);
-        allAlbums.push(...data.albums);
-        totalLikedCount += data.likedCount;
-        totalAllMusicCount += data.allMusicCount;
-        if (data.likedCount > 0) {
-          perProvider.push({ provider: providerId, count: data.likedCount });
-        }
-      }
-    }
+    playlists.push(...catalog.playlists);
+    albums.push(...catalog.albums);
+    likedSongsCount += catalog.totalLikedCount;
+    likedSongsPerProvider.push(...catalog.likedCounts);
 
-    setPlaylists(allPlaylists);
-    setAlbums(allAlbums);
-    setLikedSongsCount(totalLikedCount);
-    setLikedSongsPerProvider(perProvider);
-    setAllMusicCount(totalAllMusicCount);
-  }, [isEngineProviderEnabled, engineProviderId, enabledProviderIds]);
+    return { playlists, albums, likedSongsCount, likedSongsPerProvider };
+  }, [
+    engineProviderId,
+    engine.playlists,
+    engine.albums,
+    engine.likedCount,
+    catalog.playlists,
+    catalog.albums,
+    catalog.totalLikedCount,
+    catalog.likedCounts,
+  ]);
 
-  useEffect(() => {
-    if (!isEngineProviderEnabled || !engineProviderId) {
-      engineDataRef.current = { playlists: [], albums: [], likedCount: 0 };
-      mergeAndSetData();
-      return;
-    }
+  const stickyInitialLoadRef = useRef(false);
+  const isInitialLoadComplete = stickyInitialLoadRef.current
+    || engine.syncState.isInitialLoadComplete
+    || catalog.syncState.isInitialLoadComplete;
+  if (isInitialLoadComplete) {
+    stickyInitialLoadRef.current = true;
+  }
 
-    const engine = engineRef.current;
-    const epId = engineProviderId;
+  const isSyncing = engine.syncState.isSyncing || catalog.syncState.isSyncing;
+  const lastSyncTimestamp = Math.max(
+    engine.syncState.lastSyncTimestamp ?? 0,
+    catalog.syncState.lastSyncTimestamp ?? 0,
+  ) || null;
+  const syncError = catalog.syncState.error ?? engine.syncState.error;
 
-    const unsubscribe = engine.subscribe((state, newPlaylists, newAlbums, newLikedCount) => {
-      setSyncState(prev => ({
-        ...prev,
-        ...state,
-        isInitialLoadComplete: prev.isInitialLoadComplete || state.isInitialLoadComplete,
-      }));
-      if (newPlaylists !== undefined) {
-        logLibrary('[%s] sync engine playlists: %o', epId,
-          newPlaylists.map(p => ({ name: p.name, tracks: p.tracks })));
-        engineDataRef.current.playlists = newPlaylists.map(p => ({ ...p, provider: epId }));
-      }
-      if (newAlbums !== undefined) {
-        engineDataRef.current.albums = newAlbums.map(a => ({ ...a, provider: epId }));
-      }
-      if (newLikedCount !== undefined) {
-        engineDataRef.current.likedCount = newLikedCount;
-      }
-      if (newPlaylists !== undefined || newAlbums !== undefined || newLikedCount !== undefined) {
-        mergeAndSetData();
-      }
-    });
-
-    engine.start().catch((err) => {
-      console.error('[useLibrarySync] Failed to start sync engine:', err);
-    });
-
-    return () => {
-      unsubscribe();
-    };
-  }, [isEngineProviderEnabled, engineProviderId, mergeAndSetData]);
-
-  useEffect(() => {
-    if (catalogProviderIds.length === 0) {
-      catalogDataRef.current.clear();
-      mergeAndSetData();
-      return;
-    }
-
-    let cancelled = false;
-    const controller = new AbortController();
-
-    async function loadProviderCollections(providerId: ProviderId) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      const auth = descriptor?.auth;
-      if (!catalog || !auth || !auth.isAuthenticated()) {
-        catalogDataRef.current.set(providerId, { playlists: [], albums: [], likedCount: 0, allMusicCount: 0 });
-        return;
-      }
-
-      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
-
-      try {
-        const [collections, likedCount] = await Promise.all([
-          catalog.listCollections(controller.signal),
-          catalog.getLikedCount ? catalog.getLikedCount(controller.signal) : Promise.resolve(0),
-        ]);
-        if (cancelled) return;
-
-        logLibrary('[%s] raw collections from catalog: %o', providerId,
-          collections.map(c => ({ name: c.name, kind: c.kind, trackCount: c.trackCount })));
-
-        const { playlists, albums, allMusicCount } = splitCollections(collections);
-        logLibrary('[%s] after splitCollections — playlists: %o', providerId,
-          playlists.map(p => ({ name: p.name, tracks: p.tracks })));
-        logLibrary('[%s] after splitCollections — albums: %o', providerId,
-          albums.map(a => ({ name: a.name, total_tracks: a.total_tracks })));
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
-        writeLikedCountSnapshot(providerId, likedCount);
-        mergeAndSetData();
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          lastSyncTimestamp: Date.now(),
-        }));
-      } catch (err) {
-        if (cancelled) return;
-        if (err instanceof DOMException && err.name === 'AbortError') return;
-        console.error(`[useLibrarySync] Failed to load collections for ${providerId}:`, err);
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          error: err instanceof Error ? err.message : 'Failed to load library',
-        }));
-      }
-    }
-
-    Promise.all(catalogProviderIds.map(loadProviderCollections)).catch(() => {});
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
-
-  useEffect(() => {
-    const cleanups: Array<() => void> = [];
-    for (const providerId of catalogProviderIds) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      if (!catalog?.getLikedCount) continue;
-
-      const registryDescriptor = providerRegistry.get(providerId);
-      const eventName = registryDescriptor?.likesChangedEvent;
-      if (!eventName) continue;
-
-      const handleLikesChanged = () => {
-        catalog.getLikedCount!().then(count => {
-          const data = catalogDataRef.current.get(providerId);
-          if (data) {
-            data.likedCount = count;
-            mergeAndSetData();
-          }
-        }).catch(() => {});
-      };
-
-      window.addEventListener(eventName, handleLikesChanged);
-      cleanups.push(() => window.removeEventListener(eventName, handleLikesChanged));
-    }
-    return () => cleanups.forEach(cleanup => cleanup());
-  }, [catalogProviderIds, getDescriptor, mergeAndSetData]);
-
+  const engineRefresh = engine.refresh;
+  const catalogRefresh = catalog.refresh;
   const refreshNow = useCallback(async (scopeProviderId?: ProviderId) => {
     if (!scopeProviderId || scopeProviderId === engineProviderId) {
-      if (isEngineProviderEnabled) {
-        await engineRef.current.syncNow(true);
-      }
+      await engineRefresh();
     }
-
-    const providerIdsToRefresh = scopeProviderId
-      ? catalogProviderIds.filter(id => id === scopeProviderId)
-      : catalogProviderIds;
-
-    for (const providerId of providerIdsToRefresh) {
-      const descriptor = getDescriptor(providerId);
-      const catalog = descriptor?.catalog;
-      if (!catalog) continue;
-
-      setSyncState(prev => ({ ...prev, isSyncing: true, error: null }));
-      try {
-        const [collections, likedCount] = await Promise.all([
-          catalog.listCollections(undefined, { forceRefresh: true }),
-          catalog.getLikedCount ? catalog.getLikedCount() : Promise.resolve(0),
-        ]);
-        const { playlists, albums, allMusicCount } = splitCollections(collections);
-        catalogDataRef.current.set(providerId, { playlists, albums, likedCount, allMusicCount });
-        writeLikedCountSnapshot(providerId, likedCount);
-        mergeAndSetData();
-        setSyncState(prev => ({
-          ...prev,
-          isInitialLoadComplete: true,
-          isSyncing: false,
-          lastSyncTimestamp: Date.now(),
-        }));
-      } catch (err) {
-        setSyncState(prev => ({
-          ...prev,
-          isSyncing: false,
-          error: err instanceof Error ? err.message : 'Refresh failed',
-        }));
-      }
+    if (!scopeProviderId || scopeProviderId !== engineProviderId) {
+      await catalogRefresh(scopeProviderId);
     }
-  }, [isEngineProviderEnabled, engineProviderId, catalogProviderIds, getDescriptor, mergeAndSetData]);
+  }, [engineProviderId, engineRefresh, catalogRefresh]);
 
   useEffect(() => {
     const handleArtRefresh = () => { refreshNow().catch(() => {}); };
@@ -377,33 +132,28 @@ export function useLibrarySync(): UseLibrarySyncResult {
     };
   }, [refreshNow]);
 
+  const engineRemove = engine.removeCollection;
+  const catalogRemove = catalog.removeCollection;
   const removeCollection = useCallback((collectionId: string) => {
-    engineDataRef.current.playlists = engineDataRef.current.playlists.filter(p => p.id !== collectionId);
-    engineDataRef.current.albums = engineDataRef.current.albums.filter(a => a.id !== collectionId);
-
-    for (const [, data] of catalogDataRef.current) {
-      data.playlists = data.playlists.filter(p => p.id !== collectionId);
-      data.albums = data.albums.filter(a => a.id !== collectionId);
-    }
-
-    mergeAndSetData();
-  }, [mergeAndSetData]);
+    engineRemove(collectionId);
+    catalogRemove(collectionId);
+  }, [engineRemove, catalogRemove]);
 
   const isLikedSongsSyncing = enabledProviderIds.length > 0
-    && !syncState.isInitialLoadComplete
-    && initialSnapshot.total > 0;
+    && !isInitialLoadComplete
+    && initialLikedSnapshotTotal > 0;
 
   return {
-    playlists,
-    albums,
-    likedSongsCount,
-    likedSongsPerProvider,
-    allMusicCount,
-    isInitialLoadComplete: syncState.isInitialLoadComplete,
-    isSyncing: syncState.isSyncing,
+    playlists: merged.playlists,
+    albums: merged.albums,
+    likedSongsCount: merged.likedSongsCount,
+    likedSongsPerProvider: merged.likedSongsPerProvider,
+    allMusicCount: catalog.allMusicCount,
+    isInitialLoadComplete,
+    isSyncing,
     isLikedSongsSyncing,
-    lastSyncTimestamp: syncState.lastSyncTimestamp,
-    syncError: syncState.error,
+    lastSyncTimestamp,
+    syncError,
     refreshNow,
     removeCollection,
   };

--- a/src/hooks/useLibrarySync.ts
+++ b/src/hooks/useLibrarySync.ts
@@ -4,7 +4,7 @@ import type { AlbumInfo } from '@/services/spotify';
 import type { MediaCollection, ProviderId } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { providerRegistry } from '@/providers/registry';
-import { librarySyncEngine } from '@/services/cache/librarySyncEngine';
+import { spotifyLibrarySyncEngine } from '@/services/cache/librarySyncEngine';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logLibrary } from '@/lib/debugLog';
 import { getOrSetFirstSeenAddedAtIso } from '@/utils/libraryFirstSeen';
@@ -131,14 +131,14 @@ export function useLibrarySync(): UseLibrarySyncResult {
     error: null,
   });
 
-  const engineRef = useRef(librarySyncEngine);
+  const engineRef = useRef(spotifyLibrarySyncEngine);
 
   // The sync engine talks directly to the real Spotify Web API. In mock mode,
   // bypass it so the registry-aware catalog path (further down) loads spotify
   // collections via the mock catalog adapter instead.
-  const engineProviderId = shouldUseMockProvider()
+  const engineProviderId: ProviderId | undefined = shouldUseMockProvider()
     ? undefined
-    : (librarySyncEngine.providerId as ProviderId | undefined);
+    : spotifyLibrarySyncEngine.providerId;
 
   const engineDataRef = useRef<{ playlists: CachedPlaylistInfo[]; albums: AlbumInfo[]; likedCount: number }>({
     playlists: [], albums: [], likedCount: 0,

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -15,6 +15,7 @@ import type { TrackOperations } from '@/types/trackOperations';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { useQueueThumbnailLoader } from '@/hooks/useQueueThumbnailLoader';
 import { useQueueDurationLoader } from '@/hooks/useQueueDurationLoader';
 import { trkSummary } from './playerLogicUtils';
@@ -216,8 +217,9 @@ export function usePlayerLogic() {
     if (!drivingDescriptor) return;
     try {
       await drivingDescriptor.playback.resume();
-    } catch {
+    } catch (err) {
       // Autoplay policy or network errors are handled by the playback adapter
+      logCaughtError('usePlayerLogic.ensurePlaybackResumed', err);
     }
   }, [getDrivingProviderDescriptor]);
 
@@ -280,8 +282,9 @@ export function usePlayerLogic() {
       const drivingDescriptor = getDrivingProviderDescriptor();
       if (!drivingDescriptor) return;
       await drivingDescriptor.playback.resume();
-    } catch {
+    } catch (err) {
       // Autoplay policy or network errors are handled by the playback adapter
+      logCaughtError('usePlayerLogic.handlePlay', err);
     }
   }, [playTrack, getDrivingProviderId, getDrivingProviderDescriptor]);
 

--- a/src/hooks/useQueueDurationLoader.ts
+++ b/src/hooks/useQueueDurationLoader.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /** Maximum number of concurrent duration resolution calls per batch. */
 const RESOLVE_CONCURRENCY = 2;
@@ -70,7 +71,8 @@ export function useQueueDurationLoader(
                 batchResults.set(track.id, durationMs);
               }
               if (!controller.signal.aborted) attemptedTrackIds.current.add(track.id);
-            } catch {
+            } catch (err) {
+              logCaughtError('useQueueDurationLoader.resolveDuration', err);
               if (!controller.signal.aborted) attemptedTrackIds.current.add(track.id);
             }
           }),

--- a/src/hooks/useQueueThumbnailLoader.ts
+++ b/src/hooks/useQueueThumbnailLoader.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /** Maximum number of concurrent art resolution calls per batch. */
 const FETCH_CONCURRENCY = 3;
@@ -73,8 +74,9 @@ export function useQueueThumbnailLoader(
               const provider = providerRegistry.get(mt.provider);
               const art = await provider?.catalog.resolveArtwork?.(albumId, controller.signal);
               if (art) batchResults.set(albumId, art);
-            } catch {
+            } catch (err) {
               // Swallow errors for individual album art resolution
+              logCaughtError('useQueueThumbnailLoader.resolveArtwork', err);
             }
           }),
         );

--- a/src/hooks/useUiV2.ts
+++ b/src/hooks/useUiV2.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 /**
  * `?ui=v2` flag — opt-in mechanism for whole-screen redesigns shipped behind
@@ -63,7 +64,8 @@ function readPersistedFlag(): boolean {
     const raw = window.localStorage.getItem(STORAGE_KEYS.SETTINGS_V2_ENABLED);
     if (raw === null) return false;
     return JSON.parse(raw) === true;
-  } catch {
+  } catch (err) {
+    logCaughtError('useUiV2.readPersistedFlag', err);
     return false;
   }
 }

--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -2,6 +2,7 @@ import type { DropboxFileEntry, DropboxListFolderResult, CachedLink } from './dr
 import { TEMP_LINK_TTL_MS } from './dropboxCatalogHelpers';
 import type { DropboxAuthAdapter } from './dropboxAuthAdapter';
 import { AuthExpiredError } from '@/providers/errors';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const DEFAULT_RETRY_AFTER_SECONDS = 5;
 const MAX_RETRY_AFTER_SECONDS = 30;
@@ -15,8 +16,9 @@ async function parseRetryAfterSeconds(response: Response): Promise<number> {
   try {
     const body = await response.clone().json() as { retry_after?: number };
     if (typeof body?.retry_after === 'number' && body.retry_after > 0) return body.retry_after;
-  } catch {
+  } catch (err) {
     // 429 body wasn't JSON; fall through to default.
+    logCaughtError('dropboxApiClient.parseRetryAfterSeconds', err);
   }
   return DEFAULT_RETRY_AFTER_SECONDS;
 }

--- a/src/providers/dropbox/dropboxArtCache.ts
+++ b/src/providers/dropbox/dropboxArtCache.ts
@@ -4,6 +4,8 @@
  * without hitting the Dropbox API.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
+
 const DB_NAME = 'vorbis-dropbox-art';
 const DB_VERSION = 7;
 const STORE = 'art';
@@ -76,7 +78,8 @@ export async function getArt(path: string): Promise<string | null> {
         resolve(entry && Date.now() - entry.cachedAt < ART_TTL_MS ? entry.dataUrl : null);
       };
       req.onerror = () => resolve(null);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.getArt', err);
       resolve(null);
     }
   });
@@ -92,7 +95,8 @@ export async function putArt(path: string, dataUrl: string): Promise<void> {
       tx.objectStore(STORE).put(entry);
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.putArt', err);
       resolve();
     }
   });
@@ -121,7 +125,8 @@ export async function clearArt(): Promise<void> {
       tx.objectStore(STORE).clear();
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.clearArt', err);
       resolve();
     }
   });
@@ -133,8 +138,9 @@ export async function putDurationMs(trackId: string, durationMs: number): Promis
   try {
     const tx = database.transaction('durations', 'readwrite');
     tx.objectStore('durations').put({ trackId, durationMs });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putDurationMs', err);
   }
 }
 
@@ -151,8 +157,9 @@ export async function putTagMetadata(trackId: string, tags: Omit<CachedTagMetada
   try {
     const tx = database.transaction('tags', 'readwrite');
     tx.objectStore('tags').put({ trackId, ...tags });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putTagMetadata', err);
   }
 }
 
@@ -173,7 +180,8 @@ function batchGetFromStore<T>(database: IDBDatabase, storeName: string, ids: str
           if (--pending === 0) resolve(result);
         };
       }
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtCache.batchGetFromStore', err);
       resolve(result);
     }
   });
@@ -211,8 +219,9 @@ export async function putTrackDate(albumId: string, releaseYear: number): Promis
   try {
     const tx = database.transaction('trackDates', 'readwrite');
     tx.objectStore('trackDates').put({ albumId, releaseYear });
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxArtCache.putTrackDate', err);
   }
 }
 

--- a/src/providers/dropbox/dropboxArtworkResolver.ts
+++ b/src/providers/dropbox/dropboxArtworkResolver.ts
@@ -9,6 +9,7 @@ import {
   putAlbumArt,
 } from './dropboxArtCache';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class DropboxArtworkResolver {
   private apiClient: DropboxApiClient;
@@ -46,7 +47,8 @@ export class DropboxArtworkResolver {
 
       await putArt(path, dataUrl);
       return dataUrl;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtworkResolver.doFetchArtDataUrl', err);
       return null;
     }
   }
@@ -120,7 +122,8 @@ export class DropboxArtworkResolver {
         await putAlbumArt(albumDir, imageUrl);
       }
       return imageUrl;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxArtworkResolver.resolveAlbumArt', err);
       return null;
     }
   }

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -51,6 +51,7 @@ import {
 import { DropboxApiClient } from './dropboxApiClient';
 import { DropboxArtworkResolver } from './dropboxArtworkResolver';
 import { scanAlbumDatesInBackground } from './dropboxDateScanner';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class DropboxCatalogAdapter implements CatalogProvider {
   readonly providerId: ProviderId = 'dropbox';
@@ -190,8 +191,9 @@ export class DropboxCatalogAdapter implements CatalogProvider {
       let savedPlaylists: MediaCollection[] = [];
       try {
         savedPlaylists = await listSavedPlaylists(this.auth);
-      } catch {
+      } catch (err) {
         // Silently ignore -- saved playlists are optional
+        logCaughtError('dropboxCatalogAdapter.listSavedPlaylists', err);
       }
 
       const collections = [allMusic, ...savedPlaylists, ...albums];
@@ -368,7 +370,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
         putDurationMs(track.id, durationMs).catch(() => {});
       }
       return durationMs;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogAdapter.fetchTrackDuration', err);
       return null;
     }
   }

--- a/src/providers/dropbox/dropboxCatalogCache.ts
+++ b/src/providers/dropbox/dropboxCatalogCache.ts
@@ -1,4 +1,5 @@
 import type { MediaCollection } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { getDb } from './dropboxArtCache';
 
 const STORE = 'catalog';
@@ -35,7 +36,8 @@ export async function getCachedCatalog(): Promise<{
         });
       };
       req.onerror = () => resolve(null);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogCache.getCachedCatalog', err);
       resolve(null);
     }
   });
@@ -48,8 +50,9 @@ export async function putCatalogCache(collections: MediaCollection[]): Promise<v
     const entry: CachedCatalog = { key: KEY, collections, cachedAt: Date.now() };
     const tx = database.transaction(STORE, 'readwrite');
     tx.objectStore(STORE).put(entry);
-  } catch {
+  } catch (err) {
     // fire-and-forget
+    logCaughtError('dropboxCatalogCache.putCatalogCache', err);
   }
 }
 
@@ -62,7 +65,8 @@ export async function clearCatalogCache(): Promise<void> {
       tx.objectStore(STORE).clear();
       tx.oncomplete = () => resolve();
       tx.onerror = () => resolve();
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxCatalogCache.clearCatalogCache', err);
       resolve();
     }
   });

--- a/src/providers/dropbox/dropboxDateScanner.ts
+++ b/src/providers/dropbox/dropboxDateScanner.ts
@@ -2,6 +2,7 @@ import type { MediaCollection } from '@/types/domain';
 import type { DropboxApiClient } from './dropboxApiClient';
 import { getTrackDatesMap, putTrackDate } from './dropboxArtCache';
 import { parseID3 } from '@/utils/id3Parser';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 200;
@@ -34,8 +35,9 @@ export async function scanAlbumDatesInBackground(
             await putTrackDate(album.id, meta.releaseYear);
             album.releaseDate = String(meta.releaseYear);
           }
-        } catch {
+        } catch (err) {
           // Silently skip -- will retry on next catalog refresh
+          logCaughtError('dropboxDateScanner.scanAlbumDatesInBackground', err);
         }
       }),
     );

--- a/src/providers/dropbox/dropboxLikesCache.ts
+++ b/src/providers/dropbox/dropboxLikesCache.ts
@@ -1,4 +1,5 @@
 import type { MediaTrack } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { getDb } from './dropboxArtCache';
 
 const STORE = 'likes';
@@ -38,7 +39,8 @@ async function withIdbStore<T>(
       const store = tx.objectStore(storeName);
       fn(store, resolve);
       tx.onerror = () => resolve(fallback);
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxLikesCache.withIdbStore', err);
       resolve(fallback);
     }
   });
@@ -129,7 +131,8 @@ export async function importLikes(json: string): Promise<number> {
   try {
     entries = JSON.parse(json);
     if (!Array.isArray(entries)) return 0;
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxLikesCache.importLikes', err);
     return 0;
   }
 

--- a/src/providers/dropbox/dropboxLikesSync.ts
+++ b/src/providers/dropbox/dropboxLikesSync.ts
@@ -15,6 +15,7 @@ import {
 import { ensureVorbisFolder } from './dropboxSyncFolder';
 import { contentApiRequest } from './dropboxContentApiClient';
 import { logDropboxSync } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export interface RemoteLikesFile {
   version: 1;
@@ -93,7 +94,8 @@ export class DropboxLikesSyncService {
         return null;
       }
       return data;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxLikesSync.downloadLikesFile', err);
       console.warn('[DropboxLikesSync] Failed to parse remote likes file');
       return null;
     }
@@ -130,7 +132,8 @@ export class DropboxLikesSyncService {
       try {
         const errJson = JSON.parse(errText);
         errMsg = (errJson?.error_summary ?? errJson?.error ?? errText) || response.statusText;
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxLikesSync.uploadLikesFile.parseError', err);
         errMsg = errText || response.statusText;
       }
       console.warn('[DropboxLikesSync] Upload failed:', response.status, errMsg);

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -11,6 +11,7 @@ import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
 import { putDurationMs, putTagMetadata } from './dropboxArtCache';
 import { logArtRace } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const PLAYBACK_POLL_INTERVAL_MS = 250;
 const FETCH_LIMIT = 262144; // 256KB — enough to cover large embedded cover art in ID3 headers
@@ -136,7 +137,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
       let res: Response;
       try {
         res = await fetch(streamUrl, { headers: { Range: `bytes=0-${FETCH_LIMIT - 1}` } });
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxPlaybackAdapter.enrichMetadataInBackground', err);
         return;
       }
 

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -8,6 +8,7 @@ import type { MediaTrack, MediaCollection, ProviderId, PlaybackItemRef } from '@
 import { toSavedPlaylistId } from '@/constants/playlist';
 import { logLibrary } from '@/lib/debugLog';
 import { buildAlbumCoverMap, selectMosaicCovers } from '@/utils/mosaicSelection';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { contentApiRequest } from './dropboxContentApiClient';
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -150,8 +151,9 @@ export async function saveQueueAsPlaylist(
   try {
     const existing = await loadPlaylistFile(auth, filePath);
     if (existing?.createdAt) createdAt = existing.createdAt;
-  } catch {
+  } catch (err) {
     // New file — use current time
+    logCaughtError('dropboxPlaylistStorage.savePlaylist.loadExisting', err);
   }
 
   const data: PlaylistFile = {
@@ -317,7 +319,8 @@ async function loadPlaylistFile(
   try {
     const data: PlaylistFile = await response.json();
     return data.version === 1 ? data : null;
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxPlaylistStorage.loadPlaylistFile', err);
     return null;
   }
 }

--- a/src/providers/dropbox/dropboxPreferencesSync.ts
+++ b/src/providers/dropbox/dropboxPreferencesSync.ts
@@ -8,6 +8,7 @@ import { getPins, setPins, UNIFIED_PROVIDER, notifyPinsChanged } from '@/service
 import { ensureVorbisFolder } from './dropboxSyncFolder';
 import { contentApiRequest } from './dropboxContentApiClient';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -32,7 +33,8 @@ function parseJsonObject(raw: string | null): Record<string, string> {
   try {
     const parsed: unknown = JSON.parse(raw);
     return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {};
-  } catch {
+  } catch (err) {
+    logCaughtError('dropboxPreferencesSync.parseJsonObject', err);
     return {};
   }
 }
@@ -111,7 +113,8 @@ export class DropboxPreferencesSyncService {
         return null;
       }
       return data;
-    } catch {
+    } catch (err) {
+      logCaughtError('dropboxPreferencesSync.downloadPreferencesFile', err);
       console.warn('[DropboxPreferencesSync] Failed to parse remote preferences file');
       return null;
     }
@@ -148,7 +151,8 @@ export class DropboxPreferencesSyncService {
       try {
         const errJson = JSON.parse(errText);
         errMsg = (errJson?.error_summary ?? errJson?.error ?? errText) || response.statusText;
-      } catch {
+      } catch (err) {
+        logCaughtError('dropboxPreferencesSync.uploadPreferencesFile.parseError', err);
         errMsg = errText || response.statusText;
       }
       console.warn('[DropboxPreferencesSync] Upload failed:', response.status, errMsg);

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -1,5 +1,6 @@
 import { saveSession } from '@/services/sessionPersistence';
 import type { SessionSnapshot } from '@/services/sessionPersistence';
+import { logCaughtError } from '@/utils/logCaughtError';
 import type { MockCatalogAdapter } from './mockCatalogAdapter';
 
 const PARAM_NAME = 'mock-session';
@@ -38,7 +39,8 @@ export function parseMockSessionParam(search: string): MockSessionSeed | null {
     }
 
     return { trackId, positionMs };
-  } catch {
+  } catch (err) {
+    logCaughtError('mock.sessionSeed.parseMockSessionParam', err);
     return null;
   }
 }
@@ -82,7 +84,8 @@ export function seedSessionFromUrlParam(
     };
 
     saveSession(snapshot);
-  } catch {
+  } catch (err) {
     // Fail closed — log nothing, let the app start in default state.
+    logCaughtError('mock.sessionSeed.seedSessionFromUrlParam', err);
   }
 }

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -7,6 +7,7 @@ import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { spotifyAuth } from '@/services/spotify';
 import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 export class SpotifyAuthAdapter implements AuthProvider {
   readonly providerId: ProviderId = 'spotify';
@@ -18,7 +19,8 @@ export class SpotifyAuthAdapter implements AuthProvider {
   async getAccessToken(): Promise<string | null> {
     try {
       return await spotifyAuth.ensureValidToken();
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyAuthAdapter.getAccessToken', err);
       return spotifyAuth.getAccessToken();
     }
   }

--- a/src/providers/spotify/spotifyQueueSync.ts
+++ b/src/providers/spotify/spotifyQueueSync.ts
@@ -10,6 +10,7 @@ import { searchTrack, spotifyAuth } from '@/services/spotify';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { MediaTrack } from '@/types/domain';
 import { SPOTIFY_QUEUE_SYNC_DELAY_MS } from '@/constants/timing';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const QUEUE_URI_LIMIT = 200;
 const MAX_CONCURRENT_SEARCHES = 3;
@@ -25,7 +26,8 @@ class SpotifyQueueSyncService {
       const stored = localStorage.getItem(STORAGE_KEYS.SPOTIFY_QUEUE_SYNC);
       if (stored === null) return true; // default on
       return JSON.parse(stored);
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyQueueSync.isSyncEnabled', err);
       return true;
     }
   }
@@ -36,7 +38,8 @@ class SpotifyQueueSyncService {
       const stored = localStorage.getItem(STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER);
       if (stored === null) return true; // default on
       return JSON.parse(stored);
-    } catch {
+    } catch (err) {
+      logCaughtError('spotifyQueueSync.isResolveEnabled', err);
       return true;
     }
   }
@@ -101,8 +104,9 @@ class SpotifyQueueSyncService {
           try {
             const result = await searchTrack(track.artists, track.name);
             this.resolutionCache.set(track.id, result?.uri ?? null);
-          } catch {
+          } catch (err) {
             // Network errors — don't cache, might succeed later
+            logCaughtError('spotifyQueueSync.resolveTracksInBackground', err);
           } finally {
             this.pendingResolutions.delete(track.id);
           }

--- a/src/services/cache/__tests__/libraryCache.test.ts
+++ b/src/services/cache/__tests__/libraryCache.test.ts
@@ -412,5 +412,64 @@ describe('libraryCache', () => {
       // Restore
       vi.mocked(indexedDB.open).mockImplementation(originalOpen);
     });
+
+    it('should round-trip every store via the in-memory fallback', async () => {
+      // #given — IndexedDB is unavailable, so initCache routes everything to memory
+      const originalOpen = indexedDB.open;
+      vi.spyOn(indexedDB, 'open').mockImplementation(() => {
+        throw new Error('IndexedDB blocked');
+      });
+      closeCache();
+      await initCache();
+      expect(_testing.fallbackMode).toBe(true);
+      expect(_testing.db).toBeNull();
+
+      // #when — exercise CRUD on each typed wrapper
+      await putPlaylist(makePlaylist('p1', 'In-Memory'));
+      await putAlbum(makeAlbum('a1', 'In-Memory Album'));
+      await putTrackList('playlist:p1', [makeTrack('t1')], 'snap-mem');
+      await putMeta('playlists', { lastValidated: 42, totalCount: 1 });
+
+      // #then — values come back from the in-memory maps
+      expect((await getAllPlaylists())[0]?.name).toBe('In-Memory');
+      expect((await getAllAlbums())[0]?.name).toBe('In-Memory Album');
+      expect((await getTrackList('playlist:p1'))?.snapshotId).toBe('snap-mem');
+      expect((await getMeta('playlists'))?.totalCount).toBe(1);
+
+      // #then — and removal from the fallback map propagates
+      await removePlaylist('p1');
+      await removeAlbum('a1');
+      await removeTrackList('playlist:p1');
+      expect(await getAllPlaylists()).toEqual([]);
+      expect(await getAllAlbums()).toEqual([]);
+      expect(await getTrackList('playlist:p1')).toBeUndefined();
+
+      vi.mocked(indexedDB.open).mockImplementation(originalOpen);
+    });
+
+    it('should clear every fallback map when clearAll runs in fallback mode', async () => {
+      // #given
+      const originalOpen = indexedDB.open;
+      vi.spyOn(indexedDB, 'open').mockImplementation(() => {
+        throw new Error('IndexedDB blocked');
+      });
+      closeCache();
+      await initCache();
+      await putPlaylist(makePlaylist('p1'));
+      await putAlbum(makeAlbum('a1'));
+      await putTrackList('playlist:p1', [makeTrack('t1')]);
+      await putMeta('playlists', { lastValidated: 1, totalCount: 1 });
+
+      // #when
+      await clearAll();
+
+      // #then
+      expect(await getAllPlaylists()).toEqual([]);
+      expect(await getAllAlbums()).toEqual([]);
+      expect(await getTrackList('playlist:p1')).toBeUndefined();
+      expect(await getMeta('playlists')).toBeUndefined();
+
+      vi.mocked(indexedDB.open).mockImplementation(originalOpen);
+    });
   });
 });

--- a/src/services/cache/__tests__/librarySyncEngine.test.ts
+++ b/src/services/cache/__tests__/librarySyncEngine.test.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { LibrarySyncEngine } from '../librarySyncEngine';
+import { SpotifyLibrarySyncEngine } from '../librarySyncEngine';
 import * as cache from '../libraryCache';
 import type { CachedPlaylistInfo, SyncState } from '../cacheTypes';
 import type { AlbumInfo, SpotifyImage } from '../../spotify';
@@ -92,14 +92,14 @@ async function seedCacheMeta(opts: {
   });
 }
 
-describe('LibrarySyncEngine', () => {
-  let engine: LibrarySyncEngine;
+describe('SpotifyLibrarySyncEngine', () => {
+  let engine: SpotifyLibrarySyncEngine;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     await cache.initCache();
     await cache.clearAll();
-    engine = new LibrarySyncEngine();
+    engine = new SpotifyLibrarySyncEngine();
   });
 
   afterEach(() => {

--- a/src/services/cache/libraryCache.ts
+++ b/src/services/cache/libraryCache.ts
@@ -1,10 +1,10 @@
 /**
  * IndexedDB-based persistent cache for Spotify library data.
  *
- * Stores playlists, albums, and track lists as individual records so that
- * incremental updates (add/remove/update single entries) are efficient.
- *
- * Falls back to in-memory Maps if IndexedDB is unavailable.
+ * This module is the public surface: typed per-store CRUD wrappers built on
+ * top of `getStore<T>` from `./libraryCacheStorage`. The storage layer hides
+ * the IndexedDB / in-memory fallback split, and the lifecycle layer owns the
+ * singleton state plus the open/upgrade and migration steps.
  */
 
 import type { AlbumInfo, Track } from '../spotify';
@@ -13,302 +13,63 @@ import type {
   CachedTrackList,
   LibraryCacheMeta,
 } from './cacheTypes';
-import { STORAGE_KEYS } from '@/constants/storage';
+import {
+  closeCache,
+  getDb,
+  initCache,
+  isFallback,
+  STORE_ALBUMS,
+  STORE_META,
+  STORE_PLAYLISTS,
+  STORE_TRACK_LISTS,
+} from './libraryCacheLifecycle';
+import { fallbackStores, getStore } from './libraryCacheStorage';
 
-const DB_NAME = 'vorbis-player-library';
-const DB_VERSION = 1;
+export { initCache, closeCache };
 
-const STORE_PLAYLISTS = 'playlists';
-const STORE_ALBUMS = 'albums';
-const STORE_TRACK_LISTS = 'trackLists';
-const STORE_META = 'meta';
-
-// =============================================================================
-// In-Memory Fallback
-// =============================================================================
-
-interface FallbackStores {
-  playlists: Map<string, CachedPlaylistInfo>;
-  albums: Map<string, AlbumInfo>;
-  trackLists: Map<string, CachedTrackList>;
-  meta: Map<string, LibraryCacheMeta>;
-}
-
-const fallbackStores: FallbackStores = {
-  playlists: new Map(),
-  albums: new Map(),
-  trackLists: new Map(),
-  meta: new Map(),
-};
-
-// =============================================================================
-// State
-// =============================================================================
-
-let db: IDBDatabase | null = null;
-let fallbackMode = false;
-let initPromise: Promise<void> | null = null;
-
-// =============================================================================
-// Database Lifecycle
-// =============================================================================
-
-function openIDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onerror = () => reject(request.error);
-
-    request.onsuccess = () => resolve(request.result);
-
-    request.onupgradeneeded = (event) => {
-      const database = (event.target as IDBOpenDBRequest).result;
-      if (!database.objectStoreNames.contains(STORE_PLAYLISTS)) {
-        database.createObjectStore(STORE_PLAYLISTS, { keyPath: 'id' });
-      }
-      if (!database.objectStoreNames.contains(STORE_ALBUMS)) {
-        database.createObjectStore(STORE_ALBUMS, { keyPath: 'id' });
-      }
-      if (!database.objectStoreNames.contains(STORE_TRACK_LISTS)) {
-        database.createObjectStore(STORE_TRACK_LISTS, { keyPath: 'id' });
-      }
-      if (!database.objectStoreNames.contains(STORE_META)) {
-        database.createObjectStore(STORE_META, { keyPath: 'key' });
-      }
-    };
-  });
-}
-
-/**
- * Initialize the cache. Opens IndexedDB, migrates from localStorage,
- * or activates the in-memory fallback.
- * Safe to call multiple times — subsequent calls return the same promise.
- */
-export async function initCache(): Promise<void> {
-  if (initPromise) return initPromise;
-
-  initPromise = (async () => {
-    try {
-      if (typeof indexedDB === 'undefined') {
-        throw new Error('IndexedDB not available');
-      }
-      db = await openIDB();
-      await migrateFromLocalStorage();
-    } catch (err) {
-      console.warn('[libraryCache] IndexedDB unavailable, using in-memory fallback:', err);
-      fallbackMode = true;
-      db = null;
-    }
-  })();
-
-  return initPromise;
-}
-
-/** Close the database connection (primarily for testing). */
-export function closeCache(): void {
-  if (db) {
-    db.close();
-    db = null;
-  }
-  fallbackMode = false;
-  initPromise = null;
-  fallbackStores.playlists.clear();
-  fallbackStores.albums.clear();
-  fallbackStores.trackLists.clear();
-  fallbackStores.meta.clear();
-}
-
-// =============================================================================
-// Internal Helpers
-// =============================================================================
-
-function idbGet<T>(storeName: string, key: string): Promise<T | undefined> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readonly');
-    const store = tx.objectStore(storeName);
-    const request = store.get(key);
-    request.onsuccess = () => resolve(request.result as T | undefined);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function idbGetAll<T>(storeName: string): Promise<T[]> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readonly');
-    const store = tx.objectStore(storeName);
-    const request = store.getAll();
-    request.onsuccess = () => resolve(request.result as T[]);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function idbPut<T>(storeName: string, value: T): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readwrite');
-    const store = tx.objectStore(storeName);
-    const request = store.put(value);
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function idbDelete(storeName: string, key: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readwrite');
-    const store = tx.objectStore(storeName);
-    const request = store.delete(key);
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function idbClear(storeName: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readwrite');
-    const store = tx.objectStore(storeName);
-    const request = store.clear();
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function idbPutAll<T>(storeName: string, items: T[]): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readwrite');
-    const store = tx.objectStore(storeName);
-    for (const item of items) {
-      store.put(item);
-    }
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
-
-/** Atomically replace all records in a store: clear + putAll in a single transaction. */
-function idbReplaceAll<T>(storeName: string, items: T[]): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!db) { reject(new Error('DB not initialized')); return; }
-    const tx = db.transaction(storeName, 'readwrite');
-    const store = tx.objectStore(storeName);
-    store.clear();
-    for (const item of items) {
-      store.put(item);
-    }
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
-
-// =============================================================================
-// Generic Store Operations Factory
-// =============================================================================
-
-interface StoreOps<T extends { id: string }> {
-  getAll: () => Promise<T[]>;
-  put: (item: T) => Promise<void>;
-  remove: (id: string) => Promise<void>;
-  replaceAll: (items: T[]) => Promise<void>;
-}
-
-function createStoreOps<T extends { id: string }>(
-  storeName: string,
-  fallback: Map<string, T>,
-): StoreOps<T> {
-  return {
-    async getAll(): Promise<T[]> {
-      await initCache();
-      if (fallbackMode) return Array.from(fallback.values());
-      try {
-        return await idbGetAll<T>(storeName);
-      } catch {
-        return Array.from(fallback.values());
-      }
-    },
-
-    async put(item: T): Promise<void> {
-      await initCache();
-      if (fallbackMode) { fallback.set(item.id, item); return; }
-      try {
-        await idbPut(storeName, item);
-      } catch {
-        fallback.set(item.id, item);
-      }
-    },
-
-    async remove(id: string): Promise<void> {
-      await initCache();
-      if (fallbackMode) { fallback.delete(id); return; }
-      try {
-        await idbDelete(storeName, id);
-      } catch {
-        fallback.delete(id);
-      }
-    },
-
-    async replaceAll(items: T[]): Promise<void> {
-      await initCache();
-      if (fallbackMode) {
-        fallback.clear();
-        for (const item of items) fallback.set(item.id, item);
-        return;
-      }
-      try {
-        await idbReplaceAll(storeName, items);
-      } catch {
-        for (const item of items) fallback.set(item.id, item);
-      }
-    },
-  };
-}
+const playlists = getStore<CachedPlaylistInfo>(STORE_PLAYLISTS);
+const albums = getStore<AlbumInfo>(STORE_ALBUMS);
+const trackLists = getStore<CachedTrackList>(STORE_TRACK_LISTS);
+const meta = getStore<LibraryCacheMeta>(STORE_META);
 
 // =============================================================================
 // Playlist Operations
 // =============================================================================
 
-const playlistOps = createStoreOps<CachedPlaylistInfo>(STORE_PLAYLISTS, fallbackStores.playlists);
-
 export async function getAllPlaylists(): Promise<CachedPlaylistInfo[]> {
-  return playlistOps.getAll();
+  return playlists.getAll();
 }
 
-export async function putAllPlaylists(playlists: CachedPlaylistInfo[]): Promise<void> {
-  return playlistOps.replaceAll(playlists);
+export async function putAllPlaylists(items: CachedPlaylistInfo[]): Promise<void> {
+  return playlists.replaceAll(items.map((p) => [p.id, p]));
 }
 
 export async function putPlaylist(playlist: CachedPlaylistInfo): Promise<void> {
-  return playlistOps.put(playlist);
+  return playlists.put(playlist.id, playlist);
 }
 
 export async function removePlaylist(id: string): Promise<void> {
-  return playlistOps.remove(id);
+  return playlists.remove(id);
 }
 
 // =============================================================================
 // Album Operations
 // =============================================================================
 
-const albumOps = createStoreOps<AlbumInfo>(STORE_ALBUMS, fallbackStores.albums);
-
 export async function getAllAlbums(): Promise<AlbumInfo[]> {
-  return albumOps.getAll();
+  return albums.getAll();
 }
 
-export async function putAllAlbums(albums: AlbumInfo[]): Promise<void> {
-  return albumOps.replaceAll(albums);
+export async function putAllAlbums(items: AlbumInfo[]): Promise<void> {
+  return albums.replaceAll(items.map((a) => [a.id, a]));
 }
 
 export async function putAlbum(album: AlbumInfo): Promise<void> {
-  return albumOps.put(album);
+  return albums.put(album.id, album);
 }
 
 export async function removeAlbum(id: string): Promise<void> {
-  return albumOps.remove(id);
+  return albums.remove(id);
 }
 
 // =============================================================================
@@ -316,34 +77,20 @@ export async function removeAlbum(id: string): Promise<void> {
 // =============================================================================
 
 export async function getTrackList(id: string): Promise<CachedTrackList | undefined> {
-  await initCache();
-  if (fallbackMode) return fallbackStores.trackLists.get(id);
-  try {
-    return await idbGet<CachedTrackList>(STORE_TRACK_LISTS, id);
-  } catch {
-    return fallbackStores.trackLists.get(id);
-  }
+  return trackLists.get(id);
 }
 
-export async function putTrackList(id: string, tracks: Track[], snapshotId?: string): Promise<void> {
+export async function putTrackList(
+  id: string,
+  tracks: Track[],
+  snapshotId?: string,
+): Promise<void> {
   const entry: CachedTrackList = { id, tracks, timestamp: Date.now(), snapshotId };
-  await initCache();
-  if (fallbackMode) { fallbackStores.trackLists.set(id, entry); return; }
-  try {
-    await idbPut(STORE_TRACK_LISTS, entry);
-  } catch {
-    fallbackStores.trackLists.set(id, entry);
-  }
+  return trackLists.put(id, entry);
 }
 
 export async function removeTrackList(id: string): Promise<void> {
-  await initCache();
-  if (fallbackMode) { fallbackStores.trackLists.delete(id); return; }
-  try {
-    await idbDelete(STORE_TRACK_LISTS, id);
-  } catch {
-    fallbackStores.trackLists.delete(id);
-  }
+  return trackLists.remove(id);
 }
 
 // =============================================================================
@@ -351,80 +98,14 @@ export async function removeTrackList(id: string): Promise<void> {
 // =============================================================================
 
 export async function getMeta(key: string): Promise<LibraryCacheMeta | undefined> {
-  await initCache();
-  if (fallbackMode) return fallbackStores.meta.get(key);
-  try {
-    return await idbGet<LibraryCacheMeta>(STORE_META, key);
-  } catch {
-    return fallbackStores.meta.get(key);
-  }
+  return meta.get(key);
 }
 
-export async function putMeta(key: string, meta: Omit<LibraryCacheMeta, 'key'>): Promise<void> {
-  const entry = { ...meta, key };
-  await initCache();
-  if (fallbackMode) { fallbackStores.meta.set(key, entry); return; }
-  try {
-    await idbPut(STORE_META, entry);
-  } catch {
-    fallbackStores.meta.set(key, entry);
-  }
-}
-
-// =============================================================================
-// Migration from localStorage
-// =============================================================================
-
-interface LocalStorageCacheEntry<T> {
-  data: T;
-  timestamp: number;
-}
-
-async function migrateFromLocalStorage(): Promise<void> {
-  try {
-    const playlistsRaw = localStorage.getItem(STORAGE_KEYS.CACHE_PLAYLISTS);
-    const albumsRaw = localStorage.getItem(STORAGE_KEYS.CACHE_ALBUMS);
-
-    if (!playlistsRaw && !albumsRaw) return;
-
-    if (playlistsRaw) {
-      const entry = JSON.parse(playlistsRaw) as LocalStorageCacheEntry<CachedPlaylistInfo[]>;
-      if (entry?.data?.length) {
-        await idbPutAll(STORE_PLAYLISTS, entry.data);
-        const snapshotIds: Record<string, string> = {};
-        for (const p of entry.data) {
-          if (p.snapshot_id) snapshotIds[p.id] = p.snapshot_id;
-        }
-        await idbPut(STORE_META, {
-          key: 'playlists',
-          lastValidated: entry.timestamp,
-          totalCount: entry.data.length,
-          snapshotIds,
-        } satisfies LibraryCacheMeta);
-        localStorage.removeItem(STORAGE_KEYS.CACHE_PLAYLISTS);
-      }
-    }
-
-    if (albumsRaw) {
-      const entry = JSON.parse(albumsRaw) as LocalStorageCacheEntry<AlbumInfo[]>;
-      if (entry?.data?.length) {
-        await idbPutAll(STORE_ALBUMS, entry.data);
-        const latestAddedAt = entry.data.reduce(
-          (latest, a) => (a.added_at && a.added_at > latest ? a.added_at : latest),
-          '',
-        );
-        await idbPut(STORE_META, {
-          key: 'albums',
-          lastValidated: entry.timestamp,
-          totalCount: entry.data.length,
-          latestAddedAt: latestAddedAt || undefined,
-        } satisfies LibraryCacheMeta);
-        localStorage.removeItem(STORAGE_KEYS.CACHE_ALBUMS);
-      }
-    }
-  } catch (err) {
-    console.warn('[libraryCache] localStorage migration failed:', err);
-  }
+export async function putMeta(
+  key: string,
+  value: Omit<LibraryCacheMeta, 'key'>,
+): Promise<void> {
+  return meta.put(key, { ...value, key });
 }
 
 // =============================================================================
@@ -458,32 +139,21 @@ export async function clearCacheWithOptions(options: ClearCacheOptions = {}): Pr
 }
 
 export async function clearAll(): Promise<void> {
-  await initCache();
-  if (fallbackMode) {
-    fallbackStores.playlists.clear();
-    fallbackStores.albums.clear();
-    fallbackStores.trackLists.clear();
-    fallbackStores.meta.clear();
-    return;
-  }
-  try {
-    await Promise.all([
-      idbClear(STORE_PLAYLISTS),
-      idbClear(STORE_ALBUMS),
-      idbClear(STORE_TRACK_LISTS),
-      idbClear(STORE_META),
-    ]);
-  } catch {
-    fallbackStores.playlists.clear();
-    fallbackStores.albums.clear();
-    fallbackStores.trackLists.clear();
-    fallbackStores.meta.clear();
-  }
+  await Promise.all([
+    playlists.clear(),
+    albums.clear(),
+    trackLists.clear(),
+    meta.clear(),
+  ]);
 }
 
 /** Exported for testing only */
 export const _testing = {
-  get fallbackMode() { return fallbackMode; },
-  get db() { return db; },
+  get fallbackMode() {
+    return isFallback();
+  },
+  get db() {
+    return getDb();
+  },
   fallbackStores,
 };

--- a/src/services/cache/libraryCacheLifecycle.ts
+++ b/src/services/cache/libraryCacheLifecycle.ts
@@ -1,0 +1,210 @@
+/**
+ * Database lifecycle for the library cache.
+ *
+ * Owns the singleton IndexedDB connection and the in-memory fallback flag.
+ * Exposes the open/upgrade promise and the localStorage migration step.
+ */
+
+import type { AlbumInfo } from '../spotify';
+import type {
+  CachedPlaylistInfo,
+  CachedTrackList,
+  LibraryCacheMeta,
+} from './cacheTypes';
+import { STORAGE_KEYS } from '@/constants/storage';
+
+const DB_NAME = 'vorbis-player-library';
+const DB_VERSION = 1;
+
+export const STORE_PLAYLISTS = 'playlists';
+export const STORE_ALBUMS = 'albums';
+export const STORE_TRACK_LISTS = 'trackLists';
+export const STORE_META = 'meta';
+
+export interface FallbackStores {
+  playlists: Map<string, CachedPlaylistInfo>;
+  albums: Map<string, AlbumInfo>;
+  trackLists: Map<string, CachedTrackList>;
+  meta: Map<string, LibraryCacheMeta>;
+}
+
+export const fallbackStores: FallbackStores = {
+  playlists: new Map(),
+  albums: new Map(),
+  trackLists: new Map(),
+  meta: new Map(),
+};
+
+let db: IDBDatabase | null = null;
+let fallbackMode = false;
+let initPromise: Promise<void> | null = null;
+
+export function getDb(): IDBDatabase | null {
+  return db;
+}
+
+export function isFallback(): boolean {
+  return fallbackMode;
+}
+
+export function getFallbackMap(storeName: string): Map<string, unknown> {
+  switch (storeName) {
+    case STORE_PLAYLISTS:
+      return fallbackStores.playlists as Map<string, unknown>;
+    case STORE_ALBUMS:
+      return fallbackStores.albums as Map<string, unknown>;
+    case STORE_TRACK_LISTS:
+      return fallbackStores.trackLists as Map<string, unknown>;
+    case STORE_META:
+      return fallbackStores.meta as Map<string, unknown>;
+    default:
+      throw new Error(`[libraryCache] Unknown store: ${storeName}`);
+  }
+}
+
+function openIDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => reject(request.error);
+
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const database = (event.target as IDBOpenDBRequest).result;
+      if (!database.objectStoreNames.contains(STORE_PLAYLISTS)) {
+        database.createObjectStore(STORE_PLAYLISTS, { keyPath: 'id' });
+      }
+      if (!database.objectStoreNames.contains(STORE_ALBUMS)) {
+        database.createObjectStore(STORE_ALBUMS, { keyPath: 'id' });
+      }
+      if (!database.objectStoreNames.contains(STORE_TRACK_LISTS)) {
+        database.createObjectStore(STORE_TRACK_LISTS, { keyPath: 'id' });
+      }
+      if (!database.objectStoreNames.contains(STORE_META)) {
+        database.createObjectStore(STORE_META, { keyPath: 'key' });
+      }
+    };
+  });
+}
+
+/**
+ * Initialize the cache. Opens IndexedDB, migrates from localStorage,
+ * or activates the in-memory fallback.
+ * Safe to call multiple times — subsequent calls return the same promise.
+ */
+export async function initCache(): Promise<void> {
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    try {
+      if (typeof indexedDB === 'undefined') {
+        throw new Error('IndexedDB not available');
+      }
+      db = await openIDB();
+      await migrateFromLocalStorage();
+    } catch (err) {
+      console.warn('[libraryCache] IndexedDB unavailable, using in-memory fallback:', err);
+      fallbackMode = true;
+      db = null;
+    }
+  })();
+
+  return initPromise;
+}
+
+/** Close the database connection (primarily for testing). */
+export function closeCache(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+  fallbackMode = false;
+  initPromise = null;
+  fallbackStores.playlists.clear();
+  fallbackStores.albums.clear();
+  fallbackStores.trackLists.clear();
+  fallbackStores.meta.clear();
+}
+
+interface LocalStorageCacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+function idbPutDirect<T>(storeName: string, value: T): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) {
+      reject(new Error('DB not initialized'));
+      return;
+    }
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    const request = store.put(value);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbPutAllDirect<T>(storeName: string, items: T[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) {
+      reject(new Error('DB not initialized'));
+      return;
+    }
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    for (const item of items) {
+      store.put(item);
+    }
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function migrateFromLocalStorage(): Promise<void> {
+  try {
+    const playlistsRaw = localStorage.getItem(STORAGE_KEYS.CACHE_PLAYLISTS);
+    const albumsRaw = localStorage.getItem(STORAGE_KEYS.CACHE_ALBUMS);
+
+    if (!playlistsRaw && !albumsRaw) return;
+
+    if (playlistsRaw) {
+      const entry = JSON.parse(playlistsRaw) as LocalStorageCacheEntry<CachedPlaylistInfo[]>;
+      if (entry?.data?.length) {
+        await idbPutAllDirect(STORE_PLAYLISTS, entry.data);
+        const snapshotIds: Record<string, string> = {};
+        for (const p of entry.data) {
+          if (p.snapshot_id) snapshotIds[p.id] = p.snapshot_id;
+        }
+        await idbPutDirect(STORE_META, {
+          key: 'playlists',
+          lastValidated: entry.timestamp,
+          totalCount: entry.data.length,
+          snapshotIds,
+        } satisfies LibraryCacheMeta);
+        localStorage.removeItem(STORAGE_KEYS.CACHE_PLAYLISTS);
+      }
+    }
+
+    if (albumsRaw) {
+      const entry = JSON.parse(albumsRaw) as LocalStorageCacheEntry<AlbumInfo[]>;
+      if (entry?.data?.length) {
+        await idbPutAllDirect(STORE_ALBUMS, entry.data);
+        const latestAddedAt = entry.data.reduce(
+          (latest, a) => (a.added_at && a.added_at > latest ? a.added_at : latest),
+          '',
+        );
+        await idbPutDirect(STORE_META, {
+          key: 'albums',
+          lastValidated: entry.timestamp,
+          totalCount: entry.data.length,
+          latestAddedAt: latestAddedAt || undefined,
+        } satisfies LibraryCacheMeta);
+        localStorage.removeItem(STORAGE_KEYS.CACHE_ALBUMS);
+      }
+    }
+  } catch (err) {
+    console.warn('[libraryCache] localStorage migration failed:', err);
+  }
+}

--- a/src/services/cache/libraryCacheStorage.ts
+++ b/src/services/cache/libraryCacheStorage.ts
@@ -1,0 +1,212 @@
+/**
+ * Storage abstraction for the library cache.
+ *
+ * `getStore<T>(storeName)` returns a typed key-value interface that internally
+ * dispatches to IndexedDB (when open) or to the in-memory fallback Map.
+ * Consumers don't see the branching.
+ */
+
+import {
+  fallbackStores,
+  getDb,
+  getFallbackMap,
+  initCache,
+  isFallback,
+  STORE_ALBUMS,
+  STORE_META,
+  STORE_PLAYLISTS,
+  STORE_TRACK_LISTS,
+} from './libraryCacheLifecycle';
+
+export interface KVStore<T> {
+  get(key: string): Promise<T | undefined>;
+  getAll(): Promise<T[]>;
+  put(key: string, value: T): Promise<void>;
+  putAll(entries: Array<[string, T]>): Promise<void>;
+  remove(key: string): Promise<void>;
+  replaceAll(entries: Array<[string, T]>): Promise<void>;
+  clear(): Promise<void>;
+}
+
+type IDBMode = 'readonly' | 'readwrite';
+
+function withStore<R>(
+  storeName: string,
+  mode: IDBMode,
+  run: (store: IDBObjectStore, tx: IDBTransaction) => IDBRequest<R> | null,
+): Promise<R> {
+  return new Promise((resolve, reject) => {
+    const db = getDb();
+    if (!db) {
+      reject(new Error('DB not initialized'));
+      return;
+    }
+    const tx = db.transaction(storeName, mode);
+    const store = tx.objectStore(storeName);
+    const request = run(store, tx);
+    if (request) {
+      request.onsuccess = () => resolve(request.result as R);
+      request.onerror = () => reject(request.error);
+      return;
+    }
+    tx.oncomplete = () => resolve(undefined as R);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function idbGet<T>(storeName: string, key: string): Promise<T | undefined> {
+  return withStore<T | undefined>(storeName, 'readonly', (store) => store.get(key));
+}
+
+function idbGetAll<T>(storeName: string): Promise<T[]> {
+  return withStore<T[]>(storeName, 'readonly', (store) => store.getAll());
+}
+
+function idbPut<T>(storeName: string, value: T): Promise<void> {
+  return withStore<void>(storeName, 'readwrite', (store) => {
+    store.put(value);
+    return null;
+  });
+}
+
+function idbDelete(storeName: string, key: string): Promise<void> {
+  return withStore<void>(storeName, 'readwrite', (store) => {
+    store.delete(key);
+    return null;
+  });
+}
+
+function idbClear(storeName: string): Promise<void> {
+  return withStore<void>(storeName, 'readwrite', (store) => {
+    store.clear();
+    return null;
+  });
+}
+
+function idbPutAll<T>(storeName: string, items: T[]): Promise<void> {
+  return withStore<void>(storeName, 'readwrite', (store) => {
+    for (const item of items) store.put(item);
+    return null;
+  });
+}
+
+function idbReplaceAll<T>(storeName: string, items: T[]): Promise<void> {
+  return withStore<void>(storeName, 'readwrite', (store) => {
+    store.clear();
+    for (const item of items) store.put(item);
+    return null;
+  });
+}
+
+const KNOWN_STORES = new Set<string>([
+  STORE_PLAYLISTS,
+  STORE_ALBUMS,
+  STORE_TRACK_LISTS,
+  STORE_META,
+]);
+
+export function getStore<T>(storeName: string): KVStore<T> {
+  if (!KNOWN_STORES.has(storeName)) {
+    throw new Error(`[libraryCache] Unknown store: ${storeName}`);
+  }
+
+  const fallback = (): Map<string, T> => getFallbackMap(storeName) as Map<string, T>;
+
+  return {
+    async get(key: string): Promise<T | undefined> {
+      await initCache();
+      if (isFallback()) return fallback().get(key);
+      try {
+        return await idbGet<T>(storeName, key);
+      } catch {
+        return fallback().get(key);
+      }
+    },
+
+    async getAll(): Promise<T[]> {
+      await initCache();
+      if (isFallback()) return Array.from(fallback().values());
+      try {
+        return await idbGetAll<T>(storeName);
+      } catch {
+        return Array.from(fallback().values());
+      }
+    },
+
+    async put(key: string, value: T): Promise<void> {
+      await initCache();
+      if (isFallback()) {
+        fallback().set(key, value);
+        return;
+      }
+      try {
+        await idbPut(storeName, value);
+      } catch {
+        fallback().set(key, value);
+      }
+    },
+
+    async putAll(entries: Array<[string, T]>): Promise<void> {
+      await initCache();
+      const items = entries.map(([, value]) => value);
+      if (isFallback()) {
+        const map = fallback();
+        for (const [key, value] of entries) map.set(key, value);
+        return;
+      }
+      try {
+        await idbPutAll(storeName, items);
+      } catch {
+        const map = fallback();
+        for (const [key, value] of entries) map.set(key, value);
+      }
+    },
+
+    async remove(key: string): Promise<void> {
+      await initCache();
+      if (isFallback()) {
+        fallback().delete(key);
+        return;
+      }
+      try {
+        await idbDelete(storeName, key);
+      } catch {
+        fallback().delete(key);
+      }
+    },
+
+    async replaceAll(entries: Array<[string, T]>): Promise<void> {
+      await initCache();
+      const items = entries.map(([, value]) => value);
+      if (isFallback()) {
+        const map = fallback();
+        map.clear();
+        for (const [key, value] of entries) map.set(key, value);
+        return;
+      }
+      try {
+        await idbReplaceAll(storeName, items);
+      } catch {
+        const map = fallback();
+        map.clear();
+        for (const [key, value] of entries) map.set(key, value);
+      }
+    },
+
+    async clear(): Promise<void> {
+      await initCache();
+      if (isFallback()) {
+        fallback().clear();
+        return;
+      }
+      try {
+        await idbClear(storeName);
+      } catch {
+        fallback().clear();
+      }
+    },
+  };
+}
+
+/** Re-export fallback container for the _testing handle. */
+export { fallbackStores };

--- a/src/services/cache/libraryCacheStorage.ts
+++ b/src/services/cache/libraryCacheStorage.ts
@@ -6,6 +6,7 @@
  * Consumers don't see the branching.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
 import {
   fallbackStores,
   getDb,
@@ -118,7 +119,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       if (isFallback()) return fallback().get(key);
       try {
         return await idbGet<T>(storeName, key);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.get`, err);
         return fallback().get(key);
       }
     },
@@ -128,7 +130,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       if (isFallback()) return Array.from(fallback().values());
       try {
         return await idbGetAll<T>(storeName);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.getAll`, err);
         return Array.from(fallback().values());
       }
     },
@@ -141,7 +144,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbPut(storeName, value);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.put`, err);
         fallback().set(key, value);
       }
     },
@@ -156,7 +160,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbPutAll(storeName, items);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.putAll`, err);
         const map = fallback();
         for (const [key, value] of entries) map.set(key, value);
       }
@@ -170,7 +175,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbDelete(storeName, key);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.remove`, err);
         fallback().delete(key);
       }
     },
@@ -186,7 +192,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbReplaceAll(storeName, items);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.replaceAll`, err);
         const map = fallback();
         map.clear();
         for (const [key, value] of entries) map.set(key, value);
@@ -201,7 +208,8 @@ export function getStore<T>(storeName: string): KVStore<T> {
       }
       try {
         await idbClear(storeName);
-      } catch {
+      } catch (err) {
+        logCaughtError(`libraryCacheStorage.${storeName}.clear`, err);
         fallback().clear();
       }
     },

--- a/src/services/cache/libraryDiffEngine.ts
+++ b/src/services/cache/libraryDiffEngine.ts
@@ -10,6 +10,10 @@ import {
 import * as cache from './libraryCache';
 import type { CachedPlaylistInfo, LibraryChanges } from './cacheTypes';
 
+// One-minute stride per ordinal so synthesised timestamps preserve the
+// fetched order when the upstream playlist lacks a real added_at.
+const SYNTHETIC_ADDED_AT_STRIDE_MS = 60_000;
+
 export async function detectChanges(signal: AbortSignal): Promise<LibraryChanges> {
   const [playlistsMeta, albumsMeta, likedMeta] = await Promise.all([
     cache.getMeta('playlists'),
@@ -90,7 +94,7 @@ async function syncPlaylists(newTotal: number, signal: AbortSignal): Promise<Cac
     p.added_at =
       cached?.added_at ||
       p.added_at ||
-      new Date(Date.now() - i * 60000).toISOString();
+      new Date(Date.now() - i * SYNTHETIC_ADDED_AT_STRIDE_MS).toISOString();
   }
 
   const fetchedIds = new Set(allFetched.map(p => p.id));

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -39,8 +39,8 @@ type SyncListener = (
 
 const OPTIMISTIC_GRACE_MS = 30 * 1000;
 
-export class LibrarySyncEngine {
-  readonly providerId = 'spotify';
+export class SpotifyLibrarySyncEngine {
+  readonly providerId: 'spotify' = 'spotify';
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private listeners = new Set<SyncListener>();
   private abortController: AbortController | null = null;
@@ -352,7 +352,7 @@ export class LibrarySyncEngine {
     if (albums !== undefined) this.lastKnownAlbums = albums;
     if (likedSongsCount !== undefined) {
       this.lastKnownLikedCount = likedSongsCount;
-      writeLikedCountSnapshot(this.providerId as 'spotify', likedSongsCount);
+      writeLikedCountSnapshot(this.providerId, likedSongsCount);
     }
 
     for (const listener of this.listeners) {
@@ -384,4 +384,4 @@ export class LibrarySyncEngine {
 }
 
 /** Singleton instance for app-wide use. */
-export const librarySyncEngine = new LibrarySyncEngine();
+export const spotifyLibrarySyncEngine = new SpotifyLibrarySyncEngine();

--- a/src/services/cache/likedCountSnapshot.ts
+++ b/src/services/cache/likedCountSnapshot.ts
@@ -1,5 +1,6 @@
 import type { ProviderId } from '@/types/domain';
 import { STORAGE_KEYS } from '@/constants/storage';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface SnapshotEntry {
   count: number;
@@ -13,7 +14,8 @@ export function readLikedCountSnapshots(): LikedCountSnapshots {
     const raw = localStorage.getItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS);
     if (!raw) return {};
     return JSON.parse(raw) as LikedCountSnapshots;
-  } catch {
+  } catch (err) {
+    logCaughtError('likedCountSnapshot.readLikedCountSnapshots', err);
     return {};
   }
 }
@@ -23,7 +25,10 @@ export function writeLikedCountSnapshot(providerId: ProviderId, count: number): 
     const snapshots = readLikedCountSnapshots();
     snapshots[providerId] = { count, cachedAt: Date.now() };
     localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
-  } catch { /* quota exceeded — silent */ }
+  } catch (err) {
+    /* quota exceeded — silent */
+    logCaughtError('likedCountSnapshot.writeLikedCountSnapshot', err);
+  }
 }
 
 export function clearLikedCountSnapshot(providerId: ProviderId): void {
@@ -31,5 +36,8 @@ export function clearLikedCountSnapshot(providerId: ProviderId): void {
     const snapshots = readLikedCountSnapshots();
     delete snapshots[providerId];
     localStorage.setItem(STORAGE_KEYS.LIKED_COUNT_SNAPSHOTS, JSON.stringify(snapshots));
-  } catch { /* silent */ }
+  } catch (err) {
+    /* silent */
+    logCaughtError('likedCountSnapshot.clearLikedCountSnapshot', err);
+  }
 }

--- a/src/services/devbug/consoleCapture.ts
+++ b/src/services/devbug/consoleCapture.ts
@@ -1,5 +1,6 @@
 import createDebug from 'debug';
 import { CircularBuffer } from './circularBuffer';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const log = createDebug('vorbis:devbug');
 
@@ -74,7 +75,8 @@ function safeStringify(value: unknown, seen = new Set<unknown>()): string {
     seen.delete(value);
     const result = `{${entries.join(', ')}}`;
     return result.length > MAX_STRING_LENGTH ? result.slice(0, MAX_STRING_LENGTH) + '...[truncated]' : result;
-  } catch {
+  } catch (err) {
+    logCaughtError('consoleCapture.safeStringify', err);
     seen.delete(value);
     return '[Unserializable]';
   }

--- a/src/services/devbug/githubService.ts
+++ b/src/services/devbug/githubService.ts
@@ -1,5 +1,6 @@
 import type { BugReport } from '@/types/devbug';
 import { formatIssueBody, formatIssueTitle } from './issueFormatter';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const SCREENSHOT_PATH_PREFIX = 'docs/bug-screenshots';
@@ -85,8 +86,9 @@ export function createGitHubService(config: GitHubServiceConfig): GitHubService 
       const filename = `${report.id}.png`;
       try {
         screenshotUrl = await uploadScreenshot(report.screenshotDataUrl, filename);
-      } catch {
+      } catch (err) {
         // Continue without screenshot — don't block issue creation
+        logCaughtError('githubService.createIssue.uploadScreenshot', err);
       }
     }
 

--- a/src/services/devbug/perfCapture.ts
+++ b/src/services/devbug/perfCapture.ts
@@ -1,4 +1,5 @@
 import type { PerfData } from '@/types/devbug';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 interface MemoryInfo {
   usedJSHeapSize: number;
@@ -20,7 +21,8 @@ function readFcp(): number | null {
     const entries = performance.getEntriesByType('paint');
     const fcp = entries.find((e) => e.name === 'first-contentful-paint');
     return fcp ? fcp.startTime : null;
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.readFcp', err);
     return null;
   }
 }
@@ -33,7 +35,8 @@ function readMemory(): Pick<PerfData, 'memoryUsed' | 'memoryTotal'> {
       memoryUsed: mem.usedJSHeapSize,
       memoryTotal: mem.totalJSHeapSize,
     };
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.readMemory', err);
     return { memoryUsed: null, memoryTotal: null };
   }
 }
@@ -61,7 +64,8 @@ export function startPerfCapture(): void {
       }
     });
     lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.startPerfCapture.lcpObserver', err);
     lcpObserver = null;
   }
 
@@ -74,7 +78,8 @@ export function startPerfCapture(): void {
       }
     });
     longTaskObserver.observe({ type: 'longtask', buffered: false });
-  } catch {
+  } catch (err) {
+    logCaughtError('perfCapture.startPerfCapture.longTaskObserver', err);
     longTaskObserver = null;
   }
 }
@@ -85,8 +90,9 @@ export function stopPerfCapture(): PerfData {
   if (lcpObserver) {
     try {
       lcpObserver.disconnect();
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('perfCapture.stopPerfCapture.lcpDisconnect', err);
     }
     lcpObserver = null;
   }
@@ -94,8 +100,9 @@ export function stopPerfCapture(): PerfData {
   if (longTaskObserver) {
     try {
       longTaskObserver.disconnect();
-    } catch {
+    } catch (err) {
       // ignore
+      logCaughtError('perfCapture.stopPerfCapture.longTaskDisconnect', err);
     }
     longTaskObserver = null;
   }

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -1,4 +1,5 @@
 import type { MediaTrack, ProviderId } from '@/types/domain';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const SESSION_KEY = 'vorbis-player-last-session';
 
@@ -56,7 +57,8 @@ export function loadSession(): SessionSnapshot | null {
       return parsed as SessionSnapshot;
     }
     return null;
-  } catch {
+  } catch (err) {
+    logCaughtError('sessionPersistence.loadSession', err);
     return null;
   }
 }
@@ -78,7 +80,8 @@ export function isSessionStale(
 export function clearSession(): void {
   try {
     localStorage.removeItem(SESSION_KEY);
-  } catch {
+  } catch (err) {
     // Ignore
+    logCaughtError('sessionPersistence.clearSession', err);
   }
 }

--- a/src/services/settings/settingsDb.ts
+++ b/src/services/settings/settingsDb.ts
@@ -4,6 +4,8 @@
  * Follows the same singleton + initPromise + in-memory fallback pattern as libraryCache.ts.
  */
 
+import { logCaughtError } from '@/utils/logCaughtError';
+
 export const STORE_NAMES = { PINS: 'pins' } as const;
 
 const DB_NAME = 'vorbis-player-settings';
@@ -64,7 +66,8 @@ export async function settingsGet<T>(store: string, key: string): Promise<T | un
   }
   try {
     return await idbGet<T>(store, key);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsGet', err);
     return fallbackStores[store]?.get(key) as T | undefined;
   }
 }
@@ -78,7 +81,8 @@ export async function settingsPut<T extends { key: string }>(store: string, valu
   }
   try {
     await idbPut(store, value);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsPut', err);
     ensureFallbackStore(store);
     fallbackStores[store].set(value.key, value);
   }
@@ -92,7 +96,8 @@ export async function settingsClearStore(store: string): Promise<void> {
   }
   try {
     await idbClear(store);
-  } catch {
+  } catch (err) {
+    logCaughtError('settingsDb.settingsClearStore', err);
     fallbackStores[store]?.clear();
   }
 }

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -7,6 +7,7 @@ import { albumSavedCache, trackListCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSI
 import { formatArtists, transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import * as libraryCache from '../cache/libraryCache';
 import { ALBUM_ID_PREFIX } from '@/constants/playlist';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Shared Helpers
@@ -61,8 +62,9 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
       trackListCache.set(cacheKey, { data: tracks, timestamp: idbCached.timestamp });
       return tracksToMediaTracks(tracks);
     }
-  } catch {
+  } catch (err) {
     // IndexedDB read failed, continue to API fetch
+    logCaughtError('spotify.albums.getAlbumTracks.idbRead', err);
   }
 
   // L3: Fetch from Spotify API

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -1,5 +1,6 @@
 import type { TokenData } from './types';
 import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 
@@ -55,7 +56,8 @@ class SpotifyAuth {
         return;
       }
       this.tokenData = tokenData;
-    } catch {
+    } catch (err) {
+      logCaughtError('spotify.auth.loadTokenFromStorage', err);
       localStorage.removeItem('spotify_token');
     }
   }

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -6,6 +6,7 @@ import { trackListCache, albumSavedCache, TRACK_LIST_CACHE_TTL, TRACK_LIST_PERSI
 import { transformTrackItem, backfillProvider, tracksToMediaTracks } from './tracks';
 import { type SavedAlbumItem, transformSavedAlbumItem } from './albums';
 import * as libraryCache from '../cache/libraryCache';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Callback Types
@@ -108,8 +109,9 @@ export async function getPlaylistTracks(playlistId: string): Promise<MediaTrack[
       trackListCache.set(cacheKey, { data: tracks, timestamp: idbCached.timestamp });
       return tracksToMediaTracks(tracks);
     }
-  } catch {
+  } catch (err) {
     // IndexedDB read failed, continue to API fetch
+    logCaughtError('spotify.playlists.getPlaylistTracks.idbRead', err);
   }
 
   // L3: Fetch from Spotify API

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -16,6 +16,7 @@ import {
   setLikedSongsCache,
 } from './cache';
 import * as libraryCache from '../cache/libraryCache';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 // =============================================================================
 // Shared Utilities
@@ -118,7 +119,10 @@ export async function getLikedSongs(limit?: number): Promise<MediaTrack[]> {
         setLikedSongsCache({ data: idbCached.tracks, limit: Infinity, timestamp: idbCached.timestamp });
         return tracksToMediaTracks(idbCached.tracks);
       }
-    } catch { /* IndexedDB unavailable — fall through to API */ }
+    } catch (err) {
+      /* IndexedDB unavailable — fall through to API */
+      logCaughtError('spotify.tracks.getLikedSongs.idbRead', err);
+    }
   }
 
   const token = await spotifyAuth.ensureValidToken();

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -2,6 +2,7 @@ import { spotifyAuth } from './spotify';
 import { AuthExpiredError } from '@/providers/errors';
 import { shouldUseMockProvider } from '@/providers/mock/shouldUseMockProvider';
 import { logSpotify } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import {
   SPOTIFY_MAX_RETRIES,
   SPOTIFY_INITIAL_RETRY_DELAY_MS,
@@ -178,8 +179,9 @@ class SpotifyPlayerService {
     if (!isIOS) {
       try {
         await this.player.setVolume(volume);
-      } catch {
+      } catch (err) {
         // SDK setVolume failed; fall through to debounced API call
+        logCaughtError('spotifyPlayer.setVolume', err);
       }
     }
 
@@ -299,7 +301,7 @@ class SpotifyPlayerService {
 
       if (state) {
         if (state.paused && state.position === 0) {
-          try { await this.resume(); } catch { /* ignore */ }
+          try { await this.resume(); } catch (err) { /* ignore */ logCaughtError('spotifyPlayer.waitForPlaybackOrResume.onStateChange.resume', err); }
         }
       } else {
         await activateDevice();
@@ -318,7 +320,7 @@ class SpotifyPlayerService {
         const state = await this.getCurrentState();
         if (state) {
           if (state.paused && state.position === 0) {
-            try { await this.resume(); } catch { /* ignore */ }
+            try { await this.resume(); } catch (err) { /* ignore */ logCaughtError('spotifyPlayer.waitForPlaybackOrResume.timeout.resume', err); }
           }
         } else {
           await activateDevice();

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -2,6 +2,7 @@ import { spotifyAuth } from './spotify';
 import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 import { TRANSFER_RETRY_DELAY_MS } from '@/constants/timing';
+import { logCaughtError } from '@/utils/logCaughtError';
 
 async function parsePlayError(response: Response): Promise<string> {
   const errorText = await response.text();
@@ -10,7 +11,8 @@ async function parsePlayError(response: Response): Promise<string> {
     const json = JSON.parse(errorText);
     if (json.error?.message) reason = ` - ${json.error.message}`;
     if (json.error?.reason) reason += ` (${json.error.reason})`;
-  } catch {
+  } catch (err) {
+    logCaughtError('spotifyPlayerPlayback.parsePlayError', err);
     reason = errorText ? ` - ${errorText}` : '';
   }
   if (response.status === 429) {

--- a/src/utils/__tests__/logCaughtError.test.ts
+++ b/src/utils/__tests__/logCaughtError.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logCaughtError } from '../logCaughtError';
+
+describe('logCaughtError', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns with the contextual tag in dev', () => {
+    // #given
+    const err = new Error('boom');
+
+    // #when
+    logCaughtError('test.context', err);
+
+    // #then — vitest runs with import.meta.env.DEV === true
+    expect(warnSpy).toHaveBeenCalledWith('[test.context]', err);
+  });
+
+  it('forwards the error value verbatim', () => {
+    // #given
+    const err = { code: 42, message: 'kapow' };
+
+    // #when
+    logCaughtError('another.context', err);
+
+    // #then
+    expect(warnSpy).toHaveBeenCalledWith('[another.context]', err);
+  });
+});

--- a/src/utils/id3Parser.ts
+++ b/src/utils/id3Parser.ts
@@ -4,6 +4,8 @@
  * Extracts title, artist, album, and embedded cover art (APIC/PIC frames).
  */
 
+import { logCaughtError } from './logCaughtError';
+
 interface AudioMetadata {
   title?: string;
   artist?: string;
@@ -203,8 +205,9 @@ function parseFlac(bytes: Uint8Array): AudioMetadata {
             const dataLen = (picBytes[p] << 24) | (picBytes[p+1] << 16) | (picBytes[p+2] << 8) | picBytes[p+3];
             p += 4;
             result.coverArt = { data: picBytes.slice(p, p + dataLen), mimeType };
-          } catch {
+          } catch (err) {
             // malformed picture block — skip
+            logCaughtError('id3Parser.pictureBlock', err);
           }
         }
       }

--- a/src/utils/libraryFirstSeen.ts
+++ b/src/utils/libraryFirstSeen.ts
@@ -1,4 +1,5 @@
 import type { ProviderId } from '@/types/domain';
+import { logCaughtError } from './logCaughtError';
 
 /**
  * Stable "added to this app" time for catalog-backed collections (e.g. Dropbox)
@@ -20,7 +21,8 @@ export function getOrSetFirstSeenAddedAtIso(
     const now = new Date(Date.now() - ordinalForNew * 60000).toISOString();
     window.localStorage.setItem(key, now);
     return now;
-  } catch {
+  } catch (err) {
+    logCaughtError('libraryFirstSeen.getOrSetFirstSeenAddedAtIso', err);
     return new Date(Date.now() - ordinalForNew * 60000).toISOString();
   }
 }

--- a/src/utils/logCaughtError.ts
+++ b/src/utils/logCaughtError.ts
@@ -1,0 +1,6 @@
+export function logCaughtError(context: string, err: unknown): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(`[${context}]`, err);
+  }
+}


### PR DESCRIPTION
## Summary

Library subsystem hygiene pass: split three oversized cache/orchestrator modules into focused units, extract a 19-dep useMemo into its own hook, narrow a misleading provider-agnostic abstraction to its actual Spotify scope, and add a logging helper at every empty-catch site so silent failures leave a paper trail.

## Release summary

**Built from**: `rc/2026-05-08.1`

### Release notes

**Library decomposition**
- refactor(useLibrarySync): split engine and catalog paths into focused hooks (#1505)
- refactor(libraryCache): split into storage + lifecycle + CRUD wrappers (#1502)
- refactor(librarySyncEngine): rename to SpotifyLibrarySyncEngine and narrow providerId (#1501)
- refactor(LibraryContextMenu): extract useMenuItems hook from 19-dep useMemo (#1503)

**Hygiene**
- refactor(error-handling): log swallowed errors at empty-catch sites (#1504)
- refactor(libraryDiffEngine): name synthetic added_at stride constant (#1500)

Closes #1483
Closes #1495
Closes #1496
Closes #1497
Closes #1498
Closes #1499