### PR TITLE
fix(sources): direct-reconnect when provider enabled but auth expired

### DIFF
--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -28,7 +28,7 @@ export const MusicSourcesSection = memo(() => {
   const providers = useMemo(() => registry.getAll(), [registry]);
 
   const [disconnectDialogProviderId, setDisconnectDialogProviderId] = useState<ProviderId | null>(null);
-  const pendingPopup = useRef<{ providerId: ProviderId; popup: Window } | null>(null);
+  const pendingPopup = useRef<{ providerId: ProviderId; popup: Window; onSuccess: (id: ProviderId) => void } | null>(null);
   const popupPollInterval = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const clearPendingPopup = useCallback(() => {
@@ -48,25 +48,23 @@ export const MusicSourcesSection = memo(() => {
       if (!pending) return;
       if (event.data?.provider !== pending.providerId) return;
 
+      const { providerId, onSuccess } = pending;
       clearPendingPopup();
-      toggleProvider(pending.providerId);
+      onSuccess(providerId);
     };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [toggleProvider, clearPendingPopup]);
+  }, [clearPendingPopup]);
 
-  const handleToggleOn = useCallback(
-    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
-      if (descriptor.auth.isAuthenticated()) {
-        toggleProvider(descriptor.id);
-        return;
-      }
-
+  const openLoginPopup = useCallback(
+    (
+      descriptor: ReturnType<typeof registry.getAll>[number],
+      onSuccess: (providerId: ProviderId) => void,
+    ) => {
       const providerId = descriptor.id;
       const providerName = descriptor.name;
 
-      // Intercept window.open to capture the popup reference when beginLogin opens it
       const originalOpen = window.open.bind(window);
       window.open = (...args: Parameters<typeof window.open>) => {
         window.open = originalOpen;
@@ -76,7 +74,7 @@ export const MusicSourcesSection = memo(() => {
           return win;
         }
 
-        pendingPopup.current = { providerId, popup: win };
+        pendingPopup.current = { providerId, popup: win, onSuccess };
         popupPollInterval.current = setInterval(() => {
           if (!pendingPopup.current) return;
           if (pendingPopup.current.popup.closed) {
@@ -87,7 +85,7 @@ export const MusicSourcesSection = memo(() => {
               const name = registry.get(pending.providerId)?.name ?? pending.providerId;
               toast(`Couldn't connect to ${name}. Try again.`);
             } else {
-              toggleProvider(pending.providerId);
+              onSuccess(pending.providerId);
             }
           }
         }, 500);
@@ -101,7 +99,28 @@ export const MusicSourcesSection = memo(() => {
         toast(`Couldn't connect to ${providerName}. Try again.`);
       });
     },
-    [registry, toggleProvider, clearPendingPopup],
+    [registry, clearPendingPopup],
+  );
+
+  const handleToggleOn = useCallback(
+    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
+      if (descriptor.auth.isAuthenticated()) {
+        toggleProvider(descriptor.id);
+        return;
+      }
+
+      openLoginPopup(descriptor, (providerId) => toggleProvider(providerId));
+    },
+    [openLoginPopup, toggleProvider],
+  );
+
+  const handleReconnect = useCallback(
+    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
+      openLoginPopup(descriptor, () => {
+        // Provider is already in enabledProviderIds — no toggleProvider call needed.
+      });
+    },
+    [openLoginPopup],
   );
 
   useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
@@ -170,19 +189,22 @@ export const MusicSourcesSection = memo(() => {
         {providers.map((descriptor) => {
           const isEnabled = enabledProviderIds.includes(descriptor.id);
           const isConnected = descriptor.auth.isAuthenticated();
+          const needsReconnect = isEnabled && !isConnected;
           const isLastEnabled = enabledProviderIds.length <= 1 && isEnabled;
-          const status = isEnabled && isConnected ? 'connected' : 'disabled';
+          const status = isEnabled && isConnected ? 'connected' : needsReconnect ? 'reconnect' : 'disabled';
           return (
             <ProviderRow key={descriptor.id}>
               <ProviderName>{descriptor.name}</ProviderName>
               <ProviderStatusBadge $status={status}>
-                {status === 'connected' ? 'Connected' : ''}
+                {status === 'connected' ? 'Connected' : status === 'reconnect' ? 'Reconnect needed' : ''}
               </ProviderStatusBadge>
               <Switch
                 checked={isEnabled}
                 onCheckedChange={() => {
                   if (!isEnabled) {
                     handleToggleOn(descriptor);
+                  } else if (needsReconnect) {
+                    handleReconnect(descriptor);
                   } else {
                     setDisconnectDialogProviderId(descriptor.id);
                   }

--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -209,7 +209,7 @@ export const MusicSourcesSection = memo(() => {
                     setDisconnectDialogProviderId(descriptor.id);
                   }
                 }}
-                aria-label={`${isEnabled ? 'Disable' : 'Enable'} ${descriptor.name}`}
+                aria-label={needsReconnect ? `Reconnect ${descriptor.name}` : isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}
                 disabled={isLastEnabled}
                 variant="neutral"
               />

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -357,6 +357,20 @@ describe('MusicSourcesSection', () => {
       expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
     });
 
+    it('sets aria-label to "Reconnect <name>" when provider is enabled but auth has expired', () => {
+      // #given — Spotify is enabled but its auth token has expired
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then — screen readers hear "Reconnect Spotify", not "Disable Spotify"
+      expect(screen.getByLabelText('Reconnect Spotify')).toBeInTheDocument();
+    });
+
     it('does not open ProviderDisconnectDialog when clicking the toggle on an expired provider', async () => {
       // #given — Spotify is enabled but its auth token has expired
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
@@ -373,7 +387,7 @@ describe('MusicSourcesSection', () => {
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
       // #when
-      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
 
       // #then — disconnect dialog must NOT appear
       expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
@@ -395,7 +409,7 @@ describe('MusicSourcesSection', () => {
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
       // #when
-      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
 
       // #then — OAuth popup must be initiated
       await waitFor(() => {
@@ -423,25 +437,32 @@ describe('MusicSourcesSection', () => {
         isAuthenticated.mockReturnValue(true);
         window.open('https://accounts.spotify.com/authorize', '_blank');
       });
+      const originalOpenDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
       Object.defineProperty(window, 'open', {
         value: () => mockPopupObj,
         writable: true,
         configurable: true,
       });
 
-      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+      try {
+        render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #when
-      fireEvent.click(screen.getByLabelText('Disable Spotify'));
-      await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
+        // #when
+        fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
+        await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
 
-      // #then — toggleProvider must NOT be called (provider is already enabled)
-      await waitFor(
-        () => {
-          expect(mockToggleProvider).not.toHaveBeenCalled();
-        },
-        { timeout: 2000 },
-      );
+        // #then — toggleProvider must NOT be called (provider is already enabled)
+        await waitFor(
+          () => {
+            expect(mockToggleProvider).not.toHaveBeenCalled();
+          },
+          { timeout: 2000 },
+        );
+      } finally {
+        if (originalOpenDescriptor) {
+          Object.defineProperty(window, 'open', originalOpenDescriptor);
+        }
+      }
     });
   });
 });

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -341,4 +341,107 @@ describe('MusicSourcesSection', () => {
       expect(screen.queryByText(/reconnect/i)).not.toBeInTheDocument();
     });
   });
+
+  describe('token-expired reconnect flow', () => {
+    it('shows "Reconnect needed" badge when provider is enabled but auth has expired', () => {
+      // #given — Spotify is enabled but its auth token has expired
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+
+      // #when
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #then
+      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+    });
+
+    it('does not open ProviderDisconnectDialog when clicking the toggle on an expired provider', async () => {
+      // #given — Spotify is enabled but its auth token has expired
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      const mockPopup = { closed: false } as Window;
+      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then — disconnect dialog must NOT appear
+      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
+    });
+
+    it('calls descriptor.auth.beginLogin when clicking the toggle on an expired provider', async () => {
+      // #given — Spotify is enabled but its auth token has expired
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
+      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      const mockPopup = { closed: false } as Window;
+      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then — OAuth popup must be initiated
+      await waitFor(() => {
+        expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
+      });
+    });
+
+    it('does not call toggleProvider after a successful reconnect (provider already enabled)', async () => {
+      // #given — Spotify is enabled but its auth token has expired; reconnect completes successfully
+      const isAuthenticated = vi.fn().mockReturnValue(false);
+      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated });
+      const dropboxDesc = makeDropboxDescriptor();
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+
+      // beginLogin opens a popup that is already closed (immediate dismiss).
+      // isAuthenticated stays false until after the popup reference is captured,
+      // then switches to true so the poll detects a successful reconnect.
+      const mockPopupObj = { closed: true };
+      vi.mocked(spotifyDesc.auth.beginLogin).mockImplementation(async () => {
+        // Switch auth to "succeeded" before window.open fires so the poll sees it
+        isAuthenticated.mockReturnValue(true);
+        window.open('https://accounts.spotify.com/authorize', '_blank');
+      });
+      Object.defineProperty(window, 'open', {
+        value: () => mockPopupObj,
+        writable: true,
+        configurable: true,
+      });
+
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+      await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
+
+      // #then — toggleProvider must NOT be called (provider is already enabled)
+      await waitFor(
+        () => {
+          expect(mockToggleProvider).not.toHaveBeenCalled();
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
 });

--- a/src/components/AppSettingsMenu/styled.ts
+++ b/src/components/AppSettingsMenu/styled.ts
@@ -181,11 +181,15 @@ export const ProviderName = styled.span`
   flex-shrink: 0;
 `;
 
-export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' }>`
+export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' | 'reconnect' }>`
   font-size: 0.6875rem;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   color: ${({ $status, theme }) =>
-    $status === 'connected' ? theme.colors.success : theme.colors.muted.foreground};
+    $status === 'connected'
+      ? theme.colors.success
+      : $status === 'reconnect'
+        ? theme.colors.warning
+        : theme.colors.muted.foreground};
   flex: 1;
 `;
 

--- a/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
@@ -197,4 +197,25 @@ describe('SettingsV2 SourcesSection', () => {
       expect(screen.queryByText(/Queue$/)).not.toBeInTheDocument();
     });
   });
+
+  describe('token-expired reconnect state', () => {
+    it('shows "Reconnect needed" badge when a provider is enabled but isAuthenticated returns false', () => {
+      // #given — Spotify is enabled but its auth token has expired
+      const spotify = makeDescriptor('spotify', 'Spotify', { isAuthenticated: false });
+      const dropbox = makeDescriptor('dropbox', 'Dropbox');
+      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockRegistry.getAll.mockReturnValue([spotify, dropbox]);
+      mockRegistry.get.mockImplementation((id) => (id === 'spotify' ? spotify : dropbox));
+
+      // #when
+      render(
+        <Wrapper>
+          <SourcesSection />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- When a provider is in `enabledProviderIds` but its auth token has expired (`isEnabled && !isConnected`), clicking the toggle now goes straight to the OAuth popup instead of the disconnect-confirmation dialog — which was confusing because the user isn't actually connected.
- Adds a \"Reconnect needed\" badge (warning color) next to the provider name so the expired state is visually distinct from both \"Connected\" and \"disabled\".
- Extracts an `openLoginPopup(descriptor, onSuccess)` helper so `handleToggleOn` (calls `toggleProvider` after auth) and `handleReconnect` (skips `toggleProvider` — provider already enabled) share identical popup-intercept + poll logic. The `onSuccess` callback is also stored in `pendingPopup.current` so the `AUTH_COMPLETE_EVENT` message-channel path routes correctly for both cases.

## Test plan

- [ ] With a provider freshly connected: toggle click still opens the disconnect dialog.
- [ ] With an expired/revoked token: toggle click skips the disconnect dialog and initiates the OAuth popup.
- [ ] After a successful reconnect via the popup: `toggleProvider` is NOT called a second time (provider already enabled).
- [ ] \"Reconnect needed\" badge appears when a provider is enabled but unauthenticated.
- [ ] SettingsV2 → Sources renders and passes all existing tests (shares the underlying component).
- [ ] `npx tsc -b --noEmit && npm run test:run` is green (excluding 3 pre-existing flaky failures in LibraryContextMenu, TimelineSlider, useLibrarySearch).

Closes #1514