### PR TITLE
fix(queue): notify native-sync provider on every queue mutation

### DIFF
--- a/openspec/changes/queue-mutation-native-sync/design.md
+++ b/openspec/changes/queue-mutation-native-sync/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Spotify's playback adapter sustains a "native queue" via the Web Playback SDK: each `playTrack` call passes an `upcomingUris` array so the SDK can auto-advance without an additional command round-trip. The adapter builds that array from a snapshot of the app queue captured at `onQueueChanged` time (`spotifyPlaybackAdapter.ts:339-341`) and consumes it inside the next `playTrack` (`:82-84`).
+
+Today the only place that pushes a fresh snapshot is `useProviderPlayback.playTrack`, which calls `descriptor.playback.onQueueChanged?.(tracks, index)` immediately before invoking the adapter. That covers the track-transition case (handleNext / handlePrevious / hydrate / auto-advance / fresh collection load). It does **not** cover user-driven queue mutations that happen while a track is already playing: add-to-queue, remove-from-queue, reorder, insert-next, insert-collection-next, queue-direct. After any of those, the SDK keeps the previous upcoming list in mind and can auto-advance into the wrong tracks. The fix pushes the same notification from every mutator.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every user-initiated queue mutation notifies the driving provider when it declares `hasNativeQueueSync`.
+- One uniform call site inside `useQueueManagement.ts` (a `notifyQueueChanged` helper) so future mutators inherit the behavior by construction.
+- Keep the existing pre-`playTrack` notification — track transitions still need it, and removing it would race with mutations that haven't yet observed the new index.
+- Delete the stale comment that points to a non-existent `useEffect`.
+
+**Non-Goals:**
+- Notifying providers that have not opted in via `hasNativeQueueSync` (Dropbox, mock).
+- Touching the Spotify adapter, Dropbox provider, or anything under `src/services/spotify/` — those areas are in flight in other PRs and the only change required here is on the consumer side.
+- Adding a separate notification on every `currentTrackIndex` mutation outside of `useQueueManagement`. The existing `playTrack`-time call already covers index transitions; this change closes the queue-content gap.
+
+## Decisions
+
+**Resolve the descriptor through `getDrivingProviderDescriptor`, not `activeDescriptor`.**
+The driving provider is the one actually producing audio and the one whose native queue must stay aligned with the app. `activeDescriptor` reflects the browsing context — for a cross-provider queue (e.g. a Dropbox library view while Spotify drives audio) those two diverge. The hook already gets `activeDescriptor` for catalog calls; we add a sibling `getDrivingProviderDescriptor` accessor and read the driving descriptor at notify time so the snapshot lands on the SDK that needs it.
+
+**Read the driving descriptor lazily per call, not once per render.**
+The driving provider can change mid-session (cross-provider handoff). Capturing the accessor (a stable callback) instead of a snapshot ensures every mutation sees the current driver.
+
+**Inline `notifyQueueChanged` helper inside the hook.**
+A four-line helper closes over `getDrivingProviderDescriptor` and the latest `tracksRef` / `currentTrackIndex`. Pulling it out into a utility would force passing those refs around. The function stays private to `useQueueManagement.ts` — no other consumer needs it.
+
+**Notify with the post-mutation `tracks` and post-mutation `currentTrackIndex`.**
+Mutators build the new array before calling state setters. We pass that local array (and the locally-computed `newCurrentIndex` for reorder, otherwise the existing `currentTrackIndex`) to the notifier rather than waiting for React to commit and re-render. This matches the existing `useProviderPlayback.ts:102` semantics, which also notifies before the playback adapter call.
+
+**Keep the existing pre-`playTrack` notification at `useProviderPlayback.ts:102`.**
+That call handles track-transition events that don't pass through `useQueueManagement.ts`: hydrate from session, handleNext/Previous, auto-advance, fresh-collection load at index 0. Removing it would re-open the regressions the comment near it (mistakenly) tries to explain. We delete the misleading prose; the line of code stays.
+
+**Capability gate inside `notifyQueueChanged`, not at each call site.**
+Centralizing the `hasNativeQueueSync` check inside the helper keeps mutators free of provider-system concerns and lets a future provider opt-in by flipping the capability without revisiting every mutator.
+
+## Risks / Trade-offs
+
+- **Risk:** Extra `onQueueChanged` calls increase Spotify adapter work on every mutation. **Mitigation:** the adapter's `onQueueChanged` is a pure map-and-slice over the queue array — no I/O, no allocation pressure beyond a fresh URI array. Cheaper than the `playTrack` it precedes.
+- **Risk:** A mutation that ultimately bails (e.g. all dedup-filtered tracks rejected) notifies before bailing → notifier sees the pre-mutation queue, which is identical to the post-mutation queue. **Mitigation:** call `notifyQueueChanged` only after a mutation actually commits new state (i.e., past the dedup short-circuits). Each mutator already has a clean "commit point" where the new `tracks` array is in hand.
+- **Trade-off:** Reorder notifies twice if the user drags a track between two positions in quick succession. Acceptable — each notification overwrites the previous `pendingUpcomingUris`, so the SDK ends up with the latest snapshot. No correctness issue.

