### PR TITLE
test(providers): cover Dropbox conditional registration on env var

### DIFF
--- a/openspec/changes/test-dropbox-conditional-registration/.openspec.yaml
+++ b/openspec/changes/test-dropbox-conditional-registration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/test-dropbox-conditional-registration/design.md
+++ b/openspec/changes/test-dropbox-conditional-registration/design.md
@@ -1,0 +1,30 @@
+## Context
+
+`src/providers/dropbox/dropboxProvider.ts` wraps the three Dropbox adapters in an `if (DROPBOX_CLIENT_ID)` guard and only calls `providerRegistry.register()` inside that block. This conditional is the production implementation of the "Conditional Provider Availability" requirement in `openspec/specs/provider-system/spec.md`. No test currently exercises the guard.
+
+The mock-provider isolation pattern in `src/providers/mock/__tests__/shouldUseMockProvider.test.ts` is the established template: `vi.stubEnv()` sets the env var, `vi.resetModules()` clears the module cache, and a dynamic `import()` re-executes the module under the new env state.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Assert `providerRegistry.has('dropbox') === false` when `VITE_DROPBOX_CLIENT_ID` is empty.
+- Assert `providerRegistry.has('dropbox') === true` when `VITE_DROPBOX_CLIENT_ID` is a non-empty string.
+- Keep the two cases fully isolated (no leaked state between tests).
+
+**Non-Goals:**
+- Testing adapter behavior (auth, catalog, playback) — covered by `dropboxAdapters.test.ts`.
+- Testing the registry implementation itself — covered by `registry.test.ts`.
+
+## Decisions
+
+**Dynamic import with `vi.resetModules()` per test case**: Module-level side-effects (the `if` block calling `register()`) run once at import time. Resetting the module registry before each dynamic import ensures each case gets a fresh module evaluation under the stubbed env. This mirrors the existing `shouldUseMockProvider.test.ts` pattern and is the idiomatic Vitest approach for env-gated module initialization.
+
+**Import `providerRegistry` fresh each time**: The singleton is also re-imported dynamically after `resetModules()` so both the registry and the provider module share the same fresh instance (not two different singleton instances from different module evaluations).
+
+**Mock heavy adapter dependencies**: `dropboxProvider.ts` imports adapters that touch `localStorage`, `fetch`, and DOM APIs. A blanket `vi.mock()` at the top of the test file prevents those imports from running real code while still allowing `dropboxProvider.ts` itself to execute its conditional registration logic.
+
+## Risks / Trade-offs
+
+[Risk] Adapter constructors or `initLikesSync`/`initPreferencesSync` calls may throw in the test environment → Mitigation: mock all adapter modules (`dropboxAuthAdapter`, `dropboxCatalogAdapter`, `dropboxPlaybackAdapter`, `dropboxLikesSync`, `dropboxPreferencesSync`, `dropboxPlaylistStorage`, `DropboxIcon`) before importing the provider.
+
+[Risk] The singleton `providerRegistry` accumulates registrations across the test file if `resetModules` is not applied correctly → Mitigation: `vi.resetModules()` in `beforeEach` ensures a clean registry on each test.

--- a/openspec/changes/test-dropbox-conditional-registration/proposal.md
+++ b/openspec/changes/test-dropbox-conditional-registration/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The provider-system spec documents a "Conditional Provider Availability" scenario — Dropbox registers only when `VITE_DROPBOX_CLIENT_ID` is set — but there is no test that asserts this contract in either direction, leaving a regression risk if the conditional guard in `dropboxProvider.ts` is accidentally removed.
+
+## What Changes
+
+- Add a Vitest test file that exercises `dropboxProvider.ts` module initialization under two env-var conditions: client ID absent (no registration) and client ID present (registration occurs).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+<!-- No spec-level behavior changes; the requirement already exists in provider-system spec. -->
+
+## Impact
+
+- `src/providers/__tests__/dropboxConditionalRegistration.test.ts` — new test file.
+- No production code changes.
+- No public API change.

--- a/openspec/changes/test-dropbox-conditional-registration/tasks.md
+++ b/openspec/changes/test-dropbox-conditional-registration/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Test implementation
 
-- [ ] 1.1 Create `src/providers/__tests__/dropboxConditionalRegistration.test.ts` with `vi.mock()` declarations for all adapter modules imported by `dropboxProvider.ts`, so adapter constructors do not run real code during module initialization.
-- [ ] 1.2 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `''`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === false`.
-- [ ] 1.3 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `'test-client-id'`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === true`.
-- [ ] 1.4 Ensure `vi.resetModules()` runs in `beforeEach` and `vi.unstubAllEnvs()` + `vi.restoreAllMocks()` run in `afterEach` to prevent state leakage between cases.
+- [x] 1.1 Create `src/providers/__tests__/dropboxConditionalRegistration.test.ts` with `vi.mock()` declarations for all adapter modules imported by `dropboxProvider.ts`, so adapter constructors do not run real code during module initialization.
+- [x] 1.2 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `''`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === false`.
+- [x] 1.3 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `'test-client-id'`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === true`.
+- [x] 1.4 Ensure `vi.resetModules()` runs in `beforeEach` and `vi.unstubAllEnvs()` + `vi.restoreAllMocks()` run in `afterEach` to prevent state leakage between cases.
 
 ## 2. Verify
 
