### PR TITLE
fix(spotify): retry 401 with refresh and surface terminal auth failures

### DIFF
--- a/openspec/changes/spotify-api-401-retry/design.md
+++ b/openspec/changes/spotify-api-401-retry/design.md
@@ -1,0 +1,160 @@
+## Context
+
+The Spotify Web API layer (`src/services/spotify/api.ts`) currently has the shape:
+
+```ts
+async function executeApiRequest<T>(url, token, options) {
+  const response = await fetch(url, { ... });
+  handleRateLimitResponse(response);
+  if (!response.ok) {
+    throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
+  }
+  // ...
+}
+```
+
+The error is opaque — `status` is embedded in the message string. Two downstream sites in `spotifyPlaybackAdapter.ts` (lines 118 and 266) parse it back out with `message.includes('401')` to construct an `AuthExpiredError`. That's brittle and, more importantly, it skips the refresh-then-retry semantics that the Dropbox adapter implements (`dropboxApiClient.ts:74-82`):
+
+```ts
+let response = await makeRequest(token);
+if (response.status === 401) {
+  token = await this.auth.refreshAccessToken();
+  if (!token) throw new AuthExpiredError('dropbox');
+  response = await makeRequest(token);
+  if (response.status === 401) {
+    this.auth.reportUnauthorized();
+    throw new AuthExpiredError('dropbox');
+  }
+}
+```
+
+`reportUnauthorized()` on the Dropbox auth adapter logs out and dispatches the shared `SESSION_EXPIRED_EVENT`. Spotify's `notifySessionExpired()` exists in `src/services/spotify/auth.ts:193-198` but is private and only fires from `performRefresh()` on a 400/401 refresh failure — never from a downstream 401 in user-data requests.
+
+This change brings the Spotify API surface into parity with Dropbox on the auth-expiry contract while keeping the rest of `executeApiRequest`'s behavior (in-flight dedup, 429 backoff, single-flight refresh) untouched.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A structured `SpotifyApiError` carries the HTTP `status` (plus optional `statusText`) so downstream code can branch on `err.status` instead of `err.message.includes(...)`.
+- A single retry-after-refresh on 401: first 401 forces `spotifyAuth.refreshAccessToken()` and re-issues the request; second 401 throws `AuthExpiredError('spotify')` and calls a new public `spotifyAuth.reportUnauthorized()` (logs out + dispatches `SESSION_EXPIRED_EVENT`).
+- The two `.includes('401')` parse sites in `spotifyPlaybackAdapter.ts` use the structured error.
+- Behavior unchanged for non-401 errors: 5xx / network / unknown statuses still propagate as `SpotifyApiError` (i.e. transient, no logout).
+- `apiPlayTrack` / `apiPlayContext` / `apiPlayPlaylist` in `src/services/spotifyPlayerPlayback.ts` throw the same structured `SpotifyApiError` so the playback adapter sees the same type regardless of which code path produced the 401.
+
+**Non-Goals:**
+
+- Modifying Dropbox code. The Dropbox provider is the reference pattern, not the target.
+- Restructuring 403 / 429 handling in `spotifyPlaybackAdapter.playWithRetry`. Those `message.includes('403')` / `'429'` branches will get the same structured-error treatment in a follow-up change. This change is narrowly scoped to 401.
+- Adding a retry budget beyond `1`. Multiple refresh attempts during a single request would race with the auth singleton's `refreshInFlight` lock and would not improve recovery.
+- Changing the public function signature of `spotifyApiRequest<T>(url, token, options)`. Callers still pass the token explicitly; the wrapper re-acquires the token from `spotifyAuth.ensureValidToken()` only on the retry path.
+- Touching `useProviderPlayback.ts` / `useQueueManagement.ts` (other issues in this wave).
+
+## Decisions
+
+### Decision 1 — `SpotifyApiError extends Error` carries `status`
+
+**Choice:** Define and export `SpotifyApiError` from `src/services/spotify/api.ts`:
+
+```ts
+export class SpotifyApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  constructor(status: number, statusText: string) {
+    super(`Spotify API error: ${status} ${statusText}`);
+    this.name = 'SpotifyApiError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+```
+
+The `message` keeps the legacy format so existing log output / Sentry breadcrumbs are unchanged.
+
+**Why:**
+
+- A named subclass lets call sites use `instanceof SpotifyApiError` and `err.status` instead of regex/substring matching.
+- Keeping the legacy message text avoids invalidating any out-of-band log analysis or breadcrumb queries that match `Spotify API error:`.
+- Co-locating the class with `executeApiRequest` mirrors the pattern Dropbox uses (`AuthExpiredError` lives in `src/providers/errors.ts`; `dropboxApiClient.ts` throws plain `Error` for non-401s because Dropbox has no equivalent need for downstream `status` branching yet).
+
+**Alternatives considered:**
+
+- *Add a `status` field to `Error` directly.* Rejected — TypeScript doesn't allow augmenting the base `Error` cleanly without `as any` or a `// @ts-expect-error`, both blocked by project rules.
+- *Re-use `AuthExpiredError` for every non-OK response.* Rejected — conflates terminal auth failure with transient errors and would falsely log the user out on a 5xx.
+
+### Decision 2 — Use existing `AuthExpiredError` for the terminal-401 signal
+
+**Choice:** When the second 401 happens (after refresh), throw `AuthExpiredError('spotify')` from `@/providers/errors`. Do not introduce a `SpotifyAuthExpiredError` subclass.
+
+**Why:**
+
+- `AuthExpiredError` is already the cross-provider terminal-auth signal: `spotifyPlaybackAdapter.ts:119, 266`, `useSpotifyPlaylistManager.ts:218`, `dropboxApiClient.ts:80`, etc. all branch on it.
+- Adding a Spotify-specific subclass would force every consumer to widen its `catch` block; a flat single error type keeps the contract simple.
+- The `providerId` field on `AuthExpiredError` already distinguishes the two providers when needed.
+
+### Decision 3 — Single retry-after-refresh, force-refresh via `refreshAccessToken()`
+
+**Choice:** On the first 401, call `spotifyAuth.refreshAccessToken()` (not `ensureValidToken`), then read the fresh access token via `spotifyAuth.getAccessToken()` and re-issue the request with it. If still 401, throw `AuthExpiredError('spotify')` and call `spotifyAuth.reportUnauthorized()`.
+
+**Why:**
+
+- `ensureValidToken()` only refreshes when the token is within the 5-minute expiry buffer. A token that's been server-side revoked but not yet near expiry would short-circuit through `ensureValidToken` without refreshing, and the retry would re-use the same dead token. Forcing `refreshAccessToken()` bypasses that.
+- The Spotify auth singleton already has a single-flight guard (`refreshInFlight`) inside `refreshAccessToken`, so concurrent 401 retries from different requests collapse onto one network refresh — same shape as Dropbox.
+- Capping the retry at one mirrors Dropbox, prevents infinite refresh loops, and aligns with HTTP best practices for stale-token replay.
+
+**Alternatives considered:**
+
+- *Retry indefinitely with exponential backoff.* Rejected — a persistent 401 means the refresh token has been revoked; further retries waste battery and never recover.
+- *Skip the retry when `refreshAccessToken()` itself fails.* Already handled: `refreshAccessToken` throws when no refresh token exists or the refresh endpoint returns 400/401; the wrapper catches and re-raises as `AuthExpiredError('spotify')` after calling `reportUnauthorized()`.
+
+### Decision 4 — Promote `notifySessionExpired()` to a public `reportUnauthorized()` method
+
+**Choice:** Add a public `reportUnauthorized(): void` on the `spotifyAuth` singleton that performs `logout()` then dispatches `SESSION_EXPIRED_EVENT` (i.e. the existing `notifySessionExpired` private). The private `notifySessionExpired()` is removed; its single internal call site in `performRefresh()` is updated to call `reportUnauthorized()` instead.
+
+**Why:**
+
+- Mirrors `DropboxAuthAdapter.reportUnauthorized()` — same name, same semantics (clear tokens + notify).
+- Encapsulates "session is unrecoverable" in one place: callers don't need to remember to `logout()` + `notifySessionExpired()` in the right order.
+- Avoids exposing `notifySessionExpired` as public on its own, which would be a footgun (dispatching the event without clearing tokens leaves the app in an inconsistent state).
+
+**Alternatives considered:**
+
+- *Just make `notifySessionExpired` public.* Rejected — callers would have to remember to call `logout()` first or risk leaving stale tokens in `localStorage`.
+
+### Decision 5 — Wrap the retry inside `spotifyApiRequest`, not `executeApiRequest`
+
+**Choice:** Keep `executeApiRequest` as the low-level fetch + status-check that throws `SpotifyApiError`. Add the 401 retry-after-refresh logic inside `spotifyApiRequest`, which already owns rate-limit gating and request dedup.
+
+**Why:**
+
+- `executeApiRequest` is also called from inside the dedup `Promise` cached in `inflightRequests`. If we put the retry there, two concurrent GETs to the same URL would dedup into the same retry, which is fine — but the first 401 retry would re-enter `executeApiRequest` with the stale `token` parameter. Keeping the retry one level up lets us recompute the token for the retry call cleanly.
+- Single-flight: when `refreshAccessToken()` is in flight, all concurrent 401 retries await the same refresh and re-fire with the same fresh token. The dedup map in `spotifyApiRequest` continues to work because the retry uses a different `token`-bearing closure but the same URL/method key — the dedup logic still returns the in-flight promise to a second caller hitting the same URL.
+
+### Decision 6 — `apiPlayTrack` and friends throw `SpotifyApiError` too
+
+**Choice:** `apiPlayTrack`, `apiPlayContext`, and `apiPlayPlaylist` in `src/services/spotifyPlayerPlayback.ts` change their `throw new Error(...)` to `throw new SpotifyApiError(status, ...)`. The `parsePlayError` helper continues to format the rich message (including `error.reason`, `Retry-After`, etc.) but the thrown object now carries the structured `status` field.
+
+**Why:**
+
+- The 401 path the issue calls out (line 118 in `spotifyPlaybackAdapter.ts`) actually comes from `spotifyPlayer.playTrack()` → `apiPlayTrack()`, not from `spotifyApiRequest`. If `apiPlayTrack` keeps throwing a plain `Error`, line 118's `instanceof SpotifyApiError` check fails and we'd still need `.includes('401')` parsing as a fallback.
+- `apiPlayTrack` does not get the retry-after-refresh treatment (the play endpoint is more sensitive to replay, and the existing `playWithRetry` already retries with its own state machine). It only adopts the structured error type — the retry path stays in `playWithRetry`.
+
+**Alternatives considered:**
+
+- *Route `apiPlayTrack` through `spotifyApiRequest`.* Rejected — the request body, headers, and play-error message formatting are specific to the play endpoint, and routing through the generic helper would lose the `parsePlayError` shape that surfaces `error.reason` and `Retry-After` to logs.
+
+## Risks / Trade-offs
+
+- **Risk:** A 401 occurring inside the dedup window for a GET request would refresh once and retry; if the second 401 fires for one caller while another concurrent caller is mid-flight on the original token, only one of them will see `AuthExpiredError`. **Mitigation:** the dedup map keys by URL+method, so both concurrent callers share the *same* promise — the retry happens once and both callers receive the same outcome (success or `AuthExpiredError`). Verified by reading the dedup logic: `inflightRequests.get(key)` returns the existing promise, including its rejection.
+
+- **Risk:** `reportUnauthorized()` calls `logout()` which clears `localStorage.spotify_token`. If a refresh-then-retry sequence is racing a user-initiated re-auth (e.g. the user re-clicked the Spotify toggle mid-401), we could clear a token the user just set. **Mitigation:** `reportUnauthorized` only fires when the *second* 401 happens, by which point the post-refresh token was rejected — so any token in storage at that point is dead. The user-initiated re-auth would write a fresh token *after* the clear, so the worst case is a momentarily empty `localStorage` slot, not a lost session.
+
+- **Risk:** Existing callers that catch `Error` and inspect `err.message` to display a toast would still see the same message, but cosmetic differences (e.g. `SpotifyApiError` vs `Error` in console traces) might surprise reviewers. **Mitigation:** `SpotifyApiError` extends `Error`, sets `name = 'SpotifyApiError'`, and uses the same `message` format. Existing `instanceof Error` checks continue to work.
+
+- **Trade-off:** This change focuses on 401 only; the 403 / 429 parsing in `spotifyPlaybackAdapter.playWithRetry` remains string-based. The structured `SpotifyApiError` makes that follow-up cleanup trivial (`err.status === 429` instead of `message.includes('429')`), but is deferred to keep this change focused.
+
+## Spec strategy
+
+The behavioral contract this change codifies — Spotify Web API requests retry once after a forced token refresh on 401 and surface a terminal 401 as a structured `AuthExpiredError` plus a session-expired notification — is already captured in `openspec/specs/auth-system/spec.md` Requirements 5 ("Transient vs Terminal Failure Handling") and 6 ("Mid-Session Unrecoverable Auth Failure"), but only at the *general* provider level. Today neither requirement names a Spotify-specific scenario, so the Spotify implementation drifted (no retry, message-string parsing) without violating the literal text.
+
+The delta adds one **MODIFIED Requirement** block for each of these two requirements, keeping the existing language and adding Spotify-specific scenarios that pin down the one-shot retry-after-refresh contract and the terminal-401 handling. The general transient-vs-terminal language stays intact and continues to govern Dropbox.

