### PR TITLE
fix(dropbox): skip queue on unrecoverable playback error

### DIFF
--- a/openspec/changes/dropbox-skip-on-error/design.md
+++ b/openspec/changes/dropbox-skip-on-error/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`DropboxPlaybackAdapter` plays audio via an `HTMLAudioElement`. Its `playTrack`:
+
+1. Calls `catalog.getTemporaryLink(path)` to mint a fresh download URL (Dropbox temporary links are short-lived; `dropboxCatalogAdapter` handles refresh transparently).
+2. Assigns `audio.src` and awaits `audio.play()`.
+
+The two failure surfaces today:
+
+- **Pre-fetch / catalog**: `getTemporaryLink` rejects. `AuthExpiredError` propagates; everything else is swallowed because the catch site is `useProviderPlayback` which only special-cases `AuthExpiredError` and `UnavailableTrackError` — a generic Error there falls through to the `skipOnError` branch already, but only because `console.error` doesn't swallow re-throw. Actually it does skip via the generic branch (`useProviderPlayback.ts:133-137`). So this path already advances. It is documented for completeness.
+- **Post-fetch / media**: `audio.src` is set, then `audio.play()` is awaited. `audio.play()` can resolve before the media element actually starts playing — browsers resolve as soon as the play *intent* is honored, while a media decoding failure may surface asynchronously via the `error` event. The persistent `error` listener at line 60 captures it into `state.playbackError`, but **no subscriber reads that field**, so the queue stalls on the broken track.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A post-fetch `<audio>` error during the initial play SHALL cause `playTrack` to reject with `UnavailableTrackError`, so the engine's existing skip path advances the queue.
+- Auth expiry continues to throw `AuthExpiredError` (unchanged).
+- The `skipOnError` cooldown and ordering already enforced by `useProviderPlayback` is reused — no new engine code.
+
+**Non-Goals:**
+- Distinguishing decoder errors from network errors. The user-visible outcome is identical (skip).
+- Refreshing the temporary link mid-stream when a long-lived play stalls. That's a separate concern; tracked as a deferred enhancement. Once playback has begun successfully, mid-stream failures should be handled via the existing auto-advance path (track ends), not via a skip.
+- Surfacing `state.playbackError` to UI. Out of scope; the field can stay as-is for diagnostics.
+- Modifying `useProviderPlayback.ts`. The existing `UnavailableTrackError` branch already does what we need.
+
+## Decisions
+
+**Throw `UnavailableTrackError` from `playTrack` rather than wiring `state.playbackError` through subscriptions.**
+
+Two reasons:
+
+1. **Symmetry with Spotify.** `spotifyPlaybackAdapter` already uses this signal (`spotifyPlaybackAdapter.ts:139`). Using the same shape keeps the engine's recovery branch single-source-of-truth and avoids a second skip-trigger path that subscribers would have to dedupe against.
+2. **Minimum blast radius.** Routing `state.playbackError` into a skip would require either a new subscriber hook or extending `usePlaybackSubscription` / `useAutoAdvance` with error-aware logic. Throwing from `playTrack` reuses 100% of the existing infrastructure — the engine's `try/catch` is already there.
+
+**Race `audio.play()` against the next `error` event using a one-shot promise.**
+
+`audio.play()` returning a fulfilled promise does not mean playback succeeded — browsers fulfill it as soon as the play intent is queued; decoding/network failures surface afterward via the `error` event on `HTMLMediaElement`. We need to wait for *one of*:
+
+- The element transitions to actively playing (`playing` event fires) → resolve.
+- The element raises `error` → reject with `UnavailableTrackError`.
+
+We attach single-fire listeners for both events, clean them up in `finally`, and return whichever wins. `audio.play()`'s own rejection (e.g. `NotAllowedError` from autoplay policy) is treated as an error too — anything that prevents the element from reaching `playing` is unavailable.
+
+The iOS Safari pre-emptive `audio.play()` call at line 88 is preserved — it's a gesture-activation hack and doesn't interact with the post-`src=...` play race.
+
+**`AuthExpiredError` keeps its dedicated channel.**
+
+Auth expiry is a recoverable user-actionable state, not a track-availability problem. The engine's branch at `useProviderPlayback.ts:120-123` dispatches a re-auth prompt and explicitly does not skip. So we rethrow `AuthExpiredError` as-is from `catalog.getTemporaryLink()` and never wrap it in `UnavailableTrackError`.
+
+**Generic catalog rejections (non-Auth) fall through to the engine's generic-error skip branch.**
+
+`useProviderPlayback.ts:133-137` already skips on any non-Auth/non-Unavailable error from `playTrack`. We do not need to wrap pre-fetch errors in `UnavailableTrackError` — letting them propagate as plain `Error` gives the same outcome and avoids hiding the original stack. The test suite asserts the queue advances either way.
+
+## Risks / Trade-offs
+
+- **Risk**: A transient `error` event during a normally-playing stream (e.g. a momentary network glitch that the browser recovers from) could trigger a spurious skip if it fires during the initial play race. → Mitigation: the race is bounded to the first play; we settle on the first `playing` event and detach both listeners. After that, any later `error` event flows through the persistent listener into `pendingError` as before — no spurious skip mid-track. Mid-stream failures are not the target of this change.
+- **Risk**: A track with broken metadata that loads but never starts (`playing` never fires, `error` never fires) would leave `playTrack` hanging. → Mitigation: in practice browsers always emit one of the two within a few seconds for a real file. We intentionally do **not** add a timeout in this pass because picking a timeout that's correct across slow networks and CPU-throttled mobile is its own problem; if real-world telemetry shows hangs we can layer one on in a follow-up.
+- **Trade-off**: The race adds a small amount of state-machine glue to `playTrack` but keeps engine-level error recovery centralized.
+
+## Edge Cases
+
+- **Link refresh failure**: `getTemporaryLink` already handles 410/expired-link refresh internally. If refresh ultimately fails (e.g. file deleted), it rejects with a generic Error; the engine's generic-error branch skips. If it rejects with `AuthExpiredError`, we rethrow and the engine surfaces re-auth.
+- **Decoder error**: Audio element fires `error` with `MediaError.MEDIA_ERR_DECODE`. Caught by the race, throws `UnavailableTrackError`, skip.
+- **Network mid-stream**: Out of scope for the initial-play race. The element will pause and the existing natural-end auto-advance signal may or may not fire depending on browser; this is acknowledged as a separate gap.
+- **iOS user-gesture pre-emptive play**: Untouched. The pre-emptive `this.audio!.play().catch(() => {})` at line 88 runs before `audio.src` is set; it activates the element for later programmatic play and any rejection there is irrelevant to the real play that follows the catalog fetch.
+- **Subsequent `playTrack` supersedes a pending one**: `prepareGeneration` is already incremented at the top of `playTrack`. We add the same generation check inside the race so a stale `error` from the previous src can't reject the new play.

