### PR TITLE
fix(auth): use reportUnauthorized() for SDK authentication_error

### DIFF
--- a/src/services/__tests__/spotifyPlayer.test.ts
+++ b/src/services/__tests__/spotifyPlayer.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/services/spotify', () => ({
     isAuthenticated: vi.fn().mockReturnValue(true),
     ensureValidToken: vi.fn().mockResolvedValue('token'),
     redirectToAuth: vi.fn(),
+    reportUnauthorized: vi.fn(),
   },
 }));
 

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -102,7 +102,7 @@ class SpotifyPlayerService {
     this.player.addListener('authentication_error', ({ message }: { message: string }) => {
       console.error('Failed to authenticate', message);
       if (shouldUseMockProvider()) return;
-      spotifyAuth.redirectToAuth();
+      spotifyAuth.reportUnauthorized();
     });
 
     this.player.addListener('account_error', ({ message }: { message: string }) => {


### PR DESCRIPTION
Replace full-page redirectToAuth() call in the Spotify Web Playback SDK authentication_error handler with spotifyAuth.reportUnauthorized(), which clears tokens via logout() and dispatches SESSION_EXPIRED_EVENT - consistent with how 401s from the refresh endpoint and Dropbox API are handled.

Closes #1554

Generated with [Claude Code](https://claude.ai/code)