### PR TITLE
feat(settings-v2): add per-album glow override sub-row in Appearance

### DIFF
--- a/src/components/SettingsV2/sections/AppearanceSection.styled.ts
+++ b/src/components/SettingsV2/sections/AppearanceSection.styled.ts
@@ -60,6 +60,41 @@ export const SubControlLabel = styled.span`
   min-width: 64px;
 `;
 
+export const AlbumOverrideLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.xs};
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  min-width: 64px;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const AlbumOverrideLabelText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const OverrideMarker = styled.span`
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: hsl(var(--primary));
+`;
+
+export const OverrideOptionGroups = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
 export const SwatchRow = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AppearanceSection.test.tsx
@@ -65,11 +65,13 @@ vi.mock('@/providers/dropbox/dropboxPreferencesSync', () => ({
 }));
 
 import { AppearanceSection } from '../AppearanceSection';
+import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import {
   VisualizerProvider,
   VisualEffectsToggleProvider,
   TranslucenceProvider,
   AccentColorBackgroundProvider,
+  GlowProvider,
 } from '@/contexts/visualEffects';
 import {
   useVisualizer,
@@ -83,7 +85,9 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <VisualEffectsToggleProvider>
       <AccentColorBackgroundProvider>
         <VisualizerProvider>
-          <TranslucenceProvider>{children}</TranslucenceProvider>
+          <TranslucenceProvider>
+            <GlowProvider>{children}</GlowProvider>
+          </TranslucenceProvider>
         </VisualizerProvider>
       </AccentColorBackgroundProvider>
     </VisualEffectsToggleProvider>
@@ -111,6 +115,37 @@ describe('SettingsV2 AppearanceSection', () => {
     expect(screen.getByText('Visualizer')).toBeInTheDocument();
     expect(screen.getByText('Background gradient')).toBeInTheDocument();
     expect(screen.getByText('Translucence')).toBeInTheDocument();
+  });
+
+  it('renders the per-album glow override row when a track with albumId is playing', () => {
+    // #given
+    vi.mocked(useCurrentTrackContext).mockReturnValue({
+      currentTrack: {
+        id: 'track-1',
+        name: 'Track One',
+        artist: 'Artist',
+        album: 'Album One',
+        albumId: 'album-1',
+        duration: 1000,
+        uri: 'spotify:track:1',
+      },
+      currentTrackIndex: 0,
+      setCurrentTrackIndex: vi.fn(),
+      showQueue: false,
+      setShowQueue: vi.fn(),
+    } as unknown as ReturnType<typeof useCurrentTrackContext>);
+
+    // #when
+    render(
+      <Wrapper>
+        <AppearanceSection />
+      </Wrapper>,
+    );
+
+    // #then
+    expect(screen.getByLabelText('Album glow intensity')).toBeInTheDocument();
+    expect(screen.getByLabelText('Album glow rate')).toBeInTheDocument();
+    expect(screen.getByText('Album One')).toBeInTheDocument();
   });
 
   it('writes TRANSLUCENCE_ENABLED only (no opacity side-effect) when master toggled', () => {

--- a/src/components/SettingsV2/sections/__tests__/GlowControls.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/GlowControls.test.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 
 import { theme } from '@/styles/theme';
 import { STORAGE_KEYS } from '@/constants/storage';
+import type { MediaTrack } from '@/types/domain';
 
 const mockSetEnabled = vi.fn();
 const mockSetIntensity = vi.fn();
@@ -14,19 +15,41 @@ const mockRestoreGlowSettings = vi.fn();
 let mockEnabled = true;
 let mockIntensity = 110;
 let mockRate = 4.0;
+let mockCurrentTrack: MediaTrack | null = null;
 
 const memoryStorage = new Map<string, string>();
 
-vi.mock('@/contexts/visualEffects', () => ({
-  useVisualEffectsToggle: vi.fn(() => ({
-    visualEffectsEnabled: mockEnabled,
-    setVisualEffectsEnabled: (next: boolean) => {
-      mockEnabled = next;
-      mockSetEnabled(next);
-      memoryStorage.set(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED, JSON.stringify(next));
+const installLocalStorageShim = () => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => memoryStorage.set(key, value),
+      removeItem: (key: string) => memoryStorage.delete(key),
+      clear: () => memoryStorage.clear(),
+      key: () => null,
+      length: 0,
     },
-  })),
-}));
+    writable: true,
+    configurable: true,
+  });
+};
+
+vi.mock('@/contexts/visualEffects', async () => {
+  const actual = await vi.importActual<typeof import('@/contexts/visualEffects')>(
+    '@/contexts/visualEffects',
+  );
+  return {
+    ...actual,
+    useVisualEffectsToggle: vi.fn(() => ({
+      visualEffectsEnabled: mockEnabled,
+      setVisualEffectsEnabled: (next: boolean) => {
+        mockEnabled = next;
+        mockSetEnabled(next);
+        memoryStorage.set(STORAGE_KEYS.VISUAL_EFFECTS_ENABLED, JSON.stringify(next));
+      },
+    })),
+  };
+});
 
 vi.mock('@/hooks/useVisualEffectsState', () => ({
   useVisualEffectsState: vi.fn(() => ({
@@ -46,10 +69,34 @@ vi.mock('@/hooks/useVisualEffectsState', () => ({
   })),
 }));
 
+vi.mock('@/contexts/TrackContext', () => ({
+  useCurrentTrackContext: vi.fn(() => ({
+    currentTrack: mockCurrentTrack,
+    currentTrackIndex: 0,
+    setCurrentTrackIndex: vi.fn(),
+    showQueue: false,
+    setShowQueue: vi.fn(),
+  })),
+}));
+
 import { GlowControls } from '../appearance/GlowControls';
+import { GlowProvider } from '@/contexts/visualEffects';
+
+const buildTrack = (overrides: Partial<MediaTrack> = {}): MediaTrack => ({
+  id: 'track-1',
+  name: 'Track One',
+  artist: 'Artist',
+  album: 'Album One',
+  albumId: 'album-1',
+  duration: 1000,
+  uri: 'spotify:track:1',
+  ...overrides,
+});
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+  <ThemeProvider theme={theme}>
+    <GlowProvider>{children}</GlowProvider>
+  </ThemeProvider>
 );
 
 describe('SettingsV2 GlowControls', () => {
@@ -58,7 +105,9 @@ describe('SettingsV2 GlowControls', () => {
     mockEnabled = true;
     mockIntensity = 110;
     mockRate = 4.0;
+    mockCurrentTrack = null;
     memoryStorage.clear();
+    installLocalStorageShim();
   });
 
   it('writes VISUAL_EFFECTS_ENABLED when the toggle is flipped off', () => {
@@ -146,5 +195,197 @@ describe('SettingsV2 GlowControls', () => {
     // #then
     expect(screen.queryByText('Intensity')).not.toBeInTheDocument();
     expect(screen.queryByText('Rate')).not.toBeInTheDocument();
+  });
+
+  describe('per-album override sub-row', () => {
+    it('does not render when visual effects are off but a track with albumId is playing', () => {
+      // #given
+      mockEnabled = false;
+      mockCurrentTrack = buildTrack();
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByTestId('album-override-row')).not.toBeInTheDocument();
+    });
+
+    it('does not render when visual effects are on but no current track is set', () => {
+      // #given
+      mockEnabled = true;
+      mockCurrentTrack = null;
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByTestId('album-override-row')).not.toBeInTheDocument();
+    });
+
+    it('does not render when visual effects are on but the current track has no albumId', () => {
+      // #given
+      mockEnabled = true;
+      mockCurrentTrack = buildTrack({ albumId: undefined });
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.queryByTestId('album-override-row')).not.toBeInTheDocument();
+    });
+
+    it('highlights override presets (not the global preset) when an override exists for the album', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ albumId: 'album-1' });
+      memoryStorage.set(
+        STORAGE_KEYS.PER_ALBUM_GLOW,
+        JSON.stringify({ 'album-1': { intensity: 95, rate: 3.0 } }),
+      );
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      const intensityGroup = screen.getByLabelText('Album glow intensity');
+      const rateGroup = screen.getByLabelText('Album glow rate');
+      expect(intensityGroup.querySelector('button:nth-of-type(1)')).toHaveTextContent('Less');
+      expect(intensityGroup.querySelector('button:nth-of-type(1)')).toHaveStyle({
+        background: 'hsl(var(--primary))',
+      });
+      expect(intensityGroup.querySelector('button:nth-of-type(2)')).not.toHaveStyle({
+        background: 'hsl(var(--primary))',
+      });
+      expect(rateGroup.querySelector('button:nth-of-type(3)')).toHaveTextContent('Faster');
+      expect(rateGroup.querySelector('button:nth-of-type(3)')).toHaveStyle({
+        background: 'hsl(var(--primary))',
+      });
+    });
+
+    it('falls through to the global preset highlight when no override exists for the album', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ albumId: 'album-1' });
+      mockIntensity = 125;
+      mockRate = 5.0;
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      const intensityGroup = screen.getByLabelText('Album glow intensity');
+      const rateGroup = screen.getByLabelText('Album glow rate');
+      expect(intensityGroup.querySelector('button:nth-of-type(3)')).toHaveStyle({
+        background: 'hsl(var(--primary))',
+      });
+      expect(rateGroup.querySelector('button:nth-of-type(1)')).toHaveStyle({
+        background: 'hsl(var(--primary))',
+      });
+    });
+
+    it('writes both intensity and rate to the albumId key when a preset is clicked', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ albumId: 'album-1' });
+      mockIntensity = 110;
+      mockRate = 4.0;
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+      const intensityGroup = screen.getByLabelText('Album glow intensity');
+      fireEvent.click(intensityGroup.querySelector('button:nth-of-type(1)')!);
+
+      // #then
+      const stored = JSON.parse(memoryStorage.get(STORAGE_KEYS.PER_ALBUM_GLOW) ?? '{}');
+      expect(stored).toEqual({ 'album-1': { intensity: 95, rate: 4.0 } });
+    });
+
+    it('clears the albumId key when Reset is clicked', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ albumId: 'album-1' });
+      memoryStorage.set(
+        STORAGE_KEYS.PER_ALBUM_GLOW,
+        JSON.stringify({ 'album-1': { intensity: 95, rate: 3.0 }, 'album-2': { intensity: 125, rate: 5.0 } }),
+      );
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Reset album glow override' }));
+
+      // #then
+      const stored = JSON.parse(memoryStorage.get(STORAGE_KEYS.PER_ALBUM_GLOW) ?? '{}');
+      expect(stored).toEqual({ 'album-2': { intensity: 125, rate: 5.0 } });
+    });
+
+    it('disables Reset when no override exists for the current album', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ albumId: 'album-1' });
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Reset album glow override' })).toBeDisabled();
+    });
+
+    it('renders the album name as the override label when present', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ album: 'Kid A' });
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByTestId('album-override-row')).toHaveTextContent('Kid A');
+      expect(screen.queryByText('This album')).not.toBeInTheDocument();
+    });
+
+    it('falls back to "This album" when the track has an empty album string', () => {
+      // #given
+      mockCurrentTrack = buildTrack({ album: '' });
+
+      // #when
+      render(
+        <Wrapper>
+          <GlowControls />
+        </Wrapper>,
+      );
+
+      // #then
+      expect(screen.getByTestId('album-override-row')).toHaveTextContent('This album');
+    });
   });
 });