--- a/openspec/changes/dropbox-skip-on-error/proposal.md
+++ b/openspec/changes/dropbox-skip-on-error/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Dropbox playback failures other than auth expiry have no recovery path today. `DropboxPlaybackAdapter.playTrack` only throws `AuthExpiredError`; every other error mode — file moved out from under us, temporary link expired beyond catalog refresh, HTML5 audio decoder failure, network mid-stream drop — is captured into `state.playbackError` but no consumer reads that field, so the queue stalls on the unplayable track. This violates `openspec/specs/playback-engine/spec.md` Requirement 5 ("Error Recovery"), which says the engine SHALL skip an unavailable track.
+
+Spotify already follows the spec: `SpotifyPlaybackAdapter` throws `UnavailableTrackError` from `playTrack` on terminal failures (e.g. 403 "Restriction violated"), and `useProviderPlayback` handles it via the `skipOnError` branch (`src/hooks/useProviderPlayback.ts:125-131`) which advances to the next track after `SKIP_ON_ERROR_DELAY_MS`. Dropbox should plug into the same engine path so error recovery is uniform across providers.
+
+Tracked in #1561.
+
+## What Changes
+
+- Detect unrecoverable Dropbox playback failures inside `playTrack` and throw `UnavailableTrackError` so the existing engine skip path advances the queue. Two failure modes are covered:
+  - The `<audio>` element raises an `error` event during the initial play (decoder failure, network stall, terminal 4xx/5xx on the temporary link).
+  - `catalog.getTemporaryLink()` rejects with anything other than `AuthExpiredError` (file moved, deleted, link generation failed beyond retry).
+- Race the `<audio>` element's `playing` event against an `error` event after `audio.play()` is invoked, so the promise returned by `playTrack` resolves only when audio actually starts, and rejects with `UnavailableTrackError` otherwise.
+- Keep the existing `pendingError` capture on the persistent `error` listener for diagnostics, but the new race owns the throw decision during the initial play.
+- Add unit tests covering both failure modes plus the happy path.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: clarifies that "unavailable" for the Dropbox HTML5-audio path includes audio-element error events and post-fetch link failures, not just auth expiry. The existing Requirement 5 scenario gains a Dropbox-specific clause documenting what counts as unavailable.
+
+## Impact
+
+- `src/providers/dropbox/dropboxPlaybackAdapter.ts` — race audio error vs `playing` in `playTrack`; throw `UnavailableTrackError` on failure; rethrow `AuthExpiredError` from the catalog promise.
+- `src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts` — new tests for the error race.
+- No change to `useProviderPlayback.ts`, no change to Spotify, no auth-flow changes.
+- No public API surface change.