--- a/openspec/changes/spotify-api-401-retry/proposal.md
+++ b/openspec/changes/spotify-api-401-retry/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Spotify Web API calls in `src/services/spotify/api.ts` (`executeApiRequest`, lines 43-72) throw a generic `Error("Spotify API error: <status> <text>")` on every non-OK response. There is no 401 retry-after-refresh, no terminal-vs-transient distinction, and no path that surfaces a persistent 401 to the auth layer. Downstream code (`src/providers/spotify/spotifyPlaybackAdapter.ts:118, 266`) is forced to parse the status out of the error message string with `.includes('401')` — brittle and easy to break when the message format changes.
+
+Compare with the Dropbox provider (`src/providers/dropbox/dropboxApiClient.ts:74-82`, `dropboxContentApiClient.ts:29-37`): a 401 forces one refresh, retries once, and on a second 401 calls `reportUnauthorized()` which logs out and notifies the UI via the shared `SESSION_EXPIRED_EVENT`.
+
+This gap violates [`openspec/specs/auth-system/spec.md`](../../specs/auth-system/spec.md) Requirements 5 (Transient vs Terminal Failure Handling) and 6 (Mid-Session Unrecoverable Auth Failure): the Spotify provider currently fails an expired-token request once and surfaces a generic error, instead of forcing a refresh, retrying, and — only when the refreshed token is still rejected — performing a terminal logout + session-expired notification.
+
+Tracks issue #1553.
+
+## What Changes
+
+- Export a structured `SpotifyApiError extends Error` from `src/services/spotify/api.ts` carrying `status: number` (and the response status text). Existing call sites that catch generic `Error` continue to work.
+- Reuse the existing `AuthExpiredError` (`src/providers/errors.ts`) as the terminal-401 signal so the rest of the provider/playback layer keeps a single auth-expired contract across providers.
+- Wrap the public `spotifyApiRequest` with a single retry-after-refresh on 401: on the first 401, force a token refresh via `spotifyAuth.refreshAccessToken()`, re-issue the request with the fresh token; on a second 401 throw `AuthExpiredError('spotify')` and trigger session-expired notification + logout via a new public `spotifyAuth.reportUnauthorized()` (mirroring the Dropbox adapter).
+- Promote `notifySessionExpired()` to a public `reportUnauthorized()` on the auth singleton so the api layer can call it without reaching into a private method.
+- Replace the brittle `message.includes('401')` checks in `spotifyPlaybackAdapter.ts:118, 266` with `instanceof AuthExpiredError` / `instanceof SpotifyApiError && err.status === 401` checks. Update `apiPlayTrack` in `src/services/spotifyPlayerPlayback.ts` to throw the same `SpotifyApiError` so the structured-error contract reaches the playback adapter.
+
+No public-component change, no UI change, no keyboard shortcut change. The Dropbox provider is not touched.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `auth-system` — Requirement 5 (Transient vs Terminal Failure Handling) and Requirement 6 (Mid-Session Unrecoverable Auth Failure) gain Spotify-specific scenarios that pin down the one-shot retry-after-refresh contract and the terminal-401 handling. The general transient/terminal language stays unchanged.
+
+### New Capabilities
+
+None.
+
+## Impact
+
+- `src/services/spotify/api.ts` — adds `SpotifyApiError`, retry-after-refresh wrapper around `executeApiRequest`, calls `spotifyAuth.refreshAccessToken()` and `spotifyAuth.reportUnauthorized()`.
+- `src/services/spotify/auth.ts` — adds public `reportUnauthorized()` (logs out + notifies session expired); existing private `notifySessionExpired()` is now invoked from this public method only.
+- `src/services/spotifyPlayerPlayback.ts` — `apiPlayTrack` (and the other `apiPlay*` helpers) throw `SpotifyApiError` instead of a generic `Error` so the structured-error contract reaches `SpotifyPlaybackAdapter`.
+- `src/providers/spotify/spotifyPlaybackAdapter.ts` — replaces `.includes('401')` parsing at lines 118 and 266 with `instanceof AuthExpiredError` / `SpotifyApiError && status === 401` checks. Continues to parse 403 / 429 strings until those errors also reach the adapter as structured types (out of scope for this change).
+- `openspec/specs/auth-system/spec.md` — adds two Spotify-specific scenarios under Requirements 5 and 6.
+- `src/services/spotify/__tests__/` — new test covering `executeApiRequest` retry-after-refresh, terminal-401 logout, and structured-error fields.
+- `src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts` — existing 401 test (`probePlayable`) keeps passing under the new error contract.
+
+Out of scope:
+- Dropbox provider (`src/providers/dropbox/`): not touched.
+- `useProviderPlayback.ts`, `useQueueManagement.ts`: belong to other issues in the same wave.
+- 403 / 429 structured-error promotion in the playback adapter: tracked separately; this change only flips 401 to structured.

