### PR TITLE
feat(settings-v2): surface translucence-opacity and accent-color-background controls

### DIFF
--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 
 import { useTranslucence } from '@/contexts/visualEffects';
 import { Switch } from '@/components/ui/switch';
+import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
 
 import { AccentColorManager } from './appearance/AccentColorManager';
 import { GlowControls } from './appearance/GlowControls';
@@ -13,8 +14,16 @@ import {
   ControlLabelText,
   ControlHelp,
   SectionGroupTitle,
+  SubControlRow,
+  SubControlLabel,
   Divider,
 } from './AppearanceSection.styled';
+
+const OPACITY_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 0.6, label: 'Subtle' },
+  { value: 0.8, label: 'Default' },
+  { value: 0.95, label: 'Strong' },
+] as const;
 
 /**
  * SettingsV2 Appearance section — phase 3 port (#1451).
@@ -29,16 +38,21 @@ import {
  *     `useVisualEffectsState` (`VISUAL_EFFECTS_ENABLED` + `GLOW_INTENSITY` +
  *     `GLOW_RATE`).
  *   - {@link VisualizerStylePicker} → `VisualizerContext` (`BG_VISUALIZER_*`).
- *   - Translucence on/off          → `TranslucenceContext`
- *     (`TRANSLUCENCE_ENABLED`). Opacity slider is intentionally omitted —
- *     `TRANSLUCENCE_OPACITY` has no v1 UI today and is deferred to #1463.
+ *   - Translucence on/off + opacity → `TranslucenceContext`
+ *     (`TRANSLUCENCE_ENABLED` + `TRANSLUCENCE_OPACITY`). The opacity preset
+ *     (Subtle / Default / Strong) is revealed only when translucence is on.
  *
  * v2 chrome stays neutral (`hsl(var(--*))` only) — the player-chrome accent
  * variant lives in `controls/QuickEffectsRow` and is intentionally not
  * mirrored here.
  */
 const TranslucenceToggle: React.FC = () => {
-  const { translucenceEnabled, setTranslucenceEnabled } = useTranslucence();
+  const {
+    translucenceEnabled,
+    setTranslucenceEnabled,
+    translucenceOpacity,
+    setTranslucenceOpacity,
+  } = useTranslucence();
 
   const handleToggle = useCallback(
     (checked: boolean) => {
@@ -63,6 +77,24 @@ const TranslucenceToggle: React.FC = () => {
           variant="neutral"
         />
       </ControlRow>
+
+      {translucenceEnabled && (
+        <SubControlRow>
+          <SubControlLabel>Opacity</SubControlLabel>
+          <OptionButtonGroup aria-label="Translucence opacity">
+            {OPACITY_OPTIONS.map((opt) => (
+              <OptionButton
+                key={opt.value}
+                type="button"
+                $isActive={translucenceOpacity === opt.value}
+                onClick={() => setTranslucenceOpacity(opt.value)}
+              >
+                {opt.label}
+              </OptionButton>
+            ))}
+          </OptionButtonGroup>
+        </SubControlRow>
+      )}
     </ControlBlock>
   );
 };

--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -5,6 +5,7 @@ import { Switch } from '@/components/ui/switch';
 import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
 
 import { AccentColorManager } from './appearance/AccentColorManager';
+import { AccentColorBackgroundToggle } from './appearance/AccentColorBackgroundToggle';
 import { GlowControls } from './appearance/GlowControls';
 import { VisualizerStylePicker } from './appearance/VisualizerStylePicker';
 import {
@@ -109,6 +110,8 @@ export const AppearanceSection: React.FC = () => {
       <GlowControls />
       <Divider />
       <VisualizerStylePicker />
+      <Divider />
+      <AccentColorBackgroundToggle />
       <Divider />
       <TranslucenceToggle />
     </Container>

--- a/src/components/SettingsV2/sections/__tests__/AccentColorBackgroundToggle.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorBackgroundToggle.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+import {
+  AccentColorBackgroundProvider,
+  VisualEffectsToggleProvider,
+  useVisualEffectsToggle,
+} from '@/contexts/visualEffects';
+
+import { AccentColorBackgroundToggle } from '../appearance/AccentColorBackgroundToggle';
+
+const memoryStorage = new Map<string, string>();
+
+const installLocalStorageShim = () => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => memoryStorage.set(key, value),
+      removeItem: (key: string) => memoryStorage.delete(key),
+      clear: () => memoryStorage.clear(),
+      key: () => null,
+      length: 0,
+    },
+    writable: true,
+    configurable: true,
+  });
+};
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <VisualEffectsToggleProvider>
+      <AccentColorBackgroundProvider>{children}</AccentColorBackgroundProvider>
+    </VisualEffectsToggleProvider>
+  </ThemeProvider>
+);
+
+const MasterToggleProbe: React.FC = () => {
+  const { setVisualEffectsEnabled } = useVisualEffectsToggle();
+  return (
+    <button type="button" onClick={() => setVisualEffectsEnabled(false)}>
+      disable-master
+    </button>
+  );
+};
+
+describe('SettingsV2 AccentColorBackgroundToggle', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+    installLocalStorageShim();
+  });
+
+  it('renders the labeled switch with help text', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByText('Background gradient')).toBeInTheDocument();
+    expect(screen.getByLabelText('Toggle accent-color background')).toBeInTheDocument();
+    expect(
+      screen.getByText('Tint the page background with the current accent color. Visible when album-art glow is on.'),
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the default ACCENT_COLOR_BG_PREFERRED = false in the switch state', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByLabelText('Toggle accent-color background')).toHaveAttribute('data-state', 'unchecked');
+  });
+
+  it('persists ACCENT_COLOR_BG_PREFERRED when toggled on', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Toggle accent-color background'));
+
+    // #then
+    expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
+  });
+
+  it('stays toggleable when visualEffectsEnabled is false', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+        <MasterToggleProbe />
+      </Wrapper>,
+    );
+
+    // #when — flip the master off
+    fireEvent.click(screen.getByText('disable-master'));
+
+    // #then — the preference toggle is still enabled and writable
+    const toggle = screen.getByLabelText('Toggle accent-color background');
+    expect(toggle).not.toBeDisabled();
+
+    fireEvent.click(toggle);
+    expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
@@ -65,15 +65,27 @@ vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
 }));
 
 import { AppearanceSection } from '../AppearanceSection';
