### PR TITLE
fix(playwright): use empty destructure to satisfy fixture-arg validator

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default tseslint.config(
     rules: {
       'react-hooks/rules-of-hooks': 'off',
       'react-hooks/exhaustive-deps': 'off',
+      'no-empty-pattern': 'off',
     },
   },
 )

--- a/playwright/capture/fixtures.ts
+++ b/playwright/capture/fixtures.ts
@@ -27,7 +27,7 @@ function hasSnapshotContent(): boolean {
 }
 
 export const test = base.extend<{ capturePage: Page }>({
-  capturePage: async (_fixtures, runFixture, testInfo) => {
+  capturePage: async ({}, runFixture, testInfo) => {
     if (!hasSnapshotContent()) {
       testInfo.skip(
         true,


### PR DESCRIPTION
## Summary
- Replace `_fixtures` underscore-prefixed identifier with `{}` empty destructure in `capturePage` fixture so Playwright's fixture-arg validator accepts the module
- Disable `no-empty-pattern` under the existing `playwright/**` ESLint scope so the required empty destructure passes lint
- Unblocks `npm run capture` and restores visual-regression detection

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run lint` green (0 errors)
- `npm run test:run` green (2015 passed)
- `npm run capture -- --list` enumerates 20 tests across desktop + mobile (no longer aborts at fixture module load)

Closes #1552