--- a/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
+++ b/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Transient vs Terminal Failure Handling
+
+A provider SHALL distinguish transient failures from terminal authentication failures so that refresh tokens are preserved across retryable network errors and the user is logged out only on terminal failures.
+
+#### Scenario: Transient failure
+
+- **WHEN** a provider request fails with a transient error (network failure or server-side error)
+- **THEN** the refresh token is preserved and the user is not logged out
+
+#### Scenario: Terminal authentication failure
+
+- **WHEN** a provider request fails with a terminal authentication error
+- **THEN** the provider performs a full logout
+
+#### Scenario: Spotify Web API request receives a 401 with a non-expired refresh token
+
+- **WHEN** a Spotify Web API request returns HTTP 401 and the auth singleton holds a refresh token
+- **THEN** the provider forces a token refresh, retries the request once with the fresh access token, and treats the result as success if the retry returns a 2xx
+- **AND** the user is NOT logged out
+
+#### Scenario: Spotify Web API exposes status via structured error
+
+- **WHEN** a Spotify Web API request fails with a non-OK HTTP status (other than the 401-then-refreshed-then-OK path)
+- **THEN** the thrown error carries the HTTP `status` (and `statusText`) as structured fields rather than only embedding them in the message string
+- **AND** downstream consumers branch on the structured `status` rather than parsing the error message
+
+### Requirement: Mid-Session Unrecoverable Auth Failure
+
+When a provider's session becomes unrecoverable during normal use, the app SHALL log the provider out automatically and notify the user.
+
+#### Scenario: Provider returns terminal auth error during use
+
+- **WHEN** a provider reports an unrecoverable authentication failure during normal use
+- **THEN** the provider is logged out automatically and a "session expired" notification is shown
+
+#### Scenario: Spotify Web API returns 401 after a forced refresh
+
+- **WHEN** a Spotify Web API request returns HTTP 401, the auth singleton forces a refresh, and the retried request still returns HTTP 401
+- **THEN** the Spotify provider performs a full logout
+- **AND** a "session expired" notification is dispatched on the shared `SESSION_EXPIRED_EVENT` bus
+- **AND** the call site receives an `AuthExpiredError` carrying `providerId: 'spotify'`