--- a/openspec/changes/dropbox-skip-on-error/specs/playback-engine/spec.md
+++ b/openspec/changes/dropbox-skip-on-error/specs/playback-engine/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Error Recovery
+
+The engine SHALL handle playback adapter errors without leaving the queue stuck on an unplayable track. A track SHALL be considered unavailable when the driving provider's `playTrack` rejects with an unavailability signal, including provider-specific terminal failures during the initial play of a track.
+
+#### Scenario: Track is unavailable
+- **WHEN** the driving provider reports a track as unavailable
+- **THEN** the engine skips to the next track
+
+#### Scenario: Provider authentication expired during playback
+- **WHEN** the driving provider reports authentication has expired
+- **THEN** the engine surfaces a re-authentication prompt and does not auto-skip
+
+#### Scenario: Dropbox HTML5 audio error during initial play
+- **WHEN** the Dropbox playback adapter's `<audio>` element raises an `error` event during the initial play of a track (decoder failure, terminal 4xx/5xx on the temporary link after refresh, network failure before the element reaches the playing state), or `audio.play()` itself rejects
+- **THEN** `playTrack` rejects with an unavailability signal
+- **AND** the engine skips to the next track
+
+#### Scenario: Dropbox temporary link cannot be obtained
+- **WHEN** the Dropbox catalog adapter fails to mint a temporary link for a track for any reason other than auth expiry
+- **THEN** `playTrack` rejects
+- **AND** the engine skips to the next track

--- a/openspec/changes/dropbox-skip-on-error/tasks.md
+++ b/openspec/changes/dropbox-skip-on-error/tasks.md
@@ -1,0 +1,19 @@
+## 1. Adapter changes
+
+- [x] 1.1 In `src/providers/dropbox/dropboxPlaybackAdapter.ts`, import `UnavailableTrackError` alongside the existing `AuthExpiredError` import from `@/providers/errors`.
+- [x] 1.2 In `playTrack`, after assigning `audio.src` and invoking `audio.play()`, race the play promise against a one-shot `error` listener. On `error` (or `play()` rejection), throw `UnavailableTrackError(track.name)`. Resolve on the first `playing` event.
+- [x] 1.3 Use the existing `prepareGeneration` to invalidate the race if a newer `playTrack`/`prepareTrack` supersedes it — stale events from a prior src must not reject the new play.
+- [x] 1.4 Confirm `AuthExpiredError` from `catalog.getTemporaryLink()` continues to propagate untouched.
+
+## 2. Tests
+
+- [x] 2.1 In `src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts`, add a test that `playTrack` rejects with `UnavailableTrackError` when the audio element fires `error` during initial play.
+- [x] 2.2 Add a test that `playTrack` resolves normally when the `playing` event fires (happy path stays green).
+- [x] 2.3 Add a test that `playTrack` rethrows `AuthExpiredError` from `getTemporaryLink` (regression guard — unchanged behavior).
+- [x] 2.4 Add a test that a stale `error` event after a superseding `playTrack` does NOT reject the new play promise.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green (full suite — confirm no regressions in `useProviderPlayback` / `useSpotifyPlayback` tests).
+- [x] 3.3 `npm run build` green.

