### PR TITLE
fix(settings-v2): restore eyedropper pointer-event capture (#1467)

### DIFF
--- a/src/components/EyedropperOverlay.tsx
+++ b/src/components/EyedropperOverlay.tsx
@@ -65,6 +65,14 @@ const EyedropperOverlay: React.FC<EyedropperOverlayProps> = ({ image, onPick, on
         alignItems: 'center',
         justifyContent: 'center',
         flexDirection: 'column',
+        // When invoked from a Radix modal Dialog (e.g. SettingsV2's
+        // AccentColorManager), Radix sets `body { pointer-events: none }` and
+        // only re-enables pointer events on the dialog's DismissableLayer.
+        // The eyedropper portals to `document.body`, so it inherits `none`
+        // and every click — including the X close button — is swallowed.
+        // Forcing `auto` here restores interactivity regardless of the
+        // ancestor modal context. See issue #1467.
+        pointerEvents: 'auto',
       }}>
       <div style={{
         position: 'relative',

--- a/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
@@ -158,6 +158,42 @@ describe('SettingsV2 + real EyedropperOverlay (issue #1467)', () => {
     expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
   });
 
+  it('keeps the eyedropper portal interactive (pointer-events: auto) so the X close button is not blocked by Radix body pointer-events lockout', async () => {
+    // #given — real SettingsV2 Dialog open with the eyedropper portal mounted.
+    // Radix's modal Dialog sets `body { pointer-events: none }` while open,
+    // and the eyedropper portals to body. Without an explicit override on the
+    // overlay root, every click (including the X close button) is swallowed.
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <SettingsV2 isOpen={true} onClose={onClose} />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId('settings-v2-desktop'));
+    fireEvent.click(screen.getByLabelText('Pick color from album art'));
+    const overlay = (await waitFor(() =>
+      document.body.querySelector('[data-eyedropper-overlay="true"]'),
+    )) as HTMLElement;
+
+    // #when / #then — the overlay root carries `pointer-events: auto` inline,
+    // overriding the inherited `none` from Radix's body lockout. jsdom does
+    // not enforce CSS pointer-events for synthetic events, so we assert the
+    // inline style directly — the contract that keeps real-browser clicks alive.
+    expect(overlay.style.pointerEvents).toBe('auto');
+
+    // And the X close button inside the overlay must dismiss the picker
+    // without dismissing the surrounding Settings v2 Dialog.
+    const closeButton = overlay.querySelector('button');
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton!);
+
+    await waitFor(() =>
+      expect(document.body.querySelector('[data-eyedropper-overlay="true"]')).toBeNull(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+  });
+
   it('captures the picked color and dual-writes ACCENT_COLOR_OVERRIDES + CUSTOM_ACCENT_COLORS', async () => {
     // #given — real SettingsV2 Dialog open with AccentColorManager mounted
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary
- Root cause: Radix's modal `Dialog` sets `body { pointer-events: none }` while open and only re-enables pointer events on its own `DismissableLayer`. `EyedropperOverlay` portals to `document.body`, so it inherits `none` and every click inside the picker — pixel-pick canvas AND the X close button — is swallowed by the browser before React sees it.
- PR #1468 fixed the dismissal half of #1467 (preventing Radix from treating eyedropper pointerdowns as outside-clicks) but did not address the body-level pointer-events lockout. Tests used synthetic events that bypass jsdom's CSS hit-test, so the real-browser regression hid in CI.
- Fix: set `pointer-events: auto` inline on the `EyedropperOverlay` portal root. Defensive against any modal context the eyedropper may be invoked from. Legacy `AlbumArtSection` flow is unaffected (no Radix modal Dialog around it).
- Test: extended the #1468 integration test with a third scenario asserting both the inline `pointer-events: auto` contract and that the X close button dismisses the picker without dismissing the surrounding SettingsV2 Dialog. (jsdom limitation noted in the test — synthetic events bypass CSS hit-testing, so we assert the inline-style contract directly.)

## Test plan
- `npx tsc -b --noEmit` — clean
- `npm run test:run -- src/components/SettingsV2 src/components/EyedropperOverlay` — 82 tests passing (3 in `AccentColorManager.eyedropper.integration.test.tsx`)
- `npm run build` — clean
- Manual: `?ui=v2&settings=appearance` → Appearance → eyedropper → click pixel (color captured) AND click X (overlay closes, Dialog stays open)

Closes #1467