--- a/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
+++ b/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
@@ -16,9 +16,10 @@ A provider SHALL distinguish transient failures from terminal authentication fai
 
 #### Scenario: Spotify Web API request receives a 401 with a non-expired refresh token
 
-- **WHEN** a Spotify Web API request returns HTTP 401 and the auth singleton holds a refresh token
+- **WHEN** a `spotifyApiRequest`-based catalog/library request (i.e. requests routed through the shared API wrapper, excluding the player-playback control endpoints in `spotifyPlayerPlayback.ts`) returns HTTP 401 and the auth singleton holds a refresh token
 - **THEN** the provider forces a token refresh, retries the request once with the fresh access token, and treats the result as success if the retry returns a 2xx
 - **AND** the user is NOT logged out
+- **AND** if the refresh endpoint itself fails with a transient error (network blip, 5xx), the original `SpotifyApiError` carrying `status: 401` is rethrown — the user is NOT logged out and the refresh token is preserved
 
 #### Scenario: Spotify Web API exposes status via structured error
 

--- a/openspec/changes/spotify-api-401-retry/tasks.md
+++ b/openspec/changes/spotify-api-401-retry/tasks.md
@@ -1,0 +1,41 @@
+## 1. Structured error type
+
+- [x] 1.1 In `src/services/spotify/api.ts`, define and export `SpotifyApiError extends Error` carrying `status: number` and `statusText: string`. Keep the legacy message format (`Spotify API error: <status> <statusText>`).
+- [x] 1.2 Update `executeApiRequest` to throw `SpotifyApiError` instead of generic `Error`.
+
+## 2. Public reportUnauthorized on auth singleton
+
+- [x] 2.1 In `src/services/spotify/auth.ts`, add a public `reportUnauthorized(): void` that performs `this.logout()` then dispatches `SESSION_EXPIRED_EVENT`.
+- [x] 2.2 Update `performRefresh()` to call `this.reportUnauthorized()` instead of `this.logout() + this.notifySessionExpired()`.
+- [x] 2.3 Remove the now-redundant private `notifySessionExpired()` if its only call site was `performRefresh()`.
+
+## 3. Retry-after-refresh in spotifyApiRequest
+
+- [x] 3.1 Refactor `spotifyApiRequest` so its non-dedup return path goes through a single wrapper that catches `SpotifyApiError` with `status === 401`, forces a refresh via `spotifyAuth.refreshAccessToken()`, re-issues the request with the fresh token, and on a second 401 throws `AuthExpiredError('spotify')` after calling `spotifyAuth.reportUnauthorized()`.
+- [x] 3.2 Ensure the dedup map still keys correctly across the retry — the retry should not create a duplicate entry.
+- [x] 3.3 Verify the 429 backoff and `inflightRequests` cleanup still work after the refactor.
+
+## 4. apiPlayTrack and friends throw SpotifyApiError
+
+- [x] 4.1 In `src/services/spotifyPlayerPlayback.ts`, change `apiPlayTrack`, `apiPlayContext`, and `apiPlayPlaylist` to throw `SpotifyApiError` (preserving the rich `parsePlayError` message).
+- [x] 4.2 Do **not** add retry-after-refresh inside `apiPlayTrack`; only the error type changes. The existing `playWithRetry` state machine continues to handle 403 / 429 retries.
+
+## 5. Update spotifyPlaybackAdapter parse sites
+
+- [x] 5.1 In `src/providers/spotify/spotifyPlaybackAdapter.ts` (`playWithRetry`, around line 118), replace the `message.includes('401') || message.toLowerCase().includes('unauthorized')` branch with `error instanceof AuthExpiredError ? rethrow : error instanceof SpotifyApiError && error.status === 401 ? throw new AuthExpiredError('spotify') : ...`.
+- [x] 5.2 In `probePlayable` (around line 266), replace `message.includes('401') ? throw new AuthExpiredError(...)` with `err instanceof SpotifyApiError && err.status === 401 ? throw new AuthExpiredError('spotify') : ...`. Keep the `404 → false` branch but route it through `err.status === 404` instead of `message.includes('404')`.
+
+## 6. Tests
+
+- [x] 6.1 Add `src/services/spotify/__tests__/api.test.ts` (or extend an existing one) covering:
+  - `executeApiRequest` throws `SpotifyApiError` with `status === 500` on a transient 5xx (the user is not logged out).
+  - `spotifyApiRequest` retries once on 401: first 401 triggers `spotifyAuth.refreshAccessToken()`, second call succeeds, no `AuthExpiredError` thrown.
+  - `spotifyApiRequest` throws `AuthExpiredError('spotify')` on a second 401 after refresh and calls `spotifyAuth.reportUnauthorized()`.
+- [x] 6.2 Confirm the existing `spotifyPlaybackAdapterPrepareTrack.test.ts` 401 case (`probePlayable`) still passes under the new error contract.
+- [x] 6.3 Run `npm run test:run` and confirm zero new failures.
+
+## 7. Verify
+
+- [x] 7.1 `npx tsc -b --noEmit` clean.
+- [x] 7.2 `npm run test:run` green.
+- [x] 7.3 `npm run build` green.

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -7,7 +7,7 @@ import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
 import { spotifyPlayer, waitForSpotifyReady } from '@/services/spotifyPlayer';
 import { spotifyAuth } from '@/services/spotify';
