### PR TITLE
release: 2026-05-11

### DIFF
--- a/src/components/EyedropperOverlay.tsx
+++ b/src/components/EyedropperOverlay.tsx
@@ -65,6 +65,14 @@ const EyedropperOverlay: React.FC<EyedropperOverlayProps> = ({ image, onPick, on
         alignItems: 'center',
         justifyContent: 'center',
         flexDirection: 'column',
+        // When invoked from a Radix modal Dialog (e.g. SettingsV2's
+        // AccentColorManager), Radix sets `body { pointer-events: none }` and
+        // only re-enables pointer events on the dialog's DismissableLayer.
+        // The eyedropper portals to `document.body`, so it inherits `none`
+        // and every click — including the X close button — is swallowed.
+        // Forcing `auto` here restores interactivity regardless of the
+        // ancestor modal context. See issue #1467.
+        pointerEvents: 'auto',
       }}>
       <div style={{
         position: 'relative',

--- a/src/components/SettingsV2/sections/AppearanceSection.tsx
+++ b/src/components/SettingsV2/sections/AppearanceSection.tsx
@@ -67,8 +67,8 @@ const TranslucenceToggle: React.FC = () => {
       <SectionGroupTitle>Translucence</SectionGroupTitle>
       <ControlRow>
         <div>
-          <ControlLabelText htmlFor="settings-v2-translucence-toggle">Translucent surfaces</ControlLabelText>
-          <ControlHelp>Apply a frosted-glass effect to layered panels.</ControlHelp>
+          <ControlLabelText htmlFor="settings-v2-translucence-toggle">Translucent album art</ControlLabelText>
+          <ControlHelp>Fade the album art so the background visualizer shows through.</ControlHelp>
         </div>
         <Switch
           id="settings-v2-translucence-toggle"

--- a/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AccentColorManager.eyedropper.integration.test.tsx
@@ -158,6 +158,42 @@ describe('SettingsV2 + real EyedropperOverlay (issue #1467)', () => {
     expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
   });
 
+  it('keeps the eyedropper portal interactive (pointer-events: auto) so the X close button is not blocked by Radix body pointer-events lockout', async () => {
+    // #given — real SettingsV2 Dialog open with the eyedropper portal mounted.
+    // Radix's modal Dialog sets `body { pointer-events: none }` while open,
+    // and the eyedropper portals to body. Without an explicit override on the
+    // overlay root, every click (including the X close button) is swallowed.
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <SettingsV2 isOpen={true} onClose={onClose} />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId('settings-v2-desktop'));
+    fireEvent.click(screen.getByLabelText('Pick color from album art'));
+    const overlay = (await waitFor(() =>
+      document.body.querySelector('[data-eyedropper-overlay="true"]'),
+    )) as HTMLElement;
+
+    // #when / #then — the overlay root carries `pointer-events: auto` inline,
+    // overriding the inherited `none` from Radix's body lockout. jsdom does
+    // not enforce CSS pointer-events for synthetic events, so we assert the
+    // inline style directly — the contract that keeps real-browser clicks alive.
+    expect(overlay.style.pointerEvents).toBe('auto');
+
+    // And the X close button inside the overlay must dismiss the picker
+    // without dismissing the surrounding Settings v2 Dialog.
+    const closeButton = overlay.querySelector('button');
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton!);
+
+    await waitFor(() =>
+      expect(document.body.querySelector('[data-eyedropper-overlay="true"]')).toBeNull(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('settings-v2-desktop')).toBeInTheDocument();
+  });
+
   it('captures the picked color and dual-writes ACCENT_COLOR_OVERRIDES + CUSTOM_ACCENT_COLORS', async () => {
     // #given — real SettingsV2 Dialog open with AccentColorManager mounted
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary

Two Settings v2 fixes: restore the eyedropper's pointer-event capture (regression of #1467 — the X close button was also dead, not just pixel clicks) and correct the Translucence toggle's misleading help text.

## Release summary

**Built from**: `rc/2026-05-11.1`

### Release notes

**settings-v2**
- fix(settings-v2): restore eyedropper pointer-event capture (#1467) — Radix Dialog sets body { pointer-events: none } while open; the EyedropperOverlay portals to document.body so it inherited 'none' and swallowed every click. Fix: pointerEvents: 'auto' on the portal root.
- fix(settings-v2): correct Translucence toggle label and help text — describe the actual album-art fade behavior instead of the wrong frosted-glass-on-panels description.

Closes #1467
Fixes #1525