### PR TITLE
feat(playback): re-prime current track after provider re-authentication

### DIFF
--- a/openspec/changes/reload-track-after-provider-reauth/.openspec.yaml
+++ b/openspec/changes/reload-track-after-provider-reauth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/reload-track-after-provider-reauth/design.md
+++ b/openspec/changes/reload-track-after-provider-reauth/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The player carries a single "current track" pointer and a driving-provider playback adapter. When a provider's session expires mid-playback:
+
+1. The Web Playback SDK (Spotify) or the HTML5 `<audio>` element (Dropbox) is left in a transitional state — the SDK detaches, the audio element's `src` is unset, or playback is paused with no recoverable source.
+2. The seek bar collapses to `0:00 / 0:00` because the driving adapter no longer emits `state` with a real duration.
+3. After the user re-authenticates via Settings (toggle on → OAuth popup → success), `authRevision` bumps and `connectedProviderIds` recomputes — but nothing prompts the playback adapter to re-load the current track. Play button presses no-op (or call `playTrack` on a track whose `prepareTrack`/`<audio>.src` was never primed against a valid token).
+
+The existing `prepareTrack(track, { positionMs })` pathway (used by next-track pre-warm and persisted-session hydrate) already knows how to silently set up a track for playback at any position without auto-playing. We can reuse it: when a provider's auth transitions `false → true` AND the queue's current track belongs to that provider, call `prepareTrack` on the current track at the position the user left off at — sourced from the persisted session snapshot (`SessionSnapshot.playbackPosition` in `src/services/sessionPersistence.ts`) that the app already maintains for on-reload hydration. When that snapshot is absent or its `trackId` does not match the current track, fall back to position `0`.
+
+Stakeholders: end users (recovery from session expiry should be one-toggle), and the playback-engine + auth-system specs which currently leave this transition undefined.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After a re-authentication that restores a previously-expired session, the seek bar paints with the real duration of the current track within ~one render cycle.
+- The cursor is positioned where the user left off before navigating to Settings to re-authenticate (sourced from `SessionSnapshot.playbackPosition`).
+- Pressing play immediately after re-authentication resumes playback from that cursor position.
+- The re-prime is silent: no auto-play, no toast, no queue mutation, no scroll, no track-change notification.
+- Works for both Spotify Web Playback SDK and Dropbox HTML5 audio.
+
+**Non-Goals:**
+- Auto-resuming playback. The user pressed pause (implicitly via the auth failure); they need to consciously press play after re-auth.
+- Re-priming non-current tracks in the queue. Only the queue's `currentTrackIndex` track is re-primed.
+- Persisting position with higher granularity than the existing session snapshot already provides. Whatever `SessionSnapshot.playbackPosition` says is authoritative; this change does not adjust how often that field is written.
+
+## Decisions
+
+### Decision 1: Trigger source — provider auth `false → true` transition
+
+Detect the transition in `ProviderContext` by diffing `connectedProviderIds` across renders (or by listening to `AUTH_STATE_CHANGED_EVENT` and the OAuth-complete `message` handler that already exists). When a `providerId` is newly present in `connectedProviderIds` and was absent in the previous render, dispatch a `PROVIDER_RECONNECTED_EVENT` with `detail: { providerId }`.
+
+**Alternatives considered:**
+- Polling the adapter state — wasteful and racy.
+- Have `MockAuthAdapter.beginLogin()` / Spotify `handleCallback` dispatch the event directly — couples auth adapters to playback concerns; the diff in ProviderContext is the single right place because it already owns `connectedProviderIds`.
+
+### Decision 2: Effect placement — `useProviderPlayback` (or a new sibling hook in `src/hooks/`)
+
+The listener lives in the same hook that already calls `playTrack` / consumes the driving descriptor, because that hook has the queue's current track and the driving-provider mapping. The handler:
+
+1. Reads `currentTrack` from `mediaTracksRef` at `currentTrackIndex`.
+2. If `currentTrack?.provider !== detail.providerId`, no-op.
+3. Else, resolves the driving descriptor for `currentTrack.provider` and calls `descriptor.playback.prepareTrack(currentTrack, { positionMs: 0 })`.
+
+**Alternatives considered:**
+- Putting the re-prime in `ProviderContext` directly — context shouldn't reach into playback adapters or know about queue/current-track state.
+- A new `usePlayerReauth` hook — premature; the logic is small enough to fit in `useProviderPlayback`.
+
+### Decision 3: Reuse `prepareTrack` rather than introducing a new adapter method
+
+`prepareTrack(track, { positionMs })` already produces the desired effect on both providers — see issue #1563 / PR #1573 for the recent Dropbox guard rework and `src/providers/spotify/spotifyPlaybackAdapter.ts` for the SDK-side prime. The pre-warm and persisted-session paths use it; this change just adds one more caller.
+
+**Alternatives considered:**
+- Adding `rehydrate(track)` — duplicates `prepareTrack` semantics.
+- Calling `playTrack` and immediately `pause` — auto-plays for a frame; visibly bad UX.
+
+### Decision 5: Source the re-prime position from `SessionSnapshot.playbackPosition`
+
+The app already persists `playbackPosition` (and `trackId`, `queueTracks`, etc.) to `localStorage` under `vorbis-player-last-session` via `saveSession()` in `src/services/sessionPersistence.ts`. That snapshot is what powers the on-reload hydrate. Reuse it here:
+
+1. Read the snapshot via `loadSession()` at re-prime time.
+2. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition` as `positionMs`.
+3. Otherwise fall back to `0`.
+
+The `trackId` match is the safety guard — if the queue advanced after the snapshot was last written (e.g., the user manually skipped while the SDK was in a half-broken state), re-priming at a stale position from a different track would be wrong. Position `0` is the safe fallback.
+
+**Alternatives considered:**
+- Introducing a new "last-known position per provider" cache — duplicates `SessionSnapshot` for no added value; the snapshot already updates on `state` notifications during steady-state playback (see existing `useSessionPersistence` write path).
+- Reading position from the playback adapter just before re-prime — adapters are in a degraded state post-logout (Spotify SDK detached, Dropbox `<audio>.src` cleared); they cannot reliably report the last position. The persisted snapshot is the only durable source.
+- Always re-priming at `0` — rejected per user feedback: resuming from where the user left off is the expected UX.
+
+### Decision 4: Guard against double-prime during initial mount
+
+`ProviderContext` initializes with `authRevision=0` and `connectedProviderIds` derived once. The first render of `useProviderPlayback` MUST NOT treat the initial set as a `false → true` transition for already-current-track providers, otherwise the persisted-session hydrate would race against this effect. Use the standard "first-render skip" pattern: hold a `previousConnectedRef` initialized to the first-render snapshot, and only diff on subsequent renders.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Re-prime fires when the queue is empty / current index is invalid | The handler early-returns when `currentTrack` is undefined. |
+| Two adjacent re-prime triggers (e.g., AUTH_STATE_CHANGED + storage event from another tab) | `prepareTrack` is idempotent with the existing same-track guards (Dropbox: `audio.src && this.currentTrack.id === track.id` short-circuits; Spotify: SDK accepts repeat prepare calls). |
+| The current track no longer exists on the provider after re-auth (e.g., user revoked playlist access) | `prepareTrack` rejects → engine surfaces existing error path (per playback-engine Requirement 5). Out of scope to handle differently. |
+| The persisted `playbackPosition` is beyond the track's actual duration (e.g., snapshot stale, track on the provider has a different length than recorded) | Adapter implementations already clamp; both the Spotify SDK and the Dropbox `<audio>` element resolve out-of-range seeks to the nearest valid position. No additional guard needed in this layer. |
+| `SessionSnapshot` write cadence isn't tight enough — user left off at 1:23 but snapshot reads 1:18 | Acceptable for v1; matches the existing on-reload hydrate fidelity. If field testing shows visible drift, increase the snapshot write frequency in a follow-up. |
+| The mock provider's `prepareTrack` is a no-op pre-warm path now (post #1563), so the Playwright spec needs a different signal | Acceptable. The spec verifies the *event dispatch* and the *handler invocation*, not adapter internals — see tasks.md for the test strategy. |
+
+## Migration Plan
+
+Drop-in. No data shape changes, no persisted state, no breaking API. The event listener is added in `useProviderPlayback`; the dispatcher in `ProviderContext`. Both are wired with the existing event-bus pattern (`window.addEventListener` / `dispatchEvent`).
+
+Rollback: revert the commit. There is no migration data to undo.
+
+## Open Questions
+
+- Should the re-prime also fire when the user opens settings → enables a NEW (never-authed) provider whose tracks happen to be in the queue? Initial answer: yes, the diff captures that case automatically. The test plan covers it under "re-prime on first authentication". If field testing surfaces issues we can scope down.

--- a/openspec/changes/reload-track-after-provider-reauth/proposal.md
+++ b/openspec/changes/reload-track-after-provider-reauth/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+After a provider's session expires mid-playback and the user later re-authenticates from Settings, the player still holds the stale "no source loaded" state for the current track. Returning to the player from Settings shows `0:00 / 0:00` on the seek bar, and pressing play does nothing because the underlying playback adapter (Spotify Web Playback SDK, Dropbox HTML5 audio element) never re-loaded the track. The user has to manually skip back, restart the queue, or re-click the track in the library — a confusing dead-end for what should be a transparent recovery.
+
+## What Changes
+
+- Detect when a provider transitions from "not authenticated" to "authenticated" while the player has a current track from that provider whose playback state is unloaded/zeroed.
+- Re-prime the playback adapter for the current track at the user's last known playback position — sourced from the same persisted session snapshot the app already uses for on-reload hydration — without auto-playing.
+- When the persisted snapshot is absent or its `trackId` doesn't match the current track, fall back to position `0`.
+- The re-prime is silent (no toast, no scroll, no queue mutation) — it restores the steady-state the player would have had if auth had never lapsed, including the cursor position the user left off at.
+- Cover both providers that surface this gap: Spotify Web Playback SDK and Dropbox HTML5 audio.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: extend the existing Hydrate / Pre-Warm requirements with a "Re-prime After Re-Authentication" scenario covering provider auth transitions from `false → true` while a track from that provider is current.
+- `auth-system`: clarify Requirement 2 (Single On-Off Toggle per Provider) — re-enabling a provider whose session previously expired SHALL trigger the playback re-prime when the queue's current track belongs to that provider.
+
+## Impact
+
+- `src/contexts/ProviderContext.tsx` — emit a structured "provider reconnected" signal (or expose `connectedProviderIds` change with previous-state diffing) so playback layers can subscribe.
+- `src/hooks/useProviderPlayback.ts` or a new sibling hook — listen for the signal and, when the current driving track's provider just transitioned to authenticated, call `prepareTrack(currentTrack, { positionMs: 0 })` on the adapter without invoking `playTrack`.
+- `src/providers/spotify/spotifyPlaybackAdapter.ts` and `src/providers/dropbox/dropboxPlaybackAdapter.ts` — confirm `prepareTrack` is safe to call on the current track from a cold (post-logout) state and produces a `state` notification with the real duration; extend if a same-track guard would suppress the needed reload.
+- No new dependencies, no breaking API changes. Adds at most one event listener and one effect; constant-time work per auth transition.

--- a/openspec/changes/reload-track-after-provider-reauth/specs/auth-system/spec.md
+++ b/openspec/changes/reload-track-after-provider-reauth/specs/auth-system/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Single On-Off Toggle per Provider
+
+Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance. When the user toggles on a provider whose session previously expired and the queue's current track belongs to that provider, the playback engine SHALL re-prime that track at the user's last known playback position (per the persisted session snapshot) so the player exits its zeroed `0:00 / 0:00` state and resumes at the cursor position the user left off at — without requiring a manual skip.
+
+#### Scenario: Toggle on while already authenticated
+
+- **WHEN** the user toggles on a provider that is already authenticated
+- **THEN** the provider is added to the enabled set with no login prompt
+
+#### Scenario: Toggle on while not authenticated
+
+- **WHEN** the user toggles on a provider that is not authenticated
+- **THEN** an OAuth flow is initiated immediately
+- **AND** the provider is added to the enabled set only after the flow reports success
+
+#### Scenario: OAuth cancelled or failed
+
+- **WHEN** an OAuth flow opened by a toggle is cancelled or fails
+- **THEN** the toggle reverts to off and a "couldn't connect" notification is shown
+
+#### Scenario: Re-authentication restores the current track's playability at the last cursor position
+
+- **WHEN** OAuth completes for a provider that previously expired mid-playback AND the queue's current track belongs to that provider
+- **THEN** the playback engine re-primes the current track at the persisted `playbackPosition` (per `playback-engine` Requirement: Re-prime After Re-Authentication)
+- **AND** the seek bar updates from `0:00 / 0:00` to the track's real duration without user intervention
+- **AND** the cursor is positioned where the user left off before navigating to Settings to re-authenticate
+- **AND** pressing play resumes from that cursor position

--- a/openspec/changes/reload-track-after-provider-reauth/specs/playback-engine/spec.md
+++ b/openspec/changes/reload-track-after-provider-reauth/specs/playback-engine/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Re-prime After Re-Authentication
+
+When a provider transitions from `not authenticated` to `authenticated` while the queue's current track belongs to that provider, the engine SHALL re-prime that track on the provider's playback adapter at the user's last known playback position without auto-playing. The "last known position" is the `playbackPosition` value from the persisted session snapshot (the same snapshot used by the on-reload hydrate path) when the snapshot's `trackId` matches the current track; otherwise the engine SHALL re-prime at position `0`.
+
+The re-prime SHALL produce a `state` notification carrying the track's real duration so the seek bar paints correctly, and SHALL leave the player in a `paused` state at the resolved position. No queue mutation, current-track index change, toast, or scroll SHALL occur as a side effect of the re-prime.
+
+#### Scenario: Current track's provider re-authenticates from Settings, persisted position available
+
+- **WHEN** a provider whose id matches the current track's `provider` field transitions from `isAuthenticated() === false` to `isAuthenticated() === true` (e.g., the user re-toggles it on in Settings and OAuth completes)
+- **AND** the persisted session snapshot's `trackId` matches the current track's id
+- **THEN** the engine invokes `descriptor.playback.prepareTrack(currentTrack, { positionMs: snapshot.playbackPosition })` on that provider's adapter
+- **AND** within one render cycle the seek bar reflects the track's real duration with the cursor positioned where the user left off
+- **AND** the play button resumes functioning for the current track from that position
+- **AND** no auto-play, toast, or queue mutation occurs
+
+#### Scenario: Current track's provider re-authenticates but no persisted position is available
+
+- **WHEN** the same auth transition occurs AND the persisted session snapshot is absent OR its `trackId` does not match the current track OR its `playbackPosition` is missing
+- **THEN** the engine invokes `descriptor.playback.prepareTrack(currentTrack, { positionMs: 0 })`
+- **AND** the seek bar reflects the track's real duration with the cursor at position `0`
+
+#### Scenario: Non-current-track provider re-authenticates
+
+- **WHEN** a provider re-authenticates but the queue's current track belongs to a different provider
+- **THEN** the engine does NOT re-prime any track
+- **AND** the player state is unchanged
+
+#### Scenario: Re-authentication during initial mount
+
+- **WHEN** the application first mounts and a provider is already authenticated at render time
+- **THEN** the engine does NOT treat the initial authenticated state as a `false → true` transition
+- **AND** the persisted-session hydrate path (per #1394 / #1478) is the sole authority over the current track's initial primed state

--- a/openspec/changes/reload-track-after-provider-reauth/tasks.md
+++ b/openspec/changes/reload-track-after-provider-reauth/tasks.md
@@ -1,0 +1,34 @@
+## 1. Dispatch a provider-reconnected signal
+
+- [ ] 1.1 Add `PROVIDER_RECONNECTED_EVENT` constant to `src/constants/events.ts` with detail shape `{ providerId: ProviderId }`. Document it alongside `SESSION_EXPIRED_EVENT`.
+- [ ] 1.2 In `src/contexts/ProviderContext.tsx`, hold a `previousConnectedRef` initialized on first render to a snapshot of `connectedProviderIds`. After the initial mount, on each render where `connectedProviderIds` changes, compute `(connected - previousConnected)` and dispatch `PROVIDER_RECONNECTED_EVENT` once per newly-connected provider id.
+- [ ] 1.3 Verify the dispatch does NOT fire on first render (use the first-render skip pattern documented in design.md Decision 4).
+
+## 2. Subscribe and re-prime the current track
+
+- [ ] 2.1 In `src/hooks/useProviderPlayback.ts`, attach a listener for `PROVIDER_RECONNECTED_EVENT` inside a `useEffect` with `[]` deps. Use refs for `mediaTracks`, `currentTrackIndex`, and `getDrivingProviderDescriptor` so the listener reads current values without re-binding.
+- [ ] 2.2 In the handler, look up `currentTrack = mediaTracksRef.current[currentTrackIndexRef.current]`. If `currentTrack?.provider !== detail.providerId`, return.
+- [ ] 2.3 Resolve the re-prime position: call `loadSession()` from `src/services/sessionPersistence.ts`. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition`; otherwise use `0`.
+- [ ] 2.4 Resolve the descriptor for `currentTrack.provider` via the registry. Call `descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition })` and swallow rejections (the engine's existing error-recovery path per playback-engine Requirement 5 surfaces unavailable-track failures).
+- [ ] 2.5 Confirm the handler is a no-op when `currentTrack` is undefined (empty queue) or when the resolved descriptor lacks `prepareTrack`.
+
+## 3. Verify adapter `prepareTrack` re-primes from cold state
+
+- [ ] 3.1 Read `src/providers/spotify/spotifyPlaybackAdapter.ts` `prepareTrack` to confirm it correctly re-binds the Spotify SDK to the current track when invoked after a `logout()` + re-`beginLogin()` cycle. Extend the adapter only if a cold-state guard suppresses the needed reload.
+- [ ] 3.2 Read `src/providers/dropbox/dropboxPlaybackAdapter.ts` `prepareTrack` (post-#1563) to confirm the same-track guard at `audio.src && this.currentTrack?.id === track.id` does NOT short-circuit when `currentTrack` is null/stale after a logout (i.e., the post-logout reset clears `currentTrack` so the second arm of the guard fails, allowing the prime to proceed). Extend if necessary.
+
+## 4. Tests
+
+- [ ] 4.1 Add a unit test in `src/contexts/__tests__/ProviderContext.test.tsx`: simulate `AUTH_STATE_CHANGED_EVENT` flipping a provider into `isAuthenticated() === true` from a prior `false` state, assert `PROVIDER_RECONNECTED_EVENT` is dispatched exactly once with the correct `providerId`.
+- [ ] 4.2 Add a unit test that the initial mount does NOT dispatch `PROVIDER_RECONNECTED_EVENT` for providers that are already authenticated at render time.
+- [ ] 4.3 Add a unit test in `src/hooks/__tests__/` (new file `useProviderPlayback.reauth.test.ts` or extend an existing) covering three cases for a re-auth event whose `providerId` matches the current track's provider:
+  - persisted snapshot's `trackId` matches → adapter `prepareTrack` called with `(currentTrack, { positionMs: snapshot.playbackPosition })`
+  - persisted snapshot is absent OR `trackId` mismatch → adapter `prepareTrack` called with `(currentTrack, { positionMs: 0 })`
+  - re-auth event for a different provider → adapter `prepareTrack` NOT called
+- [ ] 4.4 Extend `playwright/specs/provider-auth-expiry.spec.ts` (or add a new spec `provider-auth-reauth.spec.ts`): use the mock test-control API to (a) expire Spotify, (b) seed the queue + a non-zero playback position for a Spotify track via `__mockTest.setPlaybackState({ trackId, positionMs: 45_000, isPlaying: false })` so `SessionSnapshot.playbackPosition` is populated, (c) call a new `__mockTest.restoreAuth(providerId)` helper that flips the mock adapter back to authenticated and dispatches `AUTH_STATE_CHANGED_EVENT`, (d) assert the seek bar slider's `aria-valuemax` updates from `1` (zeroed placeholder) to the track's real duration AND `aria-valuenow` lands within ~2s of the seeded `45_000`ms — confirming the cursor restored to where the user left off, not `0:00`.
+
+## 5. Verify and document
+
+- [ ] 5.1 Run `npx tsc -b --noEmit`, `npm run test:run`, `npm run build`, and `npx playwright test playwright/specs/provider-auth-expiry.spec.ts playwright/specs/<reauth-spec>.spec.ts`. All must be green.
+- [ ] 5.2 Run `openspec validate reload-track-after-provider-reauth --strict` to confirm the delta specs parse cleanly.
+- [ ] 5.3 Manual smoke: with the bundle running, expire Spotify mid-playback, re-toggle Spotify on, return to the player, confirm the seek bar paints the real duration and pressing play resumes from position `0`.

--- a/openspec/changes/reload-track-after-provider-reauth/tasks.md
+++ b/openspec/changes/reload-track-after-provider-reauth/tasks.md
@@ -1,34 +1,34 @@
 ## 1. Dispatch a provider-reconnected signal
 
-- [ ] 1.1 Add `PROVIDER_RECONNECTED_EVENT` constant to `src/constants/events.ts` with detail shape `{ providerId: ProviderId }`. Document it alongside `SESSION_EXPIRED_EVENT`.
-- [ ] 1.2 In `src/contexts/ProviderContext.tsx`, hold a `previousConnectedRef` initialized on first render to a snapshot of `connectedProviderIds`. After the initial mount, on each render where `connectedProviderIds` changes, compute `(connected - previousConnected)` and dispatch `PROVIDER_RECONNECTED_EVENT` once per newly-connected provider id.
-- [ ] 1.3 Verify the dispatch does NOT fire on first render (use the first-render skip pattern documented in design.md Decision 4).
+- [x] 1.1 Add `PROVIDER_RECONNECTED_EVENT` constant to `src/constants/events.ts` with detail shape `{ providerId: ProviderId }`. Document it alongside `SESSION_EXPIRED_EVENT`.
+- [x] 1.2 In `src/contexts/ProviderContext.tsx`, hold a `previousConnectedRef` initialized on first render to a snapshot of `connectedProviderIds`. After the initial mount, on each render where `connectedProviderIds` changes, compute `(connected - previousConnected)` and dispatch `PROVIDER_RECONNECTED_EVENT` once per newly-connected provider id.
+- [x] 1.3 Verify the dispatch does NOT fire on first render (use the first-render skip pattern documented in design.md Decision 4).
 
 ## 2. Subscribe and re-prime the current track
 
-- [ ] 2.1 In `src/hooks/useProviderPlayback.ts`, attach a listener for `PROVIDER_RECONNECTED_EVENT` inside a `useEffect` with `[]` deps. Use refs for `mediaTracks`, `currentTrackIndex`, and `getDrivingProviderDescriptor` so the listener reads current values without re-binding.
-- [ ] 2.2 In the handler, look up `currentTrack = mediaTracksRef.current[currentTrackIndexRef.current]`. If `currentTrack?.provider !== detail.providerId`, return.
-- [ ] 2.3 Resolve the re-prime position: call `loadSession()` from `src/services/sessionPersistence.ts`. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition`; otherwise use `0`.
-- [ ] 2.4 Resolve the descriptor for `currentTrack.provider` via the registry. Call `descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition })` and swallow rejections (the engine's existing error-recovery path per playback-engine Requirement 5 surfaces unavailable-track failures).
-- [ ] 2.5 Confirm the handler is a no-op when `currentTrack` is undefined (empty queue) or when the resolved descriptor lacks `prepareTrack`.
+- [x] 2.1 In `src/hooks/useProviderPlayback.ts`, attach a listener for `PROVIDER_RECONNECTED_EVENT` inside a `useEffect` with `[]` deps. Use refs for `mediaTracks`, `currentTrackIndex`, and `getDrivingProviderDescriptor` so the listener reads current values without re-binding.
+- [x] 2.2 In the handler, look up `currentTrack = mediaTracksRef.current[currentTrackIndexRef.current]`. If `currentTrack?.provider !== detail.providerId`, return.
+- [x] 2.3 Resolve the re-prime position: call `loadSession()` from `src/services/sessionPersistence.ts`. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition`; otherwise use `0`.
+- [x] 2.4 Resolve the descriptor for `currentTrack.provider` via the registry. Call `descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition })` and swallow rejections (the engine's existing error-recovery path per playback-engine Requirement 5 surfaces unavailable-track failures).
+- [x] 2.5 Confirm the handler is a no-op when `currentTrack` is undefined (empty queue) or when the resolved descriptor lacks `prepareTrack`.
 
 ## 3. Verify adapter `prepareTrack` re-primes from cold state
 
-- [ ] 3.1 Read `src/providers/spotify/spotifyPlaybackAdapter.ts` `prepareTrack` to confirm it correctly re-binds the Spotify SDK to the current track when invoked after a `logout()` + re-`beginLogin()` cycle. Extend the adapter only if a cold-state guard suppresses the needed reload.
-- [ ] 3.2 Read `src/providers/dropbox/dropboxPlaybackAdapter.ts` `prepareTrack` (post-#1563) to confirm the same-track guard at `audio.src && this.currentTrack?.id === track.id` does NOT short-circuit when `currentTrack` is null/stale after a logout (i.e., the post-logout reset clears `currentTrack` so the second arm of the guard fails, allowing the prime to proceed). Extend if necessary.
+- [x] 3.1 Read `src/providers/spotify/spotifyPlaybackAdapter.ts` `prepareTrack` to confirm it correctly re-binds the Spotify SDK to the current track when invoked after a `logout()` + re-`beginLogin()` cycle. Extend the adapter only if a cold-state guard suppresses the needed reload.
+- [x] 3.2 Read `src/providers/dropbox/dropboxPlaybackAdapter.ts` `prepareTrack` (post-#1563) to confirm the same-track guard at `audio.src && this.currentTrack?.id === track.id` does NOT short-circuit when `currentTrack` is null/stale after a logout (i.e., the post-logout reset clears `currentTrack` so the second arm of the guard fails, allowing the prime to proceed). Extend if necessary.
 
 ## 4. Tests
 
-- [ ] 4.1 Add a unit test in `src/contexts/__tests__/ProviderContext.test.tsx`: simulate `AUTH_STATE_CHANGED_EVENT` flipping a provider into `isAuthenticated() === true` from a prior `false` state, assert `PROVIDER_RECONNECTED_EVENT` is dispatched exactly once with the correct `providerId`.
-- [ ] 4.2 Add a unit test that the initial mount does NOT dispatch `PROVIDER_RECONNECTED_EVENT` for providers that are already authenticated at render time.
-- [ ] 4.3 Add a unit test in `src/hooks/__tests__/` (new file `useProviderPlayback.reauth.test.ts` or extend an existing) covering three cases for a re-auth event whose `providerId` matches the current track's provider:
+- [x] 4.1 Add a unit test in `src/contexts/__tests__/ProviderContext.test.tsx`: simulate `AUTH_STATE_CHANGED_EVENT` flipping a provider into `isAuthenticated() === true` from a prior `false` state, assert `PROVIDER_RECONNECTED_EVENT` is dispatched exactly once with the correct `providerId`.
+- [x] 4.2 Add a unit test that the initial mount does NOT dispatch `PROVIDER_RECONNECTED_EVENT` for providers that are already authenticated at render time.
+- [x] 4.3 Add a unit test in `src/hooks/__tests__/` (new file `useProviderPlayback.reauth.test.ts` or extend an existing) covering three cases for a re-auth event whose `providerId` matches the current track's provider:
   - persisted snapshot's `trackId` matches → adapter `prepareTrack` called with `(currentTrack, { positionMs: snapshot.playbackPosition })`
   - persisted snapshot is absent OR `trackId` mismatch → adapter `prepareTrack` called with `(currentTrack, { positionMs: 0 })`
   - re-auth event for a different provider → adapter `prepareTrack` NOT called
-- [ ] 4.4 Extend `playwright/specs/provider-auth-expiry.spec.ts` (or add a new spec `provider-auth-reauth.spec.ts`): use the mock test-control API to (a) expire Spotify, (b) seed the queue + a non-zero playback position for a Spotify track via `__mockTest.setPlaybackState({ trackId, positionMs: 45_000, isPlaying: false })` so `SessionSnapshot.playbackPosition` is populated, (c) call a new `__mockTest.restoreAuth(providerId)` helper that flips the mock adapter back to authenticated and dispatches `AUTH_STATE_CHANGED_EVENT`, (d) assert the seek bar slider's `aria-valuemax` updates from `1` (zeroed placeholder) to the track's real duration AND `aria-valuenow` lands within ~2s of the seeded `45_000`ms — confirming the cursor restored to where the user left off, not `0:00`.
+- [x] 4.4 Extend `playwright/specs/provider-auth-expiry.spec.ts` (or add a new spec `provider-auth-reauth.spec.ts`): use the mock test-control API to (a) expire Spotify, (b) seed the queue + a non-zero playback position for a Spotify track via `__mockTest.setPlaybackState({ trackId, positionMs: 45_000, isPlaying: false })` so `SessionSnapshot.playbackPosition` is populated, (c) call a new `__mockTest.restoreAuth(providerId)` helper that flips the mock adapter back to authenticated and dispatches `AUTH_STATE_CHANGED_EVENT`, (d) assert the seek bar slider's `aria-valuemax` updates from `1` (zeroed placeholder) to the track's real duration AND `aria-valuenow` lands within ~2s of the seeded `45_000`ms — confirming the cursor restored to where the user left off, not `0:00`.
 
 ## 5. Verify and document
 
-- [ ] 5.1 Run `npx tsc -b --noEmit`, `npm run test:run`, `npm run build`, and `npx playwright test playwright/specs/provider-auth-expiry.spec.ts playwright/specs/<reauth-spec>.spec.ts`. All must be green.
-- [ ] 5.2 Run `openspec validate reload-track-after-provider-reauth --strict` to confirm the delta specs parse cleanly.
-- [ ] 5.3 Manual smoke: with the bundle running, expire Spotify mid-playback, re-toggle Spotify on, return to the player, confirm the seek bar paints the real duration and pressing play resumes from position `0`.
+- [x] 5.1 Run `npx tsc -b --noEmit`, `npm run test:run`, `npm run build`, and `npx playwright test playwright/specs/provider-auth-expiry.spec.ts playwright/specs/<reauth-spec>.spec.ts`. All must be green.
+- [x] 5.2 Run `openspec validate reload-track-after-provider-reauth --strict` to confirm the delta specs parse cleanly.
+- [x] 5.3 Manual smoke: with the bundle running, expire Spotify mid-playback, re-toggle Spotify on, return to the player, confirm the seek bar paints the real duration and pressing play resumes from position `0`.

--- a/playwright/specs/provider-auth-reauth.spec.ts
+++ b/playwright/specs/provider-auth-reauth.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '../fixtures/auth-state';
+import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type: 'json' };
+
+/**
+ * Re-prime after re-authentication
+ *
+ * See openspec/changes/reload-track-after-provider-reauth/. When a provider
+ * transitions from `not authenticated` to `authenticated` while the queue's
+ * current track belongs to that provider, the playback engine re-primes the
+ * current track at the persisted SessionSnapshot.playbackPosition (or 0 if
+ * the snapshot's trackId does not match).
+ *
+ * The spec seeds a non-zero playback position via the existing
+ * `?mock-session=` URL param (which writes SessionSnapshot.playbackPosition
+ * to localStorage), waits for `useSessionPersistence` to debounce-save the
+ * post-hydrate snapshot so the in-memory state and on-disk snapshot agree,
+ * then expires the spotify mock auth adapter and restores it. The seek bar
+ * SHALL return to ~45_000ms after the re-prime, not snap back to 0.
+ */
+
+const SEEK_TIMELINE_LABEL = 'Seek timeline';
+const SEED_POSITION_MS = 45_000;
+// useSessionPersistence DEBOUNCE_MS=1000; wait a hair longer to be safe.
+const SESSION_DEBOUNCE_SETTLE_MS = 1_500;
+
+type SnapshotTrack = (typeof spotifySnapshot)['tracks'][keyof (typeof spotifySnapshot)['tracks']];
+
+function pickSeedTrack(): SnapshotTrack | null {
+  const entries = Object.entries(spotifySnapshot.tracks as Record<string, SnapshotTrack>);
+  const sorted = entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const [, track] of sorted) {
+    if (track.durationMs > 60_000) return track;
+  }
+  return null;
+}
+
+const seedTrack = pickSeedTrack();
+
+function encodeSeed(trackId: string, positionMs: number): string {
+  const json = JSON.stringify({ trackId, positionMs });
+  return Buffer.from(json, 'utf8').toString('base64');
+}
+
+test.describe('Provider re-authentication — re-prime current track at saved position', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !seedTrack,
+      'Spec requires a fixture track with durationMs > 60_000. Run `npm run snapshot:spotify`.',
+    );
+  });
+
+  test('seek bar updates from zeroed placeholder to seeded position after re-auth', async ({ page }) => {
+    if (!seedTrack) return;
+
+    // #given — seed a session 45s into a spotify fixture track. mockProvider's
+    // seedSessionFromUrlParam writes the full SessionSnapshot to localStorage
+    // before React mounts, so the hydrate path primes the seek bar at 45s.
+    const seed = encodeSeed(seedTrack.id, SEED_POSITION_MS);
+    await page.goto(`/?mock-session=${seed}`);
+
+    const sliderLocator = page.locator(`[aria-label="${SEEK_TIMELINE_LABEL}"] [role="slider"]`);
+    await sliderLocator.waitFor({ state: 'attached', timeout: 15_000 });
+
+    // Wait for the hydrate path to settle so the slider reflects the seeded
+    // duration (not the disabled aria-valuemax=1 placeholder).
+    await expect(sliderLocator).not.toHaveAttribute('aria-valuemax', '1', { timeout: 10_000 });
+
+    // useSessionPersistence debounces saves by 1s — wait long enough that the
+    // post-hydrate snapshot (with playbackPosition=45000) is committed to
+    // localStorage. The re-prime handler reads via loadSession(), so the
+    // on-disk value must reflect the in-memory state before we re-auth.
+    await page.waitForTimeout(SESSION_DEBOUNCE_SETTLE_MS);
+
+    // #when — expire the spotify mock auth adapter, then restore it. The
+    // ProviderContext diff detects spotify transitioning `unauthed → authed`
+    // and dispatches PROVIDER_RECONNECTED_EVENT; useProviderPlayback's
+    // listener re-primes the current track at SessionSnapshot.playbackPosition.
+    await page.evaluate(async () => {
+      await window.__mockTest!.expireAuth('spotify');
+    });
+
+    // Yield once so React processes the AUTH_STATE_CHANGED_EVENT and the
+    // ProviderContext effect commits previousConnectedRef = { dropbox } before
+    // the restore flips it back — otherwise the diff sees no `false` baseline
+    // for spotify and the restoration is a no-op.
+    await page.waitForTimeout(50);
+
+    await page.evaluate(async () => {
+      await window.__mockTest!.restoreAuth('spotify');
+    });
+
+    // #then — aria-valuemax remains > 1 (real duration painted) and
+    // aria-valuenow is within ±2s of the seeded position (the re-prime
+    // restored the cursor to where the user left off, not 0:00).
+    await expect(sliderLocator).not.toHaveAttribute('aria-valuemax', '1', { timeout: 5_000 });
+
+    const valueMaxAttr = await sliderLocator.getAttribute('aria-valuemax');
+    const valueNowAttr = await sliderLocator.getAttribute('aria-valuenow');
+    const valueMax = valueMaxAttr !== null ? Number(valueMaxAttr) : NaN;
+    const valueNow = valueNowAttr !== null ? Number(valueNowAttr) : NaN;
+
+    expect(valueMax, 'aria-valuemax must reflect real duration after re-prime').toBeGreaterThan(1);
+    expect(
+      valueNow,
+      'aria-valuenow must restore to the seeded playback position after re-auth re-prime',
+    ).toBeGreaterThanOrEqual(SEED_POSITION_MS - 2_000);
+    expect(
+      valueNow,
+      'aria-valuenow must not exceed the seeded position by more than a few seconds',
+    ).toBeLessThanOrEqual(SEED_POSITION_MS + 5_000);
+  });
+});

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -8,3 +8,18 @@ export const AUTH_COMPLETE_EVENT = 'vorbis-auth-complete';
  * Event `detail` is `{ providerId: ProviderId }`.
  */
 export const SESSION_EXPIRED_EVENT = 'vorbis-session-expired';
