### PR TITLE
test(domain): add explicit test for unregistered provider id in keyToCollectionRef

### DIFF
--- a/openspec/changes/test-unknown-provider-collection-ref/.openspec.yaml
+++ b/openspec/changes/test-unknown-provider-collection-ref/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/test-unknown-provider-collection-ref/design.md
+++ b/openspec/changes/test-unknown-provider-collection-ref/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`keyToCollectionRef` parses a `"providerId:kind:id"` string and returns a
+`CollectionRef` or `null`. The function already returns `null` for any provider id
+not present in the registry. The test suite exercised this via the existing
+`'returns null for unknown provider'` test (`'apple:playlist:abc'`), but that
+single case did not make the unregistered-provider-id rejection a first-class,
+named contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add one dedicated test case that names the invariant explicitly and uses a
+  provider id (`fakeprov`) that could never be registered in any environment.
+
+**Non-Goals:**
+- Changing production code — none is required.
+- Adding edge-case coverage (empty id, whitespace) — optional follow-up.
+
+## Decisions
+
+**One test, co-located with existing domain tests.**
+`src/types/__tests__/domain.test.ts` already contains the `keyToCollectionRef`
+describe block. Adding the new case there keeps related tests together with no
+new files or dependencies.
+
+## Risks / Trade-offs
+
+None. Pure test addition with no runtime impact.

--- a/openspec/changes/test-unknown-provider-collection-ref/proposal.md
+++ b/openspec/changes/test-unknown-provider-collection-ref/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+`keyToCollectionRef` in `src/types/domain.ts` correctly rejects keys whose provider id is not registered, but the test suite only exercised the `'apple:playlist:abc'` case inside the generic `'returns null for unknown provider'` test. The rejection path for any arbitrary well-formed key with an unregistered provider id had no dedicated, explicitly-named test, leaving a gap in specification coverage.
+
+## What Changes
+
+- Add a standalone test case `'returns null for a well-formed key with an unregistered provider id'` in `src/types/__tests__/domain.test.ts` using `'fakeprov:playlist:abc'` to make the unregistered-provider-id rejection explicit.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+<!-- No requirement is being added or removed. The existing provider-system spec already
+     asserts that unregistered providers yield null. This change only adds test coverage
+     for a gap — no spec-level behavior changes. -->
+
+## Impact
+
+- `src/types/__tests__/domain.test.ts` — one new test case added; no production code changed.
+- No API, runtime, or dependency impact.

--- a/openspec/changes/test-unknown-provider-collection-ref/specs/provider-system/spec.md
+++ b/openspec/changes/test-unknown-provider-collection-ref/specs/provider-system/spec.md
@@ -1,0 +1,8 @@
+## No Requirement Changes
+
+No new or modified requirements. The existing provider-system spec's "Unparseable
+serialized reference" scenario implicitly covers the unregistered-provider-id case
+(a well-formed key referencing a provider not in the registry produces null).
+
+This change adds explicit test coverage for that implicit guarantee only;
+no spec-level behavior is added, removed, or modified.

--- a/openspec/changes/test-unknown-provider-collection-ref/tasks.md
+++ b/openspec/changes/test-unknown-provider-collection-ref/tasks.md
@@ -1,0 +1,8 @@
+## 1. Test
+
+- [x] 1.1 In `src/types/__tests__/domain.test.ts`, add a dedicated test case `'returns null for a well-formed key with an unregistered provider id'` using key `'fakeprov:playlist:abc'` that asserts `keyToCollectionRef` returns `null`.
+
+## 2. Verify
+
+- [x] 2.1 Run `npm run test:run -- src/types` and confirm all 12 tests pass.
+- [x] 2.2 Run `npx tsc -b --noEmit` and confirm no type errors.

--- a/src/types/__tests__/domain.test.ts
+++ b/src/types/__tests__/domain.test.ts
@@ -55,7 +55,21 @@ describe('keyToCollectionRef', () => {
   });
 
   it('returns null for unknown provider', () => {
+    // #given a well-formed key whose provider id is not registered
+    // #when
+    // #then
     expect(keyToCollectionRef('apple:playlist:abc')).toBeNull();
+  });
+
+  it('returns null for a well-formed key with an unregistered provider id', () => {
+    // #given
+    const key = 'fakeprov:playlist:abc';
+
+    // #when
+    const result = keyToCollectionRef(key);
+
+    // #then — must be null, not a partial object
+    expect(result).toBeNull();
   });
 
   it('returns null for unknown kind', () => {


### PR DESCRIPTION
## Summary

- The existing `'returns null for unknown provider'` test in `src/types/__tests__/domain.test.ts` already asserts `null` for `'apple:playlist:abc'`, so this is effectively a **no-op confirmation**: the implementation already rejects unregistered provider ids correctly.
- Adds a dedicated test `'returns null for a well-formed key with an unregistered provider id'` using `'fakeprov:playlist:abc'` to make the intent explicit and distinct from the existing test, per the issue request.
- No production code changes were needed — `keyToCollectionRef` in `src/types/domain.ts` (line 118) already validates the provider against `'spotify'` and `'dropbox'` and returns `null` for any other value.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run test:run -- src/types` — 12/12 tests pass (was 11 before)

Closes #1540