### PR TITLE
chore: sweep post-release lint regressions and knip false positives

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,10 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "tags": [
     "-lintignore"
+  ],
+  "ignore": [
+    "public/sw.js",
+    "src/types/spotify.d.ts",
+    "src/types/styled.d.ts"
   ]
 }

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -40,7 +40,7 @@ type SyncListener = (
 const OPTIMISTIC_GRACE_MS = 30 * 1000;
 
 export class SpotifyLibrarySyncEngine {
-  readonly providerId: 'spotify' = 'spotify';
+  readonly providerId = 'spotify' as const;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private listeners = new Set<SyncListener>();
   private abortController: AbortController | null = null;

--- a/src/utils/logCaughtError.ts
+++ b/src/utils/logCaughtError.ts
@@ -1,6 +1,5 @@
 export function logCaughtError(context: string, err: unknown): void {
   if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
     console.warn(`[${context}]`, err);
   }
 }


### PR DESCRIPTION
## Summary

Post-release polishkit:sweep pass over the just-shipped library refactor batch (v2026.5.8). Three small, low-risk fixes — two lint regressions caught by `npm run lint` and one knip-config tidy.

- `src/services/cache/librarySyncEngine.ts:43` — fix `prefer-as-const` lint error introduced by [#1501](https://github.com/smallorbit/vorbis-player/pull/1501). `readonly providerId: 'spotify' = 'spotify'` → `readonly providerId = 'spotify' as const`. Same narrowed type.
- `src/utils/logCaughtError.ts:3` — drop the unused `// eslint-disable-next-line no-console` directive introduced by [#1504](https://github.com/smallorbit/vorbis-player/pull/1504). The project has no `no-console` rule, so the suppression was dead.
- `knip.json` — add ignores for three files that were false positives in `npm run knip`:
  - `public/sw.js` (runtime-loaded via `navigator.serviceWorker.register`)
  - `src/types/spotify.d.ts` (ambient `declare global`)
  - `src/types/styled.d.ts` (ambient module augmentation for `styled-components`)

Deferred from this sweep: 44 "unused exports" + 79 "unused exported types" knip findings. Most are local Props interfaces and section descriptors; #1492 just touched this area 4 days ago. Better as a dedicated `/simplify-scope` pass per directory, not a quick mass-prune.

## Test plan

- `npx tsc -b --noEmit` — clean
- `npm run lint` — 0 errors, 32 warnings (was: 1 error, 33 warnings — both fixes accounted for; remaining 32 warnings are pre-existing fast-refresh / hooks-deps that fall outside this sweep)
- `npm run knip` — `Unused files (3)` row gone; remaining unused-exports tally unchanged
- `npm run test:run` — 1975/1975 pass