-import { spotifyApiRequest } from '@/services/spotify/api';
+import { spotifyApiRequest, SpotifyApiError } from '@/services/spotify/api';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
@@ -113,17 +113,24 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     try {
       await spotifyPlayer.playTrack(uri, upcomingUris, positionMs);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      if (message.includes('401') || message.toLowerCase().includes('unauthorized')) {
+      if (error instanceof AuthExpiredError) {
+        throw error;
+      }
+      if (error instanceof SpotifyApiError && error.status === 401) {
         throw new AuthExpiredError('spotify');
       }
+
+      const message = error instanceof Error ? error.message : String(error);
 
       if (retryCount >= SPOTIFY_MAX_RETRIES) {
         throw error;
       }
 
-      if (message.includes('429')) {
+      const status = error instanceof SpotifyApiError ? error.status : null;
+      const is429 = status === 429 || (status === null && message.includes('429'));
+      const is403 = status === 403 || (status === null && message.includes('403'));
+
+      if (is429) {
         const retryAfterMatch = message.match(/retry.?after[:\s]+(\d+)/i);
         const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1], 10) : 0;
         const backoffMs = retryAfterSec > 0
@@ -134,7 +141,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
-      if (message.includes('403')) {
+      if (is403) {
         if (message.includes('Restriction violated')) {
           throw new UnavailableTrackError(trackName);
         }
@@ -262,9 +269,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       );
       return body.is_playable !== false;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('401')) throw new AuthExpiredError('spotify');
-      if (message.includes('404')) return false;
+      if (err instanceof AuthExpiredError) throw err;
+      if (err instanceof SpotifyApiError) {
+        if (err.status === 401) throw new AuthExpiredError('spotify');
+        if (err.status === 404) return false;
+      }
       throw err;
     }
   }

--- a/src/services/__tests__/spotifyAuth.test.ts
+++ b/src/services/__tests__/spotifyAuth.test.ts
@@ -405,4 +405,46 @@ describe('SpotifyAuth', () => {
       expect(window.history.replaceState).toHaveBeenCalled();
     });
   });