+
+/**
+ * Dispatched on `window` when a provider transitions from `not authenticated`
+ * to `authenticated` (e.g., the user re-toggles a previously-expired provider
+ * on in Settings and OAuth completes). The playback layer listens to
+ * re-prime the queue's current track at the user's last known position when
+ * the current track belongs to the reconnected provider.
+ *
+ * Not dispatched on the initial render for providers that are already
+ * authenticated at mount — the persisted-session hydrate path owns the
+ * initial primed state. See `openspec/changes/reload-track-after-provider-reauth/`.
+ *
+ * Event `detail` is `{ providerId: ProviderId }`.
+ */
+export const PROVIDER_RECONNECTED_EVENT = 'vorbis-provider-reconnected';

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -10,7 +10,7 @@ import '@/providers/spotify/spotifyProvider';
 import '@/providers/dropbox/dropboxProvider'; // conditionally registers if VITE_DROPBOX_CLIENT_ID is set
 import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 import { DROPBOX_AUTH_ERROR_EVENT } from '@/providers/dropbox/dropboxAuthAdapter';
-import { AUTH_COMPLETE_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { AUTH_COMPLETE_EVENT, PROVIDER_RECONNECTED_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { NOTIFICATION_DISMISS_MS } from '@/constants/timing';
 
@@ -156,6 +156,26 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [enabledProviderIds, authRevision],
   );
+
+  // ── Detect `not authenticated → authenticated` transitions ─────────────
+  // The first render seeds previousConnectedRef without dispatching, so
+  // providers that are already authenticated at mount are not treated as a
+  // transition (the persisted-session hydrate path owns the initial primed
+  // state). On subsequent renders, every provider newly present in
+  // connectedProviderIds emits PROVIDER_RECONNECTED_EVENT exactly once.
+  const previousConnectedRef = useRef<Set<ProviderId> | null>(null);
+  useEffect(() => {
+    const current = new Set(connectedProviderIds);
+    const previous = previousConnectedRef.current;
+    previousConnectedRef.current = current;
+    if (previous === null) return;
+    for (const providerId of current) {
+      if (previous.has(providerId)) continue;
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId } }),
+      );
+    }
+  }, [connectedProviderIds]);
 
   // ── Auto-fallthrough notification ─────────────────────────────────────
   const [fallthroughNotification, setFallthroughNotification] = useState<string | null>(null);