-import { VisualizerProvider, VisualEffectsToggleProvider, TranslucenceProvider } from '@/contexts/visualEffects';
-import { useVisualizer, useTranslucence, useVisualEffectsToggle } from '@/contexts/visualEffects';
+import {
+  VisualizerProvider,
+  VisualEffectsToggleProvider,
+  TranslucenceProvider,
+  AccentColorBackgroundProvider,
+} from '@/contexts/visualEffects';
+import {
+  useVisualizer,
+  useTranslucence,
+  useVisualEffectsToggle,
+  useAccentColorBackground,
+} from '@/contexts/visualEffects';
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <ThemeProvider theme={theme}>
     <VisualEffectsToggleProvider>
-      <VisualizerProvider>
-        <TranslucenceProvider>{children}</TranslucenceProvider>
-      </VisualizerProvider>
+      <AccentColorBackgroundProvider>
+        <VisualizerProvider>
+          <TranslucenceProvider>{children}</TranslucenceProvider>
+        </VisualizerProvider>
+      </AccentColorBackgroundProvider>
     </VisualEffectsToggleProvider>
   </ThemeProvider>
 );
@@ -85,7 +97,7 @@ describe('SettingsV2 AppearanceSection', () => {
     installLocalStorageShim();
   });
 
-  it('renders all four control groups', () => {
+  it('renders all five control groups', () => {
     // #given + #when
     render(
       <Wrapper>
@@ -97,6 +109,7 @@ describe('SettingsV2 AppearanceSection', () => {
     expect(screen.getByText('Accent Color')).toBeInTheDocument();
     expect(screen.getByText('Glow')).toBeInTheDocument();
     expect(screen.getByText('Visualizer')).toBeInTheDocument();
+    expect(screen.getByText('Background gradient')).toBeInTheDocument();
     expect(screen.getByText('Translucence')).toBeInTheDocument();
   });
 
@@ -187,6 +200,14 @@ describe('SettingsV2 AppearanceSection', () => {
       return null;
     };
 
+    const AccentBgStateProbe: React.FC<{ onState: (state: ReturnType<typeof useAccentColorBackground>) => void }> = ({
+      onState,
+    }) => {
+      const state = useAccentColorBackground();
+      onState(state);
+      return null;
+    };
+
     it('reflects a v2 visualizer-style change in a sibling v1-style reader', () => {
       // #given — both surfaces mounted against the same provider
       let lastVizState: ReturnType<typeof useVisualizer> | null = null;
@@ -260,6 +281,26 @@ describe('SettingsV2 AppearanceSection', () => {
       // #then
       expect(lastTransState!.translucenceEnabled).toBe(false);
       expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
+    });
+
+    it('reflects a v2 accent-color-background toggle in a sibling reader and persists the key', () => {
+      // #given
+      let lastAccentBgState: ReturnType<typeof useAccentColorBackground> | null = null;
+      render(
+        <Wrapper>
+          <AppearanceSection />
+          <AccentBgStateProbe onState={(s) => (lastAccentBgState = s)} />
+        </Wrapper>,
+      );
+
+      // #when — default is `false`, click flips it to `true`
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Toggle accent-color background'));
+      });
+
+      // #then
+      expect(lastAccentBgState!.accentColorBackgroundPreferred).toBe(true);
+      expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
     });
   });
 });

--- a/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
@@ -100,7 +100,7 @@ describe('SettingsV2 AppearanceSection', () => {
     expect(screen.getByText('Translucence')).toBeInTheDocument();
   });
 
-  it('writes TRANSLUCENCE_ENABLED only (no opacity slider) when toggled', () => {
+  it('writes TRANSLUCENCE_ENABLED only (no opacity side-effect) when master toggled', () => {
     // #given
     render(
       <Wrapper>
@@ -111,22 +111,46 @@ describe('SettingsV2 AppearanceSection', () => {
     // #when — translucence default is `true`, click toggles to `false`
     fireEvent.click(screen.getByLabelText('Toggle translucence'));
 
-    // #then — single key is written; TRANSLUCENCE_OPACITY is untouched (deferred to #1463)
+    // #then — single key is written; opacity preset must not auto-write on master flip
     expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
     expect(memoryStorage.has(STORAGE_KEYS.TRANSLUCENCE_OPACITY)).toBe(false);
   });
 
-  it('does not render an opacity slider for translucence', () => {
-    // #given + #when
+  it('renders the opacity preset only when translucence is enabled', () => {
+    // #given
     render(
       <Wrapper>
         <AppearanceSection />
       </Wrapper>,
     );
 
-    // #then — TranslucenceToggle is on/off only per stage 2 scope
-    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
-    expect(screen.queryByText(/opacity/i)).not.toBeInTheDocument();
+    // #then — translucence default is `true`, all three presets are visible
+    expect(screen.getByRole('button', { name: 'Subtle' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Default' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Strong' })).toBeInTheDocument();
+
+    // #when — flip the master off
+    fireEvent.click(screen.getByLabelText('Toggle translucence'));
+
+    // #then — presets unmount
+    expect(screen.queryByRole('button', { name: 'Subtle' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Default' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Strong' })).not.toBeInTheDocument();
+  });
+
+  it('writes the chosen opacity to TRANSLUCENCE_OPACITY when a preset is clicked', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'Subtle' }));
+
+    // #then
+    expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_OPACITY)).toBe('0.6');
   });
 
   describe('v1 ↔ v2 storage round-trip', () => {

--- a/src/components/SettingsV2/sections/appearance/AccentColorBackgroundToggle.tsx
+++ b/src/components/SettingsV2/sections/appearance/AccentColorBackgroundToggle.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback } from 'react';
+
+import { useAccentColorBackground } from '@/contexts/visualEffects';
+import { Switch } from '@/components/ui/switch';
+
+import {
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+} from '../AppearanceSection.styled';
+
+/**
+ * SettingsV2 accent-color-background toggle — phase 3 follow-up (#1463).
+ *
+ * Persists `ACCENT_COLOR_BG_PREFERRED` independently of the master
+ * `visualEffectsEnabled` flag. The storage key is a preference, not a live
+ * render flag — `AccentColorBackgroundContext.accentColorBackgroundEnabled`
+ * derives the live flag as `visualEffectsEnabled && preferred`, so the
+ * Switch stays toggleable when glow is off and the gradient simply waits
+ * for glow to come back on. The help text alone communicates the
+ * dependency.
+ */
+export const AccentColorBackgroundToggle: React.FC = () => {
+  const { accentColorBackgroundPreferred, setAccentColorBackgroundPreferred } = useAccentColorBackground();
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      setAccentColorBackgroundPreferred(checked);
+    },
+    [setAccentColorBackgroundPreferred],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Background gradient</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-accent-color-bg-toggle">Accent-color background</ControlLabelText>
+          <ControlHelp>Tint the page background with the current accent color. Visible when album-art glow is on.</ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-accent-color-bg-toggle"
+          checked={accentColorBackgroundPreferred}
+          onCheckedChange={handleToggle}
+          aria-label="Toggle accent-color background"
+          variant="neutral"
+        />
+      </ControlRow>
+    </ControlBlock>
+  );
+};
+
+AccentColorBackgroundToggle.displayName = 'SettingsV2.AccentColorBackgroundToggle';
+
+export default AccentColorBackgroundToggle;

--- a/src/contexts/visualEffects/index.tsx
+++ b/src/contexts/visualEffects/index.tsx
@@ -8,7 +8,7 @@ import { GlowProvider } from './GlowContext';
 
 export { VisualEffectsToggleProvider, useVisualEffectsToggle } from './VisualEffectsToggleContext';
 export { VisualizerProvider, useVisualizer } from './VisualizerContext';
-export { useAccentColorBackground } from './AccentColorBackgroundContext';
+export { AccentColorBackgroundProvider, useAccentColorBackground } from './AccentColorBackgroundContext';
 export { TranslucenceProvider, useTranslucence } from './TranslucenceContext';
 export { useZenMode } from './ZenModeContext';
 


### PR DESCRIPTION
## Summary

Implements the blueprint posted on #1463: surfaces two of the three orphaned `STORAGE_KEYS` from the #1451 inventory through Settings v2.

- `feat(settings-v2): add translucence opacity sub-control` — `TRANSLUCENCE_OPACITY` exposed as a tri-state preset (Subtle 0.6 / Default 0.8 / Strong 0.95) nested inside the existing `TranslucenceToggle`, revealed only when translucence is on. Mirrors the `GlowControls` Intensity/Rate idiom (no new `Slider` primitive introduced).
- `feat(settings-v2): expose accent-color background toggle` — new `AccentColorBackgroundToggle` `ControlBlock` ("Background gradient") between Visualizer and Translucence; independently togglable from `visualEffectsEnabled` (the `_PREFERRED` key is a persisted preference, not a live render flag).

`PER_ALBUM_GLOW` is **deferred** from this batch — the key has no read consumer in `useVisualEffectsState.effectiveGlow`, and the UX shape depends on unresolved product questions. See the blueprint for the full deferral rationale.

Part of #1463 (not `Closes` — `PER_ALBUM_GLOW` follow-up keeps the issue open)

## Test plan

- `npx tsc -b --noEmit` — clean
- `npm run test:run` — full suite passes (188 files / 1981 tests, including new `AccentColorBackgroundToggle.test.tsx` and updated `AppearanceSection.test.tsx`)
- `npm run lint` — 0 errors