--- a/openspec/changes/queue-mutation-native-sync/proposal.md
+++ b/openspec/changes/queue-mutation-native-sync/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`onQueueChanged` is invoked in exactly one place today — `src/hooks/useProviderPlayback.ts:102`, immediately before each `playTrack` call. Every user-initiated queue mutator in `src/hooks/useQueueManagement.ts` (add, remove, reorder, insert-next, insert-collection-next, queue-direct) skips the notification. Until the next `playTrack` fires, the Spotify SDK's "upcoming URIs" buffer (`pendingUpcomingUris`, consumed at adapter line 82-84) reflects a stale snapshot of the app queue, so the SDK's own auto-advance can play tracks that no longer match the user's reordered/cleared queue.
+
+The behavior violates `openspec/specs/playback-engine/spec.md` Requirement 8 (Native Queue Sync), which says any provider declaring `hasNativeQueueSync` SHALL be notified when the app's queue or current index changes — not only at track-transition time.
+
+The existing comment at `src/hooks/useProviderPlayback.ts:97-101` claims a "persistent useEffect-based onQueueChanged in usePlayerLogic" handles the steady-state case. No such effect exists, and the comment misdirects future readers.
+
+## What Changes
+
+- Push `onQueueChanged` notifications from every user-initiated queue mutator in `useQueueManagement.ts` (`handleAddToQueue`, `handleRemoveFromQueue`, `handleReorderQueue`, `insertTracksNext`, `queueTracksDirectly`, `insertCollectionNext`).
+- Gate each call on the driving provider's `hasNativeQueueSync` capability; resolve the descriptor via the existing `getDrivingProviderDescriptor` accessor so cross-provider queues notify the actual audio-producing provider, not the currently-active-for-browsing one.
+- Centralize the call site behind a small `notifyQueueChanged(tracks, currentTrackIndex)` helper inside the hook so every mutator routes through the same gate.
+- Remove the stale comment at `useProviderPlayback.ts:97-101`. Keep the existing pre-`playTrack` notify at line 102 — it covers track-transition events not driven by `useQueueManagement.ts` (handleNext/handlePrevious, hydrate, auto-advance).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: tightens Requirement 8 (Native Queue Sync) by enumerating the queue events that MUST trigger `onQueueChanged` (append, remove, reorder, insert-next, insert-collection-next, queue-direct, manual `playTrack` transitions) and clarifying that the notification follows the **driving** provider's capability flag, not the active provider's.
+
+## Impact
+
+- `src/hooks/useQueueManagement.ts` — accepts a `getDrivingProviderDescriptor` accessor in props; adds `notifyQueueChanged` helper; invokes it in every mutator.
+- `src/hooks/usePlayerLogic.ts` — passes the existing `getDrivingProviderDescriptor` accessor into `useQueueManagement`.
+- `src/hooks/useProviderPlayback.ts` — removes stale comment at lines 97-101 (the `onQueueChanged` call itself stays in place).
+- `src/hooks/__tests__/useQueueManagement.test.ts` — adds coverage for the notify-on-mutation behavior and the capability gate.
+- No public API change. No provider-adapter change. Performance: each notification is an O(remaining-queue) URI build inside the Spotify adapter, which is what the codebase already pays on every `playTrack`.