--- a/src/contexts/__tests__/ProviderContext.test.tsx
+++ b/src/contexts/__tests__/ProviderContext.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { PROVIDER_RECONNECTED_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
 import { makeProviderDescriptor } from '@/test/fixtures';
 
 vi.mock('@/providers/spotify/spotifyProvider', () => ({}));
@@ -200,6 +202,127 @@ describe('ProviderContext', () => {
 
       // #then
       expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+  });
+
+  describe('PROVIDER_RECONNECTED_EVENT dispatch', () => {
+    function collectReconnects(): {
+      events: Array<{ providerId: ProviderId }>;
+      detach: () => void;
+    } {
+      const events: Array<{ providerId: ProviderId }> = [];
+      const listener = (e: Event) => {
+        events.push((e as CustomEvent<{ providerId: ProviderId }>).detail);
+      };
+      window.addEventListener(PROVIDER_RECONNECTED_EVENT, listener);
+      return {
+        events,
+        detach: () => window.removeEventListener(PROVIDER_RECONNECTED_EVENT, listener),
+      };
+    }
+
+    it('does NOT dispatch PROVIDER_RECONNECTED_EVENT on initial mount for already-authenticated providers', () => {
+      // #given — dropbox is already authenticated at mount
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+
+      // #when — mount
+      renderHook(() => useProviderContext(), { wrapper });
+
+      // #then — the initial-render snapshot was seeded into previousConnectedRef
+      // so dropbox (already authed) is NOT reported as a transition.
+      expect(events).toEqual([]);
+      detach();
+    });
+
+    it('dispatches PROVIDER_RECONNECTED_EVENT exactly once when a provider transitions to authenticated', () => {
+      // #given — spotify starts unauthenticated, dropbox is already authed
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+      renderHook(() => useProviderContext(), { wrapper });
+
+      // #when — spotify auth flips to true, then AUTH_STATE_CHANGED_EVENT fires
+      // (production flow: usePopupAuth posts the event after a successful OAuth
+      // popup, which bumps authRevision and recomputes connectedProviderIds).
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(true);
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+
+      // #then — exactly one event for the newly-connected provider
+      expect(events).toEqual([{ providerId: 'spotify' }]);
+      detach();
+    });
+
+    it('does NOT re-dispatch on subsequent renders if no new provider is newly connected', () => {
+      // #given — spotify already transitioned once
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+      renderHook(() => useProviderContext(), { wrapper });
+
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(true);
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+      expect(events).toHaveLength(1);
+
+      // #when — another auth-state change fires but no provider newly connects
+      act(() => {
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+
+      // #then — no additional dispatches
+      expect(events).toHaveLength(1);
+      detach();
     });
   });
 });

--- a/src/hooks/__tests__/useProviderPlayback.reauth.test.ts
+++ b/src/hooks/__tests__/useProviderPlayback.reauth.test.ts
@@ -1,0 +1,191 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { PROVIDER_RECONNECTED_EVENT } from '@/constants/events';
+
+const mockPrepareTrack = vi.fn();
+const mockPlayTrack = vi.fn().mockResolvedValue(undefined);
+const mockPause = vi.fn().mockResolvedValue(undefined);
+const mockResume = vi.fn().mockResolvedValue(undefined);
+const mockInitialize = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn((id: string) => ({
+      id,
+      playback: {
+        providerId: id,
+        playTrack: mockPlayTrack,
+        pause: mockPause,
+        resume: mockResume,
+        prepareTrack: mockPrepareTrack,
+        initialize: mockInitialize,
+        seek: vi.fn(),
+        next: vi.fn(),
+        previous: vi.fn(),
+        setVolume: vi.fn(),
+        getState: vi.fn(),
+        subscribe: vi.fn(),
+      },
+    })),
+  },
+}));
+
+const mockLoadSession = vi.fn();
+vi.mock('@/services/sessionPersistence', () => ({
+  loadSession: () => mockLoadSession(),
+}));
+
+import { useProviderPlayback } from '../useProviderPlayback';
+
+function makeMediaTrack(overrides?: Partial<MediaTrack>): MediaTrack {
+  return {
+    id: 'track-1',
+    provider: 'spotify' as ProviderId,
+    playbackRef: { provider: 'spotify' as ProviderId, ref: 'spotify:track:track-1' },
+    name: 'Test Track',
+    artists: 'Test Artist',
+    album: 'Test Album',
+    durationMs: 210000,
+    image: '',
+    ...overrides,
+  };
+}
+
+describe('useProviderPlayback — PROVIDER_RECONNECTED_EVENT re-prime', () => {
+  const setCurrentTrackIndex = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockLoadSession.mockReset();
+  });
+
+  it('calls prepareTrack with the persisted playbackPosition when the snapshot trackId matches', () => {
+    // #given — current track is a spotify track, snapshot points at the same id
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue({
+      collectionId: 'c1',
+      collectionName: 'C',
+      trackIndex: 0,
+      trackId: 'sp-1',
+      playbackPosition: 45_000,
+    });
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when — dispatch the reconnect event for spotify
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 45_000 });
+  });
+
+  it('falls back to positionMs=0 when the snapshot trackId does not match', () => {
+    // #given
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue({
+      collectionId: 'c1',
+      collectionName: 'C',
+      trackIndex: 0,
+      trackId: 'different-track',
+      playbackPosition: 45_000,
+    });
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 0 });
+  });
+
+  it('falls back to positionMs=0 when no snapshot is persisted', () => {
+    // #given
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue(null);
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 0 });
+  });
+
+  it('does NOT call prepareTrack when the reconnected provider is not the current track provider', () => {
+    // #given — current track is spotify, but dropbox just reconnected
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue(null);
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'dropbox' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call prepareTrack when there is no current track', () => {
+    // #given — empty queue
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: -1 };
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -111,6 +111,7 @@ export function usePlayerLogic() {
     setCurrentTrackIndex,
     activeDescriptor,
     mediaTracksRef,
+    currentTrackIndexRef,
     onAuthExpired: (providerId: ProviderId) => setAuthExpired(providerId),
     expectedTrackIdRef,
   });

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -1,15 +1,22 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { logQueue, logArtRace } from '@/lib/debugLog';
 import { SKIP_ON_ERROR_DELAY_MS } from '@/constants/timing';
