### PR TITLE
release: 2026-05-09

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,10 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "tags": [
     "-lintignore"
+  ],
+  "ignore": [
+    "public/sw.js",
+    "src/types/spotify.d.ts",
+    "src/types/styled.d.ts"
   ]
 }

--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -2,8 +2,10 @@ import React, { useCallback } from 'react';
 
 import { useTranslucence } from '@/contexts/visualEffects';
 import { Switch } from '@/components/ui/switch';
+import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
 
 import { AccentColorManager } from './appearance/AccentColorManager';
+import { AccentColorBackgroundToggle } from './appearance/AccentColorBackgroundToggle';
 import { GlowControls } from './appearance/GlowControls';
 import { VisualizerStylePicker } from './appearance/VisualizerStylePicker';
 import {
@@ -13,8 +15,16 @@ import {
   ControlLabelText,
   ControlHelp,
   SectionGroupTitle,
+  SubControlRow,
+  SubControlLabel,
   Divider,
 } from './AppearanceSection.styled';
+
+const OPACITY_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 0.6, label: 'Subtle' },
+  { value: 0.8, label: 'Default' },
+  { value: 0.95, label: 'Strong' },
+] as const;
 
 /**
  * SettingsV2 Appearance section — phase 3 port (#1451).
@@ -29,16 +39,21 @@ import {
  *     `useVisualEffectsState` (`VISUAL_EFFECTS_ENABLED` + `GLOW_INTENSITY` +
  *     `GLOW_RATE`).
  *   - {@link VisualizerStylePicker} → `VisualizerContext` (`BG_VISUALIZER_*`).
- *   - Translucence on/off          → `TranslucenceContext`
- *     (`TRANSLUCENCE_ENABLED`). Opacity slider is intentionally omitted —
- *     `TRANSLUCENCE_OPACITY` has no v1 UI today and is deferred to #1463.
+ *   - Translucence on/off + opacity → `TranslucenceContext`
+ *     (`TRANSLUCENCE_ENABLED` + `TRANSLUCENCE_OPACITY`). The opacity preset
+ *     (Subtle / Default / Strong) is revealed only when translucence is on.
  *
  * v2 chrome stays neutral (`hsl(var(--*))` only) — the player-chrome accent
  * variant lives in `controls/QuickEffectsRow` and is intentionally not
  * mirrored here.
  */
 const TranslucenceToggle: React.FC = () => {
-  const { translucenceEnabled, setTranslucenceEnabled } = useTranslucence();
+  const {
+    translucenceEnabled,
+    setTranslucenceEnabled,
+    translucenceOpacity,
+    setTranslucenceOpacity,
+  } = useTranslucence();
 
   const handleToggle = useCallback(
     (checked: boolean) => {
@@ -63,6 +78,24 @@ const TranslucenceToggle: React.FC = () => {
           variant="neutral"
         />
       </ControlRow>
+
+      {translucenceEnabled && (
+        <SubControlRow>
+          <SubControlLabel>Opacity</SubControlLabel>
+          <OptionButtonGroup aria-label="Translucence opacity">
+            {OPACITY_OPTIONS.map((opt) => (
+              <OptionButton
+                key={opt.value}
+                type="button"
+                $isActive={translucenceOpacity === opt.value}
+                onClick={() => setTranslucenceOpacity(opt.value)}
+              >
+                {opt.label}
+              </OptionButton>
+            ))}
+          </OptionButtonGroup>
+        </SubControlRow>
+      )}
     </ControlBlock>
   );
 };
@@ -77,6 +110,8 @@ export const AppearanceSection: React.FC = () => {
       <GlowControls />
       <Divider />
       <VisualizerStylePicker />
+      <Divider />
+      <AccentColorBackgroundToggle />
       <Divider />
       <TranslucenceToggle />
     </Container>

--- a/src/components/SettingsV2/sections/__tests__/AccentColorBackgroundToggle.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorBackgroundToggle.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import { STORAGE_KEYS } from '@/constants/storage';
+import {
+  AccentColorBackgroundProvider,
+  VisualEffectsToggleProvider,
+  useVisualEffectsToggle,
+} from '@/contexts/visualEffects';
+
+import { AccentColorBackgroundToggle } from '../appearance/AccentColorBackgroundToggle';
+
+const memoryStorage = new Map<string, string>();
+
+const installLocalStorageShim = () => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => memoryStorage.set(key, value),
+      removeItem: (key: string) => memoryStorage.delete(key),
+      clear: () => memoryStorage.clear(),
+      key: () => null,
+      length: 0,
+    },
+    writable: true,
+    configurable: true,
+  });
+};
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <VisualEffectsToggleProvider>
+      <AccentColorBackgroundProvider>{children}</AccentColorBackgroundProvider>
+    </VisualEffectsToggleProvider>
+  </ThemeProvider>
+);
+
+const MasterToggleProbe: React.FC = () => {
+  const { setVisualEffectsEnabled } = useVisualEffectsToggle();
+  return (
+    <button type="button" onClick={() => setVisualEffectsEnabled(false)}>
+      disable-master
+    </button>
+  );
+};
+
+describe('SettingsV2 AccentColorBackgroundToggle', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+    installLocalStorageShim();
+  });
+
+  it('renders the labeled switch with help text', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByText('Background gradient')).toBeInTheDocument();
+    expect(screen.getByLabelText('Toggle accent-color background')).toBeInTheDocument();
+    expect(
+      screen.getByText('Tint the page background with the current accent color. Visible when album-art glow is on.'),
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the default ACCENT_COLOR_BG_PREFERRED = false in the switch state', () => {
+    // #given + #when
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByLabelText('Toggle accent-color background')).toHaveAttribute('data-state', 'unchecked');
+  });
+
+  it('persists ACCENT_COLOR_BG_PREFERRED when toggled on', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByLabelText('Toggle accent-color background'));
+
+    // #then
+    expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
+  });
+
+  it('stays toggleable when visualEffectsEnabled is false', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AccentColorBackgroundToggle />
+        <MasterToggleProbe />
+      </Wrapper>,
+    );
+
+    // #when — flip the master off
+    fireEvent.click(screen.getByText('disable-master'));
+
+    // #then — the preference toggle is still enabled and writable
+    const toggle = screen.getByLabelText('Toggle accent-color background');
+    expect(toggle).not.toBeDisabled();
+
+    fireEvent.click(toggle);
+    expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
+  });
+});