--- a/src/providers/__tests__/dropboxAdapters.test.ts
+++ b/src/providers/__tests__/dropboxAdapters.test.ts
@@ -98,10 +98,18 @@ describe('DropboxPlaybackAdapter', () => {
       currentTime: 0,
       duration: 180,
       volume: 1,
-      play: vi.fn().mockResolvedValue(undefined),
+      play: vi.fn().mockImplementation(() => {
+        queueMicrotask(() => audioListeners['playing']?.({} as Event));
+        return Promise.resolve();
+      }),
       pause: vi.fn(),
       addEventListener: vi.fn((event: string, handler: EventListener) => {
         audioListeners[event] = handler;
+      }),
+      removeEventListener: vi.fn((event: string, handler: EventListener) => {
+        if (audioListeners[event] === handler) {
+          delete audioListeners[event];
+        }
       }),
     };
 

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -8,6 +8,7 @@ import { DropboxPlaybackAdapter } from '../dropboxPlaybackAdapter';
 import type { DropboxCatalogAdapter } from '../dropboxCatalogAdapter';
 import { makeMediaTrack } from '@/test/fixtures';
 import type { PlaybackState } from '@/types/domain';
+import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 
 // Mock DropboxCatalogAdapter
 const mockCatalog: Partial<DropboxCatalogAdapter> = {
@@ -97,6 +98,14 @@ describe('DropboxPlaybackAdapter', () => {
       if (eventListeners[event]) {
         eventListeners[event] = eventListeners[event].filter((l) => l !== listener);
       }
+    });
+
+    // Default play() behavior: resolve immediately and asynchronously fire
+    // the `playing` event so awaitInitialPlay settles. Individual tests
+    // override this to simulate error or supersession scenarios.
+    mockAudio.play.mockImplementation(() => {
+      queueMicrotask(() => mockAudio.__triggerEvent?.('playing'));
+      return Promise.resolve();
     });
 
     adapter = new DropboxPlaybackAdapter(mockCatalog as DropboxCatalogAdapter);
@@ -498,6 +507,91 @@ describe('DropboxPlaybackAdapter', () => {
 
       // #when / #then
       await expect(adapter.probePlayable(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+  });
+
+  describe('playTrack error recovery', () => {
+    it('rejects with UnavailableTrackError when the audio element fires error during initial play', async () => {
+      // #given — audio element fails to decode/load; play() resolves but error event fires
+      const track = makeMediaTrack({
+        id: 'track-broken',
+        name: 'Broken Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/broken.mp3' },
+      });
+      await adapter.initialize();
+      mockAudio.play.mockImplementation(() => {
+        queueMicrotask(() => mockAudio.__triggerEvent?.('error'));
+        return Promise.resolve();
+      });
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(UnavailableTrackError);
+    });
+
+    it('rejects with UnavailableTrackError when audio.play() itself rejects', async () => {
+      // #given — autoplay policy blocks play, or some other terminal play() rejection
+      const track = makeMediaTrack({
+        id: 'track-blocked',
+        name: 'Blocked Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/blocked.mp3' },
+      });
+      await adapter.initialize();
+      mockAudio.play.mockImplementation(() => Promise.reject(new Error('NotAllowedError')));
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(UnavailableTrackError);
+    });
+
+    it('rethrows AuthExpiredError from catalog.getTemporaryLink unchanged', async () => {
+      // #given — Dropbox refresh-token exchange failed before audio src is assigned
+      const track = makeMediaTrack({
+        id: 'track-auth',
+        name: 'Auth Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/auth.mp3' },
+      });
+      await adapter.initialize();
+      vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(
+        new AuthExpiredError('dropbox'),
+      );
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+
+    it('ignores a stale error event after a superseding playTrack', async () => {
+      // #given — first playTrack pending; a second playTrack supersedes it via prepareGeneration
+      const trackA = makeMediaTrack({
+        id: 'track-a',
+        name: 'Track A',
+        playbackRef: { provider: 'dropbox', ref: '/Music/a.mp3' },
+      });
+      const trackB = makeMediaTrack({
+        id: 'track-b',
+        name: 'Track B',
+        playbackRef: { provider: 'dropbox', ref: '/Music/b.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!)
+        .mockResolvedValueOnce('https://example.com/a.mp3')
+        .mockResolvedValueOnce('https://example.com/b.mp3');
+      await adapter.initialize();
+
+      // First play: never fires playing or error itself; the test will fire error AFTER B settles
+      mockAudio.play.mockImplementationOnce(() => Promise.resolve());
+
+      // #when — start A but don't let it settle; immediately supersede with B (which fires playing)
+      const playA = adapter.playTrack(trackA);
+      // Yield so A reaches awaitInitialPlay and attaches listeners
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Default mock (set in beforeEach) auto-fires playing for B
+      await adapter.playTrack(trackB);
+
+      // Now fire a stale error from A's prior src — must NOT reject A (or anything)
+      mockAudio.__triggerEvent?.('error');
+
+      // #then — A resolves cleanly because generation moved past it; no rejection
+      await expect(playA).resolves.toBeUndefined();
     });
   });
 });

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -5,7 +5,7 @@
 
 import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
-import { AuthExpiredError } from '@/providers/errors';
+import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { DropboxCatalogAdapter } from './dropboxCatalogAdapter';
 import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
@@ -98,7 +98,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.hydrateHint = null;
     this.audio!.pause();
     this.audio!.src = streamUrl;
-    await this.audio!.play();
+
+    await this.awaitInitialPlay(track, this.prepareGeneration);
 
     if (options?.positionMs) {
       this.audio!.currentTime = options.positionMs / 1000;
@@ -106,6 +107,58 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
     this.startUpdateInterval();
     this.enrichMetadataInBackground(track, streamUrl);
+  }
+
+  private awaitInitialPlay(track: MediaTrack, generation: number): Promise<void> {
+    const audio = this.audio!;
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = () => {
+        audio.removeEventListener('playing', onPlaying);
+        audio.removeEventListener('error', onError);
+      };
+
+      const onPlaying = () => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve();
+      };
+
+      const onError = () => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(new UnavailableTrackError(track.name));
+      };
+
+      audio.addEventListener('playing', onPlaying);
+      audio.addEventListener('error', onError);
+
+      audio.play().catch((err) => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        logCaughtError('dropboxPlaybackAdapter.awaitInitialPlay.audioPlay', err);
+        reject(new UnavailableTrackError(track.name));
+      });
+    });
   }
 
   private hydrateAlbumArtFromCache(track: MediaTrack): void {


### PR DESCRIPTION
## Summary
- Throw `UnavailableTrackError` from Dropbox `playTrack` on unrecoverable failures (audio element `error` event, `audio.play()` rejection)
- Reuse the engine's existing `skipOnError` path to advance the queue, matching Spotify behavior
- Satisfies playback-engine spec Requirement 5 (Error Recovery) for the Dropbox HTML5 audio path

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (2019/2019)
- `npm run build` green
- New unit tests cover: audio `error` during initial play, `audio.play()` rejection, `AuthExpiredError` passthrough, stale event after supersession

Closes #1561