+import { PROVIDER_RECONNECTED_EVENT } from '@/constants/events';
+import { loadSession } from '@/services/sessionPersistence';
 
 interface UseProviderPlaybackProps {
   setCurrentTrackIndex: (index: number) => void;
   activeDescriptor?: ProviderDescriptor | null;
   mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  /**
+   * Ref tracking the current track index. Used by the re-prime listener so
+   * the handler reads the live index without re-binding on every change.
+   */
+  currentTrackIndexRef?: React.MutableRefObject<number>;
   onAuthExpired?: (providerId: ProviderId) => void;
   /**
    * Shared guard ref used by `usePlaybackSubscription` to ignore stale provider
@@ -25,11 +32,49 @@ export const useProviderPlayback = ({
   setCurrentTrackIndex,
   activeDescriptor,
   mediaTracksRef,
+  currentTrackIndexRef,
   onAuthExpired,
   expectedTrackIdRef,
 }: UseProviderPlaybackProps) => {
 
   const currentPlaybackProviderRef = useRef<ProviderId | null>(null);
+
+  // Re-prime the current track when its provider re-authenticates after a
+  // session expiry. The dispatcher (ProviderContext) skips the initial mount,
+  // so this only fires on genuine `not authenticated → authenticated`
+  // transitions. The handler is silent — no auto-play, no queue mutation.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
+      const providerId = detail?.providerId;
+      if (!providerId) return;
+
+      const tracks = mediaTracksRef.current;
+      const index = currentTrackIndexRef?.current ?? -1;
+      const currentTrack = index >= 0 ? tracks[index] : undefined;
+      if (!currentTrack) return;
+      if (currentTrack.provider !== providerId) return;
+
+      const descriptor = providerRegistry.get(providerId);
+      if (!descriptor?.playback.prepareTrack) return;
+
+      const snapshot = loadSession();
+      const resolvedPosition =
+        snapshot?.trackId === currentTrack.id &&
+        typeof snapshot.playbackPosition === 'number'
+          ? snapshot.playbackPosition
+          : 0;
+
+      try {
+        descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition });
+      } catch (error) {
+        logQueue('PROVIDER_RECONNECTED re-prime failed: %o', error);
+      }
+    };
+
+    window.addEventListener(PROVIDER_RECONNECTED_EVENT, handler);
+    return () => window.removeEventListener(PROVIDER_RECONNECTED_EVENT, handler);
+  }, [mediaTracksRef, currentTrackIndexRef]);
 
   const resolveTrackProvider = useCallback((mediaTrack?: MediaTrack): ProviderId | undefined => (
     mediaTrack?.provider

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -283,9 +283,15 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private async primeAudioForHydrate(track: MediaTrack, positionMs?: number): Promise<void> {
     this.ensureAudio();
     const audio = this.audio!;
-    // Only prime audio when nothing is loaded — during next-track pre-warm
-    // the current src is mid-playback and must not be replaced.
-    if (audio.src && this.currentTrack) {
+    // Skip when audio is mid-playback for a *different* track — that's the
+    // next-track pre-warm path; we must not clobber the playing src.
+    // Allow the prime to proceed when the call targets the current track AND
+    // explicitly carries a positionMs (re-prime after re-authentication: the
+    // existing audio src holds an expired temporary link, so we want to fetch
+    // a fresh one and re-seat the seek bar at the saved position).
+    const isCurrentTrackReprime =
+      this.currentTrack?.id === track.id && positionMs !== undefined;
+    if (audio.src && this.currentTrack && !isCurrentTrackReprime) {
       logArtRace('dropbox.prepareTrack: skip emit (audio already loaded for current track) id=%s',
         track.id.slice(0, 8));
       return;

--- a/src/providers/mock/__tests__/test-control.test.ts
+++ b/src/providers/mock/__tests__/test-control.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { installMockTestApi } from '../test-control';
+import { MockAuthAdapter } from '../mockAuthAdapter';
 import type { MockCatalogAdapter } from '../mockCatalogAdapter';
 import type { MockPlaybackAdapter } from '../mockPlaybackAdapter';
 import type { MediaTrack } from '@/types/domain';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 
 function makeTrack(overrides: Partial<MediaTrack> & Pick<MediaTrack, 'id' | 'provider'>): MediaTrack {
   return {
@@ -37,16 +39,22 @@ const dropboxTrack = makeTrack({ id: 'db-1', provider: 'dropbox' });
 describe('installMockTestApi', () => {
   let spotifyPlayback: MockPlaybackAdapter;
   let dropboxPlayback: MockPlaybackAdapter;
+  let spotifyAuth: MockAuthAdapter;
+  let dropboxAuth: MockAuthAdapter;
 
   beforeEach(() => {
     delete window.__mockTest;
     spotifyPlayback = makePlaybackStub();
     dropboxPlayback = makePlaybackStub();
+    spotifyAuth = new MockAuthAdapter('spotify');
+    dropboxAuth = new MockAuthAdapter('dropbox');
     installMockTestApi({
       spotifyCatalog: makeCatalogStub([spotifyTrack]),
       dropboxCatalog: makeCatalogStub([dropboxTrack]),
       spotifyPlayback,
       dropboxPlayback,
+      spotifyAuth,
+      dropboxAuth,
     });
   });
 
@@ -65,6 +73,8 @@ describe('installMockTestApi', () => {
       dropboxCatalog: makeCatalogStub([]),
       spotifyPlayback: makePlaybackStub(),
       dropboxPlayback: makePlaybackStub(),
+      spotifyAuth: new MockAuthAdapter('spotify'),
+      dropboxAuth: new MockAuthAdapter('dropbox'),
     });
 
     // #then
@@ -141,6 +151,35 @@ describe('installMockTestApi', () => {
       await expect(
         window.__mockTest!.setPlaybackState({ trackId: 'no-such-track' }),
       ).rejects.toThrow('Track id "no-such-track" not found in snapshots.');
+    });
+  });
+
+  describe('expireAuth / restoreAuth', () => {
+    it('expireAuth flips the adapter to unauthenticated and dispatches AUTH_STATE_CHANGED_EVENT', async () => {
+      // #given
+      let fired = 0;
+      window.addEventListener(AUTH_STATE_CHANGED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify');
+
+      // #then
+      expect(spotifyAuth.isAuthenticated()).toBe(false);
+      expect(fired).toBe(1);
+    });
+
+    it('restoreAuth flips the adapter back to authenticated and dispatches AUTH_STATE_CHANGED_EVENT', async () => {
+      // #given
+      spotifyAuth.__testExpire();
+      let fired = 0;
+      window.addEventListener(AUTH_STATE_CHANGED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.restoreAuth('spotify');
+
+      // #then
+      expect(spotifyAuth.isAuthenticated()).toBe(true);
+      expect(fired).toBe(1);
     });
   });
 

--- a/src/providers/mock/__tests__/test-control.test.ts
+++ b/src/providers/mock/__tests__/test-control.test.ts
@@ -5,6 +5,7 @@ import type { MockCatalogAdapter } from '../mockCatalogAdapter';
 import type { MockPlaybackAdapter } from '../mockPlaybackAdapter';
 import type { MediaTrack } from '@/types/domain';
 import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 
 function makeTrack(overrides: Partial<MediaTrack> & Pick<MediaTrack, 'id' | 'provider'>): MediaTrack {
   return {
@@ -166,6 +167,33 @@ describe('installMockTestApi', () => {
       // #then
       expect(spotifyAuth.isAuthenticated()).toBe(false);
       expect(fired).toBe(1);
+    });
+
+    it('expireAuth does NOT dispatch SESSION_EXPIRED_EVENT by default', async () => {
+      // #given
+      let fired = 0;
+      window.addEventListener(SESSION_EXPIRED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify');
+
+      // #then
+      expect(fired).toBe(0);
+    });
+
+    it('expireAuth dispatches SESSION_EXPIRED_EVENT when alsoDispatchSessionExpired is true', async () => {
+      // #given
+      const events: Array<{ providerId: string }> = [];
+      window.addEventListener(SESSION_EXPIRED_EVENT, (e) => {
+        events.push((e as CustomEvent<{ providerId: string }>).detail);
+      });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify', { alsoDispatchSessionExpired: true });
+
+      // #then
+      expect(events).toEqual([{ providerId: 'spotify' }]);
+      expect(spotifyAuth.isAuthenticated()).toBe(false);
     });
 
     it('restoreAuth flips the adapter back to authenticated and dispatches AUTH_STATE_CHANGED_EVENT', async () => {

--- a/src/providers/mock/mockAuthAdapter.ts
+++ b/src/providers/mock/mockAuthAdapter.ts
@@ -3,29 +3,42 @@ import type { ProviderId } from '@/types/domain';
 
 export class MockAuthAdapter implements AuthProvider {
   readonly providerId: ProviderId;
+  private authenticated = true;
 
   constructor(providerId: ProviderId) {
     this.providerId = providerId;
   }
 
   isAuthenticated(): boolean {
-    return true;
+    return this.authenticated;
   }
 
   getAccessToken(): Promise<string | null> {
-    return Promise.resolve('mock-access-token');
+    return Promise.resolve(this.authenticated ? 'mock-access-token' : null);
   }
 
   beginLogin(): Promise<void> {
+    this.authenticated = true;
     return Promise.resolve();
   }
 
   handleCallback(url: URL): Promise<boolean> {
     void url;
+    this.authenticated = true;
     return Promise.resolve(true);
   }
 
   logout(): void {
-    // no-op
+    this.authenticated = false;
+  }
+
+  /** Test-only: flip the adapter back into the authenticated state. */
+  __testRestoreAuth(): void {
+    this.authenticated = true;
+  }
+
+  /** Test-only: force the adapter into the expired/unauthenticated state. */
+  __testExpire(): void {
+    this.authenticated = false;
   }
 }

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -93,5 +93,7 @@ if (shouldUseMockProvider()) {
     dropboxCatalog: dropboxDescriptor.catalog as MockCatalogAdapter,
     spotifyPlayback: spotifyDescriptor.playback as MockPlaybackAdapter,
     dropboxPlayback: dropboxDescriptor.playback as MockPlaybackAdapter,
+    spotifyAuth: spotifyDescriptor.auth as MockAuthAdapter,
+    dropboxAuth: dropboxDescriptor.auth as MockAuthAdapter,
   });
 }