--- a/src/components/SettingsV2/sections/appearance/GlowControls.tsx
+++ b/src/components/SettingsV2/sections/appearance/GlowControls.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 
-import { useVisualEffectsToggle } from '@/contexts/visualEffects';
+import { useVisualEffectsToggle, useGlow } from '@/contexts/visualEffects';
 import { useVisualEffectsState } from '@/hooks/useVisualEffectsState';
+import { useCurrentTrackContext } from '@/contexts/TrackContext';
 import { Switch } from '@/components/ui/switch';
 import { OptionButton, OptionButtonGroup } from '@/components/AppSettingsMenu/styled';
 
@@ -13,6 +14,10 @@ import {
   SectionGroupTitle,
   SubControlRow,
   SubControlLabel,
+  AlbumOverrideLabel,
+  AlbumOverrideLabelText,
+  OverrideMarker,
+  OverrideOptionGroups,
 } from '../AppearanceSection.styled';
 
 const INTENSITY_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
@@ -27,6 +32,8 @@ const RATE_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
   { value: 3.0, label: 'Faster' },
 ] as const;
 
+const ALBUM_FALLBACK_LABEL = 'This album';
+
 /**
  * SettingsV2 glow controls — phase 3 port (#1451).
  *
@@ -35,6 +42,10 @@ const RATE_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
  * matching the hook + storage-key contract used by
  * `controls/QuickEffectsRow` so toggling in either surface reflects in
  * the other.
+ *
+ * Adds a conditional "Album override" sub-row (#1522) that writes per-album
+ * intensity/rate via `useGlow` (`PER_ALBUM_GLOW` storage key) when a track
+ * with an `albumId` is playing and visual effects are enabled.
  */
 export const GlowControls: React.FC = () => {
   const { visualEffectsEnabled, setVisualEffectsEnabled } = useVisualEffectsToggle();
@@ -45,6 +56,13 @@ export const GlowControls: React.FC = () => {
     handleGlowRateChange,
     restoreGlowSettings,
   } = useVisualEffectsState();
+  const { currentTrack } = useCurrentTrackContext();
+  const { perAlbumGlow, setPerAlbumGlow } = useGlow();
+
+  const albumId = currentTrack?.albumId;
+  const override = albumId ? perAlbumGlow[albumId] : undefined;
+  const hasOverride = albumId !== undefined && albumId in perAlbumGlow;
+  const effective = override ?? { intensity: glowIntensity, rate: glowRate };
 
   const handleToggle = useCallback(
     (checked: boolean) => {
@@ -57,6 +75,39 @@ export const GlowControls: React.FC = () => {
     },
     [setVisualEffectsEnabled, restoreGlowSettings],
   );
+
+  const handleOverrideIntensity = useCallback(
+    (intensity: number) => {
+      if (!albumId) return;
+      setPerAlbumGlow((prev) => ({
+        ...prev,
+        [albumId]: { intensity, rate: effective.rate },
+      }));
+    },
+    [albumId, effective.rate, setPerAlbumGlow],
+  );
+
+  const handleOverrideRate = useCallback(
+    (rate: number) => {
+      if (!albumId) return;
+      setPerAlbumGlow((prev) => ({
+        ...prev,
+        [albumId]: { intensity: effective.intensity, rate },
+      }));
+    },
+    [albumId, effective.intensity, setPerAlbumGlow],
+  );
+
+  const handleResetOverride = useCallback(() => {
+    if (!albumId) return;
+    setPerAlbumGlow((prev) => {
+      const next = { ...prev };
+      delete next[albumId];
+      return next;
+    });
+  }, [albumId, setPerAlbumGlow]);
+
+  const albumLabel = currentTrack?.album || ALBUM_FALLBACK_LABEL;
 
   return (
     <ControlBlock>
@@ -108,6 +159,50 @@ export const GlowControls: React.FC = () => {
               ))}
             </OptionButtonGroup>
           </SubControlRow>
+
+          {albumId && (
+            <SubControlRow data-testid="album-override-row">
+              <AlbumOverrideLabel>
+                {hasOverride && <OverrideMarker data-testid="album-override-marker" aria-hidden="true" />}
+                <AlbumOverrideLabelText>{albumLabel}</AlbumOverrideLabelText>
+              </AlbumOverrideLabel>
+              <OverrideOptionGroups>
+                <OptionButtonGroup aria-label="Album glow intensity">
+                  {INTENSITY_OPTIONS.map((opt) => (
+                    <OptionButton
+                      key={opt.value}
+                      type="button"
+                      $isActive={effective.intensity === opt.value}
+                      onClick={() => handleOverrideIntensity(opt.value)}
+                    >
+                      {opt.label}
+                    </OptionButton>
+                  ))}
+                </OptionButtonGroup>
+                <OptionButtonGroup aria-label="Album glow rate">
+                  {RATE_OPTIONS.map((opt) => (
+                    <OptionButton
+                      key={opt.value}
+                      type="button"
+                      $isActive={effective.rate === opt.value}
+                      onClick={() => handleOverrideRate(opt.value)}
+                    >
+                      {opt.label}
+                    </OptionButton>
+                  ))}
+                  <OptionButton
+                    type="button"
+                    $isActive={false}
+                    disabled={!hasOverride}
+                    onClick={handleResetOverride}
+                    aria-label="Reset album glow override"
+                  >
+                    Reset
+                  </OptionButton>
+                </OptionButtonGroup>
+              </OverrideOptionGroups>
+            </SubControlRow>
+          )}
         </>
       )}
     </ControlBlock>

