### PR TITLE
feat(visual-effects-menu): tint flip-menu controls with current accent

### DIFF
--- a/openspec/changes/archive/2026-05-15-flip-menu-accent-color/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-15-flip-menu-accent-color/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/archive/2026-05-15-flip-menu-accent-color/design.md
+++ b/openspec/changes/archive/2026-05-15-flip-menu-accent-color/design.md
@@ -1,0 +1,102 @@
+## Context
+
+Vorbis Player threads the "active album's accent color" through chrome via two CSS custom properties set on `:root` by `ColorContext` (`src/contexts/ColorContext.tsx:85-87`):
+
+- `--accent-color` — the live accent hex
+- `--accent-contrast-color` — a derived black/white that reads on top of it
+
+shadcn primitives consume a parallel namespace (`--primary`, `--accent`, etc.) defined in `src/styles/shadcn-tokens.css`. The token comment is explicit: **`--primary` stays a static neutral so dialog chrome does not retint when the playing track changes**. This is correct for dialogs and settings drawers, but the flip-menu is the opposite case — it's the surface designed to feel like an extension of the album art, and its toggles (`Switch`) already use `var(--accent-color)` via `variant="accent"` (`src/components/ui/switch.tsx:42-43`).
+
+The mismatch is in two places that bypass the Switch pattern:
+
+1. `OptionButton` (`src/components/AppSettingsMenu/styled.ts:277-295`) hard-codes its active background/border to `hsl(var(--primary))`. It was originally written for the Settings drawer, then reused inside `QuickEffectsRow` for the Glow/Visualizer sub-setting pills. The drawer call sites want the static-white treatment; the flip-menu call sites want accent.
+2. `SwatchButton` (`src/components/controls/QuickEffectsRow.tsx:70-82`) sets the active swatch's `border` to `theme.colors.white`, plus a `theme.colors.selection` outline. Combined with the swatch's own color (the candidate accent), this paints three different colors around the active swatch and competes for attention.
+
+The user-visible artifact today: half the active controls in the flip menu glow with the album's color (Switches), the other half stay generic white (pills, swatch border). The proposal makes them coherent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Active state of every `OptionButton` rendered inside `QuickEffectsRow` reflects the current `--accent-color` for background/border, with foreground in `--accent-contrast-color` for legibility.
+- Active `SwatchButton` indicator stops competing with the swatch color itself.
+- Other `OptionButton` call sites (Quick Access Panel, Performance Profiler, Visualizer Debug in the Settings drawer) keep their current static-white active treatment.
+- Zero behavioral change — same controls toggle the same values; only paint differs.
+- No new dependencies, no new exported types beyond the variant prop.
+
+**Non-Goals:**
+
+- Restyling the Settings drawer (`AppSettingsMenu/index.tsx`) or Settings v2 sections.
+- Changing the `--primary` shadcn token or the `Switch` component.
+- Replacing `OptionButton` with shadcn's `ToggleGroup`. That's a larger migration tracked separately.
+- Adding theme-bridge documentation beyond updating the inline comment on `OptionButton` to mention the new variant.
+
+## Decisions
+
+### Decision 1 — Add a `variant` prop to `OptionButton`, default `neutral`
+
+**Choice:** Add a `$variant: 'accent' | 'neutral'` transient styled-components prop. When `accent`, the active branch uses `var(--accent-color)` / `var(--accent-contrast-color)` (matching the CSS variables already published by `ColorContext`). When `neutral` (default), behavior is unchanged from today.
+
+**Why:**
+
+- Mirrors the `Switch` component's existing `variant` API, so the codebase already has a precedent and reviewers can pattern-match.
+- Default-`neutral` means zero risk of regressing the Settings-drawer call sites that consume `OptionButton` today — they don't pass the prop, so they keep the existing styling.
+- A transient prop (`$variant`) keeps styled-components from forwarding the attribute to the DOM, avoiding React's unknown-prop warning.
+
+**Alternatives considered:**
+
+- *Inline `style={{ background: ... }}` overrides at each `QuickEffectsRow` call site.* Rejected — would require recomputing the contrast color in JSX, leaks styling concerns into the consumer, and forks state-vs-hover styles awkwardly.
+- *Duplicate the styled component (`AccentOptionButton`) inside `QuickEffectsRow`.* Rejected — duplicates 18 lines of styling plus the hover variants, risks drift over time.
+- *Tailwind `data-state` attribute hooks.* Rejected — the existing component is plain styled-components, not Radix; introducing a new state attribute is more refactor than the change warrants.
+
+### Decision 2 — Active `SwatchButton` indicator: drop the white border, keep the `selection` outline
+
+**Choice:** Remove the `2px solid theme.colors.white` border on the active swatch and rely on the existing `outline: 2px solid theme.colors.selection` plus a small extra inset shadow if visual weight needs restoring. If the outline alone reads as too subtle in QA, fall back to `border: 2px solid var(--accent-color)` — the same hue as the swatch itself but rendered as a halo via a thin gap between border and inner background.
+
+**Why:**
+
+- Painting white around a colored swatch fights the swatch's own color and reads as a foreign element on the accent-tinted backside.
+- The `theme.colors.selection` outline is already in place and was the original "selected" affordance before the white border was added.
+- Keeping the fallback option (`border: 2px solid var(--accent-color)`) gives the implementer room during QA without re-litigating the design.
+
+**Alternatives considered:**
+
+- *Color the active swatch border with `--accent-contrast-color`.* Rejected — the contrast color is computed *against* the accent, so on a near-white accent it would render as near-black, which reads as a dropped shadow rather than a selection ring.
+
+### Decision 3 — Hover state of accent-variant `OptionButton`
+
+**Choice:** Active-hover keeps `var(--accent-color)` at slightly reduced alpha (e.g. `color-mix(in srgb, var(--accent-color) 87%, transparent)`), matching the existing `hsl(var(--primary) / 0.87)` pattern in the neutral variant.
+
+**Why:** Symmetry with the neutral variant's hover treatment. `color-mix` is supported in all evergreen browsers Vorbis Player targets (per `vite.config.ts` ES2020 baseline + Safari TP). Inactive-hover stays unchanged (`hsl(var(--muted))` / `theme.colors.white` foreground) so unselected pills don't preview the accent on every mouseover.
+
+### Decision 4 — `accentColor` is consumed via CSS variable, not React prop
+
+**Choice:** The styled component reads `var(--accent-color)` directly from the cascade rather than receiving the accent hex as a prop from `QuickEffectsRow`.
+
+**Why:** `ColorContext` already publishes both CSS variables globally on `:root` and updates them in a `useEffect` whenever the accent changes (`ColorContext.tsx:84-88`). Reading via CSS means the styling reacts to accent changes without any React-render coupling, matches how Switch / BottomBar / TimelineSlider consume the accent, and avoids threading another prop through `QuickEffectsRow` → `OptionButton`.
+
+## Risks / Trade-offs
+
+- **Risk:** Some album accents land on near-white (e.g., washed-out vintage covers) and the active pill becomes invisible on the flip-menu's translucent-dark backdrop.
+  **Mitigation:** `--accent-contrast-color` already adapts (the helper in `src/utils/colorExtractor` picks black on near-white accents). The pill's foreground will flip to dark, retaining legibility. The backdrop is `rgba(0,0,0,0.7)` over a blurred album image — a near-white pill on a darkened background is the *intended* failure mode, the same one BottomBar accepts today.
+
+- **Risk:** `color-mix` parsing differs across browsers older than what `vite.config.ts` targets.
+  **Mitigation:** Limit `color-mix` to the hover override branch only; the base active state uses `var(--accent-color)` directly. If a target browser doesn't support `color-mix`, hover degrades to the same flat accent (no visual regression, just no hover dim).
+
+- **Trade-off:** Adding a variant prop on `OptionButton` means future consumers must choose a side. We document the choice inline next to the existing styled component so the next contributor doesn't have to dig.
+
+- **Risk:** Visual snapshot tests (`playwright/` captures) pinned to the flip menu will diff.
+  **Mitigation:** Expected. Re-run `npm run capture` after the implementation lands and commit the new baseline. Call out in the PR.
+
+## Spec strategy
+
+`openspec/specs/` has no `visual-effects-menu` capability today — the flip-menu surface predates the OpenSpec adoption. Rather than ship this change as polish-only, this proposal also **seeds the first version** of `specs/visual-effects-menu/spec.md` from the current implementation, so the existing surface is durably documented and subsequent changes (e.g., adding a new visualizer style, exposing additional Glow controls, swapping the eyedropper) have a contract to extend.
+
+Concretely the spec file is a single `## ADDED Requirements` block covering:
+
+- the flip-menu surface (mount, dismiss, backdrop)
+- accent color selection (extracted swatches, custom override, eyedropper, reset)
+- glow / visualizer / translucence controls and their sub-settings
+- the **new** requirement that every active control reflects the current accent color (the actual behavioral target of this change)
+
+The first five requirements above describe pre-existing behavior. Including them in the seed spec is intentional: a capability spec that only documents the brand-new requirement would mislead future readers about the surface's scope. The spec describes the menu as a whole, not just the polish.

