### PR TITLE
feat(commands): add /swarm-openspec and /opsx:propose-clean wrappers

### DIFF
--- a/.claude/commands/opsx/propose-clean.md
+++ b/.claude/commands/opsx/propose-clean.md
@@ -1,0 +1,83 @@
+---
+name: "OPSX: Propose (clean)"
+description: Wraps /opsx:propose with the vorbis-player convention that no-delta changes omit the specs/ directory entirely.
+category: Workflow
+tags: [workflow, openspec, experimental]
+---
+
+Wraps `/opsx:propose` with one project convention: **if no spec-level behavior changes, do not create a `specs/` directory or any delta file**. Narrate the rationale in `design.md` instead.
+
+Use this when you know up front that the change is test-only, doc-only, refactor-only, or otherwise non-behavioral. For changes with actual spec deltas, use `/opsx:propose` directly — this wrapper adds nothing.
+
+**Input**: Same as `/opsx:propose` (kebab-case name or free-text description).
+
+## Why this wrapper exists
+
+In `/swarmkit:swarm-plus --label openspec` runs against test-only issues, builders sometimes shipped `specs/<capability>/spec.md` files containing prose like "## No Requirement Changes — no new or modified requirements…". These tripped two tools:
+
+- `openspec archive` aborted: `Delta parsing found no operations for <capability>. Provide ADDED/MODIFIED/REMOVED/RENAMED sections`. Required `--skip-specs` workaround.
+- `openspec validate` emitted a warning every time the change was inspected.
+
+Changes that simply omitted `specs/` entirely (when no delta was needed) archived cleanly with `--skip-specs` and validated quietly. This wrapper enforces that pattern.
+
+## Process
+
+### 1. Call `/opsx:propose` to produce the initial artifacts
+
+```
+Skill("openspec-propose", "$ARGUMENTS")
+```
+
+Let the underlying skill drive the interview, derive the kebab-case name, and create the change directory under `openspec/changes/<name>/` with `proposal.md`, `design.md`, `tasks.md`, and (potentially) `specs/<capability>/spec.md`.
+
+### 2. Detect a no-op delta and prune it
+
+After the underlying skill returns, inspect every file under `openspec/changes/<name>/specs/`:
+
+- If a file is empty (0 bytes) OR contains no `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, or `## RENAMED Requirements` heading, treat it as a no-op delta.
+- Delete the no-op file. After deletion, if `openspec/changes/<name>/specs/<capability>/` is empty, remove the capability directory. After that, if `openspec/changes/<name>/specs/` is empty, remove it too.
+
+### 3. Update `design.md` to narrate the no-spec decision
+
+If any pruning happened in step 2, append (or update) a section in `design.md`:
+
+```markdown
+## Why no spec delta
+
+This change does not modify any provider-system spec requirement. The behavior
+being added is <test coverage / documentation / refactor / etc.> for an existing
+requirement (<reference the spec scenario by name>). No `specs/` directory is
+included in this change by design.
+```
+
+Use the underlying interview's notes to fill in the specifics. If the interview did not capture a rationale, prompt the user with `AskUserQuestion` for a one-sentence reason before writing.
+
+### 4. Re-run validation
+
+```bash
+openspec validate <name>
+```
+
+The change should pass without the "at least one delta" parser warning (a non-blocking warning is acceptable; an error is not).
+
+### 5. Report
+
+```
+── opsx:propose-clean complete ─────────────────
+Change: <name>
+Artifacts: proposal.md, design.md, tasks.md
+Spec deltas: none (pruned <N> empty/no-op file(s))
+Next: /opsx:apply <name>
+────────────────────────────────────────────────
+```
+
+## Constraints
+
+- Never modify the underlying `openspec-propose` skill — this wrapper composes it.
+- Never delete a non-empty delta file. If a `specs/` file contains real ADDED/MODIFIED/REMOVED/RENAMED content, keep it.
+- Always update `design.md` when pruning so the rationale is preserved in the change directory rather than lost to git history.
+- If the user genuinely needs a spec delta, they should invoke `/opsx:propose` directly. Do not "auto-detect" that the user changed their mind.
+
+## When to deprecate
+
+Remove this wrapper if/when upstream `openspec-propose` learns to skip empty `specs/` files on its own, OR `openspec archive` learns to silently treat no-op deltas as `--skip-specs`.

