### PR TITLE
fix(vfx-menu): tint active swatch outline with current accent color

### DIFF
--- a/openspec/changes/active-swatch-accent-outline/design.md
+++ b/openspec/changes/active-swatch-accent-outline/design.md
@@ -1,0 +1,53 @@
+# Design — active-swatch-accent-outline
+
+## Context
+
+`QuickEffectsRow.tsx` renders accent-color swatches as 24×24 circles whose fill *is* the candidate accent color. The currently-active swatch (where `color.hex === accentColor`) needs a visual differentiator. Today that differentiator is a 2px solid outline in `theme.colors.selection` (`#ffd700` gold).
+
+Every other active state in the flip menu — option-button pills via `$variant="accent"`, switch tracks — already derives from `var(--accent-color)` (and `var(--accent-contrast-color)` for foregrounds). The swatch was deliberately skipped per the merge note in `b1e72ac`, but the visual-effects-menu spec enumerates the swatch as a control that MUST reflect the accent. The spec is the durable contract; the implementation should follow it.
+
+## Decision
+
+Use `var(--accent-contrast-color)` for the active-swatch outline.
+
+### Why not `var(--accent-color)`?
+
+The active swatch's `background` is the accent color. An outline in the same color would be invisible — defeating the purpose of marking it as active.
+
+### Why `var(--accent-contrast-color)`?
+
+- It's already wired up: `ColorContext` calls `getContrastColor(accentColor)` and sets the CSS variable alongside `--accent-color` on every accent change (`src/contexts/ColorContext.tsx:86`). Other components use it as a paired foreground (e.g. `LikeButton.tsx:86,90`).
+- It guarantees visibility against the swatch fill by construction (it's the WCAG-passing contrast of the accent).
+- The visual-effects-menu spec's "Active Controls Reflect Current Accent Color" requirement explicitly permits `--accent-contrast-color` as a derived value.
+
+### Why not a two-color ring (e.g. 2px outline + 1px inner shadow)?
+
+Considered, then rejected: it adds box-shadow geometry to fix a problem that `--accent-contrast-color` already solves cleanly. The simpler rule wins.
+
+### Why keep `theme.colors.selection` in `theme.ts`?
+
+It's a generic UI-state token (potential future use: highlighting selected rows, command-palette hits, etc.). Removing it on the back of this single-site refactor is out of scope; the token is left alone.
+
+## Implementation
+
+`src/components/controls/QuickEffectsRow.tsx:76`:
+
+```ts
+outline: ${({ $isActive }) => ($isActive ? `2px solid var(--accent-contrast-color)` : 'none')};
+```
+
+The `theme` arg is no longer needed in that styled-component getter, but is also harmless to leave; removing it is a minor cleanup commensurate with the fix.
+
+## Risks
+
+- **Low contrast for `--accent-contrast-color` when accent is a mid-tone gray.** `getContrastColor` returns either pure black or pure white based on the accent's luminance, so the outline will always be one of those two — both read clearly against a single colored disc. No new contrast risk.
+- **Tests.** `src/components/controls/__tests__/QuickEffectsRow.test.tsx` asserts `$variant="accent"` on `OptionButton`s — it does not touch the swatch outline. No test updates required.
+
+## Alternatives Considered
+
+| Option | Verdict |
+|---|---|
+| Keep static gold outline | Rejected — violates spec, motivates this issue |
+| Outline in `var(--accent-color)` | Rejected — invisible against active swatch's accent fill |
+| 2px `--accent-color` + inner 1px `--accent-contrast-color` ring via `box-shadow` | Rejected — extra geometry, no upside over single-color contrast outline |
+| Add a new theme token `theme.colors.swatchActiveOutline = var(--accent-contrast-color)` | Rejected — adds indirection without helping any other call site; the CSS variable is the project's canonical accent plumbing |

--- a/openspec/changes/active-swatch-accent-outline/proposal.md
+++ b/openspec/changes/active-swatch-accent-outline/proposal.md
@@ -1,0 +1,23 @@
+# active-swatch-accent-outline
+
+## Why
+
+The flip-menu accent-color swatch row renders its active-state outline in a static gold (`theme.colors.selection` → `#ffd700`). Every other active control in the VFX flip menu already follows the spec requirement "Active Controls Reflect Current Accent Color" by deriving its active state from `--accent-color` / `--accent-contrast-color`. The active swatch is the lone holdout; it visually clashes with the accent and reads as generic chrome instead of as an extension of the current album's identity.
+
+The selection-gold outline arrived in commit `b1e72ac` ("feat(visual-effects-menu): tint flip-menu controls with current accent"), whose body notes "leaving the existing selection outline as the sole indicator". The visual-effects-menu spec — authored around the same time — nevertheless enumerates the active swatch indicator as a control that MUST render its active state via `--accent-color`. The implementation drifted from the spec. This change resolves the drift in favor of the spec.
+
+## What Changes
+
+- Replace the static `theme.colors.selection` outline on the active swatch button with an accent-derived outline.
+  - Use `var(--accent-contrast-color)` (already populated alongside `--accent-color` by `ColorContext`) because the swatch's own fill *is* the accent when active — `var(--accent-color)` would render an invisible outline.
+  - The visual-effects-menu spec's "Active Controls Reflect Current Accent Color" requirement explicitly permits derived values such as `--accent-contrast-color` for foreground/marker roles.
+- Clarify the visual-effects-menu spec to call out that the active swatch outline uses the accent-contrast color (not raw `--accent-color`), to lock in the rationale and prevent regression to the same gold-outline state.
+
+## Impact
+
+- Affected specs: `visual-effects-menu` (Requirement: Active Controls Reflect Current Accent Color — adds a swatch-specific contrast-color clarification).
+- Affected code: `src/components/controls/QuickEffectsRow.tsx` (single-line change at line 76).
+- `theme.colors.selection` itself stays — searched usages confirm the swatch outline was its only call site in `src/`, but the token is retained because it's a generic UI-state token and removing it is out of scope.
+- No behavioral change for any other VFX menu control.
+- No global accent-color plumbing changes.
+- Closes #1559.

--- a/openspec/changes/active-swatch-accent-outline/specs/visual-effects-menu/spec.md
+++ b/openspec/changes/active-swatch-accent-outline/specs/visual-effects-menu/spec.md
@@ -1,0 +1,38 @@
+# visual-effects-menu Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: Active Controls Reflect Current Accent Color
+
+Every control in the flip menu that exposes an active visual state — Glow Intensity / Rate pills, Visualizer Style / Intensity / Speed pills, the Glow / Visualizer / Translucence switch tracks, and the active swatch indicator — SHALL render its active state using the current `--accent-color` (or a value derived from it, such as `--accent-contrast-color` for foregrounds). Inactive states MAY remain neutral. When the current track changes and the accent color is recomputed, every active control's color SHALL update accordingly without user input.
+
+The active-swatch indicator is a special case: the swatch fill itself *is* the candidate accent color, so an outline in `--accent-color` would be invisible against the active swatch. The active-swatch outline SHALL therefore use `var(--accent-contrast-color)` (the WCAG-passing contrast color paired with `--accent-color` and updated together by `ColorContext`). It SHALL NOT use a static UI-state color (e.g. the legacy `theme.colors.selection` gold).
+
+Rationale: the flip menu is the per-album personalization surface, so its active-state styling should read as an extension of the album's identity rather than as generic chrome.
+
+#### Scenario: Active option-button pill reflects accent
+
+- **WHEN** the user opens the flip menu while a track with a known accent color is playing
+- **THEN** the currently-selected Glow Intensity / Rate / Visualizer Style / Intensity / Speed pill renders with its background, border, and foreground driven by the current accent color and its derived contrast color
+
+#### Scenario: Switch tracks reflect accent
+
+- **WHEN** the Glow, Visualizer, or Translucence switch is in the on state
+- **THEN** the switch track renders in the current accent color
+
+#### Scenario: Active swatch outline uses accent-contrast color
+
+- **WHEN** the user selects an accent color via one of the swatch buttons
+- **THEN** the chosen swatch is outlined with `var(--accent-contrast-color)` (not a static UI-state color)
+- **AND** the outline remains clearly visible against the swatch's own accent-colored fill
+
+#### Scenario: Accent updates propagate when the track changes
+
+- **WHEN** the playing track changes and the extracted accent color changes accordingly
+- **THEN** every active control in the open flip menu re-renders with the new accent color without requiring the user to re-select anything
+- **AND** the active-swatch outline re-renders with the new `--accent-contrast-color`
+
+#### Scenario: Inactive controls remain neutral
+
+- **WHEN** an option-button pill is in its inactive state
+- **THEN** the pill renders with the panel's neutral muted styling (it does not preview the accent color)

--- a/openspec/changes/active-swatch-accent-outline/tasks.md
+++ b/openspec/changes/active-swatch-accent-outline/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — active-swatch-accent-outline
+
+## 1. Implementation
+
+- [x] 1.1 Update `src/components/controls/QuickEffectsRow.tsx:76` — replace `2px solid ${theme.colors.selection}` with `2px solid var(--accent-contrast-color)` for the active swatch outline.
+- [x] 1.2 Drop the unused `theme` arg from that styled getter (purely cosmetic; no behavior change).
+
+## 2. Spec delta
+
+- [x] 2.1 Add a swatch-specific clarification under the `visual-effects-menu` "Active Controls Reflect Current Accent Color" requirement noting that the active-swatch outline uses `--accent-contrast-color` (because the swatch fill itself is the accent).
+
+## 3. Verification
+
+- [x] 3.1 `npx tsc -b --noEmit` — clean.
+- [x] 3.2 `npm run test:run` — green (no existing test asserts on the outline color; `QuickEffectsRow.test.tsx` only checks `$variant="accent"` on OptionButtons).
+- [x] 3.3 `npm run build` — green.
+- [x] 3.4 Manual check (deferred to PR review): toggle accent color via the flip menu and confirm the active-swatch outline follows the contrast color, remaining clearly visible across light and dark accents.

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -73,7 +73,7 @@ const SwatchButton = styled.button<{ $color: string; $isActive: boolean }>`
   border-radius: 50%;
   background: ${({ $color }) => $color};
   border: 1px solid ${({ theme }) => theme.colors.control.border};
-  outline: ${({ theme, $isActive }) => ($isActive ? `2px solid ${theme.colors.selection}` : 'none')};
+  outline: ${({ $isActive }) => ($isActive ? '2px solid var(--accent-contrast-color)' : 'none')};
   cursor: pointer;
   padding: 0;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Replace static gold (`theme.colors.selection`) on the active swatch outline with the accent-driven CSS variable
- Brings the swatch into alignment with every other active VFX flip-menu control (covers visual-effects-menu Requirement: Active Controls Reflect Current Accent Color)

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green
- `npm run build` green
- Manual: toggle accent color; confirm active-swatch outline follows the accent

Closes #1559