### PR TITLE
fix(useLongPress): ignore non-primary mouse buttons so right-click doesn't fire onTap

### DIFF
--- a/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
+++ b/src/components/LibraryRoute/card/__tests__/LibraryCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import LibraryCard from '../LibraryCard';
 
 vi.mock('@/components/ProviderIcon', () => ({
@@ -82,5 +82,47 @@ describe('LibraryCard', () => {
 
     // #then
     expect(screen.getByTestId('library-card-album-a1')).toBeInTheDocument();
+  });
+
+  it('right-click opens context menu without firing onSelect', () => {
+    // #given
+    const onSelect = vi.fn();
+    const onContextMenuRequest = vi.fn();
+    render(
+      <LibraryCard
+        {...baseProps}
+        onSelect={onSelect}
+        onContextMenuRequest={onContextMenuRequest}
+      />,
+    );
+    const card = screen.getByTestId('library-card-playlist-p1');
+
+    // #when — dispatch native-style events with pointerType so useLongPress guard fires.
+    // jsdom's fireEvent helpers don't propagate pointerType; patching via Object.assign does.
+    act(() => {
+      card.dispatchEvent(
+        Object.assign(new Event('pointerdown', { bubbles: true }), {
+          button: 2,
+          pointerType: 'mouse',
+          clientX: 50,
+          clientY: 75,
+        }),
+      );
+    });
+    fireEvent.contextMenu(card, { clientX: 50, clientY: 75 });
+    act(() => {
+      card.dispatchEvent(
+        Object.assign(new Event('pointerup', { bubbles: true }), {
+          button: 2,
+          pointerType: 'mouse',
+          clientX: 50,
+          clientY: 75,
+        }),
+      );
+    });
+
+    // #then
+    expect(onContextMenuRequest).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
+++ b/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLongPress } from '../useLongPress';
 
-function makeEvent(overrides: Partial<{ clientX: number; clientY: number }> = {}): React.PointerEvent<HTMLElement> {
+function makeEvent(
+  overrides: Partial<{ clientX: number; clientY: number; pointerType: string; button: number }> = {},
+): React.PointerEvent<HTMLElement> {
   const target = document.createElement('div');
   return {
     clientX: overrides.clientX ?? 0,
     clientY: overrides.clientY ?? 0,
+    pointerType: overrides.pointerType ?? 'touch',
+    button: overrides.button ?? 0,
     currentTarget: target,
   } as unknown as React.PointerEvent<HTMLElement>;
 }
@@ -120,5 +124,69 @@ describe('useLongPress', () => {
 
     // #then
     expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke onTap on right-click (mouse button 2)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ pointerType: 'mouse', button: 2 }));
+      result.current.onPointerUp(makeEvent({ pointerType: 'mouse', button: 2 }));
+    });
+
+    // #then
+    expect(onTap).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not start long-press timer on right-click (mouse button 2)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ pointerType: 'mouse', button: 2 }));
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('still fires onTap on primary mouse button (button 0)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ pointerType: 'mouse', button: 0 }));
+      result.current.onPointerUp(makeEvent({ pointerType: 'mouse', button: 0 }));
+    });
+
+    // #then
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fires onTap on touch (pointerType touch, button 0)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(makeEvent({ pointerType: 'touch', button: 0 }));
+      result.current.onPointerUp(makeEvent({ pointerType: 'touch', button: 0 }));
+    });
+
+    // #then
+    expect(onTap).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
+++ b/src/components/LibraryRoute/card/__tests__/useLongPress.test.ts
@@ -189,4 +189,29 @@ describe('useLongPress', () => {
     // #then
     expect(onTap).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores secondary-button pointerup during an active primary-button long-press', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onTap }));
+
+    // #when — start a primary-button long-press
+    act(() => {
+      result.current.onPointerDown(makeEvent({ pointerType: 'mouse', button: 0 }));
+    });
+    // stray right-button pointerup fires before the primary button is released
+    act(() => {
+      result.current.onPointerUp(makeEvent({ pointerType: 'mouse', button: 2 }));
+    });
+
+    // #then — secondary-button release must not abort the long-press or fire onTap
+    expect(onTap).not.toHaveBeenCalled();
+
+    // primary button released — long-press window still intact, tap fires
+    act(() => {
+      result.current.onPointerUp(makeEvent({ pointerType: 'mouse', button: 0 }));
+    });
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/LibraryRoute/card/useLongPress.ts
+++ b/src/components/LibraryRoute/card/useLongPress.ts
@@ -75,7 +75,8 @@ export function useLongPress({ onLongPress, onTap, enabled = true }: UseLongPres
     }
   }, [clearTimer]);
 
