### PR TITLE
fix(library-search): pre-fill query when browsing artist from player popover

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -100,6 +100,7 @@ const AudioPlayerComponent = () => {
 
   const collectionNameRef = useRef<string>('');
   const collectionProviderRef = useRef<import('@/types/domain').ProviderId | undefined>(undefined);
+  const pendingLibraryQueryRef = useRef<string | undefined>(undefined);
 
   const getLivePosition = useCallback(async (): Promise<number | null> => {
     const drivingId = playbackProviderRef.current;
@@ -123,6 +124,11 @@ const AudioPlayerComponent = () => {
     state.playbackPosition,
     getLivePosition,
   );
+
+  const handleOpenLibraryWithQuery = useCallback((query: string) => {
+    pendingLibraryQueryRef.current = query;
+    handlers.handleOpenLibrary();
+  }, [handlers]);
 
   const handleAlbumPlay = useCallback((albumId: string) => {
     collectionProviderRef.current = currentTrack?.provider as import('@/types/domain').ProviderId | undefined;
@@ -327,6 +333,7 @@ const AudioPlayerComponent = () => {
       onPrevious: withResumeDismiss(handlers.handlePrevious),
       onTrackSelect: handlers.playTrack,
       onOpenLibrary,
+      onOpenLibraryWithQuery: handleOpenLibraryWithQuery,
       onCloseLibrary: handlers.handleCloseLibrary,
       onOpenQuickAccessPanel: handleOpenQuickAccessPanel,
       onPlaylistSelect: handlePlaylistSelect,
@@ -342,6 +349,7 @@ const AudioPlayerComponent = () => {
   }, [
     handlers,
     handleAlbumPlay,
+    handleOpenLibraryWithQuery,
     handlePlaylistSelect,
     handleOpenQuickAccessPanel,
     handlePlayLikedTracks,
@@ -502,6 +510,8 @@ const AudioPlayerComponent = () => {
     }
 
     if (state.currentView === 'library') {
+      const initialSearchQuery = pendingLibraryQueryRef.current;
+      pendingLibraryQueryRef.current = undefined;
       return (
         <Suspense fallback={null}>
           <LibraryRoute
@@ -515,6 +525,7 @@ const AudioPlayerComponent = () => {
             onOpenSettings={handleOpenSettings}
             onResume={handleResume}
             lastSession={null}
+            initialSearchQuery={initialSearchQuery}
             isPlaying={state.isPlaying}
             isRadioAvailable={radio.isRadioAvailable}
             isRadioGenerating={radio.radioState?.isGenerating}

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -125,11 +125,6 @@ const AudioPlayerComponent = () => {
     getLivePosition,
   );
 
-  const handleOpenLibraryWithQuery = useCallback((query: string) => {
-    pendingLibraryQueryRef.current = query;
-    handlers.handleOpenLibrary();
-  }, [handlers]);
-
   const handleAlbumPlay = useCallback((albumId: string) => {
     collectionProviderRef.current = currentTrack?.provider as import('@/types/domain').ProviderId | undefined;
     handlers.loadCollection(
@@ -242,6 +237,10 @@ const AudioPlayerComponent = () => {
     }) as T,
     [],
   );
+  const handleOpenLibraryWithQuery = useCallback((query: string) => {
+    pendingLibraryQueryRef.current = query;
+    withResumeDismiss(handlers.handleOpenLibrary)();
+  }, [handlers, withResumeDismiss]);
   useEffect(() => {
     if (showQueue) toast.dismiss(RESUME_TOAST_ID);
   }, [showQueue]);

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -180,6 +180,34 @@ describe('LibraryRoute', () => {
     expect(onMiniExpand).toHaveBeenCalledTimes(1);
   });
 
+  describe('initialSearchQuery', () => {
+    it('pre-fills search input and shows search results view when initialSearchQuery is provided', () => {
+      // #given
+      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+
+      // #when
+      renderRoute({ initialSearchQuery: 'Pink Floyd' });
+
+      // #then — search input is pre-populated
+      expect(screen.getByTestId('library-search-input-desktop')).toHaveValue('Pink Floyd');
+      // #then — SearchResultsView renders instead of HomeView
+      expect(screen.getByTestId('library-search-results')).toBeInTheDocument();
+      expect(screen.queryByTestId('library-home')).not.toBeInTheDocument();
+    });
+
+    it('leaves search input empty and shows home view when initialSearchQuery is not provided', () => {
+      // #given
+      vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);
+
+      // #when
+      renderRoute();
+
+      // #then
+      expect(screen.getByTestId('library-search-input-desktop')).toHaveValue('');
+      expect(screen.getByTestId('library-home')).toBeInTheDocument();
+    });
+  });
+
   describe('Escape key handling', () => {
     beforeEach(() => {
       vi.mocked(usePlayerSizingContext).mockReturnValue({ isMobile: false } as ReturnType<typeof usePlayerSizingContext>);

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -79,6 +79,10 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
 }) => {
   const { isMobile } = usePlayerSizingContext();
   const [view, setView] = useState<LibraryRouteView>('home');
+  // initialSearchQuery seeds the search input once on mount. Subsequent prop changes
+  // are ignored — safe today because AudioPlayer clears pendingLibraryQueryRef before
+  // rendering LibraryRoute (ref-clear-on-read), so each library open gets a fresh prop.
+  // If LibraryRoute is ever kept mounted across opens, the seed-once behavior will stale.
   const search = useLibrarySearch(initialSearchQuery);
   useEffect(() => {
     if (!onClose) return;

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -43,6 +43,7 @@ export interface LibraryRouteProps {
     id: string,
     provider?: ProviderId,
   ) => void;
+  initialSearchQuery?: string;
   isPlaying: boolean;
   isRadioAvailable?: boolean;
   isRadioGenerating?: boolean;
@@ -64,6 +65,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   onAddToQueue,
   onPlayNext,
   onStartRadioForCollection,
+  initialSearchQuery,
   isPlaying,
   isRadioAvailable,
   isRadioGenerating,
@@ -77,7 +79,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
 }) => {
   const { isMobile } = usePlayerSizingContext();
   const [view, setView] = useState<LibraryRouteView>('home');
-  const search = useLibrarySearch();
+  const search = useLibrarySearch(initialSearchQuery);
   useEffect(() => {
     if (!onClose) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/components/LibraryRoute/search/useLibrarySearch.ts
+++ b/src/components/LibraryRoute/search/useLibrarySearch.ts
@@ -32,8 +32,8 @@ export interface LibrarySearchState {
   clearAll: () => void;
 }
 
-export function useLibrarySearch(): LibrarySearchState {
-  const [query, setQuery] = useState('');
+export function useLibrarySearch(initialQuery?: string): LibrarySearchState {
+  const [query, setQuery] = useState(initialQuery ?? '');
   const [providerFilter, setProviderFilter] = useLocalStorage<ProviderId[]>(
     STORAGE_KEYS.providerFilter,
     DEFAULT_PROVIDER_FILTER,

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -20,6 +20,7 @@ export interface PlaybackHandlers {
   onPrevious: () => void;
   onTrackSelect: (index: number) => void;
   onOpenLibrary: () => void;
+  onOpenLibraryWithQuery?: (query: string) => void;
   onCloseLibrary: () => void;
   onOpenQuickAccessPanel?: () => void;
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
@@ -133,9 +134,13 @@ const PlayerContent: React.FC<PlayerContentProps> = React.memo(({
     handlers.onOpenLibrary();
   }, [handlers, setShowQueue, setShowVisualEffects]);
 
-  const handleArtistBrowse = useCallback((_artistName: string) => {
-    handleOpenLibrary();
-  }, [handleOpenLibrary]);
+  const handleArtistBrowse = useCallback((artistName: string) => {
+    if (handlers.onOpenLibraryWithQuery) {
+      handlers.onOpenLibraryWithQuery(artistName);
+    } else {
+      handleOpenLibrary();
+    }
+  }, [handlers, handleOpenLibrary]);
 
   const handleAlbumPlay = useCallback((albumId: string, albumName: string) => {
     handlers.onAlbumPlay(albumId, albumName);

--- a/src/components/__tests__/AudioPlayer.pendingQuery.test.tsx
+++ b/src/components/__tests__/AudioPlayer.pendingQuery.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Integration tests for the pendingLibraryQueryRef / ref-clear-on-read cycle.
+ *
+ * AudioPlayer stores the artist-browse query in a ref and clears it immediately
+ * when rendering LibraryRoute (ref-clear-on-read). This harness exercises that
+ * contract end-to-end: the query seeds the search input on the first open, and
+ * the input is empty on the second open (no query).
+ */
+
+import React, { useRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+vi.mock('@/contexts/PlayerSizingContext', () => ({
+  usePlayerSizingContext: vi.fn(() => ({
+    isMobile: false,
+  })),
+}));
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(() => ({
+    hasMultipleProviders: false,
+    enabledProviderIds: ['spotify'],
+  })),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(() => ({
+    unifiedTracks: [],
+    isUnifiedLikedActive: false,
+    totalCount: 0,
+    isLoading: false,
+  })),
+}));
+
+vi.mock('../LibraryRoute/hooks', () => ({
+  useResumeSection: vi.fn(() => ({ session: null, hasResumable: false })),
+  useRecentlyPlayedSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  usePinnedSection: vi.fn(() => ({
+    pinnedPlaylists: [],
+    pinnedAlbums: [],
+    combined: [],
+    isLoading: false,
+    isEmpty: true,
+  })),
+  usePlaylistsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useAlbumsSection: vi.fn(() => ({ items: [], isLoading: false, isEmpty: true })),
+  useLikedSection: vi.fn(() => ({
+    totalCount: 0,
+    perProvider: [],
+    isUnified: false,
+    isLoading: false,
+  })),
+  fetchLikedForProvider: vi.fn(async () => []),
+}));
+
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: () => ({ currentTrack: null }),
+}));
+
+vi.mock('@/hooks/usePinnedItems', () => ({
+  usePinnedItems: () => ({
+    pinnedPlaylistIds: [],
+    pinnedAlbumIds: [],
+    isPlaylistPinned: () => false,
+    isAlbumPinned: () => false,
+    togglePinPlaylist: vi.fn(),
+    togglePinAlbum: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useRecentlyPlayedCollections', () => ({
+  useRecentlyPlayedCollections: () => ({ history: [], record: vi.fn(), remove: vi.fn() }),
+}));
+
+import LibraryRoute from '../LibraryRoute';
+
+const baseProps = {
+  onPlaylistSelect: vi.fn(),
+  onOpenSettings: vi.fn(),
+  lastSession: null,
+  isPlaying: false,
+  onMiniPlay: vi.fn(),
+  onMiniPause: vi.fn(),
+  onMiniNext: vi.fn(),
+  onMiniPrevious: vi.fn(),
+  onMiniExpand: vi.fn(),
+  onAddToQueue: vi.fn().mockResolvedValue(null),
+};
+
+/**
+ * Harness that mirrors AudioPlayer's pendingLibraryQueryRef / ref-clear-on-read pattern:
+ * - calling openLibraryWithQuery(q) stores q in the ref and shows the library
+ * - calling openLibrary() shows the library without a query
+ * - calling closeLibrary() unmounts LibraryRoute (clears its useState seed)
+ * - the ref is cleared on read, exactly as AudioPlayer does at render time
+ */
+function PendingQueryHarness() {
+  const pendingQueryRef = useRef<string | undefined>(undefined);
+  const [open, setOpen] = React.useState(false);
+  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
+
+  const openLibraryWithQuery = (q: string) => {
+    pendingQueryRef.current = q;
+    setOpen(true);
+  };
+
+  const openLibrary = () => {
+    setOpen(true);
+    forceUpdate();
+  };
+
+  const closeLibrary = () => {
+    setOpen(false);
+  };
+
+  // Ref-clear-on-read: capture and clear before render, matching AudioPlayer's pattern.
+  const initialSearchQuery = pendingQueryRef.current;
+  pendingQueryRef.current = undefined;
+
+  return (
+    <ThemeProvider theme={theme}>
+      <button onClick={() => openLibraryWithQuery('Pink Floyd')}>Open with query</button>
+      <button onClick={openLibrary}>Open without query</button>
+      <button onClick={closeLibrary}>Close</button>
+      {open && (
+        <LibraryRoute
+          key={String(open) + String(initialSearchQuery)}
+          {...baseProps}
+          initialSearchQuery={initialSearchQuery}
+          onClose={closeLibrary}
+        />
+      )}
+    </ThemeProvider>
+  );
+}
+
+describe('pendingLibraryQueryRef ref-clear-on-read cycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('search input is populated on first open (with query) and empty on second open (without query)', () => {
+    // #given
+    render(<PendingQueryHarness />);
+
+    // #when — open library with a query
+    act(() => {
+      screen.getByText('Open with query').click();
+    });
+
+    // #then — search input is seeded with the query
+    expect(screen.getByTestId('library-search-input-desktop')).toHaveValue('Pink Floyd');
+
+    // #when — navigate back to player
+    act(() => {
+      screen.getByText('Close').click();
+    });
+
+    // #then — library is unmounted
+    expect(screen.queryByTestId('library-search-input-desktop')).not.toBeInTheDocument();
+
+    // #when — open library without a query
+    act(() => {
+      screen.getByText('Open without query').click();
+    });
+
+    // #then — search input is empty (ref was cleared on the previous read)
+    expect(screen.getByTestId('library-search-input-desktop')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary
- Pipes the artist name from the TrackInfo popover through `PlayerContent` → `AudioPlayer` → `LibraryRoute` so the library opens with the search box pre-populated and `SearchResultsView` renders matching results.
- Adds `onOpenLibraryWithQuery` to `PlaybackHandlers`; `AudioPlayer` stores the pending query in a `pendingLibraryQueryRef` that is consumed (and cleared) when `LibraryRoute` mounts — so repeated opens always start fresh.
- Extends `useLibrarySearch` with an optional `initialQuery` parameter seeded into `useState` once on mount, ensuring user-typed queries are never overwritten.

## Test plan
- Click an artist name in the player → choose "Browse albums by \<artist\>" → library opens with search box populated and `SearchResultsView` showing matches.
- Existing search interactions (typing, clearing, filter sheet) still work.
- Other TrackInfo popover items (external links, album play) are unaffected.
- `npx tsc -b --noEmit && npm run test:run` is green (pre-existing flaky failures in `select.test.tsx`, `LibraryContextMenu.a11y.test.tsx`, etc. are unrelated and reproduce on `develop` without this change).

Closes #1512