--- a/.claude/commands/swarm-openspec.md
+++ b/.claude/commands/swarm-openspec.md
@@ -1,0 +1,128 @@
+---
+name: "Swarm OpenSpec"
+description: Project-local wrapper around /swarmkit:swarm-plus tuned for vorbis-player's OpenSpec workflow. Forces flat-to-develop topology and auto-archives changes after merge.
+category: Workflow
+tags: [workflow, openspec, swarm]
+---
+
+Run `/swarmkit:swarm-plus` configured for OpenSpec changes in this project, then close the loop with `/opsx:bulk-archive` and an archive PR.
+
+Use this for runs that involve OpenSpec-labeled issues. For non-OpenSpec runs, invoke `/swarmkit:swarm-plus` directly.
+
+**Input**: Same grammar as `/swarmkit:swarm-plus` (no args | label | issue numbers | range). The `--no-epic` flag is always injected — do not override.
+
+## Why this wrapper exists
+
+Upstream `/swarmkit:swarm-plus` is general-purpose. This wrapper layers vorbis-player conventions on top without modifying the plugin:
+
+- **Topology**: every OpenSpec change is its own independent PR. Epic mode adds friction with no benefit for these.
+- **Archive closure**: after the code PRs merge, the OpenSpec change directories under `openspec/changes/<name>/` need to be moved to `archive/`. Doing this manually is `2N` PRs for `N` issues. Bundling it auto-cuts the count to `N+1`.
+
+What this wrapper does NOT do (left to swarm-plus + reviewer-flagged fix rounds):
+
+- Inject `/opsx:verify` into builder prompts — the issue body should convey it.
+- Strip empty `specs/` placeholders from change directories — see `/opsx:propose-clean` for that convention.
+
+If reviewer-fix-round coverage of those gaps turns out to be unreliable across runs, revisit the design (probably by introducing a third "opsx-verify pass" subagent rather than re-implementing swarm-plus).
+
+## Process
+
+### 1. Run swarm-plus with `--no-epic` injected
+
+```
+Skill("swarmkit:swarm-plus", "--no-epic $ARGUMENTS")
+```
+
+If `$ARGUMENTS` already contains `--no-epic`, do not add a duplicate. If it contains `--epic <slug>` or `--base <branch>`, abort with an explanation — those flags are incompatible with this wrapper's flat-to-develop contract. Suggest the operator invoke `/swarmkit:swarm-plus` directly if they need a different topology.
+
+Let swarm-plus run its full lifecycle: spawn → review → fix-round → leave PRs open.
+
+### 2. Run `/swarmkit:merge-stack`
+
+After swarm-plus returns control:
+
+```
+Skill("swarmkit:merge-stack")
+```
+
+This squash-merges every open `worktree-agent-*` PR into develop and deletes the remote branches. Worktrees persist locally — `/swarmkit:clean-worktrees` is a later step.
+
+### 3. Detect OpenSpec changes that just merged
+
+```bash
+openspec list --json | jq -r '.changes[].name'
+```
+
+This is the set of changes that have implementations on develop but have not been archived yet. If the list is empty, skip to step 6 — there is nothing to archive.
+
+For each change name, sanity-check by reading `openspec/changes/<name>/tasks.md` — if any incomplete `- [ ]` checkboxes remain, do NOT archive it; warn and leave it active.
+
+### 4. Run `/opsx:bulk-archive`
+
+```
+Skill("openspec-bulk-archive-change")
+```
+
+When the skill prompts for selection, select **all** ready-to-archive changes from step 3.
+
+When a change has no delta specs (the common case for test-only changes), use `--skip-specs` (the skill handles this internally per the conflict-resolution flow).
+
+### 5. Commit the archive moves and open a PR
+
+```bash
+git checkout -b chore/archive-openspec-$(date +%Y-%m-%d)
+git add openspec/changes/
+git commit -m "chore(openspec): archive <list of change names> for <issue refs>"
+git push -u origin chore/archive-openspec-$(date +%Y-%m-%d)
+gh pr create --base develop \
+  --title "chore(openspec): archive <list of change names>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Moves <N> completed OpenSpec change(s) from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`
+- Companion to the code PRs that just merged (list them with `#<N>` references and the issue they closed)
+- No delta specs to sync OR delta specs synced via /opsx:bulk-archive (state which)
+
+## Test plan
+
+- [x] `openspec list --json` returns `{"changes":[]}` after archive (or lists only changes intentionally left active)
+- [x] New directories present under `openspec/changes/archive/YYYY-MM-DD-*/`
+- [x] `git status` shows only renames — no content loss
+EOF
+)"
+```
+
+Report the archive PR URL.
+
+### 6. Clean up
+
+```
+Skill("swarmkit:clean-worktrees")
+```
+
+Removes the `worktree-agent-*` worktrees and prunes orphan local branches. The archive PR's branch stays — it belongs to this session.
+
+### 7. Report
+
+```
+── swarm-openspec complete ─────────────────────
+Code PRs merged: #A #B #C  (issues #X #Y #Z)
+Archive PR:      #N
+Cleanup:         <count> worktrees reaped
+Next:            Review and merge #N to close the loop.
+────────────────────────────────────────────────
+```
+
+## Constraints
+
+- Never enable epic mode. The whole point of this wrapper is flat-to-develop for independent OpenSpec changes.
+- Never archive a change with incomplete tasks. Warn and skip.
+- Never modify `/swarmkit:swarm-plus` or the openspec-* skills — this wrapper composes them.
+- If the auto-archive step fails (e.g. PR creation rejected), surface the error and leave the archive branch in place for manual recovery. Do not retry blindly.
+
+## When to deprecate
+
+Remove this wrapper if/when any of the following lands upstream:
+- `/swarmkit:swarm-plus` learns a `--post-merge <skill>` hook.
+- `/opsx:bulk-archive` learns to auto-open a chore PR.
+- `/swarmkit:swarm-plus` gains OpenSpec-aware prompt injection (unlikely — that would couple it to OpenSpec).


### PR DESCRIPTION
## Summary

Adds two project-local slash commands that compose existing skills with vorbis-player conventions, without modifying the upstream swarmkit plugin or the vendored openspec-* skills.

- **`/swarm-openspec`** — wraps `/swarmkit:swarm-plus` for OpenSpec-flagged issue runs. Forces flat-to-develop topology (no epic mode) and auto-runs `/opsx:bulk-archive` + opens an archive PR after `/swarmkit:merge-stack`. Cuts the PR count from `2N` to `N+1` for OpenSpec swarm runs.
- **`/opsx:propose-clean`** — wraps `/opsx:propose` with the convention "if no spec-level delta is needed, omit the `specs/` directory entirely; narrate the rationale in `design.md`." Avoids the empty/no-op delta files that trip `openspec archive` and `openspec validate`.

Both commands document explicit deprecation conditions — remove them if/when the upstream skills absorb the conventions natively.

## Why these are wrappers, not patches

The swarmkit plugin should not assume OpenSpec usage, and the openspec-* skills we vend should stay pure. Vorbis-player-specific refinements live in `.claude/commands/` and compose the upstream surfaces by calling them through `Skill(...)`. When a refinement proves itself across multiple runs, it can be considered for upstreaming; until then it stays local where iteration is cheap.

## Context

Retrospective on `/swarmkit:swarm-plus --label openspec` run from 2026-05-15 surfaced ten friction points across the swarm-plus + openspec workflow. Six of those are addressed by these two wrappers (or absorbed as process changes the wrappers enforce by convention). Remaining items (#3 reviewer-SendMessage doc, #8 termination-model choice) are noted as upstream candidates once we have confidence in the patterns.

## Test plan

- [ ] On the next OpenSpec-flagged batch of issues, invoke `/swarm-openspec --label openspec` instead of `/swarmkit:swarm-plus --label openspec` and confirm: (a) PRs target develop directly with no epic branch cut, (b) one chore archive PR is opened automatically after merge-stack lands the code PRs.
- [ ] On the next no-delta OpenSpec change proposal, invoke `/opsx:propose-clean` instead of `/opsx:propose` and confirm: (a) no `specs/` directory is created, (b) `design.md` contains a "Why no spec delta" section, (c) `openspec validate <name>` does not error on missing delta sections.
- [x] Files are markdown-only, no runtime behavior to verify on this PR itself.