-  const onPointerUp = useCallback(() => {
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
     const state = stateRef.current;
     const wasTriggered = state.triggered;
     const wasActive = state.active;

--- a/src/components/LibraryRoute/card/useLongPress.ts
+++ b/src/components/LibraryRoute/card/useLongPress.ts
@@ -46,6 +46,7 @@ export function useLongPress({ onLongPress, onTap, enabled = true }: UseLongPres
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLElement>) => {
       if (!enabled) return;
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
       const state = stateRef.current;
       state.startX = e.clientX;
       state.startY = e.clientY;

--- a/src/hooks/__tests__/useLongPress.test.ts
+++ b/src/hooks/__tests__/useLongPress.test.ts
@@ -211,4 +211,30 @@ describe('useLongPress', () => {
     // #then
     expect(onShortPress).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores secondary-button pointerup during an active primary-button long-press', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onShortPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onShortPress }));
+
+    // #when — start a primary-button press
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100, { pointerType: 'mouse', button: 0 }));
+    });
+    // stray right-button pointerup fires before the primary button is released
+    act(() => {
+      result.current.onPointerUp(createPointerEvent(100, 100, { pointerType: 'mouse', button: 2 }));
+    });
+
+    // #then — secondary-button release must not fire onShortPress or corrupt state
+    expect(onShortPress).not.toHaveBeenCalled();
+
+    // primary button released — timer still pending, short-press fires
+    act(() => {
+      result.current.onPointerUp(createPointerEvent(100, 100, { pointerType: 'mouse', button: 0 }));
+    });
+    expect(onShortPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/__tests__/useLongPress.test.ts
+++ b/src/hooks/__tests__/useLongPress.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLongPress } from '../useLongPress';
 
-const createPointerEvent = (x: number, y: number): React.PointerEvent => ({
+const createPointerEvent = (
+  x: number,
+  y: number,
+  overrides: Partial<{ pointerType: string; button: number }> = {},
+): React.PointerEvent => ({
   clientX: x,
   clientY: y,
+  pointerType: overrides.pointerType ?? 'touch',
+  button: overrides.button ?? 0,
   preventDefault: vi.fn(),
   stopPropagation: vi.fn(),
 } as unknown as React.PointerEvent);
@@ -153,5 +159,56 @@ describe('useLongPress', () => {
     // #then
     expect(onLongPress).not.toHaveBeenCalled();
     expect(onShortPress).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke onShortPress on right-click (mouse button 2)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onShortPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onShortPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100, { pointerType: 'mouse', button: 2 }));
+      result.current.onPointerUp(createPointerEvent(100, 100, { pointerType: 'mouse', button: 2 }));
+    });
+
+    // #then
+    expect(onShortPress).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not start long-press timer on right-click (mouse button 2)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100, { pointerType: 'mouse', button: 2 }));
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('still fires onShortPress on primary mouse button (button 0)', () => {
+    // #given
+    const onLongPress = vi.fn();
+    const onShortPress = vi.fn();
+    const { result } = renderHook(() => useLongPress({ onLongPress, onShortPress }));
+
+    // #when
+    act(() => {
+      result.current.onPointerDown(createPointerEvent(100, 100, { pointerType: 'mouse', button: 0 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      result.current.onPointerUp(createPointerEvent(100, 100, { pointerType: 'mouse', button: 0 }));
+    });
+
+    // #then
+    expect(onShortPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -35,6 +35,7 @@ export function useLongPress({
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     if (!enabled) return;
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
     firedRef.current = false;
     startXRef.current = e.clientX;
     startYRef.current = e.clientY;

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -47,7 +47,8 @@ export function useLongPress({
     }, LONG_PRESS_DURATION_MS);
   }, [enabled, onLongPress]);
 
-  const onPointerUp = useCallback((_e: React.PointerEvent) => {
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
     if (!enabled) return;
     const wasPending = timerRef.current !== null;
     cancel();


### PR DESCRIPTION
## Summary
- Both useLongPress hooks now early-return in `onPointerDown` when a non-primary mouse button is pressed (`pointerType === 'mouse' && e.button !== 0`). Touch and pen are unaffected because their primary press always reports `button === 0`.
- Fixes desktop right-click on Library collection cards: the context menu now opens cleanly without firing `onSelect` (which was playing the collection and dismissing the library).
- Same latent bug fixed in the global `useLongPress` hook used by `QueueTrackItem`.

## Test plan
- Right-click a Library collection card on desktop → context menu appears, no playback, library stays open.
- Long-press a card on touch → context menu still opens.
- Left-click still selects/plays.
- New unit tests in both `useLongPress` test files cover the right-click-does-not-fire-tap path (5 new cases each).
- New integration test in `LibraryCard.test.tsx` fires a right-click sequence on a card with both `onSelect` and `onContextMenuRequest`, asserts `onSelect` is NOT called and `onContextMenuRequest` IS called.
- `npx tsc -b --noEmit && npm run test:run` is green (1989 tests, 0 failures).

Closes #1518