### PR TITLE
fix(vfx-menu): reconcile flip-gesture spec with implementation

### DIFF
--- a/openspec/changes/flip-menu-gesture-spec-reconcile/design.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Reported in issue #1560. The spec scenario for opening the flip menu currently reads:
+
+> **WHEN** the user long-presses (touch) or clicks (pointer) the album art with the flip gesture enabled
+> **THEN** the flip menu opens
+
+The implementation (`src/components/PlayerContent/GestureLayer.tsx:59-62, 90-108`) only attaches the long-press handler when `zenModeEnabled === true`:
+
+```ts
+const longPressHandlers = useLongPress({
+  onLongPress: onLongPress ?? (() => {}),
+  enabled: zenModeEnabled === true && onLongPress !== undefined,
+});
+
+// ...
+
+const activePointerHandlers = zenTouchHandlers
+  ? { ...zen play/prev/next handlers... }
+  : zenModeEnabled && onLongPress
+    ? { ...longPressHandlers... }
+    : {};
+```
+
+Outside zen mode, touch users open the flip menu via the synthetic `click` event that browsers fire on tap, which lands on `GestureLayer.handleClick` → `AlbumArtSection.handleClick` → `toggleFlip`.
+
+## Decision
+
+Pick **Option B** from the issue: update the spec to describe the shipped UX. No code change.
+
+## Why Option B over Option A
+
+Option A (drop the `zenModeEnabled` gate so long-press is always active) would conflict with the surrounding zen-mode gesture design:
+
+1. **Zen-mode design owns the album-art surface.** When zen mode is on, `ZenClickZoneOverlay` renders three click zones (prev / play-pause / next) on top of the album art. A tap anywhere on the art is intentionally captured by a zone — there is no free tap target for "open flip menu" in zen mode, which is exactly why long-press exists as the escape hatch in zen mode.
+2. **Outside zen mode, tap-to-flip is more discoverable** than long-press. There is no competing gesture on the art surface outside zen, so a single tap reliably opens the flip menu and matches the pointer (click) affordance one-to-one.
+3. **No bug to fix.** Touch users outside zen mode already open the flip menu reliably via the synthetic `click` event; there is no broken interaction or accessibility regression for end users — only a documentation/spec drift.
+
+The spec scenario was written when the flip-gesture story was simpler (no zen mode); the implementation evolved as zen mode landed and the spec was not refreshed. Reconciling the spec to the implementation captures the real, working UX without churning code that has been in production.
+
+## Spec change shape
+
+The change modifies a single requirement in `visual-effects-menu`:
+
+- Prose: change "long-press on touch, click on pointer" to "tap on touch outside zen mode, long-press on touch inside zen mode, click on pointer".
+- "Opening the flip menu" scenario: replace the single WHEN/THEN with three variant clauses — one per input modality — that all converge on the same THEN (album-art card rotates 180° and the menu becomes interactive).
+
+All other requirements (`Accent Color Selection`, `Glow Control`, `Background Visualizer Control`, `Translucence Control`, `Active Controls Reflect Current Accent Color`) and their scenarios are unchanged.
+
+## Risks / Tradeoffs
+
+- Documenting "long-press only in zen mode" makes the long-press affordance contingent on a separate feature. If someone disables zen mode in the future they need to revisit this scenario too. Mitigated by writing it as a three-clause matrix so each modality reads as its own line and the zen dependency is explicit.
+- Option B intentionally leaves a latent inconsistency: a touch user who tries to long-press on the album art outside zen mode will see the flip menu open via the synthetic click that fires after they release (or be confused by no immediate feedback). Acceptable because the synthetic click reliably fires and the gesture is short.
+
+## Migration
+
+None. Spec-only change; no consumer of the openspec snapshot reads the file at runtime.

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/proposal.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Issue #1560: the `visual-effects-menu` Flip-Menu Surface requirement currently asserts that touch users open the flip menu via long-press. The implementation in `src/components/PlayerContent/GestureLayer.tsx` only attaches the long-press handler when `zenModeEnabled === true`; outside zen mode, touch users open the flip menu via the same synthetic-click path as pointer users (`AlbumArtSection.tsx` wires `onClick` → `toggleFlip`). The spec and the implementation disagree.
+
+The implementation behavior is intentional: in zen mode, the album-art surface is occupied by play-zone overlays (`ZenClickZoneOverlay` renders prev / play-pause / next click zones), so a tap on the art would trigger zone behavior rather than the flip menu. Long-press is the escape hatch from those zones to the flip menu. Outside zen mode there are no zones competing for the tap, and tap-to-flip is the more discoverable affordance. Option B from the issue applies: update the spec to describe the shipped UX.
+
+## What Changes
+
+- Modify the `Flip-Menu Surface` requirement in `openspec/specs/visual-effects-menu/spec.md` (via a delta in this change) so the prose and the "Opening the flip menu" scenario describe the actual gesture matrix:
+  - Pointer: click on the album art.
+  - Touch, outside zen mode: tap on the album art.
+  - Touch, inside zen mode: long-press on the album art (because zen-mode tap is reserved for the play / prev / next click zones).
+- No production code changes — implementation already matches the new spec.
+
+No public APIs, no keyboard shortcuts, no provider behavior, no playback behavior change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `visual-effects-menu`: the `Flip-Menu Surface` requirement's surface description and its "Opening the flip menu" scenario are reworded to capture the shipped pointer / touch / zen-mode gesture matrix.
+
+## Impact
+
+- `openspec/specs/visual-effects-menu/spec.md` — `Flip-Menu Surface` requirement prose and "Opening the flip menu" scenario reworded; all other requirements and scenarios unchanged.
+- No effect on any source file, test, fixture, or Playwright snapshot.

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Flip-Menu Surface
+
+Vorbis Player SHALL expose a flip-side panel mounted on the back face of the album-art card that hosts the visual-effect controls. The panel SHALL be reachable from the front-of-art interaction layer via the modality-appropriate gesture: tap on touch outside zen mode, long-press on touch inside zen mode (because the zen-mode tap surface is reserved for the play / prev / next click zones rendered by `ZenClickZoneOverlay`), and click on pointer. The panel SHALL render on top of a blurred, darkened version of the current album art, and SHALL provide an explicit dismiss control plus dismiss-on-outside-tap behavior. When no track is playing or no album art is available, the panel SHALL still render and SHALL offer a Retry Artwork affordance if the consumer wires one in.
+
+#### Scenario: Opening the flip menu
+
+- **WHEN** the user clicks the front of the album art with a pointer device with the flip gesture enabled
+- **OR WHEN** the user taps the front of the album art on a touch device while zen mode is disabled
+- **OR WHEN** the user long-presses the front of the album art on a touch device while zen mode is enabled
+- **THEN** the album-art card rotates 180° about the Y axis to reveal the flip menu
+- **AND** the flip menu becomes interactive (controls accept pointer / keyboard input)
+
+#### Scenario: Closing the flip menu via the close button
+
+- **WHEN** the user clicks the close button rendered at the top-right of the flip menu
+- **THEN** the album-art card rotates back to the front face
+- **AND** the flip menu's controls become non-interactive
+
+#### Scenario: Closing the flip menu via outside-tap
+
+- **WHEN** the user taps inside the flip-menu surface but outside any control
+- **THEN** the album-art card rotates back to the front face
+
+#### Scenario: Backdrop renders without album art
+
+- **WHEN** the current track has no resolvable album image
+- **THEN** the flip menu still renders with a fallback (un-imaged) backdrop
+- **AND** the Retry Artwork control is shown when the consumer provides a retry callback

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/tasks.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/tasks.md
@@ -1,0 +1,14 @@
+## 1. Spec reconciliation
+
+- [x] 1.1 In `openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md`, modify the `Flip-Menu Surface` requirement so the prose lists the actual gesture matrix (tap outside zen, long-press inside zen, click on pointer) and the "Opening the flip menu" scenario splits into three modality clauses with a shared THEN.
+- [x] 1.2 Leave all other requirements (`Accent Color Selection`, `Glow Control`, `Background Visualizer Control`, `Translucence Control`, `Active Controls Reflect Current Accent Color`) and their scenarios out of the delta.
+
+## 2. Verification
+
+- [x] 2.1 Run `npx tsc -b --noEmit` — confirm no new errors (spec-only change should be a no-op for TypeScript).
+- [x] 2.2 Run `npm run test:run` — confirm green (no test asserts against spec text).
+- [x] 2.3 Run `npm run build` — confirm clean production build.
+
+## 3. Archive
+
+- [ ] 3.1 After PR #1560 merges, run `/opsx:archive flip-menu-gesture-spec-reconcile` so the delta is merged into `openspec/specs/visual-effects-menu/spec.md`.


### PR DESCRIPTION
## Summary
- Chose **Option B** from #1560: spec-only reconciliation. The implementation in `GestureLayer.tsx` intentionally gates long-press on `zenModeEnabled` because zen mode covers the album art with `ZenClickZoneOverlay` (prev / play-pause / next). Outside zen, touch users tap to flip via the synthetic-click path; long-press is the zen-mode escape hatch. See `design.md` for full rationale.
- Adds `openspec/changes/flip-menu-gesture-spec-reconcile/` with proposal, design, tasks, and a `visual-effects-menu` delta that rewrites the `Flip-Menu Surface` requirement prose and "Opening the flip menu" scenario to describe the shipped gesture matrix (tap on touch outside zen, long-press on touch inside zen, click on pointer).
- No production code changes.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` green (192 files / 2015 tests)
- [x] `npm run build` green
- [x] `npx openspec validate flip-menu-gesture-spec-reconcile` → "Change is valid"
- [ ] Manual: confirm flip-menu opens via tap outside zen, long-press inside zen, click on pointer

Closes #1560