### PR TITLE
fix(auth): toggle provider off on session expiry; remove reconnect affordance

### DIFF
--- a/openspec/changes/remove-reconnect-affordance/design.md
+++ b/openspec/changes/remove-reconnect-affordance/design.md
@@ -20,18 +20,26 @@ This three-state model — connected / reconnect / disabled — predates the cur
 
 ### Toggle off via ref pattern, not effect deps
 
-The existing `SESSION_EXPIRED_EVENT` listener lives in a `useEffect` with `[]` deps so it attaches once and never re-binds. It must now call `toggleProvider(providerId)`, which closes over the latest `enabledProviderIds` and `setStoredEnabledIds`. Re-binding the listener on every state change would race the user's own toggle interactions and risk dropping events fired during a re-render.
+The existing `SESSION_EXPIRED_EVENT` listener lives in a `useEffect` with `[]` deps so it attaches once and never re-binds. It must now flip the provider off, which depends on the latest `enabledProviderIds` and the underlying `setStoredEnabledIds` setter. Re-binding the listener on every state change would race the user's own toggle interactions and risk dropping events fired during a re-render.
 
 Standard React pattern: keep a `latestRef` for each function or value the handler needs, update it in a separate `useEffect` on every render, and read `.current` inside the handler.
 
 ```ts
-const toggleProviderRef = useRef(toggleProvider);
+const setStoredEnabledIdsRef = useRef(setStoredEnabledIds);
 const enabledProviderIdsRef = useRef(enabledProviderIds);
-useEffect(() => { toggleProviderRef.current = toggleProvider; }, [toggleProvider]);
+useEffect(() => { setStoredEnabledIdsRef.current = setStoredEnabledIds; }, [setStoredEnabledIds]);
 useEffect(() => { enabledProviderIdsRef.current = enabledProviderIds; }, [enabledProviderIds]);
 ```
 
-Inside `handleSessionExpired`, gate the toggle on `enabledProviderIdsRef.current.includes(providerId)` so we don't accidentally re-add a provider the user just turned off.
+Inside `handleSessionExpired`, gate the write on `enabledProviderIdsRef.current.includes(providerId)` so we don't accidentally re-add a provider the user just turned off.
+
+### Session-expired bypasses the "last enabled" guard
+
+The user-facing `toggleProvider` action refuses to disable the last remaining enabled provider — it returns the current set unchanged when `current.length <= 1`. That guard exists to protect against accidental user-initiated zero-providers state (the picker would have nothing to pick from).
+
+Session-expired must not honor that guard. If the sole enabled provider has its auth fail, leaving it enabled would resurrect exactly the forbidden third state the change is removing: enabled + unauthenticated, with no badge or affordance to telegraph what's wrong. So `handleSessionExpired` writes through `setStoredEnabledIds` directly with a custom updater that always removes the expired id, bypassing the guard. The user re-enables via the existing toggle, which kicks off OAuth.
+
+`toggleProvider` retains its guard for the user-driven path; only the forced session-expired path bypasses it.
 
 ### Drop `RECONNECT_TOAST_ID` entirely
 