--- a/openspec/changes/queue-mutation-native-sync/specs/playback-engine/spec.md
+++ b/openspec/changes/queue-mutation-native-sync/specs/playback-engine/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Native Queue Sync
+
+A provider that declares a native-queue-sync capability SHALL be notified when the app's queue or current index changes, so the provider can keep its native queue aligned with the app. The notification SHALL be dispatched on every queue mutation that updates the app's tracks array or current index — specifically: appending tracks via add-to-queue, removing a track, reordering tracks, inserting tracks at the play-next slot, inserting a collection at the play-next slot, queueing tracks directly, and the implicit current-index change at every track transition (next, previous, hydrate-resume, auto-advance, fresh-collection load). The notification SHALL target the **driving** provider (the provider currently producing audio), not the active-for-browsing provider; for a cross-provider queue these two MAY differ.
+
+#### Scenario: App queue changes while a native-sync provider is driving
+- **WHEN** the app's queue or current-track index changes and the driving provider declares the native-queue-sync capability
+- **THEN** the provider is notified of the new queue and current index
+
+#### Scenario: Provider without native-sync capability
+- **WHEN** the app's queue changes and the driving provider does not declare native-queue-sync
+- **THEN** no native-sync notification is dispatched
+
+#### Scenario: Tracks appended via add-to-queue
+- **WHEN** the user adds a collection to a non-empty queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-append tracks array and the unchanged current-track index
+
+#### Scenario: Track removed from queue
+- **WHEN** the user removes a track from the queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-removal tracks array and the adjusted current-track index
+
+#### Scenario: Queue reordered
+- **WHEN** the user reorders the queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-reorder tracks array and the current-track index recomputed to follow the still-playing track
+
+#### Scenario: Tracks inserted at the play-next slot
+- **WHEN** the user inserts tracks at `currentTrackIndex + 1` (insert-next or insert-collection-next) and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-insert tracks array and the unchanged current-track index
+
+#### Scenario: Tracks queued directly
+- **WHEN** the user queues tracks directly into the app queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-append tracks array and the unchanged current-track index
+
+#### Scenario: Mutation bails without changing state
+- **WHEN** a mutator short-circuits before committing new state (empty input, dedup-empty, out-of-range index, removing the currently-playing track)
+- **THEN** no native-sync notification is dispatched
+
+#### Scenario: Track transition fires before adapter playback
+- **WHEN** the engine calls `playTrack` to start a new track on a driving provider that declares native-queue-sync
+- **THEN** the provider is notified with the current tracks array and the new index before the adapter's playback call

