### PR TITLE
fix(settings-v2): correct Translucence toggle label and help text

### DIFF
--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -67,8 +67,8 @@ const TranslucenceToggle: React.FC = () => {
       <SectionGroupTitle>Translucence</SectionGroupTitle>
       <ControlRow>
         <div>
-          <ControlLabelText htmlFor="settings-v2-translucence-toggle">Translucent surfaces</ControlLabelText>
-          <ControlHelp>Apply a frosted-glass effect to layered panels.</ControlHelp>
+          <ControlLabelText htmlFor="settings-v2-translucence-toggle">Translucent album art</ControlLabelText>
+          <ControlHelp>Fade the album art so the background visualizer shows through.</ControlHelp>
         </div>
         <Switch
           id="settings-v2-translucence-toggle"


### PR DESCRIPTION
The label "Translucent surfaces" and help copy "Apply a frosted-glass effect to layered panels." were both wrong — the toggle lowers album art opacity so the background visualizer shows through, not any panels.

Rename label to "Translucent album art" and rewrite help text to accurately describe the actual effect.

Fixes #1525

Generated with [Claude Code](https://claude.ai/code)