--- a/openspec/changes/remove-reconnect-affordance/design.md
+++ b/openspec/changes/remove-reconnect-affordance/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The "Reconnect needed" affordance grew up alongside the multi-provider toggle and the session-expired event flow (`SESSION_EXPIRED_EVENT`). When `useProviderRefresh` detects a terminal 401 it dispatches the event; `ProviderContext` reacts by setting a `reconnectPrompt` (drives a persistent action toast) and a `disconnectToast` (drives a short auto-dismiss toast), and bumping `authRevision` so `connectedProviderIds` recomputes. The provider stays in `enabledProviderIds`, so settings shows a "Reconnect needed" badge and the switch reroutes to a `handleReconnect` callback that opens the OAuth popup directly.
+
+This three-state model — connected / reconnect / disabled — predates the current spec (Requirement 2 of `auth-system/spec.md`) which explicitly forbids a separate reconnect affordance. The standard "toggle on while not authenticated" flow already kicks off OAuth, so the dedicated reconnect path is redundant.
+
+## Goals / Non-Goals
+
+**Goals**
+- Make session expiry yield a clean two-state UI: provider is either ON+authed ("Connected") or OFF.
+- Preserve the informational session-expired toast.
+- Re-enabling uses the existing "toggle on" → OAuth path.
+
+**Non-Goals**
+- Changing how `SESSION_EXPIRED_EVENT` is dispatched or which adapters dispatch it.
+- Changing `descriptor.auth.logout()` semantics — the adapter already logs itself out when a terminal failure is detected; we are only altering the UI state that accompanies the existing flow.
+- Touching `useQueueManagement` or `useProviderPlayback` — queue/playback fallthrough already works on `connectedProviderIds`, which the toggle-off updates correctly.
+
+## Decisions
+
+### Toggle off via ref pattern, not effect deps
+
+The existing `SESSION_EXPIRED_EVENT` listener lives in a `useEffect` with `[]` deps so it attaches once and never re-binds. It must now call `toggleProvider(providerId)`, which closes over the latest `enabledProviderIds` and `setStoredEnabledIds`. Re-binding the listener on every state change would race the user's own toggle interactions and risk dropping events fired during a re-render.
+
+Standard React pattern: keep a `latestRef` for each function or value the handler needs, update it in a separate `useEffect` on every render, and read `.current` inside the handler.
+
+```ts
+const toggleProviderRef = useRef(toggleProvider);
+const enabledProviderIdsRef = useRef(enabledProviderIds);
+useEffect(() => { toggleProviderRef.current = toggleProvider; }, [toggleProvider]);
+useEffect(() => { enabledProviderIdsRef.current = enabledProviderIds; }, [enabledProviderIds]);
+```
+
+Inside `handleSessionExpired`, gate the toggle on `enabledProviderIdsRef.current.includes(providerId)` so we don't accidentally re-add a provider the user just turned off.
+
+### Drop `RECONNECT_TOAST_ID` entirely
+
+The reconnect toast was the only consumer of that ID; once the toast effect is gone, the constant is dead.
+
+### Disconnect toast no longer waits for reconnect
+
+The current `disconnectToast` effect guards on `if (!disconnectToast || reconnectPrompt) return` to avoid showing two toasts at once. With reconnect gone, the guard simplifies to `if (!disconnectToast) return`.
+
+### Fallthrough copy
+
+"Reconnect in Settings." was correct under the old model (the expired provider stayed enabled and showed a reconnect badge). Under the new model the provider is fully toggled off, so the user needs to re-enable it. "Re-enable in Settings." is the accurate instruction.
+
+## Risks / Trade-offs
+
+- A user who clears their Spotify token mid-playback will lose the in-toast "Reconnect" shortcut. They must open Settings to flip the toggle back on. This matches the spec and is consistent with the rest of the multi-provider toggle UX (no toast-driven reconnect for any other failure mode).
+- Tests that pinned the old behavior need to be rewritten; one new test added at the context layer is enough to lock the new contract.
+
+## Migration Plan
+
+Single PR. No data migration — `enabledProviderIds` is a localStorage list and removing an id from it is the same shape as a user-driven toggle-off, which already round-trips cleanly. No deprecation notice needed (the affordance was internal UI).