--- a/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
@@ -65,15 +65,27 @@ vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
 }));
 
 import { AppearanceSection } from '../AppearanceSection';
-import { VisualizerProvider, VisualEffectsToggleProvider, TranslucenceProvider } from '@/contexts/visualEffects';
-import { useVisualizer, useTranslucence, useVisualEffectsToggle } from '@/contexts/visualEffects';
+import {
+  VisualizerProvider,
+  VisualEffectsToggleProvider,
+  TranslucenceProvider,
+  AccentColorBackgroundProvider,
+} from '@/contexts/visualEffects';
+import {
+  useVisualizer,
+  useTranslucence,
+  useVisualEffectsToggle,
+  useAccentColorBackground,
+} from '@/contexts/visualEffects';
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <ThemeProvider theme={theme}>
     <VisualEffectsToggleProvider>
-      <VisualizerProvider>
-        <TranslucenceProvider>{children}</TranslucenceProvider>
-      </VisualizerProvider>
+      <AccentColorBackgroundProvider>
+        <VisualizerProvider>
+          <TranslucenceProvider>{children}</TranslucenceProvider>
+        </VisualizerProvider>
+      </AccentColorBackgroundProvider>
     </VisualEffectsToggleProvider>
   </ThemeProvider>
 );
@@ -85,7 +97,7 @@ describe('SettingsV2 AppearanceSection', () => {
     installLocalStorageShim();
   });
 