+
+  describe('reportUnauthorized', () => {
+    it('dispatches SESSION_EXPIRED_EVENT even when tokenData is already null', async () => {
+      // #given — no token in storage, so tokenData starts as null
+      const auth = await freshAuth();
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      auth.reportUnauthorized();
+
+      // #then — the event still fires; the absent-tokenData branch no longer
+      // silently suppresses the toast for callers invoking after logout().
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('does not double-dispatch when called twice in the same session', async () => {
+      // #given — token present, then reportUnauthorized twice (simulates
+      // performRefresh 400/401 → reportUnauthorized → executeWithAuthRetry
+      // catch → reportUnauthorized again).
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      auth.reportUnauthorized();
+      auth.reportUnauthorized();
+
+      // #then — exactly one session-expired event reaches listeners
+      const sessionExpiredEvents = dispatchSpy.mock.calls.filter(
+        call => (call[0] as Event).type === 'vorbis-session-expired',
+      );
+      expect(sessionExpiredEvents).toHaveLength(1);
+      dispatchSpy.mockRestore();
+    });
+  });
 });

--- a/src/services/spotify/__tests__/api.test.ts
+++ b/src/services/spotify/__tests__/api.test.ts
@@ -105,10 +105,13 @@ describe('spotifyApiRequest — structured errors and retry-after-refresh', () =
     expect(reportUnauthorized).toHaveBeenCalledTimes(1);
   });
 