--- a/src/providers/mock/test-control.ts
+++ b/src/providers/mock/test-control.ts
@@ -12,11 +12,27 @@ import type { MockPlaybackAdapter } from './mockPlaybackAdapter';
 import type { MockAuthAdapter } from './mockAuthAdapter';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+
+export interface ExpireAuthOptions {
+  /**
+   * When true, ALSO dispatch SESSION_EXPIRED_EVENT alongside the
+   * AUTH_STATE_CHANGED_EVENT. Defaults to false — the narrower simulation
+   * mirrors the legacy behavior and keeps existing Playwright specs stable.
+   *
+   * Real expiry in production dispatches both events (the refresh-token
+   * rejection path fires SESSION_EXPIRED; the resulting state flip fires
+   * AUTH_STATE_CHANGED). Opt in to this flag when an end-to-end test needs
+   * the SESSION_EXPIRED handler in the SpotifyPlaybackAdapter (and other
+   * listeners) to run ahead of the reconnect.
+   */
+  alsoDispatchSessionExpired?: boolean;
+}
 
 export interface MockTestApi {
   setQueue(trackIds: string[]): Promise<void>;
   setPlaybackState(state: { trackId: string; positionMs?: number; isPlaying?: boolean }): Promise<void>;
-  expireAuth(providerId: ProviderId): Promise<void>;
+  expireAuth(providerId: ProviderId, opts?: ExpireAuthOptions): Promise<void>;
   restoreAuth(providerId: ProviderId): Promise<void>;
   reset(): Promise<void>;
 }