-  it('renders all four control groups', () => {
+  it('renders all five control groups', () => {
     // #given + #when
     render(
       <Wrapper>
@@ -97,10 +109,11 @@ describe('SettingsV2 AppearanceSection', () => {
     expect(screen.getByText('Accent Color')).toBeInTheDocument();
     expect(screen.getByText('Glow')).toBeInTheDocument();
     expect(screen.getByText('Visualizer')).toBeInTheDocument();
+    expect(screen.getByText('Background gradient')).toBeInTheDocument();
     expect(screen.getByText('Translucence')).toBeInTheDocument();
   });
 
-  it('writes TRANSLUCENCE_ENABLED only (no opacity slider) when toggled', () => {
+  it('writes TRANSLUCENCE_ENABLED only (no opacity side-effect) when master toggled', () => {
     // #given
     render(
       <Wrapper>
@@ -111,22 +124,46 @@ describe('SettingsV2 AppearanceSection', () => {
     // #when — translucence default is `true`, click toggles to `false`
     fireEvent.click(screen.getByLabelText('Toggle translucence'));
 
-    // #then — single key is written; TRANSLUCENCE_OPACITY is untouched (deferred to #1463)
+    // #then — single key is written; opacity preset must not auto-write on master flip
     expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
     expect(memoryStorage.has(STORAGE_KEYS.TRANSLUCENCE_OPACITY)).toBe(false);
   });
 
-  it('does not render an opacity slider for translucence', () => {
-    // #given + #when
+  it('renders the opacity preset only when translucence is enabled', () => {
+    // #given
     render(
       <Wrapper>
         <AppearanceSection />
       </Wrapper>,
     );
 
-    // #then — TranslucenceToggle is on/off only per stage 2 scope
-    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
-    expect(screen.queryByText(/opacity/i)).not.toBeInTheDocument();
+    // #then — translucence default is `true`, all three presets are visible
+    expect(screen.getByRole('button', { name: 'Subtle' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Default' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Strong' })).toBeInTheDocument();
+
+    // #when — flip the master off
+    fireEvent.click(screen.getByLabelText('Toggle translucence'));
+
+    // #then — presets unmount
+    expect(screen.queryByRole('button', { name: 'Subtle' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Default' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Strong' })).not.toBeInTheDocument();
+  });
+
+  it('writes the chosen opacity to TRANSLUCENCE_OPACITY when a preset is clicked', () => {
+    // #given
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #when
+    fireEvent.click(screen.getByRole('button', { name: 'Subtle' }));
+
+    // #then
+    expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_OPACITY)).toBe('0.6');
   });
 
   describe('v1 ↔ v2 storage round-trip', () => {
@@ -159,6 +196,14 @@ describe('SettingsV2 AppearanceSection', () => {
       onState,
     }) => {
       const state = useVisualEffectsToggle();
+      onState(state);
+      return null;
+    };
+
+    const AccentBgStateProbe: React.FC<{ onState: (state: ReturnType<typeof useAccentColorBackground>) => void }> = ({
+      onState,
+    }) => {
+      const state = useAccentColorBackground();
       onState(state);
       return null;
     };
@@ -236,6 +281,26 @@ describe('SettingsV2 AppearanceSection', () => {
       // #then
       expect(lastTransState!.translucenceEnabled).toBe(false);
       expect(memoryStorage.get(STORAGE_KEYS.TRANSLUCENCE_ENABLED)).toBe('false');
+    });
+
+    it('reflects a v2 accent-color-background toggle in a sibling reader and persists the key', () => {
+      // #given
+      let lastAccentBgState: ReturnType<typeof useAccentColorBackground> | null = null;
+      render(
+        <Wrapper>
+          <AppearanceSection />
+          <AccentBgStateProbe onState={(s) => (lastAccentBgState = s)} />
+        </Wrapper>,
+      );
+
+      // #when — default is `false`, click flips it to `true`
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Toggle accent-color background'));
+      });
+
+      // #then
+      expect(lastAccentBgState!.accentColorBackgroundPreferred).toBe(true);
+      expect(memoryStorage.get(STORAGE_KEYS.ACCENT_COLOR_BG_PREFERRED)).toBe('true');
     });
   });
 });

--- a/src/components/SettingsV2/sections/appearance/AccentColorBackgroundToggle.tsx
+++ b/src/components/SettingsV2/sections/appearance/AccentColorBackgroundToggle.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback } from 'react';
+
+import { useAccentColorBackground } from '@/contexts/visualEffects';
+import { Switch } from '@/components/ui/switch';
+
+import {
+  ControlBlock,
+  ControlRow,
+  ControlLabelText,
+  ControlHelp,
+  SectionGroupTitle,
+} from '../AppearanceSection.styled';
+
+/**
+ * SettingsV2 accent-color-background toggle — phase 3 follow-up (#1463).
+ *
+ * Persists `ACCENT_COLOR_BG_PREFERRED` independently of the master
+ * `visualEffectsEnabled` flag. The storage key is a preference, not a live
+ * render flag — `AccentColorBackgroundContext.accentColorBackgroundEnabled`
+ * derives the live flag as `visualEffectsEnabled && preferred`, so the
+ * Switch stays toggleable when glow is off and the gradient simply waits
+ * for glow to come back on. The help text alone communicates the
+ * dependency.
+ */
+export const AccentColorBackgroundToggle: React.FC = () => {
+  const { accentColorBackgroundPreferred, setAccentColorBackgroundPreferred } = useAccentColorBackground();
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      setAccentColorBackgroundPreferred(checked);
+    },
+    [setAccentColorBackgroundPreferred],
+  );
+
+  return (
+    <ControlBlock>
+      <SectionGroupTitle>Background gradient</SectionGroupTitle>
+      <ControlRow>
+        <div>
+          <ControlLabelText htmlFor="settings-v2-accent-color-bg-toggle">Accent-color background</ControlLabelText>
+          <ControlHelp>Tint the page background with the current accent color. Visible when album-art glow is on.</ControlHelp>
+        </div>
+        <Switch
+          id="settings-v2-accent-color-bg-toggle"
+          checked={accentColorBackgroundPreferred}
+          onCheckedChange={handleToggle}
+          aria-label="Toggle accent-color background"
+          variant="neutral"
+        />
+      </ControlRow>
+    </ControlBlock>
+  );
+};
+
+AccentColorBackgroundToggle.displayName = 'SettingsV2.AccentColorBackgroundToggle';
+
+export default AccentColorBackgroundToggle;

--- a/src/contexts/visualEffects/index.tsx
+++ b/src/contexts/visualEffects/index.tsx
@@ -8,7 +8,7 @@ import { GlowProvider } from './GlowContext';
 
 export { VisualEffectsToggleProvider, useVisualEffectsToggle } from './VisualEffectsToggleContext';
 export { VisualizerProvider, useVisualizer } from './VisualizerContext';
-export { useAccentColorBackground } from './AccentColorBackgroundContext';
+export { AccentColorBackgroundProvider, useAccentColorBackground } from './AccentColorBackgroundContext';
 export { TranslucenceProvider, useTranslucence } from './TranslucenceContext';
 export { useZenMode } from './ZenModeContext';
 

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -40,7 +40,7 @@ type SyncListener = (
 const OPTIMISTIC_GRACE_MS = 30 * 1000;
 
 export class SpotifyLibrarySyncEngine {
-  readonly providerId: 'spotify' = 'spotify';
+  readonly providerId = 'spotify' as const;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private listeners = new Set<SyncListener>();
   private abortController: AbortController | null = null;

--- a/src/utils/logCaughtError.ts
+++ b/src/utils/logCaughtError.ts
@@ -1,6 +1,5 @@
 export function logCaughtError(context: string, err: unknown): void {
   if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
     console.warn(`[${context}]`, err);
   }
 }


### PR DESCRIPTION
## Summary

Two follow-ups on the v2026.5.8 library-refactor batch: surface two of the three orphaned `STORAGE_KEYS` in Settings v2 (translucence opacity preset + accent-color background toggle), and a polishkit:sweep that clears lint regressions and knip false positives introduced by that batch.

## Release summary

**Built from**: `rc/2026-05-09.1`

### Release notes

**settings-v2**
- feat(settings-v2): surface translucence-opacity and accent-color-background controls (#1509) — `TRANSLUCENCE_OPACITY` exposed as a tri-state preset (Subtle 0.6 / Default 0.8 / Strong 0.95) nested inside `TranslucenceToggle`; new `AccentColorBackgroundToggle` ("Background gradient") between Visualizer and Translucence, bound to `ACCENT_COLOR_BG_PREFERRED` and independently togglable from `visualEffectsEnabled`. `PER_ALBUM_GLOW` deferred — no read consumer + unresolved UX shape (Part of #1463).

**hygiene**
- chore: sweep post-release lint regressions and knip false positives (#1508) — fixes `prefer-as-const` regression in `SpotifyLibrarySyncEngine` (from #1501), drops dead `no-console` disable in `logCaughtError` (from #1504), adds knip ignores for `public/sw.js` + ambient `src/types/{spotify,styled}.d.ts` runtime/ambient false positives.

### Changes
- feat(settings-v2): surface translucence-opacity and accent-color-background controls (#1509)
- chore: sweep post-release lint regressions and knip false positives (#1508)