### PR TITLE
fix(auth): skip disconnect confirmation when provider has no queued tracks

### DIFF
--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/design.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`MusicSourcesSection` in `src/components/AppSettingsMenu/SourcesSections.tsx` exposes a single on/off `Switch` per provider. Toggling off currently calls `setDisconnectDialogProviderId(descriptor.id)` unconditionally, which opens `ProviderDisconnectDialog` and waits for the user to confirm or cancel. The dialog computes `affectedQueueCount` by filtering `tracks` for the pending provider id; the dialog body already hides its destructive-warning bar when that count is zero, so an empty-queue prompt asks the user "Are you sure?" with no destructive consequence shown.
+
+`handleConfirmDisconnect` performs the real work: pausing playback, removing the provider's tracks from `tracks` / `originalTracks`, fixing up `currentTrackIndex`, calling `descriptor.auth.logout()`, and finally `toggleProvider(id)`. Today it reads the target id from the dialog state (`disconnectDialogProviderId`).
+
+## Goals / Non-Goals
+
+**Goals**
+- Skip the confirmation dialog when the toggled-off provider has zero tracks in the queue.
+- Preserve current behavior when the provider has one or more tracks in the queue.
+- Update `auth-system` Requirement 3 to make the empty-queue path explicit in the spec.
+
+**Non-Goals**
+- Changing the destructive-cleanup logic (track removal, index fix-up, logout). The same cleanup runs in both branches.
+- Changing `ProviderDisconnectDialog.tsx`. Its warning-bar gating is already correct and stays.
+- Changing the reconnect path or the first-time-login (toggle-on) path.
+- Changing `descriptor.auth.logout()` semantics in Spotify or Dropbox adapters.
+- Adding an "undo" affordance — the spec explicitly rejects confirmation when there is nothing destructive to confirm.
+
+## Decisions
+
+### Decision 1: Gate the dialog on `affectedQueueCount > 0` in the toggle handler
+
+**What**: At toggle-off time, compute `tracks.filter(t => t.provider === descriptor.id).length`. If `> 0`, set `disconnectDialogProviderId` as today (opens the dialog). If `=== 0`, call the disconnect handler immediately with the provider id and skip the dialog.
+
+**Why**: Cheap (O(n) over the queue, which is bounded). Keeps the dialog state machine intact — the dialog is only opened when there is real destructive cleanup to confirm. Aligns with the existing dialog body, which already hides its warning bar in the empty-queue case.
+
+**Alternatives considered**:
+- _Always show the dialog with a generic "Are you sure?" copy._ Rejected: doesn't reduce friction, and the spec explicitly describes confirmation as a guard against destructive queue cleanup, not as a generic logout barrier.
+- _Move the gating into `ProviderDisconnectDialog` (auto-confirm on mount when count is 0)._ Rejected: violates the dialog's contract (it would still flash, would still emit `onConfirm` from inside the modal lifecycle). Cleaner to short-circuit at the call site.
+
+### Decision 2: Generalize `handleConfirmDisconnect` to accept the provider id
+
+**What**: Change `handleConfirmDisconnect` from a no-arg callback that reads `disconnectDialogProviderId` to a callback that accepts a `ProviderId` argument. The dialog's `onConfirm` wraps it as `() => handleConfirmDisconnect(disconnectDialogProviderId!)`, and the empty-queue branch calls `handleConfirmDisconnect(descriptor.id)` directly.
+
+**Why**: Avoids round-tripping through React state (`setDisconnectDialogProviderId` → effect → handler) when we already know the id at the call site. Keeps the cleanup logic in one place.
+
+**Alternatives considered**:
+- _Set `disconnectDialogProviderId` then immediately call the existing no-arg handler._ Rejected: relies on closure-over-stale-state and either needs a `useEffect` (overcomplication) or a `flushSync` (premature optimization workaround). The id-as-argument approach is the obvious React pattern.
+
+### Decision 3: Spec the empty-queue path explicitly under Requirement 3
+
+**What**: Add a new scenario to Requirement 3: _"Toggle off with no queued tracks → the provider is logged out, removed from the enabled set, and no confirmation prompt is shown."_ Soften the requirement statement to make the gating explicit: _"Disconnecting a provider SHALL prompt the user **when its tracks are in the queue**, and on confirmation (or immediately when no tracks are affected) SHALL log the provider out…"_.
+
+**Why**: The current Requirement 3 already implies the gating ("Disconnecting a provider SHALL prompt the user when its tracks are in the queue"), but only the queued-tracks scenario is documented. Adding the empty-queue scenario closes the gap so future implementations don't drift back to the unconditional-prompt behavior.
+
+## Risks / Trade-offs
+
+- **Risk**: A user expecting the existing prompt may be surprised when toggling off an empty-queue provider logs them out immediately. **Mitigation**: This is the documented behavior the spec was always written toward; the prompt's purpose is to guard against queue loss. Toggling back on requires reauth only when the token has also expired — usually it doesn't, so the user can flip back instantly.
+- **Risk**: If a future feature adds destructive cleanup beyond queue tracks (e.g. clearing cached art, signing out of Spotify SDK), the gating-on-queue-count check stops being a proxy for "is there anything destructive to confirm?". **Mitigation**: When that arrives, broaden the gate to a `hasDestructiveCleanup(providerId)` predicate; the current change keeps the gate narrowly scoped to the only destructive consequence today.
+
+## Migration Plan
+
+Single-step change; no migrations or feature flags required. The behavior is opt-out from the user's perspective (it removes a prompt step), not opt-in.
+
+## Open Questions
+
+None.

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/proposal.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The disconnect-confirmation dialog in `MusicSourcesSection` (`src/components/AppSettingsMenu/SourcesSections.tsx`) opens unconditionally when an enabled provider toggle is turned off, even when that provider has zero tracks in the queue. The dialog body in `src/components/ProviderDisconnectDialog.tsx` already gates the destructive-warning bar on `affectedQueueCount > 0`, so when the queue contribution is empty the user is asked "Are you sure?" without any destructive consequence to confirm.
+
+This diverges from `openspec/specs/auth-system/spec.md` Requirement 3 (Disconnect Confirmation and Cleanup), whose scenarios only describe the path "WHEN the user toggles off a provider **whose tracks are in the queue** THEN a confirmation prompt is shown stating the provider name and the count of tracks that will be removed". The spec does not require a prompt when there is no destructive cleanup to confirm; the implementation prompts anyway.
+
+Fixing the implementation is a one-line gate change, but the spec is currently silent on the empty-queue path. This change codifies the empty-queue behavior in the spec and aligns the implementation with it.
+
+## What Changes
+
+- In `SourcesSections.tsx`, compute `affectedQueueCount` for `descriptor.id` at the moment of toggle-off (currently it is only computed for the already-open dialog). If the count is zero, perform the logout + cleanup path directly without opening the confirmation dialog. If the count is greater than zero, keep the existing dialog-based flow.
+- Modify `openspec/specs/auth-system/spec.md` Requirement 3 (Disconnect Confirmation and Cleanup) to document the empty-queue path: when toggling off a provider with no tracks in the queue, the provider is logged out and state is cleaned up immediately, without a confirmation prompt.
+
+No public API changes. No change to `descriptor.auth.logout()` semantics or any provider implementation. No change to `ProviderDisconnectDialog.tsx` (its existing warning-bar gating remains correct). No change to other `AppSettingsMenu` sections or to the reconnect / first-time-login paths.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `auth-system`: Requirement 3 (Disconnect Confirmation and Cleanup) — clarifies that the confirmation prompt is gated on the presence of queued tracks for the disconnecting provider.
+
+## Impact
+
+- `src/components/AppSettingsMenu/SourcesSections.tsx` — toggle-off handler computes `affectedQueueCount` before deciding to open the dialog; existing `handleConfirmDisconnect` is generalized to accept the provider id directly so the empty-queue branch can call it without first setting dialog state.
+- `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` — add a Vitest case asserting that toggling off a provider with an empty queue performs logout + `toggleProvider` immediately and does not open `ProviderDisconnectDialog`. Existing cases for the queued-tracks confirmation path remain unchanged.
+- `openspec/specs/auth-system/spec.md` — Requirement 3 gains an "Toggle off with no queued tracks" scenario; existing scenarios are unchanged.
+- No effect on `src/components/ProviderDisconnectDialog.tsx`.
+- No effect on Spotify or Dropbox auth adapters (`logout()` semantics unchanged).
+- No effect on Playwright snapshots or visual capture.

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/specs/auth-system/spec.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/specs/auth-system/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Disconnect Confirmation and Cleanup
+
+Disconnecting a provider SHALL prompt the user for confirmation when its tracks are in the queue. On confirmation, or immediately when no tracks are affected, the app SHALL log the provider out, remove it from the enabled set, and remove its tracks from the queue and playback state.
+
+#### Scenario: Toggle off with queued tracks
+- **WHEN** the user toggles off a provider whose tracks are in the queue
+- **THEN** a confirmation prompt is shown stating the provider name and the count of tracks that will be removed
+
+#### Scenario: Toggle off with no queued tracks
+- **WHEN** the user toggles off a provider that has no tracks in the queue
+- **THEN** no confirmation prompt is shown
+- **AND** the provider is logged out, removed from the enabled set, and playback state is unchanged
+
+#### Scenario: Confirming disconnect
+- **WHEN** the user confirms the disconnect prompt
+- **THEN** the provider is logged out, removed from the enabled set, and its tracks are removed from the queue and playback state
+
+#### Scenario: Cancelling disconnect
+- **WHEN** the user cancels the disconnect prompt
+- **THEN** the enabled set, queue, and playback state are unchanged

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/tasks.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/tasks.md
@@ -1,0 +1,23 @@
+## 1. Toggle-off gating
+
+- [x] 1.1 In `src/components/AppSettingsMenu/SourcesSections.tsx`, generalize `handleConfirmDisconnect` to accept a `ProviderId` argument (drop the dependency on `disconnectDialogProviderId` inside the handler body; clear the dialog state at the top of the body only if it is set).
+- [x] 1.2 In the `Switch` `onCheckedChange` toggle-off branch, compute `affectedQueueCount = tracks.filter(t => t.provider === descriptor.id).length`. If `> 0`, call `setDisconnectDialogProviderId(descriptor.id)` (existing behavior). If `=== 0`, call `handleConfirmDisconnect(descriptor.id)` directly and skip the dialog.
+- [x] 1.3 Update the dialog's `onConfirm` prop to wrap the generalized handler: `onConfirm={() => disconnectDialogProviderId && handleConfirmDisconnect(disconnectDialogProviderId)}`.
+
+## 2. Test coverage
+
+- [x] 2.1 Add a Vitest case in `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` under the `toggle-off: disconnect dialog flow` describe block: "performs logout and toggleProvider immediately without opening the dialog when the provider has no queued tracks". The test seeds `mockTracks` with only the other provider's tracks, clicks the disable toggle for the empty-queue provider, and asserts both `descriptor.auth.logout` and `mockToggleProvider` were called, and that the dialog title text does not appear.
+- [x] 2.2 Confirm the existing "opens ProviderDisconnectDialog when an enabled provider toggle is turned off" test still passes — that test seeds an empty queue today, so it will need to be reframed against a queue with at least one matching track to preserve its intent ("dialog opens when there is destructive cleanup to confirm"). Update the `#given` to add a matching track for that provider before clicking the toggle.
+- [x] 2.3 Confirm "calls descriptor.auth.logout() and toggleProvider when dialog is confirmed" still passes — same reframing applies (give the disconnecting provider a track in `mockTracks` so the dialog path is exercised).
+- [x] 2.4 Confirm "closes the dialog and leaves state unchanged when Cancel is clicked" still passes — same reframing.
+- [x] 2.5 Confirm "shows affected-track count in disconnect dialog when provider has queued tracks" still passes unchanged (it already seeds a non-empty queue).
+
+## 3. Verify
+
+- [x] 3.1 Run `npx tsc -b --noEmit` — clean.
+- [x] 3.2 Run `npm run test:run` — green.
+- [x] 3.3 Run `npm run build` — clean.
+
+## 4. Spec sync
+
+- [x] 4.1 On archive, ensure `openspec/specs/auth-system/spec.md` Requirement 3 is updated from the change's delta: requirement statement softened to make the gating explicit, and the new "Toggle off with no queued tracks" scenario merged in.