-  it('throws AuthExpiredError and calls reportUnauthorized when refresh itself fails', async () => {
-    // #given — first call 401, refresh throws (e.g. no refresh token)
+  it('throws AuthExpiredError when refresh fails terminally (auth cleared by performRefresh)', async () => {
+    // #given — first call 401, refresh throws AND performRefresh cleared tokenData
+    //          (i.e. accounts.spotify.com/api/token returned 400/401 and the auth
+    //          singleton already invoked reportUnauthorized → logout → getAccessToken null)
     fetchMock.mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
-    refreshAccessToken.mockRejectedValue(new Error('No refresh token available'));
+    refreshAccessToken.mockRejectedValue(new Error('Token refresh failed: Bad Request'));
+    getAccessToken.mockReturnValue(null);
 
     // #when / #then
     const promise = spotifyApiRequest<unknown>(
@@ -117,7 +120,28 @@ describe('spotifyApiRequest — structured errors and retry-after-refresh', () =
       { method: 'POST' },
     );
     await expect(promise).rejects.toBeInstanceOf(AuthExpiredError);
-    expect(reportUnauthorized).toHaveBeenCalledTimes(1);
+    // reportUnauthorized was called by performRefresh itself, not by the wrapper —
+    // the wrapper relies on the cleared-token signal and does not re-invoke it.
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows original SpotifyApiError(401) on transient refresh failure (network blip / 5xx)', async () => {
+    // #given — first call 401, refresh throws a transient error (network blip),
+    //          and the auth singleton still has its tokenData (getAccessToken returns the stale token)
+    fetchMock.mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockRejectedValue(new Error('network blip'));
+    getAccessToken.mockReturnValue('token-1-stale');
+
+    // #when / #then — caller sees the original 401, not AuthExpiredError; user is NOT logged out
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 401 });
+    expect(reportUnauthorized).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/services/spotify/__tests__/api.test.ts
+++ b/src/services/spotify/__tests__/api.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const refreshAccessToken = vi.fn();
+const getAccessToken = vi.fn();
+const reportUnauthorized = vi.fn();
+
+vi.mock('../auth', () => ({
+  spotifyAuth: {
+    refreshAccessToken: (...args: unknown[]) => refreshAccessToken(...args),
+    getAccessToken: (...args: unknown[]) => getAccessToken(...args),
+    reportUnauthorized: (...args: unknown[]) => reportUnauthorized(...args),
+  },
+}));
+
+import { spotifyApiRequest, SpotifyApiError } from '../api';
+import { AuthExpiredError } from '@/providers/errors';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function emptyResponse(status: number, statusText = ''): Response {
+  return new Response(null, { status, statusText });
+}
+
+describe('spotifyApiRequest — structured errors and retry-after-refresh', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    refreshAccessToken.mockReset();
+    getAccessToken.mockReset();
+    reportUnauthorized.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws SpotifyApiError carrying status on a 5xx (transient — no refresh, no logout)', async () => {
+    // #given — server returns 500
+    fetchMock.mockResolvedValueOnce(emptyResponse(500, 'Internal Server Error'));
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 500 });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('forces a refresh and retries once on first 401, succeeding on the retry', async () => {
+    // #given — first call 401, second call (after refresh) 200
+    fetchMock
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'))
+      .mockResolvedValueOnce(jsonResponse({ id: 'me-1' }));
+    refreshAccessToken.mockResolvedValue(undefined);
+    getAccessToken.mockReturnValue('token-2-fresh');
+
+    // #when
+    const result = await spotifyApiRequest<{ id: string }>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+
+    // #then
+    expect(result).toEqual({ id: 'me-1' });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+
+    // #and the retry used the freshly-refreshed token
+    const retryInit = fetchMock.mock.calls[1][1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>).Authorization).toBe(
+      'Bearer token-2-fresh',
+    );
+  });
+
+  it('throws AuthExpiredError and calls reportUnauthorized on a second 401 after refresh', async () => {
+    // #given — both calls 401; refresh succeeds but the freshly-minted token is also rejected
+    fetchMock
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'))
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockResolvedValue(undefined);
+    getAccessToken.mockReturnValue('token-2-fresh-but-dead');
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(AuthExpiredError);
+    await expect(promise).rejects.toMatchObject({ providerId: 'spotify' });
+    expect(reportUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws AuthExpiredError and calls reportUnauthorized when refresh itself fails', async () => {
+    // #given — first call 401, refresh throws (e.g. no refresh token)
+    fetchMock.mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockRejectedValue(new Error('No refresh token available'));
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(AuthExpiredError);
+    expect(reportUnauthorized).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on non-401 errors (e.g. 403)', async () => {
+    // #given — server returns 403
+    fetchMock.mockResolvedValueOnce(emptyResponse(403, 'Forbidden'));
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me/player',
+      'token-1',
+      { method: 'PUT' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 403 });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -98,7 +98,17 @@ async function executeApiRequest<T>(
  * and notify the auth layer via `reportUnauthorized()`, which logs out and
  * dispatches `SESSION_EXPIRED_EVENT`.
  *
- * Non-401 errors propagate as `SpotifyApiError` (transient — no logout).
+ * Refresh-endpoint failures are split: a terminal 400/401 from
+ * `accounts.spotify.com/api/token` (`performRefresh` already cleared
+ * `tokenData` and called `reportUnauthorized()`) escalates to
+ * `AuthExpiredError`. Any other refresh exception (network blip, 5xx) is
+ * treated as transient — we rethrow the original `SpotifyApiError(401)` so
+ * the caller can retry later without the user being logged out. This mirrors
+ * `performRefresh`'s policy of only treating 400/401 from the refresh
+ * endpoint as terminal.
+ *
+ * Non-401 errors from the resource request propagate as `SpotifyApiError`
+ * (transient — no logout).
  */
 async function executeWithAuthRetry<T>(
   url: string,
@@ -123,8 +133,10 @@ async function executeWithAuthRetry<T>(
       refreshedToken = next;
     } catch (refreshErr) {
       if (refreshErr instanceof AuthExpiredError) throw refreshErr;
-      spotifyAuth.reportUnauthorized();
-      throw new AuthExpiredError('spotify');
+      if (spotifyAuth.getAccessToken() === null) {
+        throw new AuthExpiredError('spotify');
+      }
+      throw err;
     }
 
     try {

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -1,5 +1,25 @@
 import type { PaginatedResponse } from './types';
 import { SPOTIFY_RATE_LIMIT_WAIT_S } from '@/constants/spotify';
+import { spotifyAuth } from './auth';
+import { AuthExpiredError } from '@/providers/errors';
+
+/**
+ * Structured error thrown for any non-OK Spotify Web API response.
+ * Carries the HTTP `status` so downstream consumers can branch on the status
+ * code without parsing the error message string. The message format is kept
+ * stable (`Spotify API error: <status> <statusText>`) so log/breadcrumb queries
+ * targeting the legacy generic-Error message continue to match.
+ */
+export class SpotifyApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  constructor(status: number, statusText: string, message?: string) {
+    super(message ?? `Spotify API error: ${status} ${statusText}`);
+    this.name = 'SpotifyApiError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
 
 // =============================================================================
 // Rate Limiting & Request Deduplication
@@ -57,7 +77,7 @@ async function executeApiRequest<T>(
   handleRateLimitResponse(response);
 
   if (!response.ok) {
-    throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
+    throw new SpotifyApiError(response.status, response.statusText);
   }
 
   if (response.status === 204) {
@@ -69,6 +89,54 @@ async function executeApiRequest<T>(
     return undefined as T;
   }
   return JSON.parse(text);
+}
+
+/**
+ * Wrap a single `executeApiRequest` call with one-shot retry-after-refresh on
+ * 401: on the first 401 we force a token refresh and re-issue the request with
+ * the freshly-minted access token; on a second 401 we throw `AuthExpiredError`
+ * and notify the auth layer via `reportUnauthorized()`, which logs out and
+ * dispatches `SESSION_EXPIRED_EVENT`.
+ *
+ * Non-401 errors propagate as `SpotifyApiError` (transient — no logout).
+ */
+async function executeWithAuthRetry<T>(
+  url: string,
+  token: string,
+  options: RequestInit,
+): Promise<T> {
+  try {
+    return await executeApiRequest<T>(url, token, options);
+  } catch (err) {
+    if (!(err instanceof SpotifyApiError) || err.status !== 401) {
+      throw err;
+    }
+
+    let refreshedToken: string;
+    try {
+      await spotifyAuth.refreshAccessToken();
+      const next = spotifyAuth.getAccessToken();
+      if (!next) {
+        spotifyAuth.reportUnauthorized();
+        throw new AuthExpiredError('spotify');
+      }
+      refreshedToken = next;
+    } catch (refreshErr) {
+      if (refreshErr instanceof AuthExpiredError) throw refreshErr;
+      spotifyAuth.reportUnauthorized();
+      throw new AuthExpiredError('spotify');
+    }
+
+    try {
+      return await executeApiRequest<T>(url, refreshedToken, options);
+    } catch (retryErr) {
+      if (retryErr instanceof SpotifyApiError && retryErr.status === 401) {
+        spotifyAuth.reportUnauthorized();
+        throw new AuthExpiredError('spotify');
+      }
+      throw retryErr;
+    }
+  }
 }
 
 export async function spotifyApiRequest<T>(
@@ -93,14 +161,14 @@ export async function spotifyApiRequest<T>(
       return existing as Promise<T>;
     }
 
-    const promise = executeApiRequest<T>(url, token, options).finally(() => {
+    const promise = executeWithAuthRetry<T>(url, token, options).finally(() => {
       inflightRequests.delete(key);
     });
     inflightRequests.set(key, promise);
     return promise;
   }
 
-  return executeApiRequest<T>(url, token, options);
+  return executeWithAuthRetry<T>(url, token, options);
 }
 
 export async function fetchAllPaginated<TItem, TResult>(

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -176,8 +176,7 @@ class SpotifyAuth {
 
     if (!response.ok) {
       if (response.status === 400 || response.status === 401) {
-        this.logout();
-        this.notifySessionExpired();
+        this.reportUnauthorized();
       }
       throw new Error(`Token refresh failed: ${response.statusText}`);
     }
@@ -190,7 +189,14 @@ class SpotifyAuth {
     });
   }
 
-  private notifySessionExpired(): void {
+  /**
+   * Called by API consumers when a freshly-refreshed token is still rejected (401).
+   * Treats this as an invalid session: clears all tokens and notifies the UI.
+   */
+  public reportUnauthorized(): void {
+    if (!this.tokenData) return;
+    console.warn('[spotifyAuth] Persistent 401 — logging out');
+    this.logout();
     if (typeof window === 'undefined') return;
     window.dispatchEvent(
       new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -34,6 +34,7 @@ const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 class SpotifyAuth {
   private tokenData: TokenData | null = null;
   private refreshInFlight: Promise<void> | null = null;
+  private sessionExpiredNotified = false;
 
   constructor() {
     this.loadTokenFromStorage();
@@ -64,6 +65,7 @@ class SpotifyAuth {
 
   private saveTokenToStorage(tokenData: TokenData): void {
     this.tokenData = tokenData;
+    this.sessionExpiredNotified = false;
     localStorage.setItem('spotify_token', JSON.stringify(tokenData));
   }
 
@@ -190,13 +192,24 @@ class SpotifyAuth {
   }
 
   /**
-   * Called by API consumers when a freshly-refreshed token is still rejected (401).
-   * Treats this as an invalid session: clears all tokens and notifies the UI.
+   * Called by API consumers (and `performRefresh` itself on a 400/401 from the
+   * refresh endpoint) when the session is no longer recoverable. Clears any
+   * surviving tokens and dispatches `SESSION_EXPIRED_EVENT` once per session.
+   *
+   * Idempotent: a follow-up invocation after `logout()` (e.g. a wrapper catch
+   * path after `performRefresh` already cleared `tokenData`) re-dispatches
+   * nothing thanks to `sessionExpiredNotified`, but earlier we would have
+   * silently skipped the event entirely whenever `tokenData` was already null.
+   * The notification flag resets on the next successful `saveTokenToStorage`,
+   * so a fresh login can surface a future session-expired toast.
    */
   public reportUnauthorized(): void {
-    if (!this.tokenData) return;
+    if (this.sessionExpiredNotified) return;
+    this.sessionExpiredNotified = true;
     console.warn('[spotifyAuth] Persistent 401 — logging out');
-    this.logout();
+    if (this.tokenData) {
+      this.logout();
+    }
     if (typeof window === 'undefined') return;
     window.dispatchEvent(
       new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -1,10 +1,11 @@
 import { spotifyAuth } from './spotify';
+import { SpotifyApiError } from './spotify/api';
 import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 import { TRANSFER_RETRY_DELAY_MS } from '@/constants/timing';
 import { logCaughtError } from '@/utils/logCaughtError';
 
-async function parsePlayError(response: Response): Promise<string> {
+async function buildPlayApiError(response: Response): Promise<SpotifyApiError> {
   const errorText = await response.text();
   let reason = '';
   try {
@@ -12,14 +13,18 @@ async function parsePlayError(response: Response): Promise<string> {
     if (json.error?.message) reason = ` - ${json.error.message}`;
     if (json.error?.reason) reason += ` (${json.error.reason})`;
   } catch (err) {
-    logCaughtError('spotifyPlayerPlayback.parsePlayError', err);
+    logCaughtError('spotifyPlayerPlayback.buildPlayApiError', err);
     reason = errorText ? ` - ${errorText}` : '';
   }
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
     if (retryAfter) reason += ` Retry-After: ${retryAfter}`;
   }
-  return `Spotify API error: ${response.status}${reason}`;
+  return new SpotifyApiError(
+    response.status,
+    response.statusText,
+    `Spotify API error: ${response.status}${reason}`,
+  );
 }
 
 /**
@@ -80,7 +85,7 @@ export async function apiPlayTrack(
   logSpotify('Web API play track response status=%d ok=%s', response.status, response.ok);
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 
@@ -110,7 +115,7 @@ export async function apiPlayContext(
   });
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 
@@ -136,7 +141,7 @@ export async function apiPlayPlaylist(
   logSpotify('Web API play URIs response status=%d ok=%s', response.status, response.ok);
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add structured `SpotifyApiError` carrying `status`; reuse existing `AuthExpiredError` for terminal 401s
- Retry Spotify Web API 401 once after forced token refresh; throw `AuthExpiredError` and notify session expired if still 401
- Promote `notifySessionExpired()` to a public `reportUnauthorized()` mirroring `DropboxAuthAdapter`
- Replace brittle `.includes('401')` / `.includes('403')` / `.includes('404')` parsing in `spotifyPlaybackAdapter.ts` with structured-error checks (`err.status === N`); also routes `apiPlayTrack` / `apiPlayContext` / `apiPlayPlaylist` through `SpotifyApiError`

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` green (2020 tests passed, including new `src/services/spotify/__tests__/api.test.ts` covering 5xx, single-401 retry, persistent-401 logout, refresh failure, and non-401 passthrough)
- [x] `npm run build` green
- [ ] Manual: revoke Spotify token mid-session and confirm logout + session-expired toast (covered by openspec auth-system Requirements 5 & 6)

## OpenSpec
- `openspec/changes/spotify-api-401-retry/` (proposal, design, tasks, delta for `auth-system`)
- `openspec validate spotify-api-401-retry --strict` clean

Closes #1553