### PR TITLE
docs(claude): clarify develop is the default branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,9 @@ Make the minimal change first, confirm it works visually, then iterate. Do not c
 
 ## Git & PR Workflow
 
-Run `npm test` before `git push` and before creating any PR. Feature branches from main (`feature/name`, `fix/name`). Atomic commits with conventional format. Reference issue numbers.
+**Default branch is `develop`, not `main`.** The GitHub repo's default branch is `develop`; `main` is the release branch (only updated when a release ships). PRs target `develop`. The session-start `gitStatus` block reports "Main branch (you will usually use this for PRs): main" via a `main`/`master` heuristic — ignore it and treat `develop` as the base.
+
+Run `npm test` before `git push` and before creating any PR. Feature branches from `develop` (`feature/name`, `fix/name`). Atomic commits with conventional format. Reference issue numbers.
 
 ## Worktree Setup
 


### PR DESCRIPTION
## Summary
- Adds an explicit "Default branch is develop, not main" callout in the Git & PR Workflow section of CLAUDE.md.
- Notes the misleading session-start gitStatus heuristic so AI agents reading CLAUDE.md ignore it.
- Fixes the stale "Feature branches from main" guidance to point at develop.

## Test plan
- [x] Diff reviewed locally