--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -125,10 +125,7 @@ export const MusicSourcesSection = memo(() => {
 
   useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
 
-  const handleConfirmDisconnect = useCallback(() => {
-    const id = disconnectDialogProviderId;
-    if (!id) return;
-
+  const performDisconnect = useCallback((id: ProviderId) => {
     setDisconnectDialogProviderId(null);
 
     const descriptor = registry.get(id);
@@ -163,7 +160,6 @@ export const MusicSourcesSection = memo(() => {
     descriptor?.auth.logout();
     toggleProvider(id);
   }, [
-    disconnectDialogProviderId,
     registry,
     tracks,
     currentTrackIndex,
@@ -172,6 +168,23 @@ export const MusicSourcesSection = memo(() => {
     setCurrentTrackIndex,
     toggleProvider,
   ]);
+
+  const handleConfirmDisconnect = useCallback(() => {
+    if (!disconnectDialogProviderId) return;
+    performDisconnect(disconnectDialogProviderId);
+  }, [disconnectDialogProviderId, performDisconnect]);
+
+  const handleToggleOff = useCallback(
+    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
+      const affectedQueueCount = tracks.filter(t => t.provider === descriptor.id).length;
+      if (affectedQueueCount > 0) {
+        setDisconnectDialogProviderId(descriptor.id);
+      } else {
+        performDisconnect(descriptor.id);
+      }
+    },
+    [tracks, performDisconnect],
+  );
 
   if (providers.length < 2) return null;
 
@@ -206,7 +219,7 @@ export const MusicSourcesSection = memo(() => {
                   } else if (needsReconnect) {
                     handleReconnect(descriptor);
                   } else {
-                    setDisconnectDialogProviderId(descriptor.id);
+                    handleToggleOff(descriptor);
                   }
                 }}
                 aria-label={needsReconnect ? `Reconnect ${descriptor.name}` : isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -93,8 +93,9 @@ describe('MusicSourcesSection', () => {
   });
 
   describe('toggle-off: disconnect dialog flow', () => {
-    it('opens ProviderDisconnectDialog when an enabled provider toggle is turned off', () => {
+    it('opens ProviderDisconnectDialog when an enabled provider with queued tracks is toggled off', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -113,6 +114,7 @@ describe('MusicSourcesSection', () => {
 
     it('calls descriptor.auth.logout() and toggleProvider when dialog is confirmed', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -133,6 +135,7 @@ describe('MusicSourcesSection', () => {
 
     it('closes the dialog and leaves state unchanged when Cancel is clicked', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -147,6 +150,26 @@ describe('MusicSourcesSection', () => {
       expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
       expect(spotifyDesc.auth.logout).not.toHaveBeenCalled();
       expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('performs logout and toggleProvider immediately without opening the dialog when the provider has no queued tracks', () => {
+      // #given — only dropbox has queued tracks; toggling off spotify should skip the prompt
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'dropbox' as 'spotify' })];
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then
+      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
+      expect(spotifyDesc.auth.logout).toHaveBeenCalledOnce();
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
     });
 
     it('shows affected-track count in disconnect dialog when provider has queued tracks', () => {


### PR DESCRIPTION
## Summary
- Gate the disconnect-confirmation dialog on `affectedQueueCount > 0`
- Empty-queue toggle-off performs logout + cleanup immediately; matches the spirit of auth-system Requirement 3

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (2016/2016)
- `npm run build` green
- Manual: toggle off a provider with empty queue → no prompt, immediate logout; toggle off with queued tracks → existing prompt

Closes #1557