### PR TITLE
fix(auth): clear all Spotify IDB and in-memory caches on logout

### DIFF
--- a/openspec/changes/spotify-logout-cache-clear/specs/auth-system/spec.md
+++ b/openspec/changes/spotify-logout-cache-clear/specs/auth-system/spec.md
@@ -1,0 +1,27 @@
+# auth-system — Delta Spec: Logout Cache Clearing
+
+## Change
+
+Extends **Requirement: Disconnect Confirmation and Cleanup** to require that provider
+logout clears all provider-derived cached data, not only queue and playback state.
+
+## New Requirement: Provider Logout Clears All Derived Caches
+
+On logout, a provider adapter SHALL clear all cached data it wrote during the session,
+including in-memory caches and IndexedDB stores.
+
+**Rationale**: without this, playlist, track, and search data from a previous account
+persist into the next session on the same device — a data-hygiene leak. Dropbox already
+satisfies this requirement; this delta brings Spotify to parity.
+
+### Scenario: Spotify logout clears in-memory caches
+
+- **WHEN** the Spotify provider is logged out
+- **THEN** the in-memory track-saved, album-saved, and track-list caches are cleared
+- **AND** the in-memory liked-songs count and liked-songs list caches are cleared
+
+### Scenario: Spotify logout clears IndexedDB library cache
+
+- **WHEN** the Spotify provider is logged out
+- **THEN** the IndexedDB library cache (playlists, albums, track lists, meta stores)
+  is cleared so no data from the previous account leaks into the next session

--- a/src/providers/spotify/__tests__/spotifyAuthAdapter.test.ts
+++ b/src/providers/spotify/__tests__/spotifyAuthAdapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockSpotifyLogout,
+  mockSpotifyIsAuthenticated,
+  mockClearLikedCountSnapshot,
+  mockClearAllSpotifyInMemoryCaches,
+  mockClearLibraryCache,
+} = vi.hoisted(() => ({
+  mockSpotifyLogout: vi.fn(),
+  mockSpotifyIsAuthenticated: vi.fn().mockReturnValue(true),
+  mockClearLikedCountSnapshot: vi.fn(),
+  mockClearAllSpotifyInMemoryCaches: vi.fn(),
+  mockClearLibraryCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/spotify', () => ({
+  spotifyAuth: {
+    isAuthenticated: mockSpotifyIsAuthenticated,
+    logout: mockSpotifyLogout,
+    ensureValidToken: vi.fn().mockResolvedValue('tok'),
+    getAccessToken: vi.fn().mockReturnValue('tok'),
+    getAuthUrl: vi.fn().mockResolvedValue('https://accounts.spotify.com/authorize'),
+    redirectToAuth: vi.fn().mockResolvedValue(undefined),
+    handleRedirect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/services/cache/likedCountSnapshot', () => ({
+  clearLikedCountSnapshot: mockClearLikedCountSnapshot,
+}));
+
+vi.mock('@/services/spotify/cache', () => ({
+  clearAllSpotifyInMemoryCaches: mockClearAllSpotifyInMemoryCaches,
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  clearAll: mockClearLibraryCache,
+}));
+
+import { SpotifyAuthAdapter } from '@/providers/spotify/spotifyAuthAdapter';
+
+describe('SpotifyAuthAdapter.logout', () => {
+  let adapter: SpotifyAuthAdapter;
+
+  beforeEach(() => {
+    adapter = new SpotifyAuthAdapter();
+    vi.clearAllMocks();
+    mockClearLibraryCache.mockResolvedValue(undefined);
+  });
+
+  it('calls spotifyAuth.logout', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockSpotifyLogout).toHaveBeenCalledOnce();
+  });
+
+  it('clears liked count snapshot', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearLikedCountSnapshot).toHaveBeenCalledWith('spotify');
+  });
+
+  it('clears all in-memory Spotify caches', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearAllSpotifyInMemoryCaches).toHaveBeenCalledOnce();
+  });
+
+  it('fires IDB library cache clear', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearLibraryCache).toHaveBeenCalledOnce();
+  });
+});

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -7,6 +7,8 @@ import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { spotifyAuth } from '@/services/spotify';
 import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { clearAllSpotifyInMemoryCaches } from '@/services/spotify/cache';
+import { clearAll as clearLibraryCache } from '@/services/cache/libraryCache';
 import { logCaughtError } from '@/utils/logCaughtError';
 
 export class SpotifyAuthAdapter implements AuthProvider {
@@ -61,5 +63,7 @@ export class SpotifyAuthAdapter implements AuthProvider {
   logout(): void {
     spotifyAuth.logout();
     clearLikedCountSnapshot('spotify');
+    clearAllSpotifyInMemoryCaches();
+    void clearLibraryCache();
   }
 }

--- a/src/services/spotify/cache.ts
+++ b/src/services/spotify/cache.ts
@@ -58,3 +58,15 @@ export function getLikedSongsCache(): { data: Track[]; limit: number; timestamp:
 export function setLikedSongsCache(value: { data: Track[]; limit: number; timestamp: number } | null): void {
   likedSongsCacheData = value;
 }
+
+/**
+ * Clear all in-memory Spotify caches. Called on logout so the next session
+ * starts with a clean slate instead of serving stale data from a previous account.
+ */
+export function clearAllSpotifyInMemoryCaches(): void {
+  trackSavedCache.clear();
+  albumSavedCache.clear();
+  trackListCache.clear();
+  likedSongsCountCacheData = null;
+  likedSongsCacheData = null;
+}


### PR DESCRIPTION
Closes #1558

Mirror Dropbox's logout cache-clearing pattern in `SpotifyAuthAdapter`:

- Add `clearAllSpotifyInMemoryCaches()` to `src/services/spotify/cache.ts` to reset all five in-memory cache structures
- Call `clearAllSpotifyInMemoryCaches()` and `clearAll()` (IDB library cache) in `SpotifyAuthAdapter.logout()`
- Add test for all logout side-effects
- Add OpenSpec delta spec for auth-system

Prevents playlist, track, and search data from a previous account leaking into the next session on the same device.

Generated with [Claude Code](https://claude.ai/code)