--- a/openspec/changes/queue-mutation-native-sync/tasks.md
+++ b/openspec/changes/queue-mutation-native-sync/tasks.md
@@ -1,0 +1,33 @@
+## 1. Hook plumbing
+
+- [ ] 1.1 In `src/hooks/useQueueManagement.ts`, extend `UseQueueManagementProps` with `getDrivingProviderDescriptor: () => ProviderDescriptor | undefined`.
+- [ ] 1.2 Add a private `notifyQueueChanged(nextTracks: MediaTrack[], nextIndex: number)` helper inside the hook that resolves the driving descriptor, checks `capabilities.hasNativeQueueSync`, and forwards to `descriptor.playback.onQueueChanged?.(nextTracks, nextIndex)`.
+
+## 2. Mutator wiring
+
+- [ ] 2.1 `handleAddToQueue`: after the append commit (post-dedup, post-`setTracks`), call `notifyQueueChanged([...tracksRef.current, ...uniqueNewTracks], currentTrackIndex)`.
+- [ ] 2.2 `handleRemoveFromQueue`: after the splice commit, call `notifyQueueChanged(nextTracks, adjustedIndex)` using the same locally-computed values used for the setters.
+- [ ] 2.3 `handleReorderQueue`: after computing `newTracks` and `newCurrentIndex`, call `notifyQueueChanged(newTracks, newCurrentIndex >= 0 ? newCurrentIndex : 0)`.
+- [ ] 2.4 `queueTracksDirectly`: after the append commit, call `notifyQueueChanged([...tracksRef.current, ...uniqueNewTracks], currentTrackIndex)`.
+- [ ] 2.5 `insertTracksNext`: after building `nextTracks`, call `notifyQueueChanged(nextTracks, currentTrackIndex)` for the non-empty path; for the empty-queue path, call `notifyQueueChanged(uniqueNewTracks, 0)`.
+- [ ] 2.6 `insertCollectionNext`: no direct change — delegates to `insertTracksNext`, which already notifies.
+
+## 3. Caller wiring
+
+- [ ] 3.1 In `src/hooks/usePlayerLogic.ts`, pass the existing `getDrivingProviderDescriptor` into the `useQueueManagement({...})` call.
+
+## 4. Stale comment cleanup
+
+- [ ] 4.1 In `src/hooks/useProviderPlayback.ts`, remove the comment block at lines 97-101 referencing a non-existent `useEffect-based onQueueChanged in usePlayerLogic`. Keep the `descriptor.playback.onQueueChanged?.(tracks, index)` call on line 102.
+
+## 5. Tests
+
+- [ ] 5.1 Extend `src/hooks/__tests__/useQueueManagement.test.ts` to cover: each mutator invokes `onQueueChanged` with the post-mutation tracks and index when the driving descriptor declares `hasNativeQueueSync`.
+- [ ] 5.2 Add a negative test: when the driving descriptor lacks `hasNativeQueueSync`, mutators do not call `onQueueChanged`.
+- [ ] 5.3 Add a test that mutators which bail early (dedup-empty, out-of-range index) do not call `onQueueChanged`.
+
+## 6. Verify
+
+- [ ] 6.1 `npx tsc -b --noEmit` clean.
+- [ ] 6.2 `npm run test:run` green.
+- [ ] 6.3 `npm run build` green.

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -30,6 +30,7 @@ describe('useQueueManagement', () => {
   let mockGetDescriptor: ReturnType<typeof vi.fn>;
   let mockActiveDescriptor: { id: string; [key: string]: unknown };
   let mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  let mockGetDrivingProviderDescriptor: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockHandlePlaylistSelect = vi.fn();
@@ -40,6 +41,9 @@ describe('useQueueManagement', () => {
     mockGetDescriptor = vi.fn();
     mockActiveDescriptor = { id: 'spotify' };
     mediaTracksRef = { current: [] };
+    // Default: no driving descriptor (notify is a no-op). Tests covering native-sync
+    // override this with a descriptor that declares `hasNativeQueueSync`.
+    mockGetDrivingProviderDescriptor = vi.fn(() => undefined);
     vi.mocked(toast).mockClear();
   });
 
@@ -55,6 +59,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -81,6 +86,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -116,6 +122,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -143,6 +150,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -174,6 +182,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: dropboxDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -213,6 +222,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: dropboxDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -248,6 +258,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -286,6 +297,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -309,6 +321,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: undefined,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -340,6 +353,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -372,6 +386,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -404,6 +419,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -438,6 +454,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -471,6 +488,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -501,6 +519,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -530,6 +549,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -561,6 +581,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -594,6 +615,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -625,6 +647,7 @@ describe('useQueueManagement', () => {
       handleBackToLibrary: mockHandleBackToLibrary,
       activeDescriptor: mockActiveDescriptor,
       getDescriptor: mockGetDescriptor,
+      getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
     };
 
     const { result, rerender } = renderHook((p: typeof props) => useQueueManagement(p), {
@@ -648,6 +671,347 @@ describe('useQueueManagement', () => {
     expect(result.current.handleAddToQueue).toBe(initialAdd);
   });
 
+  describe('native-queue-sync notifications', () => {
+    function makeDrivingDescriptor(opts: { hasNativeQueueSync: boolean }): {
+      descriptor: { id: 'spotify'; capabilities: { hasNativeQueueSync: boolean }; playback: { onQueueChanged: ReturnType<typeof vi.fn>; pause: ReturnType<typeof vi.fn> } };
+      onQueueChanged: ReturnType<typeof vi.fn>;
+    } {
+      const onQueueChanged = vi.fn();
+      return {
+        descriptor: {
+          id: 'spotify',
+          capabilities: { hasNativeQueueSync: opts.hasNativeQueueSync },
+          playback: { onQueueChanged, pause: vi.fn() },
+        },
+        onQueueChanged,
+      };
+    }
+
+    it('handleAddToQueue notifies the driving provider with the post-append tracks and unchanged index', async () => {
+      // #given — non-empty queue, driving provider declares native-queue-sync
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('3'), makeMediaTrack('4')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2', '3', '4']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('handleRemoveFromQueue notifies with the post-removal tracks and adjusted index', () => {
+      // #given — currently playing index 2; remove index 0 → adjusted to 1
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2'), makeMediaTrack('3')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' }), makeTrack({ id: '3' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 2,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleRemoveFromQueue(0);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['2', '3']);
+      expect(notifiedIndex).toBe(1);
+    });
+
+    it('handleReorderQueue notifies with the reordered tracks and the followed-current index', () => {
+      // #given — playing index 0 ('a'); reorder 0→2 follows the playing track to index 2
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleReorderQueue(0, 2);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['b', 'c', 'a']);
+      expect(notifiedIndex).toBe(2);
+    });
+
+    it('insertTracksNext notifies with the spliced tracks and unchanged current index', () => {
+      // #given — playing index 1 of 4; insert one track at index 2
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c'), makeMediaTrack('d')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' }), makeTrack({ id: 'd' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 1,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'b', 'x', 'c', 'd']);
+      expect(notifiedIndex).toBe(1);
+    });
+
+    it('insertTracksNext notifies with index 0 when the queue starts empty', () => {
+      // #given — empty queue; fall-through path treats inserted tracks as the new queue
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks: [],
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('queueTracksDirectly notifies with the post-append tracks and unchanged index', () => {
+      // #given — non-empty queue, driving provider declares native-queue-sync
+      mediaTracksRef.current = [makeMediaTrack('1')];
+      const tracks = [makeTrack({ id: '1' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('2'), makeMediaTrack('3')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2', '3']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('insertCollectionNext notifies through insertTracksNext on the non-empty path', async () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const fetched = [makeMediaTrack('p1'), makeMediaTrack('p2')];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue(fetched) };
+      mockActiveDescriptor.catalog = mockCatalog;
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.insertCollectionNext('p1');
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'p1', 'p2', 'b']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('does not notify when the driving provider lacks the native-queue-sync capability', () => {
+      // #given — driving descriptor without the capability flag
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: false });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleReorderQueue(0, 2);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when a mutation bails before committing new state', () => {
+      // #given — removing the currently playing index is a no-op
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 1,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when — attempt to remove the playing track (bails)
+      act(() => {
+        result.current.handleRemoveFromQueue(1);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when insertTracksNext dedups to zero new tracks', () => {
+      // #given — every incoming track is already in the queue
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
@@ -663,6 +1027,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -462,6 +462,7 @@ export function usePlayerLogic() {
     handleBackToLibrary,
     activeDescriptor,
     getDescriptor,
+    getDrivingProviderDescriptor,
   });
 
   const dismissRadioProgress = useCallback(() => setRadioProgress(null), []);

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -93,12 +93,12 @@ export const useProviderPlayback = ({
       return;
     }
 
-    // Sync the queue to the provider synchronously before playTrack so the
-    // adapter sees the current track list. The persistent useEffect-based
-    // onQueueChanged in usePlayerLogic only fires after React commits new
-    // state — too late for the playTrack we're about to await, which would
-    // otherwise hand Spotify a stale upcomingUris list (or no list at all
-    // on cold start) and let the SDK auto-advance into the wrong tracks.
+    // Push the latest queue snapshot to the driving provider before invoking
+    // playTrack so adapters that build their native queue from this signal
+    // (Spotify's upcomingUris) see the current list for the imminent
+    // playback call. User-driven queue mutations notify separately via
+    // useQueueManagement.ts; this call covers track transitions
+    // (next/previous/hydrate/auto-advance) that bypass that hook.
     descriptor.playback.onQueueChanged?.(tracks, index);
 
     try {

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -31,6 +31,13 @@ interface UseQueueManagementProps {
   handleBackToLibrary: () => void;
   activeDescriptor: ProviderDescriptor | undefined;
   getDescriptor: (providerId: ProviderId) => ProviderDescriptor | undefined;
+  /**
+   * Resolves the **driving** provider descriptor — the one producing audio, which
+   * may differ from `activeDescriptor` for cross-provider queues. Native-queue-sync
+   * notifications must target this descriptor so the SDK whose queue we are mirroring
+   * receives the update.
+   */
+  getDrivingProviderDescriptor: () => ProviderDescriptor | undefined;
 }
 
 interface UseQueueManagementReturn {
@@ -51,10 +58,21 @@ export function useQueueManagement({
   handleBackToLibrary,
   activeDescriptor,
   getDescriptor,
+  getDrivingProviderDescriptor,
 }: UseQueueManagementProps): UseQueueManagementReturn {
   const { setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef } = trackOps;
   const tracksRef = useRef(tracks);
   tracksRef.current = tracks;
+
+  const notifyQueueChanged = useCallback(
+    (nextTracks: MediaTrack[], nextIndex: number): void => {
+      const driving = getDrivingProviderDescriptor();
+      if (!driving) return;
+      if (!driving.capabilities?.hasNativeQueueSync) return;
+      driving.playback.onQueueChanged?.(nextTracks, nextIndex);
+    },
+    [getDrivingProviderDescriptor],
+  );
 
   /**
    * Fetch tracks from a collection (album/playlist) and append them to the
@@ -115,9 +133,11 @@ export function useQueueManagement({
           tracksRef.current.length,
           mediaTracksRef.current.length,
         );
+        const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-        setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+        setOriginalTracks(nextTracks);
         setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+        notifyQueueChanged(nextTracks, currentTrackIndex);
         logQueue(
           'handleAddToQueue — after append: mediaRef=%d, newTracks added: %s',
           mediaTracksRef.current.length,
@@ -131,7 +151,7 @@ export function useQueueManagement({
       }
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex]
   );
 
   const handleRemoveFromQueue = useCallback(
@@ -153,17 +173,21 @@ export function useQueueManagement({
       setOriginalTracks((prev) => prev.filter((t) => t.id !== removedTrack.id));
 
       // Adjust currentTrackIndex if removing before current
+      const adjustedIndex = index < currentTrackIndex ? currentTrackIndex - 1 : currentTrackIndex;
       if (index < currentTrackIndex) {
         setCurrentTrackIndex(prev => prev - 1);
       }
 
       // Remove from tracks by index
+      const nextTracks = tracks.filter((_, i) => i !== index);
       setTracks(prev => prev.filter((_, i) => i !== index));
+
+      notifyQueueChanged(nextTracks, adjustedIndex);
 
       logQueue('handleRemoveFromQueue — done, new queueLen=%d', tracks.length - 1);
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
+    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef, notifyQueueChanged]
   );
 
   const handleReorderQueue = useCallback(
@@ -199,13 +223,16 @@ export function useQueueManagement({
         setOriginalTracks(newTracks);
       }
 
-      setCurrentTrackIndex(newCurrentIndex >= 0 ? newCurrentIndex : 0);
+      const finalIndex = newCurrentIndex >= 0 ? newCurrentIndex : 0;
+      setCurrentTrackIndex(finalIndex);
       setTracks(newTracks);
+
+      notifyQueueChanged(newTracks, finalIndex);
 
       logQueue('handleReorderQueue — done, currentIndex=%d', newCurrentIndex);
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
+    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef, notifyQueueChanged]
   );
 
   const queueTracksDirectly = useCallback(
@@ -226,12 +253,14 @@ export function useQueueManagement({
         tracksRef.current.length,
         mediaTracksRef.current.length,
       );
+      const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
       mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-      setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+      setOriginalTracks(nextTracks);
       setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+      notifyQueueChanged(nextTracks, currentTrackIndex);
       return { added: uniqueNewTracks.length, collectionName };
     },
-    [mediaTracksRef, setOriginalTracks, setTracks]
+    [mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
   );
 
   /**
@@ -256,6 +285,7 @@ export function useQueueManagement({
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
         setOriginalTracks([...uniqueNewTracks]);
         setTracks([...uniqueNewTracks]);
+        notifyQueueChanged([...uniqueNewTracks], 0);
         return { added: uniqueNewTracks.length, collectionName };
       }
 
@@ -274,6 +304,8 @@ export function useQueueManagement({
       setOriginalTracks(nextTracks);
       setTracks(nextTracks);
 
+      notifyQueueChanged(nextTracks, currentTrackIndex);
+
       logQueue(
         'insertTracksNext — after insert: mediaRef=%d, newTracks added: %s',
         mediaTracksRef.current.length,
@@ -281,7 +313,7 @@ export function useQueueManagement({
       );
       return { added: uniqueNewTracks.length, collectionName };
     },
-    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks],
+    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
   );
 
   /**


### PR DESCRIPTION
## Summary
- Call `drivingDescriptor.playback.onQueueChanged?.(tracks, index)` on every user-initiated queue mutation in `useQueueManagement.ts`, gated on `hasNativeQueueSync` capability
- Remove stale comment in `useProviderPlayback.ts` referencing a removed/never-landed useEffect-based sync

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green
- `npm run build` green
- Manually with Spotify driving: add/reorder mid-track; Spotify SDK auto-advance respects new order (covers playback-engine Requirement 8)

Closes #1562