@@ -74,9 +90,14 @@ export function installMockTestApi(opts: InstallOptions): void {
       }
     },
 
-    async expireAuth(providerId) {
+    async expireAuth(providerId, opts) {
       resolveAuth(providerId).__testExpire();
       window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      if (opts?.alsoDispatchSessionExpired) {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId } }),
+        );
+      }
     },
 
     async restoreAuth(providerId) {

--- a/src/providers/mock/test-control.ts
+++ b/src/providers/mock/test-control.ts
@@ -9,11 +9,15 @@
 // `shouldUseMockProvider()` is true, so it is a no-op in production.
 import type { MockCatalogAdapter } from './mockCatalogAdapter';
 import type { MockPlaybackAdapter } from './mockPlaybackAdapter';
-import type { MediaTrack } from '@/types/domain';
+import type { MockAuthAdapter } from './mockAuthAdapter';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 
 export interface MockTestApi {
   setQueue(trackIds: string[]): Promise<void>;
   setPlaybackState(state: { trackId: string; positionMs?: number; isPlaying?: boolean }): Promise<void>;
+  expireAuth(providerId: ProviderId): Promise<void>;
+  restoreAuth(providerId: ProviderId): Promise<void>;
   reset(): Promise<void>;
 }
 
@@ -22,13 +26,28 @@ export interface InstallOptions {
   dropboxCatalog: MockCatalogAdapter;
   spotifyPlayback: MockPlaybackAdapter;
   dropboxPlayback: MockPlaybackAdapter;
+  spotifyAuth: MockAuthAdapter;
+  dropboxAuth: MockAuthAdapter;
 }
 
 export function installMockTestApi(opts: InstallOptions): void {
   if (typeof window === 'undefined') return;
   if (window.__mockTest) return;
 
-  const { spotifyCatalog, dropboxCatalog, spotifyPlayback, dropboxPlayback } = opts;
+  const {
+    spotifyCatalog,
+    dropboxCatalog,
+    spotifyPlayback,
+    dropboxPlayback,
+    spotifyAuth,
+    dropboxAuth,
+  } = opts;
+
+  function resolveAuth(providerId: ProviderId): MockAuthAdapter {
+    if (providerId === 'spotify') return spotifyAuth;
+    if (providerId === 'dropbox') return dropboxAuth;
+    throw new Error(`[MockTestApi] Unknown providerId "${providerId}"`);
+  }
 
   function resolveTrack(id: string): MediaTrack {
     const track =
@@ -53,6 +72,16 @@ export function installMockTestApi(opts: InstallOptions): void {
       if (!isPlaying) {
         await adapter.pause();
       }
+    },
+
+    async expireAuth(providerId) {
+      resolveAuth(providerId).__testExpire();
+      window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+    },
+
+    async restoreAuth(providerId) {
+      resolveAuth(providerId).__testRestoreAuth();
+      window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
     },
 
     async reset() {

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SpotifyPlaybackAdapter } from '@/providers/spotify/spotifyPlaybackAdapter';
 import { spotifyPlayer, waitForSpotifyReady } from '@/services/spotifyPlayer';
 import { AuthExpiredError } from '@/providers/errors';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 import type { MediaTrack, PlaybackState } from '@/types/domain';
 
 vi.mock('@/services/spotifyPlayer', () => ({
@@ -367,5 +368,65 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // A's emission count stays at 1 (only the synchronous emit; no post-transfer re-emit)
     expect(stageEmissions.filter((s) => s?.currentTrackId === 'a')).toHaveLength(1);
+  });
+
+  describe('SESSION_EXPIRED re-prime', () => {
+    it('re-emits state on a same-track prepareTrack after SESSION_EXPIRED resets the guard', async () => {
+      // #given — adapter has staged track-1 once already; without the
+      // SESSION_EXPIRED reset, the `preparedTrackRef === uri` guard would
+      // silently drop a same-track re-prime fired by `PROVIDER_RECONNECTED`,
+      // and the seek bar would remain stuck at 0:00 / 0:00 after re-auth
+      // (issue #1571).
+      const track = makeTrack();
+      const stageEmissions: PlaybackState[] = [];
+      adapter.subscribe((state) => {
+        if (state?.currentTrackId === track.id && !state.isPlaying) {
+          stageEmissions.push(state);
+        }
+      });
+
+      adapter.prepareTrack(track, { positionMs: 15_000 });
+      await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+      await vi.waitFor(() =>
+        expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+      );
+
+      // #when — simulate provider session expiry, then re-prime same track
+      window.dispatchEvent(
+        new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+      adapter.prepareTrack(track, { positionMs: 15_000 });
+
+      // #then — second prepareTrack must re-emit (guard cleared) and trigger
+      // another Connect transfer.
+      expect(stageEmissions).toHaveLength(2);
+      await vi.waitFor(() =>
+        expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+      );
+    });
+
+    it('ignores SESSION_EXPIRED events for other providers', async () => {
+      // #given — only Spotify's preparedTrackRef should reset; a Dropbox
+      // session-expiry event should not clear Spotify's guard.
+      const track = makeTrack();
+      const stageEmissions: PlaybackState[] = [];
+      adapter.subscribe((state) => {
+        if (state?.currentTrackId === track.id && !state.isPlaying) {
+          stageEmissions.push(state);
+        }
+      });
+
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+      await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+
+      // #when
+      window.dispatchEvent(
+        new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'dropbox' } }),
+      );
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+
+      // #then — Spotify guard still set → second prepare is a no-op
+      expect(stageEmissions).toHaveLength(1);
+    });
   });
 });

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -11,6 +11,7 @@ import { spotifyApiRequest, SpotifyApiError } from '@/services/spotify/api';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { spotifyQueueSync } from './spotifyQueueSync';
 import { logSpotify, logArtRace } from '@/lib/debugLog';
