### PR TITLE
fix(mock): guard pre-warm to avoid interrupting current audio

### DIFF
--- a/openspec/changes/mock-prewarm-no-interrupt/design.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The mock provider serves as the testing harness for Playwright specs and `?provider=mock` dev runs. It must mirror the observable behavior of the real Spotify and Dropbox adapters; otherwise tests that exercise queue transitions against the mock will diverge from production behavior.
+
+`playback-engine` Requirement 6 already declares: "Pre-warming SHALL NOT change the current-track index or any visible state." The Dropbox adapter implements this by short-circuiting `primeAudioForHydrate` when `audio.src && this.currentTrack` (see `dropboxPlaybackAdapter.ts:235`). The mock implementation did not — it unconditionally reset the audio src before checking the hydrate intent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Bring `MockPlaybackAdapter.prepareTrack` into conformance with Requirement 6.
+- Match Dropbox's pre-warm pattern: load the audio element only when the call is a hydrate (positionMs supplied).
+- Add a regression test that exercises the single-provider pre-warm path (current track === next track) and asserts `audio.src` is preserved.
+
+**Non-Goals:**
+- Changing `useProviderPlayback.ts` or the broader pre-warm caller — the contract is "pre-warm is best-effort and idempotent against the current src," and the fix lives in the adapter that violates it.
+- Changing Spotify or Dropbox adapters.
+- Adding new spec requirements — the existing Requirement 6 already covers the behavior.
+
+## Decisions
+
+**No delta spec.** Requirement 6 in `openspec/specs/playback-engine/spec.md` already states the invariant verbatim. This change brings an existing implementation into conformance; it does not modify the requirement. Adding an empty delta would be noise.
+
+**Guard inside the hydrate branch as well.** The original code had a latent bug: even a hydrate call retargeted at the currently-playing track would have reset its src. The Dropbox guard (`audio.src && this.currentTrack`) covers both pre-warm and same-track-hydrate. The mock now mirrors that: it skips the load inside the hydrate branch when `audio.src && this.currentTrack?.id === track.id`.
+
+**Pre-warm becomes a true no-op for the audio element.** Mirrors Dropbox's behavior — the adapter only `prefetchTemporaryLink`s during pre-warm, which has no mock-side analog (the clip URL is deterministic from the track id). So the mock's pre-warm is a literal no-op, which is fine: `playTrack` will load the src when the transition actually fires.
+
+## Risks / Trade-offs
+
+- The mock pre-warm no longer warms the `<audio>` element at all. This is intentional and matches Dropbox semantics — the real cost (network fetch) doesn't exist for the mock, and the previous "warm" was actively harmful (interrupted current playback).
+- If a future test relied on `audio.src` being set after a pre-warm without positionMs, it would need to call `playTrack` instead. No such test exists today.