-- [ ] 2.1 Run `npm run test:run -- src/providers/__tests__/dropboxConditionalRegistration.test.ts` and confirm both cases pass.
-- [ ] 2.2 Run `npx tsc -b --noEmit` and confirm no type errors.
-- [ ] 2.3 Run `npm run test:run -- src/providers` and confirm no regressions across the full provider test suite.
+- [x] 2.1 Run `npm run test:run -- src/providers/__tests__/dropboxConditionalRegistration.test.ts` and confirm both cases pass.
+- [x] 2.2 Run `npx tsc -b --noEmit` and confirm no type errors.
+- [x] 2.3 Run `npm run test:run -- src/providers` and confirm no regressions across the full provider test suite.

--- a/openspec/changes/test-dropbox-conditional-registration/tasks.md
+++ b/openspec/changes/test-dropbox-conditional-registration/tasks.md
@@ -1,0 +1,12 @@
+## 1. Test implementation
+
+- [ ] 1.1 Create `src/providers/__tests__/dropboxConditionalRegistration.test.ts` with `vi.mock()` declarations for all adapter modules imported by `dropboxProvider.ts`, so adapter constructors do not run real code during module initialization.
+- [ ] 1.2 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `''`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === false`.
+- [ ] 1.3 Add test case: with `VITE_DROPBOX_CLIENT_ID` stubbed to `'test-client-id'`, dynamically import `dropboxProvider.ts` and assert `providerRegistry.has('dropbox') === true`.
+- [ ] 1.4 Ensure `vi.resetModules()` runs in `beforeEach` and `vi.unstubAllEnvs()` + `vi.restoreAllMocks()` run in `afterEach` to prevent state leakage between cases.
+
+## 2. Verify
+
+- [ ] 2.1 Run `npm run test:run -- src/providers/__tests__/dropboxConditionalRegistration.test.ts` and confirm both cases pass.
+- [ ] 2.2 Run `npx tsc -b --noEmit` and confirm no type errors.
+- [ ] 2.3 Run `npm run test:run -- src/providers` and confirm no regressions across the full provider test suite.

--- a/src/providers/__tests__/dropboxConditionalRegistration.test.ts
+++ b/src/providers/__tests__/dropboxConditionalRegistration.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('dropboxProvider conditional registration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  async function importProviderWithMocks() {
+    vi.doMock('@/providers/dropbox/dropboxAuthAdapter', () => ({
+      DropboxAuthAdapter: vi.fn().mockImplementation(() => ({
+        isAuthenticated: vi.fn().mockReturnValue(false),
+      })),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxCatalogAdapter', () => ({
+      DropboxCatalogAdapter: vi.fn().mockImplementation(() => ({})),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxPlaybackAdapter', () => ({
+      DropboxPlaybackAdapter: vi.fn().mockImplementation(() => ({})),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxLikesSync', () => ({
+      initLikesSync: vi.fn(),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxPreferencesSync', () => ({
+      initPreferencesSync: vi.fn(),
+      getPreferencesSync: vi.fn().mockReturnValue(null),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxPlaylistStorage', () => ({
+      saveQueueAsPlaylist: vi.fn(),
+    }));
+    vi.doMock('@/providers/dropbox/DropboxIcon', () => ({
+      DropboxIcon: vi.fn(),
+    }));
+    vi.doMock('@/providers/dropbox/dropboxLikesCache', () => ({
+      LIKES_CHANGED_EVENT: 'dropbox-likes-changed',
+    }));
+
+    await import('@/providers/dropbox/dropboxProvider');
+    const { providerRegistry } = await import('@/providers/registry');
+    return providerRegistry;
+  }
+
+  it('does not register dropbox when VITE_DROPBOX_CLIENT_ID is empty', async () => {
+    // #given
+    vi.stubEnv('VITE_DROPBOX_CLIENT_ID', '');
+
+    // #when
+    const registry = await importProviderWithMocks();
+
+    // #then
+    expect(registry.has('dropbox')).toBe(false);
+  });
+
+  it('registers dropbox when VITE_DROPBOX_CLIENT_ID is set', async () => {
+    // #given
+    vi.stubEnv('VITE_DROPBOX_CLIENT_ID', 'test-client-id');
+
+    // #when
+    const registry = await importProviderWithMocks();
+
+    // #then
+    expect(registry.has('dropbox')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/providers/__tests__/dropboxConditionalRegistration.test.ts` with two isolated test cases verifying the `VITE_DROPBOX_CLIENT_ID` guard in `dropboxProvider.ts`.
- Case 1: env var empty → `providerRegistry.has('dropbox') === false`.
- Case 2: env var set → `providerRegistry.has('dropbox') === true`.
- Uses `vi.doMock()` + `vi.resetModules()` + dynamic `import()` per case to prevent cross-test state leakage, following the pattern from `src/providers/mock/__tests__/shouldUseMockProvider.test.ts`.
- Includes OpenSpec change artifacts under `openspec/changes/test-dropbox-conditional-registration/` (proposal, design, tasks, delta spec stub).

## Test plan

- [x] `npm run test:run -- src/providers/__tests__/dropboxConditionalRegistration.test.ts` — 2/2 pass
- [x] `npx tsc -b --noEmit` — clean, exit 0
- [x] `npm run test:run -- src/providers` — 255/255 across 20 files, no regressions

Closes #1538