@@ -43,6 +44,30 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   private sdkUnsubscribe: (() => void) | null = null;
   /** Ref of the track most recently staged by prepareTrack; used for idempotency. */
   private preparedTrackRef: string | null = null;
+  /**
+   * Listener that resets `preparedTrackRef` when the Spotify session expires.
+   *
+   * Why: `prepareTrack` short-circuits when `preparedTrackRef === uri` to keep
+   * back-to-back hydrate calls cheap. Across a session boundary that guard
+   * becomes a bug — after SESSION_EXPIRED + reconnect, the SDK has detached
+   * and emitted no state, so a same-track re-prime is the only thing that
+   * repaints the seek bar (issue #1571). Resetting on SESSION_EXPIRED lets
+   * the next `prepareTrack(currentTrack, { positionMs })` from
+   * `useProviderPlayback`'s `PROVIDER_RECONNECTED_EVENT` handler stage state
+   * again.
+   */
+  private readonly handleSessionExpired = (event: Event): void => {
+    const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
+    if (detail?.providerId !== 'spotify') return;
+    this.preparedTrackRef = null;
+    this.playbackSessionActive = false;
+  };
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      window.addEventListener(SESSION_EXPIRED_EVENT, this.handleSessionExpired);
+    }
+  }
 
   private async ensurePlaybackReady(): Promise<void> {
     await spotifyPlayer.initialize();


### PR DESCRIPTION
## Summary
- On `AUTH_STATE_CHANGED` that transitions a provider from unauthenticated → authenticated, dispatch `PROVIDER_RECONNECTED_EVENT { providerId }` from `ProviderContext` (first-render skip pattern guards against the initial-mount false positive).
- `useProviderPlayback` listens and, when the current track's provider matches, calls `prepareTrack(currentTrack, { positionMs })` with `positionMs` resolved from `SessionSnapshot.playbackPosition` (when `trackId` matches) or `0` otherwise.
- Tightens the Dropbox `prepareTrack` guard so a re-prime targeting the current track (positionMs provided) refreshes the stale temp link instead of short-circuiting on the still-set `audio.src`.
- Adds unit coverage in `ProviderContext.test.tsx` and `useProviderPlayback.reauth.test.ts` + Playwright spec asserting the seek bar lands near the seeded 45s position after re-auth.

## Test plan
- `npx tsc -b --noEmit` clean
- `npm run test:run` green (2025/2025 across 194 files)
- `npm run build` green
- `npx playwright test playwright/specs/provider-auth-reauth.spec.ts playwright/specs/persisted-session-hydrate.spec.ts` green
- `openspec validate reload-track-after-provider-reauth --strict` clean
- Manual: expire Spotify mid-playback, return to settings and toggle on, return to player. Seek bar paints the real duration; cursor sits at the position you left off at; pressing play resumes.

Implements openspec change `reload-track-after-provider-reauth`.