--- a/openspec/changes/remove-reconnect-affordance/proposal.md
+++ b/openspec/changes/remove-reconnect-affordance/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The settings UI currently exposes a third provider status — "Reconnect needed" (`isEnabled && !isConnected`) — as a separate visual and interaction affordance:
+
+- `src/components/AppSettingsMenu/SourcesSections.tsx` renders a "Reconnect needed" status badge and branches the switch's `onCheckedChange` to a dedicated `handleReconnect` flow.
+- `src/components/AudioPlayer.tsx` surfaces a persistent reconnect-action toast via `acceptReconnectPrompt`.
+- `src/contexts/ProviderContext.tsx` manages `reconnectPrompt` state and exposes `acceptReconnectPrompt` / `dismissReconnectPrompt`.
+
+This third state violates `openspec/specs/auth-system/spec.md` Requirement 2 (Single On-Off Toggle per Provider): "Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance."
+
+It also creates a real user-visible bug (reported May 16 2026): when Spotify's access token is cleared mid-playback in a dual-provider session, the Spotify toggle stays ON with the "Reconnect needed" badge instead of toggling OFF. The user has to flip it off and back on to trigger the OAuth flow — exactly the sort of "third state" the spec already forbids.
+
+## What Changes
+
+- When a `SESSION_EXPIRED_EVENT` fires for a provider, `ProviderContext` SHALL fully toggle that provider OFF (remove it from `enabledProviderIds`) in addition to dispatching the existing disconnect toast.
+- Remove the "Reconnect needed" status badge, the `handleReconnect` branch on the toggle, the `needsReconnect` flag, and the "Reconnect <name>" aria-label from `SourcesSections.tsx`. Status simplifies to `'connected' | 'disabled'`.
+- Remove `reconnectPrompt` state, `acceptReconnectPrompt`, `dismissReconnectPrompt` from `ProviderContext` and `ProviderContextValue`.
+- Remove the reconnect-action toast from `AudioPlayer.tsx` and the `RECONNECT_TOAST_ID` constant. Drop the `|| reconnectPrompt` gate on the disconnect-toast effect.
+- Update the auto-fallthrough notification copy from "Reconnect in Settings." to "Re-enable in Settings." (the provider is no longer in a special "reconnect" state — it's plainly off).
+- Re-enabling is the standard Requirement 2 scenario: toggling the provider back ON while not authenticated kicks off OAuth — no special path required.
+
+No changes to provider auth adapters (`spotify`, `dropbox`), no changes to the `SESSION_EXPIRED_EVENT` dispatch itself, no changes to `useQueueManagement` or `useProviderPlayback`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `auth-system`: Requirement 2 clarifies that session expiry MUST toggle the provider off (no separate reconnect state). Requirement 6 clarifies that the session-expired notification is informational only — no action button.
+
+## Impact
+
+- `src/contexts/ProviderContext.tsx` — `handleSessionExpired` toggles the provider off via a ref pattern; `reconnectPrompt` state + accept/dismiss callbacks deleted; fallthrough copy updated.
+- `src/components/AppSettingsMenu/SourcesSections.tsx` — `handleReconnect`, `needsReconnect`, the `'reconnect'` status branch, and the `Reconnect <name>` aria-label all removed.
+- `src/components/AppSettingsMenu/styled.ts` — `ProviderStatusBadge` `$status` union narrowed to `'connected' | 'disabled'`; reconnect color branch removed.
+- `src/components/AudioPlayer.tsx` — reconnect-toast effect + `RECONNECT_TOAST_ID` deleted; disconnect-toast effect no longer gates on `reconnectPrompt`.
+- `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` — token-expired tests replaced with an assertion that the toggle is unchecked when the provider is enabled-but-unauth (matches the new spec) and a baseline "no Reconnect button visible" assertion stays.
+- `src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx` — stale "Reconnect needed" badge test deleted.
+- `src/contexts/__tests__/ProviderContext.test.tsx` — new test asserting that a `SESSION_EXPIRED_EVENT` removes the provider id from `enabledProviderIds`.

--- a/openspec/changes/remove-reconnect-affordance/specs/auth-system/spec.md
+++ b/openspec/changes/remove-reconnect-affordance/specs/auth-system/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Single On-Off Toggle per Provider
+
+Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance. When a provider's session becomes unrecoverable, the app SHALL toggle the provider off rather than expose a third "reconnect needed" state.
+
+#### Scenario: Toggle on while already authenticated
+- **WHEN** the user toggles on a provider that is already authenticated
+- **THEN** the provider is added to the enabled set with no login prompt
+
+#### Scenario: Toggle on while not authenticated
+- **WHEN** the user toggles on a provider that is not authenticated
+- **THEN** an OAuth flow is initiated immediately
+- **AND** the provider is added to the enabled set only after the flow reports success
+
+#### Scenario: OAuth cancelled or failed
+- **WHEN** an OAuth flow opened by a toggle is cancelled or fails
+- **THEN** the toggle reverts to off and a "couldn't connect" notification is shown
+
+#### Scenario: Session expires mid-use
+- **WHEN** a provider's session becomes unrecoverable during normal use
+- **THEN** the provider is removed from the enabled set so the toggle reads off
+- **AND** the re-enable path is the standard "toggle on while not authenticated" flow
+
+### Requirement: Mid-Session Unrecoverable Auth Failure
+
+When a provider's session becomes unrecoverable during normal use, the app SHALL log the provider out automatically, toggle the provider off in settings, and surface an informational "session expired" notification. The notification SHALL NOT carry a reconnect action button — re-enabling flows through the standard toggle path.
+
+#### Scenario: Provider returns terminal auth error during use
+- **WHEN** a provider reports an unrecoverable authentication failure during normal use
+- **THEN** the provider is logged out automatically
+- **AND** the provider is removed from the enabled set
+- **AND** an informational "session expired" notification is shown with no action button

--- a/openspec/changes/remove-reconnect-affordance/tasks.md
+++ b/openspec/changes/remove-reconnect-affordance/tasks.md
@@ -1,0 +1,22 @@
+## 1. Implementation
+
+- [x] 1.1 In `src/contexts/ProviderContext.tsx`, add `toggleProviderRef` and `enabledProviderIdsRef` and keep them current via per-deps `useEffect`s.
+- [x] 1.2 In `handleSessionExpired`, after dispatching `disconnectToast` and bumping `authRevision`, if `enabledProviderIdsRef.current.includes(providerId)` call `toggleProviderRef.current(providerId)`.
+- [x] 1.3 Delete `reconnectPrompt` state, `setReconnectPrompt`, `dismissReconnectPrompt`, `acceptReconnectPrompt`, and their entries on `ProviderContextValue` + the memoized context value.
+- [x] 1.4 Change the fallthrough notification copy from "Reconnect in Settings." to "Re-enable in Settings.".
+- [x] 1.5 In `src/components/AudioPlayer.tsx`, drop `reconnectPrompt`, `acceptReconnectPrompt`, `dismissReconnectPrompt` from the `useProviderContext()` destructure; delete the reconnect-toast `useEffect`; delete `RECONNECT_TOAST_ID`; remove the `|| reconnectPrompt` guard on the disconnect-toast effect.
+- [x] 1.6 In `src/components/AppSettingsMenu/SourcesSections.tsx`, remove `handleReconnect`, `needsReconnect`, the `'reconnect'` status branch, and the `Reconnect <name>` aria-label. Simplify `onCheckedChange` to two branches: `if (!isEnabled) handleToggleOn; else setDisconnectDialogProviderId`.
+- [x] 1.7 Narrow `ProviderStatusBadge` `$status` union to `'connected' | 'disabled'` in `src/components/AppSettingsMenu/styled.ts` and drop the reconnect color branch.
+
+## 2. Tests
+
+- [x] 2.1 Replace the `'token-expired reconnect flow'` test block in `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` with assertions that match the new behavior (toggle is unchecked when the provider is enabled-but-unauth after a SESSION_EXPIRED_EVENT propagates; no `"Reconnect needed"` text in DOM).
+- [x] 2.2 Remove the stale `"Reconnect needed" badge` test from `src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx`.
+- [x] 2.3 Add `src/contexts/__tests__/ProviderContext.test.tsx` asserting that dispatching `SESSION_EXPIRED_EVENT` removes the provider id from `enabledProviderIds`.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green.
+- [x] 3.3 `npm run build` green.
+- [x] 3.4 `grep -rn "reconnectPrompt\|acceptReconnectPrompt\|dismissReconnectPrompt\|handleReconnect\|'Reconnect needed'\|needsReconnect\|Tap to reconnect" src/` returns no production-code hits.

--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -114,15 +114,6 @@ export const MusicSourcesSection = memo(() => {
     [openLoginPopup, toggleProvider],
   );
 
-  const handleReconnect = useCallback(
-    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
-      openLoginPopup(descriptor, () => {
-        // Provider is already in enabledProviderIds — no toggleProvider call needed.
-      });
-    },
-    [openLoginPopup],
-  );
-
   useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
 
   const handleConfirmDisconnect = useCallback(() => {
@@ -189,27 +180,24 @@ export const MusicSourcesSection = memo(() => {
         {providers.map((descriptor) => {
           const isEnabled = enabledProviderIds.includes(descriptor.id);
           const isConnected = descriptor.auth.isAuthenticated();
-          const needsReconnect = isEnabled && !isConnected;
           const isLastEnabled = enabledProviderIds.length <= 1 && isEnabled;
-          const status = isEnabled && isConnected ? 'connected' : needsReconnect ? 'reconnect' : 'disabled';
+          const status: 'connected' | 'disabled' = isEnabled && isConnected ? 'connected' : 'disabled';
           return (
             <ProviderRow key={descriptor.id}>
               <ProviderName>{descriptor.name}</ProviderName>
               <ProviderStatusBadge $status={status}>
-                {status === 'connected' ? 'Connected' : status === 'reconnect' ? 'Reconnect needed' : ''}
+                {status === 'connected' ? 'Connected' : ''}
               </ProviderStatusBadge>
               <Switch
                 checked={isEnabled}
                 onCheckedChange={() => {
                   if (!isEnabled) {
                     handleToggleOn(descriptor);
-                  } else if (needsReconnect) {
-                    handleReconnect(descriptor);
                   } else {
                     setDisconnectDialogProviderId(descriptor.id);
                   }
                 }}
-                aria-label={needsReconnect ? `Reconnect ${descriptor.name}` : isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}
+                aria-label={isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}
                 disabled={isLastEnabled}
                 variant="neutral"
               />

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -342,8 +342,8 @@ describe('MusicSourcesSection', () => {
     });
   });
 
-  describe('token-expired reconnect flow', () => {
-    it('shows "Reconnect needed" badge when provider is enabled but auth has expired', () => {
+  describe('session-expired: provider toggles off (no reconnect affordance)', () => {
+    it('does not render a "Reconnect needed" badge when a provider is enabled but auth has expired', () => {
       // #given — Spotify is enabled but its auth token has expired
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       const dropboxDesc = makeDropboxDescriptor();
@@ -353,30 +353,36 @@ describe('MusicSourcesSection', () => {
       // #when
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #then
-      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+      // #then — the third "reconnect" state is gone
+      expect(screen.queryByText('Reconnect needed')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Reconnect Spotify')).not.toBeInTheDocument();
     });
 
-    it('sets aria-label to "Reconnect <name>" when provider is enabled but auth has expired', () => {
-      // #given — Spotify is enabled but its auth token has expired
+    it('shows Spotify toggle as unchecked once SESSION_EXPIRED has removed it from enabledProviderIds', () => {
+      // #given — SESSION_EXPIRED handler in ProviderContext has already removed Spotify
+      // from the enabled set; Dropbox stays enabled+connected
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockEnabledProviderIds = ['dropbox'];
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
 
       // #when
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #then — screen readers hear "Reconnect Spotify", not "Disable Spotify"
-      expect(screen.getByLabelText('Reconnect Spotify')).toBeInTheDocument();
+      // #then — Spotify toggle reads "Enable Spotify" (i.e. off) and is unchecked
+      const spotifyToggle = screen.getByLabelText('Enable Spotify');
+      expect(spotifyToggle).toHaveAttribute('aria-checked', 'false');
+      // Dropbox toggle stays on
+      const dropboxToggle = screen.getByLabelText('Disable Dropbox');
+      expect(dropboxToggle).toHaveAttribute('aria-checked', 'true');
     });
 
-    it('does not open ProviderDisconnectDialog when clicking the toggle on an expired provider', async () => {
-      // #given — Spotify is enabled but its auth token has expired
+    it('routes a re-enable click on the expired provider through the standard OAuth flow', async () => {
+      // #given — Spotify has been toggled off (session expired); user is about to flip it back on
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
       const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockEnabledProviderIds = ['dropbox'];
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
       mockRegistry.get.mockImplementation((id: string) =>
         id === 'spotify' ? spotifyDesc : dropboxDesc,
@@ -386,83 +392,13 @@ describe('MusicSourcesSection', () => {
 
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #when
-      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
+      // #when — user flips the off toggle back on
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
 
-      // #then — disconnect dialog must NOT appear
-      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
-    });
-
-    it('calls descriptor.auth.beginLogin when clicking the toggle on an expired provider', async () => {
-      // #given — Spotify is enabled but its auth token has expired
-      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
-      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
-      const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
-      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
-      mockRegistry.get.mockImplementation((id: string) =>
-        id === 'spotify' ? spotifyDesc : dropboxDesc,
-      );
-      const mockPopup = { closed: false } as Window;
-      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
-
-      render(<Wrapper><MusicSourcesSection /></Wrapper>);
-
-      // #when
-      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
-
-      // #then — OAuth popup must be initiated
+      // #then — standard "toggle on while not authenticated" flow kicks off OAuth
       await waitFor(() => {
         expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
       });
-    });
-
-    it('does not call toggleProvider after a successful reconnect (provider already enabled)', async () => {
-      // #given — Spotify is enabled but its auth token has expired; reconnect completes successfully
-      const isAuthenticated = vi.fn().mockReturnValue(false);
-      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated });
-      const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
-      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
-      mockRegistry.get.mockImplementation((id: string) =>
-        id === 'spotify' ? spotifyDesc : dropboxDesc,
-      );
-
-      // beginLogin opens a popup that is already closed (immediate dismiss).
-      // isAuthenticated stays false until after the popup reference is captured,
-      // then switches to true so the poll detects a successful reconnect.
-      const mockPopupObj = { closed: true };
-      vi.mocked(spotifyDesc.auth.beginLogin).mockImplementation(async () => {
-        // Switch auth to "succeeded" before window.open fires so the poll sees it
-        isAuthenticated.mockReturnValue(true);
-        window.open('https://accounts.spotify.com/authorize', '_blank');
-      });
-      const originalOpenDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
-      Object.defineProperty(window, 'open', {
-        value: () => mockPopupObj,
-        writable: true,
-        configurable: true,
-      });
-
-      try {
-        render(<Wrapper><MusicSourcesSection /></Wrapper>);
-
-        // #when
-        fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
-        await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
-
-        // #then — toggleProvider must NOT be called (provider is already enabled)
-        await waitFor(
-          () => {
-            expect(mockToggleProvider).not.toHaveBeenCalled();
-          },
-          { timeout: 2000 },
-        );
-      } finally {
-        if (originalOpenDescriptor) {
-          Object.defineProperty(window, 'open', originalOpenDescriptor);
-        }
-      }
     });
   });
 });

--- a/src/components/AppSettingsMenu/styled.ts
+++ b/src/components/AppSettingsMenu/styled.ts
@@ -181,15 +181,13 @@ export const ProviderName = styled.span`
   flex-shrink: 0;
 `;
 
-export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' | 'reconnect' }>`
+export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' }>`
   font-size: 0.6875rem;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   color: ${({ $status, theme }) =>
     $status === 'connected'
       ? theme.colors.success
-      : $status === 'reconnect'
-        ? theme.colors.warning
-        : theme.colors.muted.foreground};
+      : theme.colors.muted.foreground};
   flex: 1;
 `;
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -41,7 +41,6 @@ const LibraryRoute = lazy(() => import('./LibraryRoute'));
 
 const RESUME_TOAST_ID = 'resume-toast';
 const FALLTHROUGH_TOAST_ID = 'fallthrough-toast';
-const RECONNECT_TOAST_ID = 'reconnect-toast';
 const DISCONNECT_TOAST_ID = 'disconnect-toast';
 
 const Container = styled.div`
@@ -356,7 +355,7 @@ const AudioPlayerComponent = () => {
     withResumeDismiss,
   ]);
 
-  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();
+  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, disconnectToast, dismissDisconnectToast } = useProviderContext();
 
   useEffect(() => {
     if (!fallthroughNotification) return;
@@ -368,26 +367,13 @@ const AudioPlayerComponent = () => {
   }, [fallthroughNotification, dismissFallthroughNotification]);
 
   useEffect(() => {
-    if (!reconnectPrompt) {
-      toast.dismiss(RECONNECT_TOAST_ID);
-      return;
-    }
-    toast(reconnectPrompt.message, {
-      id: RECONNECT_TOAST_ID,
-      duration: Infinity,
-      action: { label: 'Reconnect', onClick: acceptReconnectPrompt },
-      onDismiss: dismissReconnectPrompt,
-    });
-  }, [reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt]);
-
-  useEffect(() => {
-    if (!disconnectToast || reconnectPrompt) return;
+    if (!disconnectToast) return;
     toast(disconnectToast, {
       id: DISCONNECT_TOAST_ID,
       onDismiss: dismissDisconnectToast,
       onAutoClose: dismissDisconnectToast,
     });
-  }, [disconnectToast, reconnectPrompt, dismissDisconnectToast]);
+  }, [disconnectToast, dismissDisconnectToast]);
 
   // Setup is needed when no provider has been chosen yet and none are connected,
   // or when the active provider isn't authenticated and no other enabled provider is either.

--- a/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
@@ -198,9 +198,10 @@ describe('SettingsV2 SourcesSection', () => {
     });
   });
 
-  describe('token-expired reconnect state', () => {
-    it('shows "Reconnect needed" badge when a provider is enabled but isAuthenticated returns false', () => {
-      // #given — Spotify is enabled but its auth token has expired
+  describe('session-expired: no reconnect affordance', () => {
+    it('does not render a "Reconnect needed" badge when a provider is enabled but isAuthenticated returns false', () => {
+      // #given — Spotify is enabled but its auth token has expired; the session-expired
+      // handler in ProviderContext will toggle it off, so the reconnect state never surfaces
       const spotify = makeDescriptor('spotify', 'Spotify', { isAuthenticated: false });
       const dropbox = makeDescriptor('dropbox', 'Dropbox');
       mockEnabledProviderIds = ['spotify', 'dropbox'];
@@ -215,7 +216,7 @@ describe('SettingsV2 SourcesSection', () => {
       );
 
       // #then
-      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+      expect(screen.queryByText('Reconnect needed')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -273,12 +273,25 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     activeDescriptor?.playback.pause().catch(() => {});
     setStoredProviderId(fallback);
 
+    // Toggle the expired provider off so the settings UI reflects its
+    // not-connected state. Mirrors handleSessionExpired and bypasses
+    // toggleProvider's "last enabled" guard by writing setStoredEnabledIds
+    // directly — the underlying auth has failed and the toggle must
+    // accurately reflect that regardless of how many providers remain.
+    const expiredId = storedProviderId;
+    setStoredEnabledIds(prev => {
+      const current =
+        prev === null ? allProviderIds : prev.filter(pid => providerRegistry.has(pid));
+      if (!current.includes(expiredId)) return current;
+      return current.filter(pid => pid !== expiredId);
+    });
+
     // Notify the user
     const expiredName = activeDescriptor?.name ?? storedProviderId;
     setFallthroughNotification(
       `${expiredName} session expired — switched to ${fallbackDesc.name}. Re-enable in Settings.`,
     );
-  }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId]);
+  }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId, setStoredEnabledIds, allProviderIds]);
 
   // ── Auto-switch when active provider is disabled ──────────────────────
   useEffect(() => {

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -104,29 +104,31 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   // ── Enabled providers (multi-toggle) ───────────────────────────────────
-  const [storedEnabledIds, setStoredEnabledIds] = useLocalStorage<ProviderId[]>(
+  // Stored value uses `null` as the "uninitialized" sentinel (default to all
+  // registered providers). An explicit `[]` means the user — or a forced
+  // session-expired toggle-off — has emptied the set, and we must honor it
+  // rather than re-defaulting.
+  const [storedEnabledIds, setStoredEnabledIds] = useLocalStorage<ProviderId[] | null>(
     STORAGE_KEYS.ENABLED_PROVIDERS,
-    [],
+    null,
   );
 
-  // Validate stored enabled IDs — only keep those that are actually registered.
-  // If nothing is stored yet, default to all registered providers.
   const enabledProviderIds = useMemo(() => {
-    const valid = storedEnabledIds.filter(id => providerRegistry.has(id));
-    if (valid.length > 0) return valid;
-    // Default: enable all registered providers
-    return allProviderIds;
+    if (storedEnabledIds === null) return allProviderIds;
+    return storedEnabledIds.filter(id => providerRegistry.has(id));
   }, [storedEnabledIds, allProviderIds]);
 
   const toggleProvider = useCallback(
     (id: ProviderId) => {
       if (!providerRegistry.has(id)) return;
       setStoredEnabledIds(prev => {
-        const validPrev = prev.filter(pid => providerRegistry.has(pid));
-        const current = validPrev.length > 0 ? validPrev : allProviderIds;
+        const current =
+          prev === null ? allProviderIds : prev.filter(pid => providerRegistry.has(pid));
         const isCurrentlyEnabled = current.includes(id);
         if (isCurrentlyEnabled) {
-          // Don't disable the last remaining provider
+          // Don't disable the last remaining provider via the user-facing
+          // toggle. Session-expired bypasses this guard by writing through
+          // `setStoredEnabledIds` directly (see handleSessionExpired below).
           if (current.length <= 1) return current;
           return current.filter(pid => pid !== id);
         } else {
@@ -164,17 +166,28 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   const dismissDisconnectToast = useCallback(() => setDisconnectToast(null), []);
 
   // Latest-value refs so the SESSION_EXPIRED_EVENT listener (attached once,
-  // []-deps) can read the current toggle helpers without re-binding on every
+  // []-deps) can read the current state setters without re-binding on every
   // render. Re-binding would race user-driven toggles and risk dropping events
   // fired during a re-render.
-  const toggleProviderRef = useRef(toggleProvider);
+  //
+  // Session-expired uses `setStoredEnabledIds` directly instead of going
+  // through `toggleProvider` so it can bypass the "do not disable the last
+  // remaining provider" guard. That guard exists to prevent accidental
+  // user-initiated zero-provider states; a forced session-expired toggle-off
+  // must accurately reflect that the underlying auth has failed, regardless
+  // of how many providers remain enabled.
+  const setStoredEnabledIdsRef = useRef(setStoredEnabledIds);
   const enabledProviderIdsRef = useRef(enabledProviderIds);
+  const allProviderIdsRef = useRef(allProviderIds);
   useEffect(() => {
-    toggleProviderRef.current = toggleProvider;
-  }, [toggleProvider]);
+    setStoredEnabledIdsRef.current = setStoredEnabledIds;
+  }, [setStoredEnabledIds]);
   useEffect(() => {
     enabledProviderIdsRef.current = enabledProviderIds;
   }, [enabledProviderIds]);
+  useEffect(() => {
+    allProviderIdsRef.current = allProviderIds;
+  }, [allProviderIds]);
 
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
@@ -186,7 +199,14 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       setDisconnectToast(`${name} disconnected — session expired.`);
       setAuthRevision(prev => prev + 1);
       if (enabledProviderIdsRef.current.includes(providerId)) {
-        toggleProviderRef.current(providerId);
+        setStoredEnabledIdsRef.current(prev => {
+          const current =
+            prev === null
+              ? allProviderIdsRef.current
+              : prev.filter(pid => providerRegistry.has(pid));
+          if (!current.includes(providerId)) return current;
+          return current.filter(pid => pid !== providerId);
+        });
       }
     };
 

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -56,13 +56,6 @@ interface ProviderContextValue {
   /** Dismiss the fallthrough notification. */
   dismissFallthroughNotification: () => void;
 
-  /** Reconnect prompt shown when a provider's refresh token is rejected (400/401). Persists until acted upon. */
-  reconnectPrompt: { providerId: ProviderId; message: string } | null;
-  /** Trigger the OAuth flow for the provider with a pending reconnect prompt. */
-  acceptReconnectPrompt: () => void;
-  /** Dismiss the reconnect prompt without reconnecting. */
-  dismissReconnectPrompt: () => void;
-
   /** Auto-dismiss toast shown immediately when a provider is disconnected due to an unrecoverable 401. */
   disconnectToast: string | null;
   /** Dismiss the disconnect toast. */
@@ -166,12 +159,22 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   const [fallthroughNotification, setFallthroughNotification] = useState<string | null>(null);
   const dismissFallthroughNotification = useCallback(() => setFallthroughNotification(null), []);
 
-  // ── Session-expired reconnect prompt ─────────────────────────────────
-  const [reconnectPrompt, setReconnectPrompt] = useState<{ providerId: ProviderId; message: string } | null>(null);
-
   // ── Disconnect toast (auto-dismiss) ──────────────────────────────────
   const [disconnectToast, setDisconnectToast] = useState<string | null>(null);
   const dismissDisconnectToast = useCallback(() => setDisconnectToast(null), []);
+
+  // Latest-value refs so the SESSION_EXPIRED_EVENT listener (attached once,
+  // []-deps) can read the current toggle helpers without re-binding on every
+  // render. Re-binding would race user-driven toggles and risk dropping events
+  // fired during a re-render.
+  const toggleProviderRef = useRef(toggleProvider);
+  const enabledProviderIdsRef = useRef(enabledProviderIds);
+  useEffect(() => {
+    toggleProviderRef.current = toggleProvider;
+  }, [toggleProvider]);
+  useEffect(() => {
+    enabledProviderIdsRef.current = enabledProviderIds;
+  }, [enabledProviderIds]);
 
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
@@ -180,32 +183,15 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       if (!providerId) return;
       const descriptor = providerRegistry.get(providerId);
       const name = descriptor?.name ?? providerId;
-      setReconnectPrompt(prev => {
-        if (prev?.providerId === providerId) return prev;
-        return {
-          providerId,
-          message: `Your ${name} session has expired. Tap to reconnect.`,
-        };
-      });
       setDisconnectToast(`${name} disconnected — session expired.`);
       setAuthRevision(prev => prev + 1);
+      if (enabledProviderIdsRef.current.includes(providerId)) {
+        toggleProviderRef.current(providerId);
+      }
     };
 
     window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
     return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
-  }, []);
-
-  const dismissReconnectPrompt = useCallback(() => setReconnectPrompt(null), []);
-
-  const acceptReconnectPrompt = useCallback(() => {
-    setReconnectPrompt(current => {
-      if (!current) return null;
-      const descriptor = providerRegistry.get(current.providerId);
-      descriptor?.auth.beginLogin({ popup: true }).catch(error => {
-        console.warn('[ProviderContext] Failed to begin login for reconnect:', error);
-      });
-      return null;
-    });
   }, []);
 
   // ── Active provider (for playback) ─────────────────────────────────────
@@ -270,7 +256,7 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     // Notify the user
     const expiredName = activeDescriptor?.name ?? storedProviderId;
     setFallthroughNotification(
-      `${expiredName} session expired — switched to ${fallbackDesc.name}. Reconnect in Settings.`,
+      `${expiredName} session expired — switched to ${fallbackDesc.name}. Re-enable in Settings.`,
     );
   }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId]);
 
@@ -310,15 +296,12 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       connectedProviderIds,
       fallthroughNotification,
       dismissFallthroughNotification,
-      reconnectPrompt,
-      acceptReconnectPrompt,
-      dismissReconnectPrompt,
       disconnectToast,
       dismissDisconnectToast,
     }),
     // authRevision triggers re-evaluation when a popup completes OAuth
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast, authRevision],
+    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, disconnectToast, dismissDisconnectToast, authRevision],
   );
 
   return (

--- a/src/contexts/__tests__/ProviderContext.test.tsx
+++ b/src/contexts/__tests__/ProviderContext.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { STORAGE_KEYS } from '@/constants/storage';
+import type { ProviderDescriptor } from '@/types/providers';
+import { makeProviderDescriptor } from '@/test/fixtures';
+
+vi.mock('@/providers/spotify/spotifyProvider', () => ({}));
+vi.mock('@/providers/dropbox/dropboxProvider', () => ({}));
+
+import { providerRegistry } from '@/providers/registry';
+import { ProviderProvider, useProviderContext } from '@/contexts/ProviderContext';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <ProviderProvider>{children}</ProviderProvider>;
+}
+
+function registerProvider(overrides: Partial<ProviderDescriptor>): ProviderDescriptor {
+  const descriptor = makeProviderDescriptor(overrides);
+  providerRegistry.register(descriptor);
+  return descriptor;
+}
+
+function resetRegistry() {
+  for (const descriptor of providerRegistry.getAll()) {
+    (providerRegistry as unknown as { providers: Map<string, ProviderDescriptor> }).providers.delete(
+      descriptor.id,
+    );
+  }
+}
+
+function stubLocalStorage(entries: Record<string, string>): void {
+  const store: Record<string, string> = { ...entries };
+  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) =>
+    Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
+  );
+  vi.mocked(window.localStorage.setItem).mockImplementation((key: string, value: string) => {
+    store[key] = value;
+  });
+  vi.mocked(window.localStorage.removeItem).mockImplementation((key: string) => {
+    delete store[key];
+  });
+}
+
+describe('ProviderContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRegistry();
+  });
+
+  describe('SESSION_EXPIRED_EVENT', () => {
+    it('removes the provider from enabledProviderIds when its session expires', () => {
+      // #given — Spotify + Dropbox are both registered and enabled
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['spotify', 'dropbox']);
+
+      // #when — Spotify's session is reported as expired
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(false);
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Spotify is removed from the enabled set; Dropbox stays
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+    });
+
+    it('does not toggle a provider that is already disabled', () => {
+      // #given — Spotify is registered but disabled; only Dropbox is enabled
+      registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+
+      // #when — a stray SESSION_EXPIRED for the already-disabled Spotify fires
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Dropbox is not re-toggled and remains the sole enabled provider
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+    });
+
+    it('surfaces the disconnect toast', () => {
+      // #given
+      registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+
+      // #when
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then
+      expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+  });
+});

--- a/src/contexts/__tests__/ProviderContext.test.tsx
+++ b/src/contexts/__tests__/ProviderContext.test.tsx
@@ -126,6 +126,46 @@ describe('ProviderContext', () => {
       expect(result.current.enabledProviderIds).toEqual(['dropbox']);
     });
 
+    it('removes the sole enabled provider on session expiry, bypassing the "last enabled" guard', () => {
+      // #given — only Spotify is enabled (Dropbox registered but disabled)
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['spotify']);
+
+      // #when — Spotify's session expires while it is the sole enabled provider
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(false);
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Spotify is removed even though it was the last enabled provider
+      expect(result.current.enabledProviderIds).toEqual([]);
+      // #then — the disconnect toast still surfaces so the user knows why
+      expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+
     it('surfaces the disconnect toast', () => {
       // #given
       registerProvider({


### PR DESCRIPTION
## Summary
- On `SESSION_EXPIRED_EVENT`, fully toggle the affected provider off (matches auth-system Requirement 2's "single on/off toggle")
- Remove the "Reconnect needed" status badge, `handleReconnect` switch branch, and the persistent reconnect-action toast
- Re-enable now flows through the standard "toggle on while not authenticated" path (which kicks off OAuth)

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (replaced "Reconnect needed" badge tests with toggle-off-on-expiry assertions)
- `npm run build` green
- Manual: clear Spotify access token mid-playback → Spotify toggle flips OFF in settings (Dropbox remains on); toggling Spotify back on re-runs OAuth

Closes #1556