--- a/openspec/changes/archive/2026-05-15-flip-menu-accent-color/proposal.md
+++ b/openspec/changes/archive/2026-05-15-flip-menu-accent-color/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The flip-menu (`AlbumArtQuickSwapBack` → `QuickEffectsRow`) is the player's primary surface for tweaking visual effects (accent color, glow, background visualizer, translucence). Its `Switch` toggles already track the runtime `--accent-color` so they recolor per album, but its `OptionButton` pills (Glow Intensity / Rate, Visualizer Style / Intensity / Speed) and the active swatch border remain near-white because they consume the static shadcn `--primary` token and `theme.colors.white` respectively. The result is a visually inconsistent panel — half the active controls reflect the album's accent, half stay generic white — which undercuts the personality the rest of player chrome (BottomBar, LikeButton, TimelineSlider, glow) already projects.
+
+This change also seeds the first-ever capability spec for the flip-menu surface itself. No `openspec/specs/<capability>/` describes it today, so future changes to glow / visualizer / translucence / accent-picking controls have no anchor to write against. Promoting the existing implementation into a `visual-effects-menu` spec gives subsequent work a contract to extend.
+
+## What Changes
+
+- Add a `variant: 'accent' | 'neutral'` prop to the shared `OptionButton` styled component (mirrors the existing `Switch` variant pattern), defaulting to `neutral` so non-flip-menu call sites (Quick Access Panel, Performance Profiler, Visualizer Debug toggles in the Settings drawer) keep their current static-white active state.
+- In `QuickEffectsRow`, render every `OptionButton` with `variant="accent"` so the active pill's background/border tracks `var(--accent-color)` and its foreground uses `var(--accent-contrast-color)` for legibility on both light and dark accents.
+- In `QuickEffectsRow`, change the active `SwatchButton`'s indicator from `theme.colors.white` to either rely on the existing `theme.colors.selection` outline alone, or fall back to an accent-tinted border if QA finds the outline too subtle.
+- Seed `openspec/specs/visual-effects-menu/spec.md` (new capability) from the current implementation, plus the new accent-color theming requirement.
+
+No public APIs, no keyboard shortcuts, no provider behavior, no playback behavior change.
+
+## Capabilities
+
+### New Capabilities
+
+- `visual-effects-menu`: The flip-side panel behind the album art that exposes visual-effect toggles and their sub-settings (accent color, glow, background visualizer, translucence). This spec captures the existing surface plus the new requirement that every active control reflect the current accent color.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src/components/AppSettingsMenu/styled.ts` — `OptionButton` gains a `$variant` transient prop; default branch is unchanged.
+- `src/components/controls/QuickEffectsRow.tsx` — every `OptionButton` call gets `variant="accent"`; `SwatchButton` active-state border changes from white to accent-aware (or relies on existing outline).
+- `openspec/specs/visual-effects-menu/spec.md` — new file landed via archive.
+- `src/components/SettingsV2/sections/__tests__/VisualizerStylePicker.test.tsx` and any `AppSettingsMenu` consumers of `OptionButton` — should remain untouched because the default variant preserves prior behavior.
+- No effect on Settings v2 (`SettingsV2/sections/appearance/*`), the legacy Settings drawer (`AppSettingsMenu/index.tsx`), or any provider / playback / queue code path.
+- No effect on mock-provider fixtures or Playwright snapshots beyond pixel differences in the flip-menu region.

--- a/openspec/changes/archive/2026-05-15-flip-menu-accent-color/specs/visual-effects-menu/spec.md
+++ b/openspec/changes/archive/2026-05-15-flip-menu-accent-color/specs/visual-effects-menu/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Flip-Menu Surface
+
+Vorbis Player SHALL expose a flip-side panel mounted on the back face of the album-art card that hosts the visual-effect controls. The panel SHALL be reachable from the front-of-art interaction layer (long-press on touch, click on pointer), SHALL render on top of a blurred, darkened version of the current album art, and SHALL provide an explicit dismiss control plus dismiss-on-outside-tap behavior. When no track is playing or no album art is available, the panel SHALL still render and SHALL offer a Retry Artwork affordance if the consumer wires one in.
+
+#### Scenario: Opening the flip menu
+
+- **WHEN** the user long-presses (touch) or clicks the front of the album art with the flip gesture enabled
+- **THEN** the album-art card rotates 180° about the Y axis to reveal the flip menu
+- **AND** the flip menu becomes interactive (controls accept pointer / keyboard input)
+
+#### Scenario: Closing the flip menu via the close button
+
+- **WHEN** the user clicks the close button rendered at the top-right of the flip menu
+- **THEN** the album-art card rotates back to the front face
+- **AND** the flip menu's controls become non-interactive
+
+#### Scenario: Closing the flip menu via outside-tap
+
+- **WHEN** the user taps inside the flip-menu surface but outside any control
+- **THEN** the album-art card rotates back to the front face
+
+#### Scenario: Backdrop renders without album art
+
+- **WHEN** the current track has no resolvable album image
+- **THEN** the flip menu still renders with a fallback (un-imaged) backdrop
+- **AND** the Retry Artwork control is shown when the consumer provides a retry callback
+
+### Requirement: Accent Color Selection
+
+The flip menu SHALL let the user choose the active accent color via three input paths: (a) selecting one of the top vibrant swatches extracted from the current album art, (b) selecting a previously-saved custom override for the current album, and (c) picking any pixel from the album image via an eyedropper overlay. The user SHALL be able to reset to the default extracted accent. The active swatch SHALL be visually distinguishable from inactive swatches.
+
+#### Scenario: Selecting an extracted swatch
+
+- **WHEN** the user clicks one of the extracted-swatch buttons
+- **THEN** the accent color updates to the swatch's hex value
+- **AND** the swatch displays as the active swatch
+
+#### Scenario: Using the eyedropper
+
+- **WHEN** the user activates the eyedropper and picks a pixel from the album art
+- **THEN** the picked color is saved as the album's custom accent override
+- **AND** the accent color updates to the picked color
+- **AND** the eyedropper overlay dismisses
+
+#### Scenario: Resetting to default
+
+- **WHEN** the user clicks the Reset control
+- **THEN** any custom override for the current album is cleared
+- **AND** the accent color reverts to the default extracted accent for the current album
+
+### Requirement: Glow Control
+
+The flip menu SHALL expose a toggle that enables or disables the album-art glow effect. While enabled, the menu SHALL expose Intensity (Less / Normal / More) and Rate (Slower / Normal / Faster) sub-settings whose selected value is visually indicated. Sub-settings SHALL be hidden while the toggle is off. Toggling SHALL be reversible without loss of the user's previous sub-setting selections.
+
+#### Scenario: Enabling glow
+
+- **WHEN** the user flips the glow switch on
+- **THEN** glow is applied to the album art using the current accent color
+- **AND** the Intensity and Rate sub-settings become visible
+
+#### Scenario: Disabling glow
+
+- **WHEN** the user flips the glow switch off
+- **THEN** glow is removed from the album art
+- **AND** the Intensity and Rate sub-settings are hidden
+
+#### Scenario: Selecting an Intensity / Rate value
+
+- **WHEN** the user clicks one of the Intensity (or Rate) option buttons
+- **THEN** the glow effect updates to the selected value
+- **AND** the chosen option button is rendered in the active state
+
+### Requirement: Background Visualizer Control
+
+The flip menu SHALL expose a toggle that enables or disables the background visualizer. While enabled, the menu SHALL expose Style (Fireflies / Comet / Wave / Grid), Intensity (Less / Normal / More), and Speed (Slower / Normal / Faster) sub-settings whose selected value is visually indicated. Sub-settings SHALL be hidden while the toggle is off.
+
+#### Scenario: Enabling the visualizer
+
+- **WHEN** the user flips the visualizer switch on
+- **THEN** the selected visualizer style is rendered behind the player
+- **AND** the Style, Intensity, and Speed sub-settings become visible
+
+#### Scenario: Switching style
+
+- **WHEN** the user clicks one of the Style option buttons (Fireflies, Comet, Wave, or Grid)
+- **THEN** the running visualizer swaps to the selected style without disabling the visualizer
+- **AND** the chosen option button is rendered in the active state
+
+#### Scenario: Disabling the visualizer
+
+- **WHEN** the user flips the visualizer switch off
+- **THEN** the background visualizer stops rendering
+- **AND** the Style, Intensity, and Speed sub-settings are hidden
+
+### Requirement: Translucence Control
+
+The flip menu SHALL expose a toggle that enables or disables the album-art translucence effect. The toggle SHALL persist across track changes for the duration of the session.
+
+#### Scenario: Toggling translucence
+
+- **WHEN** the user flips the translucence switch
+- **THEN** translucence is applied or removed on the album art accordingly
+
+### Requirement: Active Controls Reflect Current Accent Color
+
+Every control in the flip menu that exposes an active visual state — Glow Intensity / Rate pills, Visualizer Style / Intensity / Speed pills, the Glow / Visualizer / Translucence switch tracks, and the active swatch indicator — SHALL render its active state using the current `--accent-color` (or a value derived from it, such as `--accent-contrast-color` for foregrounds). Inactive states MAY remain neutral. When the current track changes and the accent color is recomputed, every active control's color SHALL update accordingly without user input.
+
+Rationale: the flip menu is the per-album personalization surface, so its active-state styling should read as an extension of the album's identity rather than as generic chrome.
+
+#### Scenario: Active option-button pill reflects accent
+
+- **WHEN** the user opens the flip menu while a track with a known accent color is playing
+- **THEN** the currently-selected Glow Intensity / Rate / Visualizer Style / Intensity / Speed pill renders with its background, border, and foreground driven by the current accent color and its derived contrast color
+
+#### Scenario: Switch tracks reflect accent
+
+- **WHEN** the Glow, Visualizer, or Translucence switch is in the on state
+- **THEN** the switch track renders in the current accent color
+
+#### Scenario: Accent updates propagate when the track changes
+
+- **WHEN** the playing track changes and the extracted accent color changes accordingly
+- **THEN** every active control in the open flip menu re-renders with the new accent color without requiring the user to re-select anything
+
+#### Scenario: Inactive controls remain neutral
+
+- **WHEN** an option-button pill is in its inactive state
+- **THEN** the pill renders with the panel's neutral muted styling (it does not preview the accent color)

--- a/openspec/changes/archive/2026-05-15-flip-menu-accent-color/tasks.md
+++ b/openspec/changes/archive/2026-05-15-flip-menu-accent-color/tasks.md
@@ -1,0 +1,47 @@
+## 1. OptionButton — variant prop
+
+- [x] 1.1 In `src/components/AppSettingsMenu/styled.ts`, add a `$variant: 'accent' | 'neutral'` transient prop to `OptionButton` (default `'neutral'`).
+- [x] 1.2 Branch the active-state background/border in the styled component: `neutral` → existing `hsl(var(--primary))`; `accent` → `var(--accent-color)`.
+- [x] 1.3 Branch the active-state foreground: `neutral` → existing `hsl(var(--primary-foreground))`; `accent` → `var(--accent-contrast-color)`.
+- [x] 1.4 Branch the active-hover background: `neutral` → existing `hsl(var(--primary) / 0.87)`; `accent` → `color-mix(in srgb, var(--accent-color) 87%, transparent)`.
+- [x] 1.5 Keep the inactive-state and inactive-hover branches unchanged for both variants.
+- [x] 1.6 Add a single inline comment above the styled-component block that points readers to `src/components/ui/switch.tsx` as the variant-pattern precedent (no multi-line doc; one short line).
+
+## 2. QuickEffectsRow — adopt accent variant
+
+- [x] 2.1 In `src/components/controls/QuickEffectsRow.tsx`, pass `variant="accent"` to every `<OptionButton>` (Glow Intensity, Glow Rate, Visualizer Style, Visualizer Intensity, Visualizer Speed). _(Implemented as transient prop `$variant="accent"` to match the existing `$isActive` styled-components convention.)_
+- [x] 2.2 Verify by inspection that no other file in the repo passes `variant` to `OptionButton`; `AppSettingsMenu/index.tsx` should rely on the default `'neutral'`.
+
+## 3. QuickEffectsRow — active swatch indicator
+
+- [x] 3.1 In `src/components/controls/QuickEffectsRow.tsx`, remove the `2px solid ${theme.colors.white}` active branch from `SwatchButton`.
+- [x] 3.2 First-try: keep only the existing `outline: 2px solid ${theme.colors.selection}` for the active state, plus a uniform `1px solid ${theme.colors.control.border}` border. Run the app, confirm visually that the active swatch reads clearly on both vibrant and washed-out accents.
+- [x] 3.3 If QA finds the outline-only treatment too subtle, fall back to `border: 2px solid var(--accent-color)` with the existing outline retained — pick one approach and commit; do not ship both. _(Shipping the outline-only first-try treatment per 3.2; flag this for QA — fall back to accent-border only if visual review finds it too subtle.)_
+
+## 4. Tests
+
+- [x] 4.1 Add or update a Vitest case under `src/components/controls/__tests__/QuickEffectsRow.test.tsx` (creating the file if it does not exist) that asserts every `OptionButton` rendered inside `QuickEffectsRow` receives `variant="accent"` (and therefore the accent-state CSS).
+- [x] 4.2 Confirm `src/components/SettingsV2/sections/__tests__/VisualizerStylePicker.test.tsx` (which exercises the Settings drawer path) still passes — no regression in the neutral-variant default.
+- [x] 4.3 Run `npm run test:run` and confirm zero failures. _(192 files / 2015 tests passed)_
+
+## 5. Visual verification
+
+- [x] 5.1 Run `VITE_MOCK_PROVIDER=true npm run dev`, open the player, flip the album art, and confirm:
+  - Active Glow Intensity / Rate pills render in the current accent color
+  - Active Visualizer Style / Intensity / Speed pills render in the current accent color
+  - Active swatch indicator no longer competes with a pure-white border
+  - Switches still behave as before (variant="accent" remains the default)
+- [x] 5.2 Switch playback to a track with a markedly different accent and confirm every active control retints without re-opening the menu.
+- [x] 5.3 Open the Settings drawer (Shift+S or BottomBar gear) and confirm Quick Access Panel, Performance Profiler, and Visualizer Debug On/Off pills still render in the static-white (neutral) treatment.
+
+## 6. Snapshot + build hygiene
+
+- [x] 6.1 Run `npx tsc -b --noEmit` and confirm zero new errors.
+- [x] 6.2 Run `npm run build` and confirm a clean production build.
+- [x] 6.3 Run `npm run lint` and confirm no new warnings. _(34 pre-existing warnings, 0 errors; none in `AppSettingsMenu/styled.ts` or `controls/QuickEffectsRow.tsx`.)_
+- [x] 6.4 Re-run `npm run capture` to refresh Playwright visual baselines for the flip-menu region; commit the updated artifacts; call out the change in the PR description. _(SKIPPED by request — `npm run capture` is currently blocked by a pre-existing Playwright fixture-loader bug at `playwright/capture/fixtures.ts:29` (`First argument must use the object destructuring pattern: _fixtures`), unrelated to this change. Visual baseline refresh deferred until that loader bug is fixed in a separate change.)_
+
+## 7. Spec archive
+
+- [x] 7.1 After implementation lands and the PR merges, run `/opsx:archive flip-menu-accent-color` so `openspec/specs/visual-effects-menu/spec.md` is created from the change's delta. _(Run pre-merge by request — spec landed in the same PR as the implementation. Sync seeded `openspec/specs/visual-effects-menu/spec.md` with all 6 requirements.)_
+- [x] 7.2 Verify `openspec list` shows `visual-effects-menu` as a new capability and `openspec validate` is clean repo-wide. _(`openspec validate visual-effects-menu --type spec` → "Specification 'visual-effects-menu' is valid".)_

--- a/openspec/specs/visual-effects-menu/spec.md
+++ b/openspec/specs/visual-effects-menu/spec.md
@@ -1,0 +1,136 @@
+# visual-effects-menu Specification
+
+## Purpose
+
+The visual-effects menu is the per-album personalization surface for Vorbis Player. It is mounted on the back face of the album-art card (the "flip menu") and hosts user-facing controls for the accent color, the album-art glow effect, the background visualizer, and the album-art translucence effect. The menu's active-state styling reads as an extension of the playing album's identity by deriving its colors from the current accent color.
+
+## Requirements
+
+### Requirement: Flip-Menu Surface
+
+Vorbis Player SHALL expose a flip-side panel mounted on the back face of the album-art card that hosts the visual-effect controls. The panel SHALL be reachable from the front-of-art interaction layer (long-press on touch, click on pointer), SHALL render on top of a blurred, darkened version of the current album art, and SHALL provide an explicit dismiss control plus dismiss-on-outside-tap behavior. When no track is playing or no album art is available, the panel SHALL still render and SHALL offer a Retry Artwork affordance if the consumer wires one in.
+
+#### Scenario: Opening the flip menu
+
+- **WHEN** the user long-presses (touch) or clicks the front of the album art with the flip gesture enabled
+- **THEN** the album-art card rotates 180° about the Y axis to reveal the flip menu
+- **AND** the flip menu becomes interactive (controls accept pointer / keyboard input)
+
+#### Scenario: Closing the flip menu via the close button
+
+- **WHEN** the user clicks the close button rendered at the top-right of the flip menu
+- **THEN** the album-art card rotates back to the front face
+- **AND** the flip menu's controls become non-interactive
+
+#### Scenario: Closing the flip menu via outside-tap
+
+- **WHEN** the user taps inside the flip-menu surface but outside any control
+- **THEN** the album-art card rotates back to the front face
+
+#### Scenario: Backdrop renders without album art
+
+- **WHEN** the current track has no resolvable album image
+- **THEN** the flip menu still renders with a fallback (un-imaged) backdrop
+- **AND** the Retry Artwork control is shown when the consumer provides a retry callback
+
+### Requirement: Accent Color Selection
+
+The flip menu SHALL let the user choose the active accent color via three input paths: (a) selecting one of the top vibrant swatches extracted from the current album art, (b) selecting a previously-saved custom override for the current album, and (c) picking any pixel from the album image via an eyedropper overlay. The user SHALL be able to reset to the default extracted accent. The active swatch SHALL be visually distinguishable from inactive swatches.
+
+#### Scenario: Selecting an extracted swatch
+
+- **WHEN** the user clicks one of the extracted-swatch buttons
+- **THEN** the accent color updates to the swatch's hex value
+- **AND** the swatch displays as the active swatch
+
+#### Scenario: Using the eyedropper
+
+- **WHEN** the user activates the eyedropper and picks a pixel from the album art
+- **THEN** the picked color is saved as the album's custom accent override
+- **AND** the accent color updates to the picked color
+- **AND** the eyedropper overlay dismisses
+
+#### Scenario: Resetting to default
+
+- **WHEN** the user clicks the Reset control
+- **THEN** any custom override for the current album is cleared
+- **AND** the accent color reverts to the default extracted accent for the current album
+
+### Requirement: Glow Control
+
+The flip menu SHALL expose a toggle that enables or disables the album-art glow effect. While enabled, the menu SHALL expose Intensity (Less / Normal / More) and Rate (Slower / Normal / Faster) sub-settings whose selected value is visually indicated. Sub-settings SHALL be hidden while the toggle is off. Toggling SHALL be reversible without loss of the user's previous sub-setting selections.
+
+#### Scenario: Enabling glow
+
+- **WHEN** the user flips the glow switch on
+- **THEN** glow is applied to the album art using the current accent color
+- **AND** the Intensity and Rate sub-settings become visible
+
+#### Scenario: Disabling glow
+
+- **WHEN** the user flips the glow switch off
+- **THEN** glow is removed from the album art
+- **AND** the Intensity and Rate sub-settings are hidden
+
+#### Scenario: Selecting an Intensity / Rate value
+
+- **WHEN** the user clicks one of the Intensity (or Rate) option buttons
+- **THEN** the glow effect updates to the selected value
+- **AND** the chosen option button is rendered in the active state
+
+### Requirement: Background Visualizer Control
+
+The flip menu SHALL expose a toggle that enables or disables the background visualizer. While enabled, the menu SHALL expose Style (Fireflies / Comet / Wave / Grid), Intensity (Less / Normal / More), and Speed (Slower / Normal / Faster) sub-settings whose selected value is visually indicated. Sub-settings SHALL be hidden while the toggle is off.
+
+#### Scenario: Enabling the visualizer
+
+- **WHEN** the user flips the visualizer switch on
+- **THEN** the selected visualizer style is rendered behind the player
+- **AND** the Style, Intensity, and Speed sub-settings become visible
+
+#### Scenario: Switching style
+
+- **WHEN** the user clicks one of the Style option buttons (Fireflies, Comet, Wave, or Grid)
+- **THEN** the running visualizer swaps to the selected style without disabling the visualizer
+- **AND** the chosen option button is rendered in the active state
+
+#### Scenario: Disabling the visualizer
+
+- **WHEN** the user flips the visualizer switch off
+- **THEN** the background visualizer stops rendering
+- **AND** the Style, Intensity, and Speed sub-settings are hidden
+
+### Requirement: Translucence Control
+
+The flip menu SHALL expose a toggle that enables or disables the album-art translucence effect. The toggle SHALL persist across track changes for the duration of the session.
+
+#### Scenario: Toggling translucence
+
+- **WHEN** the user flips the translucence switch
+- **THEN** translucence is applied or removed on the album art accordingly
+
+### Requirement: Active Controls Reflect Current Accent Color
+
+Every control in the flip menu that exposes an active visual state — Glow Intensity / Rate pills, Visualizer Style / Intensity / Speed pills, the Glow / Visualizer / Translucence switch tracks, and the active swatch indicator — SHALL render its active state using the current `--accent-color` (or a value derived from it, such as `--accent-contrast-color` for foregrounds). Inactive states MAY remain neutral. When the current track changes and the accent color is recomputed, every active control's color SHALL update accordingly without user input.
+
+Rationale: the flip menu is the per-album personalization surface, so its active-state styling should read as an extension of the album's identity rather than as generic chrome.
+
+#### Scenario: Active option-button pill reflects accent
+
+- **WHEN** the user opens the flip menu while a track with a known accent color is playing
+- **THEN** the currently-selected Glow Intensity / Rate / Visualizer Style / Intensity / Speed pill renders with its background, border, and foreground driven by the current accent color and its derived contrast color
+
+#### Scenario: Switch tracks reflect accent
+
+- **WHEN** the Glow, Visualizer, or Translucence switch is in the on state
+- **THEN** the switch track renders in the current accent color
+
+#### Scenario: Accent updates propagate when the track changes
+
+- **WHEN** the playing track changes and the extracted accent color changes accordingly
+- **THEN** every active control in the open flip menu re-renders with the new accent color without requiring the user to re-select anything
+
+#### Scenario: Inactive controls remain neutral
+
+- **WHEN** an option-button pill is in its inactive state
+- **THEN** the pill renders with the panel's neutral muted styling (it does not preview the accent color)

--- a/src/components/AppSettingsMenu/styled.ts
+++ b/src/components/AppSettingsMenu/styled.ts
@@ -274,10 +274,28 @@ export const CacheCancelButton = styled.button`
   }
 `;
 
-export const OptionButton = styled.button<{ $isActive: boolean }>`
-  background: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary))' : theme.colors.muted.background};
-  border: 1px solid ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary))' : theme.colors.border};
-  color: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary-foreground))' : theme.colors.muted.foreground};
+export type OptionButtonVariant = 'accent' | 'neutral';
+
+// $variant mirrors the Switch variant pattern in src/components/ui/switch.tsx.
+export const OptionButton = styled.button<{ $isActive: boolean; $variant?: OptionButtonVariant }>`
+  background: ${({ $isActive, $variant = 'neutral', theme }) =>
+    $isActive
+      ? $variant === 'accent'
+        ? 'var(--accent-color)'
+        : 'hsl(var(--primary))'
+      : theme.colors.muted.background};
+  border: 1px solid ${({ $isActive, $variant = 'neutral', theme }) =>
+    $isActive
+      ? $variant === 'accent'
+        ? 'var(--accent-color)'
+        : 'hsl(var(--primary))'
+      : theme.colors.border};
+  color: ${({ $isActive, $variant = 'neutral', theme }) =>
+    $isActive
+      ? $variant === 'accent'
+        ? 'var(--accent-contrast-color)'
+        : 'hsl(var(--primary-foreground))'
+      : theme.colors.muted.foreground};
   padding: 0.375rem 0.75rem;
   border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
@@ -287,9 +305,19 @@ export const OptionButton = styled.button<{ $isActive: boolean }>`
   min-width: 60px;
 
   &:hover {
-    background: ${({ $isActive }) => $isActive ? 'hsl(var(--primary) / 0.87)' : 'hsl(var(--muted))'};
+    background: ${({ $isActive, $variant = 'neutral' }) =>
+      $isActive
+        ? $variant === 'accent'
+          ? 'color-mix(in srgb, var(--accent-color) 87%, transparent)'
+          : 'hsl(var(--primary) / 0.87)'
+        : 'hsl(var(--muted))'};
     border-color: hsl(var(--ring));
-    color: ${({ $isActive, theme }) => $isActive ? 'hsl(var(--primary-foreground))' : theme.colors.white};
+    color: ${({ $isActive, $variant = 'neutral', theme }) =>
+      $isActive
+        ? $variant === 'accent'
+          ? 'var(--accent-contrast-color)'
+          : 'hsl(var(--primary-foreground))'
+        : theme.colors.white};
     transform: translateY(-1px);
   }
 `;

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -72,13 +72,12 @@ const SwatchButton = styled.button<{ $color: string; $isActive: boolean }>`
   height: 24px;
   border-radius: 50%;
   background: ${({ $color }) => $color};
-  border: ${({ theme, $isActive }) =>
-    $isActive ? `2px solid ${theme.colors.white}` : `1px solid ${theme.colors.control.border}`};
+  border: 1px solid ${({ theme }) => theme.colors.control.border};
   outline: ${({ theme, $isActive }) => ($isActive ? `2px solid ${theme.colors.selection}` : 'none')};
   cursor: pointer;
   padding: 0;
   flex-shrink: 0;
-  transition: border ${({ theme }) => theme.transitions.fast};
+  transition: outline ${({ theme }) => theme.transitions.fast};
 `;
 
 const IconButton = styled.button`
@@ -275,9 +274,9 @@ function QuickEffectsRow({
               <SubSettingRow>
                 <SubLabel>Intensity</SubLabel>
                 <OptionButtonGroup>
-                  <OptionButton $isActive={glowIntensity === 95} onClick={() => onGlowIntensityChange(95)}>Less</OptionButton>
-                  <OptionButton $isActive={glowIntensity === 110} onClick={() => onGlowIntensityChange(110)}>Normal</OptionButton>
-                  <OptionButton $isActive={glowIntensity === 125} onClick={() => onGlowIntensityChange(125)}>More</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowIntensity === 95} onClick={() => onGlowIntensityChange(95)}>Less</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowIntensity === 110} onClick={() => onGlowIntensityChange(110)}>Normal</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowIntensity === 125} onClick={() => onGlowIntensityChange(125)}>More</OptionButton>
                 </OptionButtonGroup>
               </SubSettingRow>
             )}
@@ -285,9 +284,9 @@ function QuickEffectsRow({
               <SubSettingRow>
                 <SubLabel>Rate</SubLabel>
                 <OptionButtonGroup>
-                  <OptionButton $isActive={glowRate === 5.0} onClick={() => onGlowRateChange(5.0)}>Slower</OptionButton>
-                  <OptionButton $isActive={glowRate === 4.0} onClick={() => onGlowRateChange(4.0)}>Normal</OptionButton>
-                  <OptionButton $isActive={glowRate === 3.0} onClick={() => onGlowRateChange(3.0)}>Faster</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowRate === 5.0} onClick={() => onGlowRateChange(5.0)}>Slower</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowRate === 4.0} onClick={() => onGlowRateChange(4.0)}>Normal</OptionButton>
+                  <OptionButton $variant="accent" $isActive={glowRate === 3.0} onClick={() => onGlowRateChange(3.0)}>Faster</OptionButton>
                 </OptionButtonGroup>
               </SubSettingRow>
             )}
@@ -306,24 +305,28 @@ function QuickEffectsRow({
             <SubLabel>Style</SubLabel>
             <OptionButtonGroup>
               <OptionButton
+                $variant="accent"
                 $isActive={backgroundVisualizerStyle === 'fireflies'}
                 onClick={() => onBackgroundVisualizerStyleChange('fireflies')}
               >
                 Fireflies
               </OptionButton>
               <OptionButton
+                $variant="accent"
                 $isActive={backgroundVisualizerStyle === 'comet'}
                 onClick={() => onBackgroundVisualizerStyleChange('comet')}
               >
                 Comet
               </OptionButton>
               <OptionButton
+                $variant="accent"
                 $isActive={backgroundVisualizerStyle === 'wave'}
                 onClick={() => onBackgroundVisualizerStyleChange('wave')}
               >
                 Wave
               </OptionButton>
               <OptionButton
+                $variant="accent"
                 $isActive={backgroundVisualizerStyle === 'grid'}
                 onClick={() => onBackgroundVisualizerStyleChange('grid')}
               >
@@ -336,18 +339,21 @@ function QuickEffectsRow({
               <SubLabel>Intensity</SubLabel>
               <OptionButtonGroup>
                 <OptionButton
+                  $variant="accent"
                   $isActive={backgroundVisualizerIntensity === 20}
                   onClick={() => onBackgroundVisualizerIntensityChange(20)}
                 >
                   Less
                 </OptionButton>
                 <OptionButton
+                  $variant="accent"
                   $isActive={backgroundVisualizerIntensity === 40}
                   onClick={() => onBackgroundVisualizerIntensityChange(40)}
                 >
                   Normal
                 </OptionButton>
                 <OptionButton
+                  $variant="accent"
                   $isActive={backgroundVisualizerIntensity === 60}
                   onClick={() => onBackgroundVisualizerIntensityChange(60)}
                 >
@@ -360,9 +366,9 @@ function QuickEffectsRow({
             <SubSettingRow>
               <SubLabel>Speed</SubLabel>
               <OptionButtonGroup>
-                <OptionButton $isActive={backgroundVisualizerSpeed === 0.5} onClick={() => onBackgroundVisualizerSpeedChange(0.5)}>Slower</OptionButton>
-                <OptionButton $isActive={backgroundVisualizerSpeed === 0.7} onClick={() => onBackgroundVisualizerSpeedChange(0.7)}>Normal</OptionButton>
-                <OptionButton $isActive={backgroundVisualizerSpeed === 1.2} onClick={() => onBackgroundVisualizerSpeedChange(1.2)}>Faster</OptionButton>
+                <OptionButton $variant="accent" $isActive={backgroundVisualizerSpeed === 0.5} onClick={() => onBackgroundVisualizerSpeedChange(0.5)}>Slower</OptionButton>
+                <OptionButton $variant="accent" $isActive={backgroundVisualizerSpeed === 0.7} onClick={() => onBackgroundVisualizerSpeedChange(0.7)}>Normal</OptionButton>
+                <OptionButton $variant="accent" $isActive={backgroundVisualizerSpeed === 1.2} onClick={() => onBackgroundVisualizerSpeedChange(1.2)}>Faster</OptionButton>
               </OptionButtonGroup>
             </SubSettingRow>
           )}

--- a/src/components/controls/__tests__/QuickEffectsRow.test.tsx
+++ b/src/components/controls/__tests__/QuickEffectsRow.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '@/styles/theme';
+import type { MediaTrack } from '@/types/domain';
+
+const optionButtonRenders: Array<Record<string, unknown>> = [];
+
+vi.mock('@/components/AppSettingsMenu/styled', async () => {
+  const actual = await vi.importActual<typeof import('@/components/AppSettingsMenu/styled')>(
+    '@/components/AppSettingsMenu/styled',
+  );
+  return {
+    ...actual,
+    OptionButton: (props: Record<string, unknown>) => {
+      optionButtonRenders.push(props);
+      const { children, $isActive: _$isActive, $variant: _$variant, ...rest } = props as {
+        children?: React.ReactNode;
+        $isActive?: boolean;
+        $variant?: string;
+      } & Record<string, unknown>;
+      return <button {...rest}>{children}</button>;
+    },
+  };
+});
+
+vi.mock('@/utils/colorExtractor', () => ({
+  extractTopVibrantColors: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/components/EyedropperOverlay', () => ({
+  default: () => null,
+}));
+
+import QuickEffectsRow from '../QuickEffectsRow';
+
+const baseProps = {
+  currentTrack: { albumId: 'album-1', image: undefined } as unknown as MediaTrack,
+  accentColor: '#abcdef',
+  onAccentColorChange: vi.fn(),
+  customAccentColorOverrides: {},
+  onCustomAccentColor: vi.fn(),
+  glowEnabled: true,
+  onGlowToggle: vi.fn(),
+  glowIntensity: 110,
+  onGlowIntensityChange: vi.fn(),
+  glowRate: 4.0,
+  onGlowRateChange: vi.fn(),
+  backgroundVisualizerEnabled: true,
+  onBackgroundVisualizerToggle: vi.fn(),
+  backgroundVisualizerStyle: 'fireflies' as const,
+  onBackgroundVisualizerStyleChange: vi.fn(),
+  backgroundVisualizerIntensity: 40,
+  onBackgroundVisualizerIntensityChange: vi.fn(),
+  backgroundVisualizerSpeed: 0.7,
+  onBackgroundVisualizerSpeedChange: vi.fn(),
+  translucenceEnabled: false,
+  onTranslucenceToggle: vi.fn(),
+  isMobile: false,
+  isTablet: false,
+};
+
+describe('QuickEffectsRow OptionButton variant wiring', () => {
+  beforeEach(() => {
+    optionButtonRenders.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('renders every OptionButton with $variant="accent"', () => {
+    // #given — Glow + Visualizer both enabled so all sub-setting pills mount
+    // #when
+    render(
+      <ThemeProvider theme={theme}>
+        <QuickEffectsRow {...baseProps} />
+      </ThemeProvider>,
+    );
+
+    // #then — every rendered pill carries the accent variant. React 18 StrictMode
+    // can double-invoke the render, so we assert against the full set instead of a
+    // fixed count: at least the 16 expected pills (3 glow intensity + 3 glow rate +
+    // 4 viz style + 3 viz intensity + 3 viz speed) must be present.
+    expect(optionButtonRenders.length).toBeGreaterThanOrEqual(16);
+    for (const props of optionButtonRenders) {
+      expect(props.$variant).toBe('accent');
+    }
+  });
+
+  it('omits sub-setting pills (and so OptionButtons) when glow + visualizer are disabled', () => {
+    // #given
+    // #when
+    render(
+      <ThemeProvider theme={theme}>
+        <QuickEffectsRow
+          {...baseProps}
+          glowEnabled={false}
+          backgroundVisualizerEnabled={false}
+        />
+      </ThemeProvider>,
+    );
+
+    // #then
+    expect(optionButtonRenders).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `$variant: 'accent' | 'neutral'` (default `neutral`) to `OptionButton` so the flip-menu sub-setting pills (Glow Intensity/Rate, Visualizer Style/Intensity/Speed) render their active state in `var(--accent-color)` / `var(--accent-contrast-color)` instead of the static shadcn `--primary` token. Mirrors the existing `Switch` variant pattern.
- Drops the white border on the active `SwatchButton` — it was painting a third color around an already-colored swatch — leaving only the existing `selection` outline as the active indicator.
- Settings drawer (`AppSettingsMenu`, `AppearanceSection`, `VisualizerStylePicker`, `GlowControls`) keeps the static-white treatment via the default neutral variant. No behavioral change anywhere.
- Seeds `openspec/specs/visual-effects-menu/` as a brand-new capability spec — first time the flip-menu surface has a contract — and archives the change under `openspec/changes/archive/2026-05-15-flip-menu-accent-color/`.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run build` clean (built in 2.44s)
- [x] `npm run lint` — 0 new warnings (34 pre-existing, none in touched files)
- [x] `npm run test:run` — 192 files / 2015 tests pass (includes new `QuickEffectsRow.test.tsx` asserting every `OptionButton` in the row carries `$variant="accent"`)
- [x] `openspec validate --all` — 5 specs pass (now includes `visual-effects-menu`)
- [x] Manual visual QA: flipped album art, confirmed Glow + Visualizer pills retint with accent on track change; Settings drawer pills remain static-white
- [ ] **Skipped:** `npm run capture` Playwright baseline refresh — blocked by pre-existing fixture-loader bug at `playwright/capture/fixtures.ts:29` (`First argument must use the object destructuring pattern: _fixtures`); needs a separate fix