--- a/openspec/changes/mock-prewarm-no-interrupt/proposal.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`MockPlaybackAdapter.prepareTrack` unconditionally executed `audio.src = clipUrlForTrack(track.id); audio.load();` before checking `options?.positionMs`. For a single-provider mock queue, `nextDescriptor === currentDescriptor` during the pre-warm call in `useProviderPlayback`, so the pre-warm wiped the currently-playing src and halted audio — violating `playback-engine` Requirement 6 (Next-Track Pre-Warm: "Pre-warming SHALL NOT change the current-track index or any visible state").
+
+The Dropbox adapter's `primeAudioForHydrate` already short-circuits when `audio.src && this.currentTrack`. The mock was the outlier.
+
+## What Changes
+
+- Move the `audio.src` / `audio.load()` mutation in `MockPlaybackAdapter.prepareTrack` inside the `if (options?.positionMs !== undefined)` (hydrate) branch, mirroring Dropbox's no-op-when-already-playing behavior. Pre-warm calls become a no-op for the audio element.
+- Within the hydrate branch, also guard the load when `audio.src` is already set for the same track id, so a hydrate retargeted at the currently-playing track does not restart it.
+- Extend `mockPlaybackAdapter.test.ts` with one assertion that `audio.src` is preserved (and `audio.load()` is not called) during a pre-warm call.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+<!-- No spec-level requirement is changing. The existing playback-engine spec already declares Requirement 6 ("Next-Track Pre-Warm: Pre-warming SHALL NOT change the current-track index or any visible state"). This change brings the mock adapter into conformance with that requirement — no delta spec needed. -->
+
+## Impact
+
+- `src/providers/mock/mockPlaybackAdapter.ts` — guard `audio.src`/`audio.load()` behind the positionMs check.
+- `src/providers/mock/__tests__/mockPlaybackAdapter.test.ts` — extend pre-warm coverage with a src-preservation assertion.
+- No production code changes outside the mock provider; no API changes; no new dependencies.
+- Resolves [#1563](https://github.com/smallorbit/vorbis-player/issues/1563).

--- a/openspec/changes/mock-prewarm-no-interrupt/tasks.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/tasks.md
@@ -1,0 +1,14 @@
+## 1. Guard pre-warm in MockPlaybackAdapter
+
+- [x] 1.1 Move `audio.src = clipUrlForTrack(track.id)` and `audio.load()` inside the `if (options?.positionMs !== undefined)` branch in `MockPlaybackAdapter.prepareTrack`.
+- [x] 1.2 Within the hydrate branch, skip the load when `audio.src && this.currentTrack?.id === track.id`, mirroring Dropbox's `primeAudioForHydrate` guard.
+
+## 2. Test coverage
+
+- [x] 2.1 Extend `mockPlaybackAdapter.test.ts` with an assertion that `audio.src` is unchanged and `audio.load` is not called when `prepareTrack` is invoked without `positionMs` against an already-playing track.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green.
+- [x] 3.3 `npm run build` green.

--- a/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
+++ b/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
@@ -201,6 +201,20 @@ describe('MockPlaybackAdapter', () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
+    it('preserves audio.src when pre-warming against an already-playing track', () => {
+      // #given an audio element already loaded with a clip (mid-playback)
+      const originalSrc = 'blob:mock/currently-playing-clip';
+      mockAudio.src = originalSrc;
+      // #when prepareTrack is called without positionMs (pre-warm intent) —
+      // this happens in single-provider queues where nextDescriptor ===
+      // currentDescriptor at the pre-warm call site
+      adapter.prepareTrack(makeTrack('seed-track'));
+      // #then audio.src is unchanged and load() is not invoked, so the
+      // currently-playing audio is not interrupted
+      expect(mockAudio.src).toBe(originalSrc);
+      expect(mockAudio.load).not.toHaveBeenCalled();
+    });
+
     it('does not emit state when positionMs is undefined', () => {
       // #given a subscribed listener
       const listener = vi.fn();

--- a/src/providers/mock/mockPlaybackAdapter.ts
+++ b/src/providers/mock/mockPlaybackAdapter.ts
@@ -167,15 +167,24 @@ export class MockPlaybackAdapter implements PlaybackProvider {
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     const audio = this.ensureAudio();
-    audio.src = clipUrlForTrack(track.id);
-    audio.load();
 
     if (options?.positionMs !== undefined) {
+      // Hydrate intent: load the requested clip and emit staged state. Skip
+      // the load when the audio element already holds the same track to avoid
+      // restarting a mid-flight playback.
+      if (!(audio.src && this.currentTrack?.id === track.id)) {
+        audio.src = clipUrlForTrack(track.id);
+        audio.load();
+      }
       this.currentTrack = track;
       this.startedAtPositionMs = options.positionMs;
       this.startedAtMs = Date.now();
       this.notifyListeners();
     }
+    // Pre-warm intent (options omitted / positionMs undefined): no-op. The
+    // real providers do not mutate the audio element during pre-warm, so the
+    // mock must preserve the currently-playing src — see Dropbox's
+    // primeAudioForHydrate guard at dropboxPlaybackAdapter.ts:235.
   }
 
   probePlayable(track: MediaTrack): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Guard `audio.src` / `audio.load()` mutation in mock `prepareTrack` behind the `options?.positionMs !== undefined` check, mirroring Dropbox's pre-warm pattern
- Extend test to assert `audio.src` is preserved when pre-warming an already-playing track

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (new assertion in `mockPlaybackAdapter.test.ts`)
- `npm run build` green
- Covers playback-engine Requirement 6 (Next-Track Pre-Warm) for the mock provider

Closes #1563