--- a/src/contexts/visualEffects/index.tsx
+++ b/src/contexts/visualEffects/index.tsx
@@ -11,6 +11,7 @@ export { VisualizerProvider, useVisualizer } from './VisualizerContext';
 export { AccentColorBackgroundProvider, useAccentColorBackground } from './AccentColorBackgroundContext';
 export { TranslucenceProvider, useTranslucence } from './TranslucenceContext';
 export { useZenMode } from './ZenModeContext';
+export { GlowProvider, useGlow } from './GlowContext';
 
 export function VisualEffectsProvider({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
Adds the per-album glow override UX scoped in #1463: a conditional third sub-row inside the existing Glow ControlBlock in Settings v2 Appearance that writes to the orphan `PER_ALBUM_GLOW` storage key when a track with an `albumId` is playing and visual effects are enabled. The sub-row exposes the same Intensity/Rate presets as the global rows plus a Reset affordance; writes capture both axes verbatim so single-preset clicks never drop the other axis. `useGlow`/`GlowProvider` are now re-exported from the `@/contexts/visualEffects` barrel for direct consumption.

## Test plan

- [x] Override sub-row mounts only when `visualEffectsEnabled && currentTrack?.albumId` (three negative cases: effects off, no track, missing albumId)
- [x] Preset highlight reflects the override when one exists for the album
- [x] Preset highlight falls through to the global value when no override exists
- [x] Clicking a preset writes both intensity and rate to the `albumId` key in `PER_ALBUM_GLOW`
- [x] Reset removes the `albumId` entry and is disabled when no override is present
- [x] Label renders `currentTrack.album` when present; falls back to "This album" when empty
- [x] `AppearanceSection` test wrapper includes `<GlowProvider>` and verifies the new sub-row renders for a track with `albumId`
- [x] `npx tsc -b --noEmit`, `npm run test:run` (2011 passing), `npm run lint` all clean

Closes #1522
Part of #1463