### PR TITLE
release: 2026-05-20

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default tseslint.config(
     rules: {
       'react-hooks/rules-of-hooks': 'off',
       'react-hooks/exhaustive-deps': 'off',
+      'no-empty-pattern': 'off',
     },
   },
 )

--- a/openspec/changes/active-swatch-accent-outline/design.md
+++ b/openspec/changes/active-swatch-accent-outline/design.md
@@ -1,0 +1,53 @@
+# Design — active-swatch-accent-outline
+
+## Context
+
+`QuickEffectsRow.tsx` renders accent-color swatches as 24×24 circles whose fill *is* the candidate accent color. The currently-active swatch (where `color.hex === accentColor`) needs a visual differentiator. Today that differentiator is a 2px solid outline in `theme.colors.selection` (`#ffd700` gold).
+
+Every other active state in the flip menu — option-button pills via `$variant="accent"`, switch tracks — already derives from `var(--accent-color)` (and `var(--accent-contrast-color)` for foregrounds). The swatch was deliberately skipped per the merge note in `b1e72ac`, but the visual-effects-menu spec enumerates the swatch as a control that MUST reflect the accent. The spec is the durable contract; the implementation should follow it.
+
+## Decision
+
+Use `var(--accent-contrast-color)` for the active-swatch outline.
+
+### Why not `var(--accent-color)`?
+
+The active swatch's `background` is the accent color. An outline in the same color would be invisible — defeating the purpose of marking it as active.
+
+### Why `var(--accent-contrast-color)`?
+
+- It's already wired up: `ColorContext` calls `getContrastColor(accentColor)` and sets the CSS variable alongside `--accent-color` on every accent change (`src/contexts/ColorContext.tsx:86`). Other components use it as a paired foreground (e.g. `LikeButton.tsx:86,90`).
+- It guarantees visibility against the swatch fill by construction (it's the WCAG-passing contrast of the accent).
+- The visual-effects-menu spec's "Active Controls Reflect Current Accent Color" requirement explicitly permits `--accent-contrast-color` as a derived value.
+
+### Why not a two-color ring (e.g. 2px outline + 1px inner shadow)?
+
+Considered, then rejected: it adds box-shadow geometry to fix a problem that `--accent-contrast-color` already solves cleanly. The simpler rule wins.
+
+### Why keep `theme.colors.selection` in `theme.ts`?
+
+It's a generic UI-state token (potential future use: highlighting selected rows, command-palette hits, etc.). Removing it on the back of this single-site refactor is out of scope; the token is left alone.
+
+## Implementation
+
+`src/components/controls/QuickEffectsRow.tsx:76`:
+
+```ts
+outline: ${({ $isActive }) => ($isActive ? `2px solid var(--accent-contrast-color)` : 'none')};
+```
+
+The `theme` arg is no longer needed in that styled-component getter, but is also harmless to leave; removing it is a minor cleanup commensurate with the fix.
+
+## Risks
+
+- **Low contrast for `--accent-contrast-color` when accent is a mid-tone gray.** `getContrastColor` returns either pure black or pure white based on the accent's luminance, so the outline will always be one of those two — both read clearly against a single colored disc. No new contrast risk.
+- **Tests.** `src/components/controls/__tests__/QuickEffectsRow.test.tsx` asserts `$variant="accent"` on `OptionButton`s — it does not touch the swatch outline. No test updates required.
+
+## Alternatives Considered
+
+| Option | Verdict |
+|---|---|
+| Keep static gold outline | Rejected — violates spec, motivates this issue |
+| Outline in `var(--accent-color)` | Rejected — invisible against active swatch's accent fill |
+| 2px `--accent-color` + inner 1px `--accent-contrast-color` ring via `box-shadow` | Rejected — extra geometry, no upside over single-color contrast outline |
+| Add a new theme token `theme.colors.swatchActiveOutline = var(--accent-contrast-color)` | Rejected — adds indirection without helping any other call site; the CSS variable is the project's canonical accent plumbing |

--- a/openspec/changes/active-swatch-accent-outline/proposal.md
+++ b/openspec/changes/active-swatch-accent-outline/proposal.md
@@ -1,0 +1,23 @@
+# active-swatch-accent-outline
+
+## Why
+
+The flip-menu accent-color swatch row renders its active-state outline in a static gold (`theme.colors.selection` → `#ffd700`). Every other active control in the VFX flip menu already follows the spec requirement "Active Controls Reflect Current Accent Color" by deriving its active state from `--accent-color` / `--accent-contrast-color`. The active swatch is the lone holdout; it visually clashes with the accent and reads as generic chrome instead of as an extension of the current album's identity.
+
+The selection-gold outline arrived in commit `b1e72ac` ("feat(visual-effects-menu): tint flip-menu controls with current accent"), whose body notes "leaving the existing selection outline as the sole indicator". The visual-effects-menu spec — authored around the same time — nevertheless enumerates the active swatch indicator as a control that MUST render its active state via `--accent-color`. The implementation drifted from the spec. This change resolves the drift in favor of the spec.
+
+## What Changes
+
+- Replace the static `theme.colors.selection` outline on the active swatch button with an accent-derived outline.
+  - Use `var(--accent-contrast-color)` (already populated alongside `--accent-color` by `ColorContext`) because the swatch's own fill *is* the accent when active — `var(--accent-color)` would render an invisible outline.
+  - The visual-effects-menu spec's "Active Controls Reflect Current Accent Color" requirement explicitly permits derived values such as `--accent-contrast-color` for foreground/marker roles.
+- Clarify the visual-effects-menu spec to call out that the active swatch outline uses the accent-contrast color (not raw `--accent-color`), to lock in the rationale and prevent regression to the same gold-outline state.
+
+## Impact
+
+- Affected specs: `visual-effects-menu` (Requirement: Active Controls Reflect Current Accent Color — adds a swatch-specific contrast-color clarification).
+- Affected code: `src/components/controls/QuickEffectsRow.tsx` (single-line change at line 76).
+- `theme.colors.selection` itself stays — searched usages confirm the swatch outline was its only call site in `src/`, but the token is retained because it's a generic UI-state token and removing it is out of scope.
+- No behavioral change for any other VFX menu control.
+- No global accent-color plumbing changes.
+- Closes #1559.

--- a/openspec/changes/active-swatch-accent-outline/specs/visual-effects-menu/spec.md
+++ b/openspec/changes/active-swatch-accent-outline/specs/visual-effects-menu/spec.md
@@ -1,0 +1,38 @@
+# visual-effects-menu Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: Active Controls Reflect Current Accent Color
+
+Every control in the flip menu that exposes an active visual state — Glow Intensity / Rate pills, Visualizer Style / Intensity / Speed pills, the Glow / Visualizer / Translucence switch tracks, and the active swatch indicator — SHALL render its active state using the current `--accent-color` (or a value derived from it, such as `--accent-contrast-color` for foregrounds). Inactive states MAY remain neutral. When the current track changes and the accent color is recomputed, every active control's color SHALL update accordingly without user input.
+
+The active-swatch indicator is a special case: the swatch fill itself *is* the candidate accent color, so an outline in `--accent-color` would be invisible against the active swatch. The active-swatch outline SHALL therefore use `var(--accent-contrast-color)` (the WCAG-passing contrast color paired with `--accent-color` and updated together by `ColorContext`). It SHALL NOT use a static UI-state color (e.g. the legacy `theme.colors.selection` gold).
+
+Rationale: the flip menu is the per-album personalization surface, so its active-state styling should read as an extension of the album's identity rather than as generic chrome.
+
+#### Scenario: Active option-button pill reflects accent
+
+- **WHEN** the user opens the flip menu while a track with a known accent color is playing
+- **THEN** the currently-selected Glow Intensity / Rate / Visualizer Style / Intensity / Speed pill renders with its background, border, and foreground driven by the current accent color and its derived contrast color
+
+#### Scenario: Switch tracks reflect accent
+
+- **WHEN** the Glow, Visualizer, or Translucence switch is in the on state
+- **THEN** the switch track renders in the current accent color
+
+#### Scenario: Active swatch outline uses accent-contrast color
+
+- **WHEN** the user selects an accent color via one of the swatch buttons
+- **THEN** the chosen swatch is outlined with `var(--accent-contrast-color)` (not a static UI-state color)
+- **AND** the outline remains clearly visible against the swatch's own accent-colored fill
+
+#### Scenario: Accent updates propagate when the track changes
+
+- **WHEN** the playing track changes and the extracted accent color changes accordingly
+- **THEN** every active control in the open flip menu re-renders with the new accent color without requiring the user to re-select anything
+- **AND** the active-swatch outline re-renders with the new `--accent-contrast-color`
+
+#### Scenario: Inactive controls remain neutral
+
+- **WHEN** an option-button pill is in its inactive state
+- **THEN** the pill renders with the panel's neutral muted styling (it does not preview the accent color)

--- a/openspec/changes/active-swatch-accent-outline/tasks.md
+++ b/openspec/changes/active-swatch-accent-outline/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — active-swatch-accent-outline
+
+## 1. Implementation
+
+- [x] 1.1 Update `src/components/controls/QuickEffectsRow.tsx:76` — replace `2px solid ${theme.colors.selection}` with `2px solid var(--accent-contrast-color)` for the active swatch outline.
+- [x] 1.2 Drop the unused `theme` arg from that styled getter (purely cosmetic; no behavior change).
+
+## 2. Spec delta
+
+- [x] 2.1 Add a swatch-specific clarification under the `visual-effects-menu` "Active Controls Reflect Current Accent Color" requirement noting that the active-swatch outline uses `--accent-contrast-color` (because the swatch fill itself is the accent).
+
+## 3. Verification
+
+- [x] 3.1 `npx tsc -b --noEmit` — clean.
+- [x] 3.2 `npm run test:run` — green (no existing test asserts on the outline color; `QuickEffectsRow.test.tsx` only checks `$variant="accent"` on OptionButtons).
+- [x] 3.3 `npm run build` — green.
+- [x] 3.4 Manual check (deferred to PR review): toggle accent color via the flip menu and confirm the active-swatch outline follows the contrast color, remaining clearly visible across light and dark accents.

--- a/openspec/changes/dropbox-skip-on-error/design.md
+++ b/openspec/changes/dropbox-skip-on-error/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`DropboxPlaybackAdapter` plays audio via an `HTMLAudioElement`. Its `playTrack`:
+
+1. Calls `catalog.getTemporaryLink(path)` to mint a fresh download URL (Dropbox temporary links are short-lived; `dropboxCatalogAdapter` handles refresh transparently).
+2. Assigns `audio.src` and awaits `audio.play()`.
+
+The two failure surfaces today:
+
+- **Pre-fetch / catalog**: `getTemporaryLink` rejects. `AuthExpiredError` propagates; everything else is swallowed because the catch site is `useProviderPlayback` which only special-cases `AuthExpiredError` and `UnavailableTrackError` — a generic Error there falls through to the `skipOnError` branch already, but only because `console.error` doesn't swallow re-throw. Actually it does skip via the generic branch (`useProviderPlayback.ts:133-137`). So this path already advances. It is documented for completeness.
+- **Post-fetch / media**: `audio.src` is set, then `audio.play()` is awaited. `audio.play()` can resolve before the media element actually starts playing — browsers resolve as soon as the play *intent* is honored, while a media decoding failure may surface asynchronously via the `error` event. The persistent `error` listener at line 60 captures it into `state.playbackError`, but **no subscriber reads that field**, so the queue stalls on the broken track.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A post-fetch `<audio>` error during the initial play SHALL cause `playTrack` to reject with `UnavailableTrackError`, so the engine's existing skip path advances the queue.
+- Auth expiry continues to throw `AuthExpiredError` (unchanged).
+- The `skipOnError` cooldown and ordering already enforced by `useProviderPlayback` is reused — no new engine code.
+
+**Non-Goals:**
+- Distinguishing decoder errors from network errors. The user-visible outcome is identical (skip).
+- Refreshing the temporary link mid-stream when a long-lived play stalls. That's a separate concern; tracked as a deferred enhancement. Once playback has begun successfully, mid-stream failures should be handled via the existing auto-advance path (track ends), not via a skip.
+- Surfacing `state.playbackError` to UI. Out of scope; the field can stay as-is for diagnostics.
+- Modifying `useProviderPlayback.ts`. The existing `UnavailableTrackError` branch already does what we need.
+
+## Decisions
+
+**Throw `UnavailableTrackError` from `playTrack` rather than wiring `state.playbackError` through subscriptions.**
+
+Two reasons:
+
+1. **Symmetry with Spotify.** `spotifyPlaybackAdapter` already uses this signal (`spotifyPlaybackAdapter.ts:139`). Using the same shape keeps the engine's recovery branch single-source-of-truth and avoids a second skip-trigger path that subscribers would have to dedupe against.
+2. **Minimum blast radius.** Routing `state.playbackError` into a skip would require either a new subscriber hook or extending `usePlaybackSubscription` / `useAutoAdvance` with error-aware logic. Throwing from `playTrack` reuses 100% of the existing infrastructure — the engine's `try/catch` is already there.
+
+**Race `audio.play()` against the next `error` event using a one-shot promise.**
+
+`audio.play()` returning a fulfilled promise does not mean playback succeeded — browsers fulfill it as soon as the play intent is queued; decoding/network failures surface afterward via the `error` event on `HTMLMediaElement`. We need to wait for *one of*:
+
+- The element transitions to actively playing (`playing` event fires) → resolve.
+- The element raises `error` → reject with `UnavailableTrackError`.
+
+We attach single-fire listeners for both events, clean them up in `finally`, and return whichever wins. `audio.play()`'s own rejection (e.g. `NotAllowedError` from autoplay policy) is treated as an error too — anything that prevents the element from reaching `playing` is unavailable.
+
+The iOS Safari pre-emptive `audio.play()` call at line 88 is preserved — it's a gesture-activation hack and doesn't interact with the post-`src=...` play race.
+
+**`AuthExpiredError` keeps its dedicated channel.**
+
+Auth expiry is a recoverable user-actionable state, not a track-availability problem. The engine's branch at `useProviderPlayback.ts:120-123` dispatches a re-auth prompt and explicitly does not skip. So we rethrow `AuthExpiredError` as-is from `catalog.getTemporaryLink()` and never wrap it in `UnavailableTrackError`.
+
+**Generic catalog rejections (non-Auth) fall through to the engine's generic-error skip branch.**
+
+`useProviderPlayback.ts:133-137` already skips on any non-Auth/non-Unavailable error from `playTrack`. We do not need to wrap pre-fetch errors in `UnavailableTrackError` — letting them propagate as plain `Error` gives the same outcome and avoids hiding the original stack. The test suite asserts the queue advances either way.
+
+## Risks / Trade-offs
+
+- **Risk**: A transient `error` event during a normally-playing stream (e.g. a momentary network glitch that the browser recovers from) could trigger a spurious skip if it fires during the initial play race. → Mitigation: the race is bounded to the first play; we settle on the first `playing` event and detach both listeners. After that, any later `error` event flows through the persistent listener into `pendingError` as before — no spurious skip mid-track. Mid-stream failures are not the target of this change.
+- **Risk**: A track with broken metadata that loads but never starts (`playing` never fires, `error` never fires) would leave `playTrack` hanging. → Mitigation: in practice browsers always emit one of the two within a few seconds for a real file. We intentionally do **not** add a timeout in this pass because picking a timeout that's correct across slow networks and CPU-throttled mobile is its own problem; if real-world telemetry shows hangs we can layer one on in a follow-up.
+- **Trade-off**: The race adds a small amount of state-machine glue to `playTrack` but keeps engine-level error recovery centralized.
+
+## Edge Cases
+
+- **Link refresh failure**: `getTemporaryLink` already handles 410/expired-link refresh internally. If refresh ultimately fails (e.g. file deleted), it rejects with a generic Error; the engine's generic-error branch skips. If it rejects with `AuthExpiredError`, we rethrow and the engine surfaces re-auth.
+- **Decoder error**: Audio element fires `error` with `MediaError.MEDIA_ERR_DECODE`. Caught by the race, throws `UnavailableTrackError`, skip.
+- **Network mid-stream**: Out of scope for the initial-play race. The element will pause and the existing natural-end auto-advance signal may or may not fire depending on browser; this is acknowledged as a separate gap.
+- **iOS user-gesture pre-emptive play**: Untouched. The pre-emptive `this.audio!.play().catch(() => {})` at line 88 runs before `audio.src` is set; it activates the element for later programmatic play and any rejection there is irrelevant to the real play that follows the catalog fetch.
+- **Subsequent `playTrack` supersedes a pending one**: `prepareGeneration` is already incremented at the top of `playTrack`. We add the same generation check inside the race so a stale `error` from the previous src can't reject the new play.

--- a/openspec/changes/dropbox-skip-on-error/proposal.md
+++ b/openspec/changes/dropbox-skip-on-error/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Dropbox playback failures other than auth expiry have no recovery path today. `DropboxPlaybackAdapter.playTrack` only throws `AuthExpiredError`; every other error mode — file moved out from under us, temporary link expired beyond catalog refresh, HTML5 audio decoder failure, network mid-stream drop — is captured into `state.playbackError` but no consumer reads that field, so the queue stalls on the unplayable track. This violates `openspec/specs/playback-engine/spec.md` Requirement 5 ("Error Recovery"), which says the engine SHALL skip an unavailable track.
+
+Spotify already follows the spec: `SpotifyPlaybackAdapter` throws `UnavailableTrackError` from `playTrack` on terminal failures (e.g. 403 "Restriction violated"), and `useProviderPlayback` handles it via the `skipOnError` branch (`src/hooks/useProviderPlayback.ts:125-131`) which advances to the next track after `SKIP_ON_ERROR_DELAY_MS`. Dropbox should plug into the same engine path so error recovery is uniform across providers.
+
+Tracked in #1561.
+
+## What Changes
+
+- Detect unrecoverable Dropbox playback failures inside `playTrack` and throw `UnavailableTrackError` so the existing engine skip path advances the queue. Two failure modes are covered:
+  - The `<audio>` element raises an `error` event during the initial play (decoder failure, network stall, terminal 4xx/5xx on the temporary link).
+  - `catalog.getTemporaryLink()` rejects with anything other than `AuthExpiredError` (file moved, deleted, link generation failed beyond retry).
+- Race the `<audio>` element's `playing` event against an `error` event after `audio.play()` is invoked, so the promise returned by `playTrack` resolves only when audio actually starts, and rejects with `UnavailableTrackError` otherwise.
+- Keep the existing `pendingError` capture on the persistent `error` listener for diagnostics, but the new race owns the throw decision during the initial play.
+- Add unit tests covering both failure modes plus the happy path.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: clarifies that "unavailable" for the Dropbox HTML5-audio path includes audio-element error events and post-fetch link failures, not just auth expiry. The existing Requirement 5 scenario gains a Dropbox-specific clause documenting what counts as unavailable.
+
+## Impact
+
+- `src/providers/dropbox/dropboxPlaybackAdapter.ts` — race audio error vs `playing` in `playTrack`; throw `UnavailableTrackError` on failure; rethrow `AuthExpiredError` from the catalog promise.
+- `src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts` — new tests for the error race.
+- No change to `useProviderPlayback.ts`, no change to Spotify, no auth-flow changes.
+- No public API surface change.

--- a/openspec/changes/dropbox-skip-on-error/specs/playback-engine/spec.md
+++ b/openspec/changes/dropbox-skip-on-error/specs/playback-engine/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Error Recovery
+
+The engine SHALL handle playback adapter errors without leaving the queue stuck on an unplayable track. A track SHALL be considered unavailable when the driving provider's `playTrack` rejects with an unavailability signal, including provider-specific terminal failures during the initial play of a track.
+
+#### Scenario: Track is unavailable
+- **WHEN** the driving provider reports a track as unavailable
+- **THEN** the engine skips to the next track
+
+#### Scenario: Provider authentication expired during playback
+- **WHEN** the driving provider reports authentication has expired
+- **THEN** the engine surfaces a re-authentication prompt and does not auto-skip
+
+#### Scenario: Dropbox HTML5 audio error during initial play
+- **WHEN** the Dropbox playback adapter's `<audio>` element raises an `error` event during the initial play of a track (decoder failure, terminal 4xx/5xx on the temporary link after refresh, network failure before the element reaches the playing state), or `audio.play()` itself rejects
+- **THEN** `playTrack` rejects with an unavailability signal
+- **AND** the engine skips to the next track
+
+#### Scenario: Dropbox temporary link cannot be obtained
+- **WHEN** the Dropbox catalog adapter fails to mint a temporary link for a track for any reason other than auth expiry
+- **THEN** `playTrack` rejects
+- **AND** the engine skips to the next track

--- a/openspec/changes/dropbox-skip-on-error/tasks.md
+++ b/openspec/changes/dropbox-skip-on-error/tasks.md
@@ -1,0 +1,19 @@
+## 1. Adapter changes
+
+- [x] 1.1 In `src/providers/dropbox/dropboxPlaybackAdapter.ts`, import `UnavailableTrackError` alongside the existing `AuthExpiredError` import from `@/providers/errors`.
+- [x] 1.2 In `playTrack`, after assigning `audio.src` and invoking `audio.play()`, race the play promise against a one-shot `error` listener. On `error` (or `play()` rejection), throw `UnavailableTrackError(track.name)`. Resolve on the first `playing` event.
+- [x] 1.3 Use the existing `prepareGeneration` to invalidate the race if a newer `playTrack`/`prepareTrack` supersedes it — stale events from a prior src must not reject the new play.
+- [x] 1.4 Confirm `AuthExpiredError` from `catalog.getTemporaryLink()` continues to propagate untouched.
+
+## 2. Tests
+
+- [x] 2.1 In `src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts`, add a test that `playTrack` rejects with `UnavailableTrackError` when the audio element fires `error` during initial play.
+- [x] 2.2 Add a test that `playTrack` resolves normally when the `playing` event fires (happy path stays green).
+- [x] 2.3 Add a test that `playTrack` rethrows `AuthExpiredError` from `getTemporaryLink` (regression guard — unchanged behavior).
+- [x] 2.4 Add a test that a stale `error` event after a superseding `playTrack` does NOT reject the new play promise.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green (full suite — confirm no regressions in `useProviderPlayback` / `useSpotifyPlayback` tests).
+- [x] 3.3 `npm run build` green.

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/design.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Reported in issue #1560. The spec scenario for opening the flip menu currently reads:
+
+> **WHEN** the user long-presses (touch) or clicks (pointer) the album art with the flip gesture enabled
+> **THEN** the flip menu opens
+
+The implementation (`src/components/PlayerContent/GestureLayer.tsx:59-62, 90-108`) only attaches the long-press handler when `zenModeEnabled === true`:
+
+```ts
+const longPressHandlers = useLongPress({
+  onLongPress: onLongPress ?? (() => {}),
+  enabled: zenModeEnabled === true && onLongPress !== undefined,
+});
+
+// ...
+
+const activePointerHandlers = zenTouchHandlers
+  ? { ...zen play/prev/next handlers... }
+  : zenModeEnabled && onLongPress
+    ? { ...longPressHandlers... }
+    : {};
+```
+
+Outside zen mode, touch users open the flip menu via the synthetic `click` event that browsers fire on tap, which lands on `GestureLayer.handleClick` → `AlbumArtSection.handleClick` → `toggleFlip`.
+
+## Decision
+
+Pick **Option B** from the issue: update the spec to describe the shipped UX. No code change.
+
+## Why Option B over Option A
+
+Option A (drop the `zenModeEnabled` gate so long-press is always active) would conflict with the surrounding zen-mode gesture design:
+
+1. **Zen-mode design owns the album-art surface.** When zen mode is on, `ZenClickZoneOverlay` renders three click zones (prev / play-pause / next) on top of the album art. A tap anywhere on the art is intentionally captured by a zone — there is no free tap target for "open flip menu" in zen mode, which is exactly why long-press exists as the escape hatch in zen mode.
+2. **Outside zen mode, tap-to-flip is more discoverable** than long-press. There is no competing gesture on the art surface outside zen, so a single tap reliably opens the flip menu and matches the pointer (click) affordance one-to-one.
+3. **No bug to fix.** Touch users outside zen mode already open the flip menu reliably via the synthetic `click` event; there is no broken interaction or accessibility regression for end users — only a documentation/spec drift.
+
+The spec scenario was written when the flip-gesture story was simpler (no zen mode); the implementation evolved as zen mode landed and the spec was not refreshed. Reconciling the spec to the implementation captures the real, working UX without churning code that has been in production.
+
+## Spec change shape
+
+The change modifies a single requirement in `visual-effects-menu`:
+
+- Prose: change "long-press on touch, click on pointer" to "tap on touch outside zen mode, long-press on touch inside zen mode, click on pointer".
+- "Opening the flip menu" scenario: replace the single WHEN/THEN with three variant clauses — one per input modality — that all converge on the same THEN (album-art card rotates 180° and the menu becomes interactive).
+
+All other requirements (`Accent Color Selection`, `Glow Control`, `Background Visualizer Control`, `Translucence Control`, `Active Controls Reflect Current Accent Color`) and their scenarios are unchanged.
+
+## Risks / Tradeoffs
+
+- Documenting "long-press only in zen mode" makes the long-press affordance contingent on a separate feature. If someone disables zen mode in the future they need to revisit this scenario too. Mitigated by writing it as a three-clause matrix so each modality reads as its own line and the zen dependency is explicit.
+- Option B intentionally leaves a latent inconsistency: a touch user who tries to long-press on the album art outside zen mode will see the flip menu open via the synthetic click that fires after they release (or be confused by no immediate feedback). Acceptable because the synthetic click reliably fires and the gesture is short.
+
+## Migration
+
+None. Spec-only change; no consumer of the openspec snapshot reads the file at runtime.

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/proposal.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Issue #1560: the `visual-effects-menu` Flip-Menu Surface requirement currently asserts that touch users open the flip menu via long-press. The implementation in `src/components/PlayerContent/GestureLayer.tsx` only attaches the long-press handler when `zenModeEnabled === true`; outside zen mode, touch users open the flip menu via the same synthetic-click path as pointer users (`AlbumArtSection.tsx` wires `onClick` → `toggleFlip`). The spec and the implementation disagree.
+
+The implementation behavior is intentional: in zen mode, the album-art surface is occupied by play-zone overlays (`ZenClickZoneOverlay` renders prev / play-pause / next click zones), so a tap on the art would trigger zone behavior rather than the flip menu. Long-press is the escape hatch from those zones to the flip menu. Outside zen mode there are no zones competing for the tap, and tap-to-flip is the more discoverable affordance. Option B from the issue applies: update the spec to describe the shipped UX.
+
+## What Changes
+
+- Modify the `Flip-Menu Surface` requirement in `openspec/specs/visual-effects-menu/spec.md` (via a delta in this change) so the prose and the "Opening the flip menu" scenario describe the actual gesture matrix:
+  - Pointer: click on the album art.
+  - Touch, outside zen mode: tap on the album art.
+  - Touch, inside zen mode: long-press on the album art (because zen-mode tap is reserved for the play / prev / next click zones).
+- No production code changes — implementation already matches the new spec.
+
+No public APIs, no keyboard shortcuts, no provider behavior, no playback behavior change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `visual-effects-menu`: the `Flip-Menu Surface` requirement's surface description and its "Opening the flip menu" scenario are reworded to capture the shipped pointer / touch / zen-mode gesture matrix.
+
+## Impact
+
+- `openspec/specs/visual-effects-menu/spec.md` — `Flip-Menu Surface` requirement prose and "Opening the flip menu" scenario reworded; all other requirements and scenarios unchanged.
+- No effect on any source file, test, fixture, or Playwright snapshot.

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Flip-Menu Surface
+
+Vorbis Player SHALL expose a flip-side panel mounted on the back face of the album-art card that hosts the visual-effect controls. The panel SHALL be reachable from the front-of-art interaction layer via the modality-appropriate gesture: tap on touch outside zen mode, long-press on touch inside zen mode (because the zen-mode tap surface is reserved for the play / prev / next click zones rendered by `ZenClickZoneOverlay`), and click on pointer. The panel SHALL render on top of a blurred, darkened version of the current album art, and SHALL provide an explicit dismiss control plus dismiss-on-outside-tap behavior. When no track is playing or no album art is available, the panel SHALL still render and SHALL offer a Retry Artwork affordance if the consumer wires one in.
+
+#### Scenario: Opening the flip menu
+
+- **WHEN** the user clicks the front of the album art with a pointer device with the flip gesture enabled
+- **OR WHEN** the user taps the front of the album art on a touch device while zen mode is disabled
+- **OR WHEN** the user long-presses the front of the album art on a touch device while zen mode is enabled
+- **THEN** the album-art card rotates 180° about the Y axis to reveal the flip menu
+- **AND** the flip menu becomes interactive (controls accept pointer / keyboard input)
+
+#### Scenario: Closing the flip menu via the close button
+
+- **WHEN** the user clicks the close button rendered at the top-right of the flip menu
+- **THEN** the album-art card rotates back to the front face
+- **AND** the flip menu's controls become non-interactive
+
+#### Scenario: Closing the flip menu via outside-tap
+
+- **WHEN** the user taps inside the flip-menu surface but outside any control
+- **THEN** the album-art card rotates back to the front face
+
+#### Scenario: Backdrop renders without album art
+
+- **WHEN** the current track has no resolvable album image
+- **THEN** the flip menu still renders with a fallback (un-imaged) backdrop
+- **AND** the Retry Artwork control is shown when the consumer provides a retry callback

--- a/openspec/changes/flip-menu-gesture-spec-reconcile/tasks.md
+++ b/openspec/changes/flip-menu-gesture-spec-reconcile/tasks.md
@@ -1,0 +1,14 @@
+## 1. Spec reconciliation
+
+- [x] 1.1 In `openspec/changes/flip-menu-gesture-spec-reconcile/specs/visual-effects-menu/spec.md`, modify the `Flip-Menu Surface` requirement so the prose lists the actual gesture matrix (tap outside zen, long-press inside zen, click on pointer) and the "Opening the flip menu" scenario splits into three modality clauses with a shared THEN.
+- [x] 1.2 Leave all other requirements (`Accent Color Selection`, `Glow Control`, `Background Visualizer Control`, `Translucence Control`, `Active Controls Reflect Current Accent Color`) and their scenarios out of the delta.
+
+## 2. Verification
+
+- [x] 2.1 Run `npx tsc -b --noEmit` — confirm no new errors (spec-only change should be a no-op for TypeScript).
+- [x] 2.2 Run `npm run test:run` — confirm green (no test asserts against spec text).
+- [x] 2.3 Run `npm run build` — confirm clean production build.
+
+## 3. Archive
+
+- [ ] 3.1 After PR #1560 merges, run `/opsx:archive flip-menu-gesture-spec-reconcile` so the delta is merged into `openspec/specs/visual-effects-menu/spec.md`.

--- a/openspec/changes/mock-prewarm-no-interrupt/design.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The mock provider serves as the testing harness for Playwright specs and `?provider=mock` dev runs. It must mirror the observable behavior of the real Spotify and Dropbox adapters; otherwise tests that exercise queue transitions against the mock will diverge from production behavior.
+
+`playback-engine` Requirement 6 already declares: "Pre-warming SHALL NOT change the current-track index or any visible state." The Dropbox adapter implements this by short-circuiting `primeAudioForHydrate` when `audio.src && this.currentTrack` (see `dropboxPlaybackAdapter.ts:235`). The mock implementation did not — it unconditionally reset the audio src before checking the hydrate intent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Bring `MockPlaybackAdapter.prepareTrack` into conformance with Requirement 6.
+- Match Dropbox's pre-warm pattern: load the audio element only when the call is a hydrate (positionMs supplied).
+- Add a regression test that exercises the single-provider pre-warm path (current track === next track) and asserts `audio.src` is preserved.
+
+**Non-Goals:**
+- Changing `useProviderPlayback.ts` or the broader pre-warm caller — the contract is "pre-warm is best-effort and idempotent against the current src," and the fix lives in the adapter that violates it.
+- Changing Spotify or Dropbox adapters.
+- Adding new spec requirements — the existing Requirement 6 already covers the behavior.
+
+## Decisions
+
+**No delta spec.** Requirement 6 in `openspec/specs/playback-engine/spec.md` already states the invariant verbatim. This change brings an existing implementation into conformance; it does not modify the requirement. Adding an empty delta would be noise.
+
+**Guard inside the hydrate branch as well.** The original code had a latent bug: even a hydrate call retargeted at the currently-playing track would have reset its src. The Dropbox guard (`audio.src && this.currentTrack`) covers both pre-warm and same-track-hydrate. The mock now mirrors that: it skips the load inside the hydrate branch when `audio.src && this.currentTrack?.id === track.id`.
+
+**Pre-warm becomes a true no-op for the audio element.** Mirrors Dropbox's behavior — the adapter only `prefetchTemporaryLink`s during pre-warm, which has no mock-side analog (the clip URL is deterministic from the track id). So the mock's pre-warm is a literal no-op, which is fine: `playTrack` will load the src when the transition actually fires.
+
+## Risks / Trade-offs
+
+- The mock pre-warm no longer warms the `<audio>` element at all. This is intentional and matches Dropbox semantics — the real cost (network fetch) doesn't exist for the mock, and the previous "warm" was actively harmful (interrupted current playback).
+- If a future test relied on `audio.src` being set after a pre-warm without positionMs, it would need to call `playTrack` instead. No such test exists today.

--- a/openspec/changes/mock-prewarm-no-interrupt/proposal.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`MockPlaybackAdapter.prepareTrack` unconditionally executed `audio.src = clipUrlForTrack(track.id); audio.load();` before checking `options?.positionMs`. For a single-provider mock queue, `nextDescriptor === currentDescriptor` during the pre-warm call in `useProviderPlayback`, so the pre-warm wiped the currently-playing src and halted audio — violating `playback-engine` Requirement 6 (Next-Track Pre-Warm: "Pre-warming SHALL NOT change the current-track index or any visible state").
+
+The Dropbox adapter's `primeAudioForHydrate` already short-circuits when `audio.src && this.currentTrack`. The mock was the outlier.
+
+## What Changes
+
+- Move the `audio.src` / `audio.load()` mutation in `MockPlaybackAdapter.prepareTrack` inside the `if (options?.positionMs !== undefined)` (hydrate) branch, mirroring Dropbox's no-op-when-already-playing behavior. Pre-warm calls become a no-op for the audio element.
+- Within the hydrate branch, also guard the load when `audio.src` is already set for the same track id, so a hydrate retargeted at the currently-playing track does not restart it.
+- Extend `mockPlaybackAdapter.test.ts` with one assertion that `audio.src` is preserved (and `audio.load()` is not called) during a pre-warm call.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+<!-- No spec-level requirement is changing. The existing playback-engine spec already declares Requirement 6 ("Next-Track Pre-Warm: Pre-warming SHALL NOT change the current-track index or any visible state"). This change brings the mock adapter into conformance with that requirement — no delta spec needed. -->
+
+## Impact
+
+- `src/providers/mock/mockPlaybackAdapter.ts` — guard `audio.src`/`audio.load()` behind the positionMs check.
+- `src/providers/mock/__tests__/mockPlaybackAdapter.test.ts` — extend pre-warm coverage with a src-preservation assertion.
+- No production code changes outside the mock provider; no API changes; no new dependencies.
+- Resolves [#1563](https://github.com/smallorbit/vorbis-player/issues/1563).

--- a/openspec/changes/mock-prewarm-no-interrupt/tasks.md
+++ b/openspec/changes/mock-prewarm-no-interrupt/tasks.md
@@ -1,0 +1,14 @@
+## 1. Guard pre-warm in MockPlaybackAdapter
+
+- [x] 1.1 Move `audio.src = clipUrlForTrack(track.id)` and `audio.load()` inside the `if (options?.positionMs !== undefined)` branch in `MockPlaybackAdapter.prepareTrack`.
+- [x] 1.2 Within the hydrate branch, skip the load when `audio.src && this.currentTrack?.id === track.id`, mirroring Dropbox's `primeAudioForHydrate` guard.
+
+## 2. Test coverage
+
+- [x] 2.1 Extend `mockPlaybackAdapter.test.ts` with an assertion that `audio.src` is unchanged and `audio.load` is not called when `prepareTrack` is invoked without `positionMs` against an already-playing track.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green.
+- [x] 3.3 `npm run build` green.

--- a/openspec/changes/queue-mutation-native-sync/design.md
+++ b/openspec/changes/queue-mutation-native-sync/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Spotify's playback adapter sustains a "native queue" via the Web Playback SDK: each `playTrack` call passes an `upcomingUris` array so the SDK can auto-advance without an additional command round-trip. The adapter builds that array from a snapshot of the app queue captured at `onQueueChanged` time (`spotifyPlaybackAdapter.ts:339-341`) and consumes it inside the next `playTrack` (`:82-84`).
+
+Today the only place that pushes a fresh snapshot is `useProviderPlayback.playTrack`, which calls `descriptor.playback.onQueueChanged?.(tracks, index)` immediately before invoking the adapter. That covers the track-transition case (handleNext / handlePrevious / hydrate / auto-advance / fresh collection load). It does **not** cover user-driven queue mutations that happen while a track is already playing: add-to-queue, remove-from-queue, reorder, insert-next, insert-collection-next, queue-direct. After any of those, the SDK keeps the previous upcoming list in mind and can auto-advance into the wrong tracks. The fix pushes the same notification from every mutator.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every user-initiated queue mutation notifies the driving provider when it declares `hasNativeQueueSync`.
+- One uniform call site inside `useQueueManagement.ts` (a `notifyQueueChanged` helper) so future mutators inherit the behavior by construction.
+- Keep the existing pre-`playTrack` notification — track transitions still need it, and removing it would race with mutations that haven't yet observed the new index.
+- Delete the stale comment that points to a non-existent `useEffect`.
+
+**Non-Goals:**
+- Notifying providers that have not opted in via `hasNativeQueueSync` (Dropbox, mock).
+- Touching the Spotify adapter, Dropbox provider, or anything under `src/services/spotify/` — those areas are in flight in other PRs and the only change required here is on the consumer side.
+- Adding a separate notification on every `currentTrackIndex` mutation outside of `useQueueManagement`. The existing `playTrack`-time call already covers index transitions; this change closes the queue-content gap.
+
+## Decisions
+
+**Resolve the descriptor through `getDrivingProviderDescriptor`, not `activeDescriptor`.**
+The driving provider is the one actually producing audio and the one whose native queue must stay aligned with the app. `activeDescriptor` reflects the browsing context — for a cross-provider queue (e.g. a Dropbox library view while Spotify drives audio) those two diverge. The hook already gets `activeDescriptor` for catalog calls; we add a sibling `getDrivingProviderDescriptor` accessor and read the driving descriptor at notify time so the snapshot lands on the SDK that needs it.
+
+**Read the driving descriptor lazily per call, not once per render.**
+The driving provider can change mid-session (cross-provider handoff). Capturing the accessor (a stable callback) instead of a snapshot ensures every mutation sees the current driver.
+
+**Inline `notifyQueueChanged` helper inside the hook.**
+A four-line helper closes over `getDrivingProviderDescriptor` and the latest `tracksRef` / `currentTrackIndex`. Pulling it out into a utility would force passing those refs around. The function stays private to `useQueueManagement.ts` — no other consumer needs it.
+
+**Notify with the post-mutation `tracks` and post-mutation `currentTrackIndex`.**
+Mutators build the new array before calling state setters. We pass that local array (and the locally-computed `newCurrentIndex` for reorder, otherwise the existing `currentTrackIndex`) to the notifier rather than waiting for React to commit and re-render. This matches the existing `useProviderPlayback.ts:102` semantics, which also notifies before the playback adapter call.
+
+**Keep the existing pre-`playTrack` notification at `useProviderPlayback.ts:102`.**
+That call handles track-transition events that don't pass through `useQueueManagement.ts`: hydrate from session, handleNext/Previous, auto-advance, fresh-collection load at index 0. Removing it would re-open the regressions the comment near it (mistakenly) tries to explain. We delete the misleading prose; the line of code stays.
+
+**Capability gate inside `notifyQueueChanged`, not at each call site.**
+Centralizing the `hasNativeQueueSync` check inside the helper keeps mutators free of provider-system concerns and lets a future provider opt-in by flipping the capability without revisiting every mutator.
+
+## Risks / Trade-offs
+
+- **Risk:** Extra `onQueueChanged` calls increase Spotify adapter work on every mutation. **Mitigation:** the adapter's `onQueueChanged` is a pure map-and-slice over the queue array — no I/O, no allocation pressure beyond a fresh URI array. Cheaper than the `playTrack` it precedes.
+- **Risk:** A mutation that ultimately bails (e.g. all dedup-filtered tracks rejected) notifies before bailing → notifier sees the pre-mutation queue, which is identical to the post-mutation queue. **Mitigation:** call `notifyQueueChanged` only after a mutation actually commits new state (i.e., past the dedup short-circuits). Each mutator already has a clean "commit point" where the new `tracks` array is in hand.
+- **Trade-off:** Reorder notifies twice if the user drags a track between two positions in quick succession. Acceptable — each notification overwrites the previous `pendingUpcomingUris`, so the SDK ends up with the latest snapshot. No correctness issue.

--- a/openspec/changes/queue-mutation-native-sync/proposal.md
+++ b/openspec/changes/queue-mutation-native-sync/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`onQueueChanged` is invoked in exactly one place today — `src/hooks/useProviderPlayback.ts:102`, immediately before each `playTrack` call. Every user-initiated queue mutator in `src/hooks/useQueueManagement.ts` (add, remove, reorder, insert-next, insert-collection-next, queue-direct) skips the notification. Until the next `playTrack` fires, the Spotify SDK's "upcoming URIs" buffer (`pendingUpcomingUris`, consumed at adapter line 82-84) reflects a stale snapshot of the app queue, so the SDK's own auto-advance can play tracks that no longer match the user's reordered/cleared queue.
+
+The behavior violates `openspec/specs/playback-engine/spec.md` Requirement 8 (Native Queue Sync), which says any provider declaring `hasNativeQueueSync` SHALL be notified when the app's queue or current index changes — not only at track-transition time.
+
+The existing comment at `src/hooks/useProviderPlayback.ts:97-101` claims a "persistent useEffect-based onQueueChanged in usePlayerLogic" handles the steady-state case. No such effect exists, and the comment misdirects future readers.
+
+## What Changes
+
+- Push `onQueueChanged` notifications from every user-initiated queue mutator in `useQueueManagement.ts` (`handleAddToQueue`, `handleRemoveFromQueue`, `handleReorderQueue`, `insertTracksNext`, `queueTracksDirectly`, `insertCollectionNext`).
+- Gate each call on the driving provider's `hasNativeQueueSync` capability; resolve the descriptor via the existing `getDrivingProviderDescriptor` accessor so cross-provider queues notify the actual audio-producing provider, not the currently-active-for-browsing one.
+- Centralize the call site behind a small `notifyQueueChanged(tracks, currentTrackIndex)` helper inside the hook so every mutator routes through the same gate.
+- Remove the stale comment at `useProviderPlayback.ts:97-101`. Keep the existing pre-`playTrack` notify at line 102 — it covers track-transition events not driven by `useQueueManagement.ts` (handleNext/handlePrevious, hydrate, auto-advance).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: tightens Requirement 8 (Native Queue Sync) by enumerating the queue events that MUST trigger `onQueueChanged` (append, remove, reorder, insert-next, insert-collection-next, queue-direct, manual `playTrack` transitions) and clarifying that the notification follows the **driving** provider's capability flag, not the active provider's.
+
+## Impact
+
+- `src/hooks/useQueueManagement.ts` — accepts a `getDrivingProviderDescriptor` accessor in props; adds `notifyQueueChanged` helper; invokes it in every mutator.
+- `src/hooks/usePlayerLogic.ts` — passes the existing `getDrivingProviderDescriptor` accessor into `useQueueManagement`.
+- `src/hooks/useProviderPlayback.ts` — removes stale comment at lines 97-101 (the `onQueueChanged` call itself stays in place).
+- `src/hooks/__tests__/useQueueManagement.test.ts` — adds coverage for the notify-on-mutation behavior and the capability gate.
+- No public API change. No provider-adapter change. Performance: each notification is an O(remaining-queue) URI build inside the Spotify adapter, which is what the codebase already pays on every `playTrack`.

--- a/openspec/changes/queue-mutation-native-sync/specs/playback-engine/spec.md
+++ b/openspec/changes/queue-mutation-native-sync/specs/playback-engine/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Native Queue Sync
+
+A provider that declares a native-queue-sync capability SHALL be notified when the app's queue or current index changes, so the provider can keep its native queue aligned with the app. The notification SHALL be dispatched on every queue mutation that updates the app's tracks array or current index — specifically: appending tracks via add-to-queue, removing a track, reordering tracks, inserting tracks at the play-next slot, inserting a collection at the play-next slot, queueing tracks directly, and the implicit current-index change at every track transition (next, previous, hydrate-resume, auto-advance, fresh-collection load). The notification SHALL target the **driving** provider (the provider currently producing audio), not the active-for-browsing provider; for a cross-provider queue these two MAY differ.
+
+#### Scenario: App queue changes while a native-sync provider is driving
+- **WHEN** the app's queue or current-track index changes and the driving provider declares the native-queue-sync capability
+- **THEN** the provider is notified of the new queue and current index
+
+#### Scenario: Provider without native-sync capability
+- **WHEN** the app's queue changes and the driving provider does not declare native-queue-sync
+- **THEN** no native-sync notification is dispatched
+
+#### Scenario: Tracks appended via add-to-queue
+- **WHEN** the user adds a collection to a non-empty queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-append tracks array and the unchanged current-track index
+
+#### Scenario: Track removed from queue
+- **WHEN** the user removes a track from the queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-removal tracks array and the adjusted current-track index
+
+#### Scenario: Queue reordered
+- **WHEN** the user reorders the queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-reorder tracks array and the current-track index recomputed to follow the still-playing track
+
+#### Scenario: Tracks inserted at the play-next slot
+- **WHEN** the user inserts tracks at `currentTrackIndex + 1` (insert-next or insert-collection-next) and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-insert tracks array and the unchanged current-track index
+
+#### Scenario: Tracks queued directly
+- **WHEN** the user queues tracks directly into the app queue and the driving provider declares native-queue-sync
+- **THEN** the provider is notified with the post-append tracks array and the unchanged current-track index
+
+#### Scenario: Mutation bails without changing state
+- **WHEN** a mutator short-circuits before committing new state (empty input, dedup-empty, out-of-range index, removing the currently-playing track)
+- **THEN** no native-sync notification is dispatched
+
+#### Scenario: Track transition fires before adapter playback
+- **WHEN** the engine calls `playTrack` to start a new track on a driving provider that declares native-queue-sync
+- **THEN** the provider is notified with the current tracks array and the new index before the adapter's playback call

--- a/openspec/changes/queue-mutation-native-sync/tasks.md
+++ b/openspec/changes/queue-mutation-native-sync/tasks.md
@@ -1,0 +1,33 @@
+## 1. Hook plumbing
+
+- [ ] 1.1 In `src/hooks/useQueueManagement.ts`, extend `UseQueueManagementProps` with `getDrivingProviderDescriptor: () => ProviderDescriptor | undefined`.
+- [ ] 1.2 Add a private `notifyQueueChanged(nextTracks: MediaTrack[], nextIndex: number)` helper inside the hook that resolves the driving descriptor, checks `capabilities.hasNativeQueueSync`, and forwards to `descriptor.playback.onQueueChanged?.(nextTracks, nextIndex)`.
+
+## 2. Mutator wiring
+
+- [ ] 2.1 `handleAddToQueue`: after the append commit (post-dedup, post-`setTracks`), call `notifyQueueChanged([...tracksRef.current, ...uniqueNewTracks], currentTrackIndex)`.
+- [ ] 2.2 `handleRemoveFromQueue`: after the splice commit, call `notifyQueueChanged(nextTracks, adjustedIndex)` using the same locally-computed values used for the setters.
+- [ ] 2.3 `handleReorderQueue`: after computing `newTracks` and `newCurrentIndex`, call `notifyQueueChanged(newTracks, newCurrentIndex >= 0 ? newCurrentIndex : 0)`.
+- [ ] 2.4 `queueTracksDirectly`: after the append commit, call `notifyQueueChanged([...tracksRef.current, ...uniqueNewTracks], currentTrackIndex)`.
+- [ ] 2.5 `insertTracksNext`: after building `nextTracks`, call `notifyQueueChanged(nextTracks, currentTrackIndex)` for the non-empty path; for the empty-queue path, call `notifyQueueChanged(uniqueNewTracks, 0)`.
+- [ ] 2.6 `insertCollectionNext`: no direct change — delegates to `insertTracksNext`, which already notifies.
+
+## 3. Caller wiring
+
+- [ ] 3.1 In `src/hooks/usePlayerLogic.ts`, pass the existing `getDrivingProviderDescriptor` into the `useQueueManagement({...})` call.
+
+## 4. Stale comment cleanup
+
+- [ ] 4.1 In `src/hooks/useProviderPlayback.ts`, remove the comment block at lines 97-101 referencing a non-existent `useEffect-based onQueueChanged in usePlayerLogic`. Keep the `descriptor.playback.onQueueChanged?.(tracks, index)` call on line 102.
+
+## 5. Tests
+
+- [ ] 5.1 Extend `src/hooks/__tests__/useQueueManagement.test.ts` to cover: each mutator invokes `onQueueChanged` with the post-mutation tracks and index when the driving descriptor declares `hasNativeQueueSync`.
+- [ ] 5.2 Add a negative test: when the driving descriptor lacks `hasNativeQueueSync`, mutators do not call `onQueueChanged`.
+- [ ] 5.3 Add a test that mutators which bail early (dedup-empty, out-of-range index) do not call `onQueueChanged`.
+
+## 6. Verify
+
+- [ ] 6.1 `npx tsc -b --noEmit` clean.
+- [ ] 6.2 `npm run test:run` green.
+- [ ] 6.3 `npm run build` green.

--- a/openspec/changes/reload-track-after-provider-reauth/.openspec.yaml
+++ b/openspec/changes/reload-track-after-provider-reauth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/reload-track-after-provider-reauth/design.md
+++ b/openspec/changes/reload-track-after-provider-reauth/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The player carries a single "current track" pointer and a driving-provider playback adapter. When a provider's session expires mid-playback:
+
+1. The Web Playback SDK (Spotify) or the HTML5 `<audio>` element (Dropbox) is left in a transitional state — the SDK detaches, the audio element's `src` is unset, or playback is paused with no recoverable source.
+2. The seek bar collapses to `0:00 / 0:00` because the driving adapter no longer emits `state` with a real duration.
+3. After the user re-authenticates via Settings (toggle on → OAuth popup → success), `authRevision` bumps and `connectedProviderIds` recomputes — but nothing prompts the playback adapter to re-load the current track. Play button presses no-op (or call `playTrack` on a track whose `prepareTrack`/`<audio>.src` was never primed against a valid token).
+
+The existing `prepareTrack(track, { positionMs })` pathway (used by next-track pre-warm and persisted-session hydrate) already knows how to silently set up a track for playback at any position without auto-playing. We can reuse it: when a provider's auth transitions `false → true` AND the queue's current track belongs to that provider, call `prepareTrack` on the current track at the position the user left off at — sourced from the persisted session snapshot (`SessionSnapshot.playbackPosition` in `src/services/sessionPersistence.ts`) that the app already maintains for on-reload hydration. When that snapshot is absent or its `trackId` does not match the current track, fall back to position `0`.
+
+Stakeholders: end users (recovery from session expiry should be one-toggle), and the playback-engine + auth-system specs which currently leave this transition undefined.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After a re-authentication that restores a previously-expired session, the seek bar paints with the real duration of the current track within ~one render cycle.
+- The cursor is positioned where the user left off before navigating to Settings to re-authenticate (sourced from `SessionSnapshot.playbackPosition`).
+- Pressing play immediately after re-authentication resumes playback from that cursor position.
+- The re-prime is silent: no auto-play, no toast, no queue mutation, no scroll, no track-change notification.
+- Works for both Spotify Web Playback SDK and Dropbox HTML5 audio.
+
+**Non-Goals:**
+- Auto-resuming playback. The user pressed pause (implicitly via the auth failure); they need to consciously press play after re-auth.
+- Re-priming non-current tracks in the queue. Only the queue's `currentTrackIndex` track is re-primed.
+- Persisting position with higher granularity than the existing session snapshot already provides. Whatever `SessionSnapshot.playbackPosition` says is authoritative; this change does not adjust how often that field is written.
+
+## Decisions
+
+### Decision 1: Trigger source — provider auth `false → true` transition
+
+Detect the transition in `ProviderContext` by diffing `connectedProviderIds` across renders (or by listening to `AUTH_STATE_CHANGED_EVENT` and the OAuth-complete `message` handler that already exists). When a `providerId` is newly present in `connectedProviderIds` and was absent in the previous render, dispatch a `PROVIDER_RECONNECTED_EVENT` with `detail: { providerId }`.
+
+**Alternatives considered:**
+- Polling the adapter state — wasteful and racy.
+- Have `MockAuthAdapter.beginLogin()` / Spotify `handleCallback` dispatch the event directly — couples auth adapters to playback concerns; the diff in ProviderContext is the single right place because it already owns `connectedProviderIds`.
+
+### Decision 2: Effect placement — `useProviderPlayback` (or a new sibling hook in `src/hooks/`)
+
+The listener lives in the same hook that already calls `playTrack` / consumes the driving descriptor, because that hook has the queue's current track and the driving-provider mapping. The handler:
+
+1. Reads `currentTrack` from `mediaTracksRef` at `currentTrackIndex`.
+2. If `currentTrack?.provider !== detail.providerId`, no-op.
+3. Else, resolves the driving descriptor for `currentTrack.provider` and calls `descriptor.playback.prepareTrack(currentTrack, { positionMs: 0 })`.
+
+**Alternatives considered:**
+- Putting the re-prime in `ProviderContext` directly — context shouldn't reach into playback adapters or know about queue/current-track state.
+- A new `usePlayerReauth` hook — premature; the logic is small enough to fit in `useProviderPlayback`.
+
+### Decision 3: Reuse `prepareTrack` rather than introducing a new adapter method
+
+`prepareTrack(track, { positionMs })` already produces the desired effect on both providers — see issue #1563 / PR #1573 for the recent Dropbox guard rework and `src/providers/spotify/spotifyPlaybackAdapter.ts` for the SDK-side prime. The pre-warm and persisted-session paths use it; this change just adds one more caller.
+
+**Alternatives considered:**
+- Adding `rehydrate(track)` — duplicates `prepareTrack` semantics.
+- Calling `playTrack` and immediately `pause` — auto-plays for a frame; visibly bad UX.
+
+### Decision 5: Source the re-prime position from `SessionSnapshot.playbackPosition`
+
+The app already persists `playbackPosition` (and `trackId`, `queueTracks`, etc.) to `localStorage` under `vorbis-player-last-session` via `saveSession()` in `src/services/sessionPersistence.ts`. That snapshot is what powers the on-reload hydrate. Reuse it here:
+
+1. Read the snapshot via `loadSession()` at re-prime time.
+2. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition` as `positionMs`.
+3. Otherwise fall back to `0`.
+
+The `trackId` match is the safety guard — if the queue advanced after the snapshot was last written (e.g., the user manually skipped while the SDK was in a half-broken state), re-priming at a stale position from a different track would be wrong. Position `0` is the safe fallback.
+
+**Alternatives considered:**
+- Introducing a new "last-known position per provider" cache — duplicates `SessionSnapshot` for no added value; the snapshot already updates on `state` notifications during steady-state playback (see existing `useSessionPersistence` write path).
+- Reading position from the playback adapter just before re-prime — adapters are in a degraded state post-logout (Spotify SDK detached, Dropbox `<audio>.src` cleared); they cannot reliably report the last position. The persisted snapshot is the only durable source.
+- Always re-priming at `0` — rejected per user feedback: resuming from where the user left off is the expected UX.
+
+### Decision 4: Guard against double-prime during initial mount
+
+`ProviderContext` initializes with `authRevision=0` and `connectedProviderIds` derived once. The first render of `useProviderPlayback` MUST NOT treat the initial set as a `false → true` transition for already-current-track providers, otherwise the persisted-session hydrate would race against this effect. Use the standard "first-render skip" pattern: hold a `previousConnectedRef` initialized to the first-render snapshot, and only diff on subsequent renders.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Re-prime fires when the queue is empty / current index is invalid | The handler early-returns when `currentTrack` is undefined. |
+| Two adjacent re-prime triggers (e.g., AUTH_STATE_CHANGED + storage event from another tab) | `prepareTrack` is idempotent with the existing same-track guards (Dropbox: `audio.src && this.currentTrack.id === track.id` short-circuits; Spotify: SDK accepts repeat prepare calls). |
+| The current track no longer exists on the provider after re-auth (e.g., user revoked playlist access) | `prepareTrack` rejects → engine surfaces existing error path (per playback-engine Requirement 5). Out of scope to handle differently. |
+| The persisted `playbackPosition` is beyond the track's actual duration (e.g., snapshot stale, track on the provider has a different length than recorded) | Adapter implementations already clamp; both the Spotify SDK and the Dropbox `<audio>` element resolve out-of-range seeks to the nearest valid position. No additional guard needed in this layer. |
+| `SessionSnapshot` write cadence isn't tight enough — user left off at 1:23 but snapshot reads 1:18 | Acceptable for v1; matches the existing on-reload hydrate fidelity. If field testing shows visible drift, increase the snapshot write frequency in a follow-up. |
+| The mock provider's `prepareTrack` is a no-op pre-warm path now (post #1563), so the Playwright spec needs a different signal | Acceptable. The spec verifies the *event dispatch* and the *handler invocation*, not adapter internals — see tasks.md for the test strategy. |
+
+## Migration Plan
+
+Drop-in. No data shape changes, no persisted state, no breaking API. The event listener is added in `useProviderPlayback`; the dispatcher in `ProviderContext`. Both are wired with the existing event-bus pattern (`window.addEventListener` / `dispatchEvent`).
+
+Rollback: revert the commit. There is no migration data to undo.
+
+## Open Questions
+
+- Should the re-prime also fire when the user opens settings → enables a NEW (never-authed) provider whose tracks happen to be in the queue? Initial answer: yes, the diff captures that case automatically. The test plan covers it under "re-prime on first authentication". If field testing surfaces issues we can scope down.

--- a/openspec/changes/reload-track-after-provider-reauth/proposal.md
+++ b/openspec/changes/reload-track-after-provider-reauth/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+After a provider's session expires mid-playback and the user later re-authenticates from Settings, the player still holds the stale "no source loaded" state for the current track. Returning to the player from Settings shows `0:00 / 0:00` on the seek bar, and pressing play does nothing because the underlying playback adapter (Spotify Web Playback SDK, Dropbox HTML5 audio element) never re-loaded the track. The user has to manually skip back, restart the queue, or re-click the track in the library — a confusing dead-end for what should be a transparent recovery.
+
+## What Changes
+
+- Detect when a provider transitions from "not authenticated" to "authenticated" while the player has a current track from that provider whose playback state is unloaded/zeroed.
+- Re-prime the playback adapter for the current track at the user's last known playback position — sourced from the same persisted session snapshot the app already uses for on-reload hydration — without auto-playing.
+- When the persisted snapshot is absent or its `trackId` doesn't match the current track, fall back to position `0`.
+- The re-prime is silent (no toast, no scroll, no queue mutation) — it restores the steady-state the player would have had if auth had never lapsed, including the cursor position the user left off at.
+- Cover both providers that surface this gap: Spotify Web Playback SDK and Dropbox HTML5 audio.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `playback-engine`: extend the existing Hydrate / Pre-Warm requirements with a "Re-prime After Re-Authentication" scenario covering provider auth transitions from `false → true` while a track from that provider is current.
+- `auth-system`: clarify Requirement 2 (Single On-Off Toggle per Provider) — re-enabling a provider whose session previously expired SHALL trigger the playback re-prime when the queue's current track belongs to that provider.
+
+## Impact
+
+- `src/contexts/ProviderContext.tsx` — emit a structured "provider reconnected" signal (or expose `connectedProviderIds` change with previous-state diffing) so playback layers can subscribe.
+- `src/hooks/useProviderPlayback.ts` or a new sibling hook — listen for the signal and, when the current driving track's provider just transitioned to authenticated, call `prepareTrack(currentTrack, { positionMs: 0 })` on the adapter without invoking `playTrack`.
+- `src/providers/spotify/spotifyPlaybackAdapter.ts` and `src/providers/dropbox/dropboxPlaybackAdapter.ts` — confirm `prepareTrack` is safe to call on the current track from a cold (post-logout) state and produces a `state` notification with the real duration; extend if a same-track guard would suppress the needed reload.
+- No new dependencies, no breaking API changes. Adds at most one event listener and one effect; constant-time work per auth transition.

--- a/openspec/changes/reload-track-after-provider-reauth/specs/auth-system/spec.md
+++ b/openspec/changes/reload-track-after-provider-reauth/specs/auth-system/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Single On-Off Toggle per Provider
+
+Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance. When the user toggles on a provider whose session previously expired and the queue's current track belongs to that provider, the playback engine SHALL re-prime that track at the user's last known playback position (per the persisted session snapshot) so the player exits its zeroed `0:00 / 0:00` state and resumes at the cursor position the user left off at — without requiring a manual skip.
+
+#### Scenario: Toggle on while already authenticated
+
+- **WHEN** the user toggles on a provider that is already authenticated
+- **THEN** the provider is added to the enabled set with no login prompt
+
+#### Scenario: Toggle on while not authenticated
+
+- **WHEN** the user toggles on a provider that is not authenticated
+- **THEN** an OAuth flow is initiated immediately
+- **AND** the provider is added to the enabled set only after the flow reports success
+
+#### Scenario: OAuth cancelled or failed
+
+- **WHEN** an OAuth flow opened by a toggle is cancelled or fails
+- **THEN** the toggle reverts to off and a "couldn't connect" notification is shown
+
+#### Scenario: Re-authentication restores the current track's playability at the last cursor position
+
+- **WHEN** OAuth completes for a provider that previously expired mid-playback AND the queue's current track belongs to that provider
+- **THEN** the playback engine re-primes the current track at the persisted `playbackPosition` (per `playback-engine` Requirement: Re-prime After Re-Authentication)
+- **AND** the seek bar updates from `0:00 / 0:00` to the track's real duration without user intervention
+- **AND** the cursor is positioned where the user left off before navigating to Settings to re-authenticate
+- **AND** pressing play resumes from that cursor position

--- a/openspec/changes/reload-track-after-provider-reauth/specs/playback-engine/spec.md
+++ b/openspec/changes/reload-track-after-provider-reauth/specs/playback-engine/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Re-prime After Re-Authentication
+
+When a provider transitions from `not authenticated` to `authenticated` while the queue's current track belongs to that provider, the engine SHALL re-prime that track on the provider's playback adapter at the user's last known playback position without auto-playing. The "last known position" is the `playbackPosition` value from the persisted session snapshot (the same snapshot used by the on-reload hydrate path) when the snapshot's `trackId` matches the current track; otherwise the engine SHALL re-prime at position `0`.
+
+The re-prime SHALL produce a `state` notification carrying the track's real duration so the seek bar paints correctly, and SHALL leave the player in a `paused` state at the resolved position. No queue mutation, current-track index change, toast, or scroll SHALL occur as a side effect of the re-prime.
+
+#### Scenario: Current track's provider re-authenticates from Settings, persisted position available
+
+- **WHEN** a provider whose id matches the current track's `provider` field transitions from `isAuthenticated() === false` to `isAuthenticated() === true` (e.g., the user re-toggles it on in Settings and OAuth completes)
+- **AND** the persisted session snapshot's `trackId` matches the current track's id
+- **THEN** the engine invokes `descriptor.playback.prepareTrack(currentTrack, { positionMs: snapshot.playbackPosition })` on that provider's adapter
+- **AND** within one render cycle the seek bar reflects the track's real duration with the cursor positioned where the user left off
+- **AND** the play button resumes functioning for the current track from that position
+- **AND** no auto-play, toast, or queue mutation occurs
+
+#### Scenario: Current track's provider re-authenticates but no persisted position is available
+
+- **WHEN** the same auth transition occurs AND the persisted session snapshot is absent OR its `trackId` does not match the current track OR its `playbackPosition` is missing
+- **THEN** the engine invokes `descriptor.playback.prepareTrack(currentTrack, { positionMs: 0 })`
+- **AND** the seek bar reflects the track's real duration with the cursor at position `0`
+
+#### Scenario: Non-current-track provider re-authenticates
+
+- **WHEN** a provider re-authenticates but the queue's current track belongs to a different provider
+- **THEN** the engine does NOT re-prime any track
+- **AND** the player state is unchanged
+
+#### Scenario: Re-authentication during initial mount
+
+- **WHEN** the application first mounts and a provider is already authenticated at render time
+- **THEN** the engine does NOT treat the initial authenticated state as a `false → true` transition
+- **AND** the persisted-session hydrate path (per #1394 / #1478) is the sole authority over the current track's initial primed state

--- a/openspec/changes/reload-track-after-provider-reauth/tasks.md
+++ b/openspec/changes/reload-track-after-provider-reauth/tasks.md
@@ -1,0 +1,34 @@
+## 1. Dispatch a provider-reconnected signal
+
+- [x] 1.1 Add `PROVIDER_RECONNECTED_EVENT` constant to `src/constants/events.ts` with detail shape `{ providerId: ProviderId }`. Document it alongside `SESSION_EXPIRED_EVENT`.
+- [x] 1.2 In `src/contexts/ProviderContext.tsx`, hold a `previousConnectedRef` initialized on first render to a snapshot of `connectedProviderIds`. After the initial mount, on each render where `connectedProviderIds` changes, compute `(connected - previousConnected)` and dispatch `PROVIDER_RECONNECTED_EVENT` once per newly-connected provider id.
+- [x] 1.3 Verify the dispatch does NOT fire on first render (use the first-render skip pattern documented in design.md Decision 4).
+
+## 2. Subscribe and re-prime the current track
+
+- [x] 2.1 In `src/hooks/useProviderPlayback.ts`, attach a listener for `PROVIDER_RECONNECTED_EVENT` inside a `useEffect` with `[]` deps. Use refs for `mediaTracks`, `currentTrackIndex`, and `getDrivingProviderDescriptor` so the listener reads current values without re-binding.
+- [x] 2.2 In the handler, look up `currentTrack = mediaTracksRef.current[currentTrackIndexRef.current]`. If `currentTrack?.provider !== detail.providerId`, return.
+- [x] 2.3 Resolve the re-prime position: call `loadSession()` from `src/services/sessionPersistence.ts`. If `snapshot?.trackId === currentTrack.id` AND `typeof snapshot.playbackPosition === 'number'`, use `snapshot.playbackPosition`; otherwise use `0`.
+- [x] 2.4 Resolve the descriptor for `currentTrack.provider` via the registry. Call `descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition })` and swallow rejections (the engine's existing error-recovery path per playback-engine Requirement 5 surfaces unavailable-track failures).
+- [x] 2.5 Confirm the handler is a no-op when `currentTrack` is undefined (empty queue) or when the resolved descriptor lacks `prepareTrack`.
+
+## 3. Verify adapter `prepareTrack` re-primes from cold state
+
+- [x] 3.1 Read `src/providers/spotify/spotifyPlaybackAdapter.ts` `prepareTrack` to confirm it correctly re-binds the Spotify SDK to the current track when invoked after a `logout()` + re-`beginLogin()` cycle. Extend the adapter only if a cold-state guard suppresses the needed reload.
+- [x] 3.2 Read `src/providers/dropbox/dropboxPlaybackAdapter.ts` `prepareTrack` (post-#1563) to confirm the same-track guard at `audio.src && this.currentTrack?.id === track.id` does NOT short-circuit when `currentTrack` is null/stale after a logout (i.e., the post-logout reset clears `currentTrack` so the second arm of the guard fails, allowing the prime to proceed). Extend if necessary.
+
+## 4. Tests
+
+- [x] 4.1 Add a unit test in `src/contexts/__tests__/ProviderContext.test.tsx`: simulate `AUTH_STATE_CHANGED_EVENT` flipping a provider into `isAuthenticated() === true` from a prior `false` state, assert `PROVIDER_RECONNECTED_EVENT` is dispatched exactly once with the correct `providerId`.
+- [x] 4.2 Add a unit test that the initial mount does NOT dispatch `PROVIDER_RECONNECTED_EVENT` for providers that are already authenticated at render time.
+- [x] 4.3 Add a unit test in `src/hooks/__tests__/` (new file `useProviderPlayback.reauth.test.ts` or extend an existing) covering three cases for a re-auth event whose `providerId` matches the current track's provider:
+  - persisted snapshot's `trackId` matches → adapter `prepareTrack` called with `(currentTrack, { positionMs: snapshot.playbackPosition })`
+  - persisted snapshot is absent OR `trackId` mismatch → adapter `prepareTrack` called with `(currentTrack, { positionMs: 0 })`
+  - re-auth event for a different provider → adapter `prepareTrack` NOT called
+- [x] 4.4 Extend `playwright/specs/provider-auth-expiry.spec.ts` (or add a new spec `provider-auth-reauth.spec.ts`): use the mock test-control API to (a) expire Spotify, (b) seed the queue + a non-zero playback position for a Spotify track via `__mockTest.setPlaybackState({ trackId, positionMs: 45_000, isPlaying: false })` so `SessionSnapshot.playbackPosition` is populated, (c) call a new `__mockTest.restoreAuth(providerId)` helper that flips the mock adapter back to authenticated and dispatches `AUTH_STATE_CHANGED_EVENT`, (d) assert the seek bar slider's `aria-valuemax` updates from `1` (zeroed placeholder) to the track's real duration AND `aria-valuenow` lands within ~2s of the seeded `45_000`ms — confirming the cursor restored to where the user left off, not `0:00`.
+
+## 5. Verify and document
+
+- [x] 5.1 Run `npx tsc -b --noEmit`, `npm run test:run`, `npm run build`, and `npx playwright test playwright/specs/provider-auth-expiry.spec.ts playwright/specs/<reauth-spec>.spec.ts`. All must be green.
+- [x] 5.2 Run `openspec validate reload-track-after-provider-reauth --strict` to confirm the delta specs parse cleanly.
+- [x] 5.3 Manual smoke: with the bundle running, expire Spotify mid-playback, re-toggle Spotify on, return to the player, confirm the seek bar paints the real duration and pressing play resumes from position `0`.

--- a/openspec/changes/remove-reconnect-affordance/design.md
+++ b/openspec/changes/remove-reconnect-affordance/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The "Reconnect needed" affordance grew up alongside the multi-provider toggle and the session-expired event flow (`SESSION_EXPIRED_EVENT`). When `useProviderRefresh` detects a terminal 401 it dispatches the event; `ProviderContext` reacts by setting a `reconnectPrompt` (drives a persistent action toast) and a `disconnectToast` (drives a short auto-dismiss toast), and bumping `authRevision` so `connectedProviderIds` recomputes. The provider stays in `enabledProviderIds`, so settings shows a "Reconnect needed" badge and the switch reroutes to a `handleReconnect` callback that opens the OAuth popup directly.
+
+This three-state model — connected / reconnect / disabled — predates the current spec (Requirement 2 of `auth-system/spec.md`) which explicitly forbids a separate reconnect affordance. The standard "toggle on while not authenticated" flow already kicks off OAuth, so the dedicated reconnect path is redundant.
+
+## Goals / Non-Goals
+
+**Goals**
+- Make session expiry yield a clean two-state UI: provider is either ON+authed ("Connected") or OFF.
+- Preserve the informational session-expired toast.
+- Re-enabling uses the existing "toggle on" → OAuth path.
+
+**Non-Goals**
+- Changing how `SESSION_EXPIRED_EVENT` is dispatched or which adapters dispatch it.
+- Changing `descriptor.auth.logout()` semantics — the adapter already logs itself out when a terminal failure is detected; we are only altering the UI state that accompanies the existing flow.
+- Touching `useQueueManagement` or `useProviderPlayback` — queue/playback fallthrough already works on `connectedProviderIds`, which the toggle-off updates correctly.
+
+## Decisions
+
+### Toggle off via ref pattern, not effect deps
+
+The existing `SESSION_EXPIRED_EVENT` listener lives in a `useEffect` with `[]` deps so it attaches once and never re-binds. It must now flip the provider off, which depends on the latest `enabledProviderIds` and the underlying `setStoredEnabledIds` setter. Re-binding the listener on every state change would race the user's own toggle interactions and risk dropping events fired during a re-render.
+
+Standard React pattern: keep a `latestRef` for each function or value the handler needs, update it in a separate `useEffect` on every render, and read `.current` inside the handler.
+
+```ts
+const setStoredEnabledIdsRef = useRef(setStoredEnabledIds);
+const enabledProviderIdsRef = useRef(enabledProviderIds);
+useEffect(() => { setStoredEnabledIdsRef.current = setStoredEnabledIds; }, [setStoredEnabledIds]);
+useEffect(() => { enabledProviderIdsRef.current = enabledProviderIds; }, [enabledProviderIds]);
+```
+
+Inside `handleSessionExpired`, gate the write on `enabledProviderIdsRef.current.includes(providerId)` so we don't accidentally re-add a provider the user just turned off.
+
+### Session-expired bypasses the "last enabled" guard
+
+The user-facing `toggleProvider` action refuses to disable the last remaining enabled provider — it returns the current set unchanged when `current.length <= 1`. That guard exists to protect against accidental user-initiated zero-providers state (the picker would have nothing to pick from).
+
+Session-expired must not honor that guard. If the sole enabled provider has its auth fail, leaving it enabled would resurrect exactly the forbidden third state the change is removing: enabled + unauthenticated, with no badge or affordance to telegraph what's wrong. So `handleSessionExpired` writes through `setStoredEnabledIds` directly with a custom updater that always removes the expired id, bypassing the guard. The user re-enables via the existing toggle, which kicks off OAuth.
+
+`toggleProvider` retains its guard for the user-driven path; only the forced session-expired path bypasses it.
+
+### Drop `RECONNECT_TOAST_ID` entirely
+
+The reconnect toast was the only consumer of that ID; once the toast effect is gone, the constant is dead.
+
+### Disconnect toast no longer waits for reconnect
+
+The current `disconnectToast` effect guards on `if (!disconnectToast || reconnectPrompt) return` to avoid showing two toasts at once. With reconnect gone, the guard simplifies to `if (!disconnectToast) return`.
+
+### Fallthrough copy
+
+"Reconnect in Settings." was correct under the old model (the expired provider stayed enabled and showed a reconnect badge). Under the new model the provider is fully toggled off, so the user needs to re-enable it. "Re-enable in Settings." is the accurate instruction.
+
+## Risks / Trade-offs
+
+- A user who clears their Spotify token mid-playback will lose the in-toast "Reconnect" shortcut. They must open Settings to flip the toggle back on. This matches the spec and is consistent with the rest of the multi-provider toggle UX (no toast-driven reconnect for any other failure mode).
+- Tests that pinned the old behavior need to be rewritten; one new test added at the context layer is enough to lock the new contract.
+
+## Migration Plan
+
+Single PR. No data migration — `enabledProviderIds` is a localStorage list and removing an id from it is the same shape as a user-driven toggle-off, which already round-trips cleanly. No deprecation notice needed (the affordance was internal UI).

--- a/openspec/changes/remove-reconnect-affordance/proposal.md
+++ b/openspec/changes/remove-reconnect-affordance/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The settings UI currently exposes a third provider status — "Reconnect needed" (`isEnabled && !isConnected`) — as a separate visual and interaction affordance:
+
+- `src/components/AppSettingsMenu/SourcesSections.tsx` renders a "Reconnect needed" status badge and branches the switch's `onCheckedChange` to a dedicated `handleReconnect` flow.
+- `src/components/AudioPlayer.tsx` surfaces a persistent reconnect-action toast via `acceptReconnectPrompt`.
+- `src/contexts/ProviderContext.tsx` manages `reconnectPrompt` state and exposes `acceptReconnectPrompt` / `dismissReconnectPrompt`.
+
+This third state violates `openspec/specs/auth-system/spec.md` Requirement 2 (Single On-Off Toggle per Provider): "Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance."
+
+It also creates a real user-visible bug (reported May 16 2026): when Spotify's access token is cleared mid-playback in a dual-provider session, the Spotify toggle stays ON with the "Reconnect needed" badge instead of toggling OFF. The user has to flip it off and back on to trigger the OAuth flow — exactly the sort of "third state" the spec already forbids.
+
+## What Changes
+
+- When a `SESSION_EXPIRED_EVENT` fires for a provider, `ProviderContext` SHALL fully toggle that provider OFF (remove it from `enabledProviderIds`) in addition to dispatching the existing disconnect toast.
+- Remove the "Reconnect needed" status badge, the `handleReconnect` branch on the toggle, the `needsReconnect` flag, and the "Reconnect <name>" aria-label from `SourcesSections.tsx`. Status simplifies to `'connected' | 'disabled'`.
+- Remove `reconnectPrompt` state, `acceptReconnectPrompt`, `dismissReconnectPrompt` from `ProviderContext` and `ProviderContextValue`.
+- Remove the reconnect-action toast from `AudioPlayer.tsx` and the `RECONNECT_TOAST_ID` constant. Drop the `|| reconnectPrompt` gate on the disconnect-toast effect.
+- Update the auto-fallthrough notification copy from "Reconnect in Settings." to "Re-enable in Settings." (the provider is no longer in a special "reconnect" state — it's plainly off).
+- Re-enabling is the standard Requirement 2 scenario: toggling the provider back ON while not authenticated kicks off OAuth — no special path required.
+
+No changes to provider auth adapters (`spotify`, `dropbox`), no changes to the `SESSION_EXPIRED_EVENT` dispatch itself, no changes to `useQueueManagement` or `useProviderPlayback`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `auth-system`: Requirement 2 clarifies that session expiry MUST toggle the provider off (no separate reconnect state). Requirement 6 clarifies that the session-expired notification is informational only — no action button.
+
+## Impact
+
+- `src/contexts/ProviderContext.tsx` — `handleSessionExpired` toggles the provider off via a ref pattern; `reconnectPrompt` state + accept/dismiss callbacks deleted; fallthrough copy updated.
+- `src/components/AppSettingsMenu/SourcesSections.tsx` — `handleReconnect`, `needsReconnect`, the `'reconnect'` status branch, and the `Reconnect <name>` aria-label all removed.
+- `src/components/AppSettingsMenu/styled.ts` — `ProviderStatusBadge` `$status` union narrowed to `'connected' | 'disabled'`; reconnect color branch removed.
+- `src/components/AudioPlayer.tsx` — reconnect-toast effect + `RECONNECT_TOAST_ID` deleted; disconnect-toast effect no longer gates on `reconnectPrompt`.
+- `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` — token-expired tests replaced with an assertion that the toggle is unchecked when the provider is enabled-but-unauth (matches the new spec) and a baseline "no Reconnect button visible" assertion stays.
+- `src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx` — stale "Reconnect needed" badge test deleted.
+- `src/contexts/__tests__/ProviderContext.test.tsx` — new test asserting that a `SESSION_EXPIRED_EVENT` removes the provider id from `enabledProviderIds`.

--- a/openspec/changes/remove-reconnect-affordance/specs/auth-system/spec.md
+++ b/openspec/changes/remove-reconnect-affordance/specs/auth-system/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Single On-Off Toggle per Provider
+
+Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance. When a provider's session becomes unrecoverable, the app SHALL toggle the provider off rather than expose a third "reconnect needed" state.
+
+#### Scenario: Toggle on while already authenticated
+- **WHEN** the user toggles on a provider that is already authenticated
+- **THEN** the provider is added to the enabled set with no login prompt
+
+#### Scenario: Toggle on while not authenticated
+- **WHEN** the user toggles on a provider that is not authenticated
+- **THEN** an OAuth flow is initiated immediately
+- **AND** the provider is added to the enabled set only after the flow reports success
+
+#### Scenario: OAuth cancelled or failed
+- **WHEN** an OAuth flow opened by a toggle is cancelled or fails
+- **THEN** the toggle reverts to off and a "couldn't connect" notification is shown
+
+#### Scenario: Session expires mid-use
+- **WHEN** a provider's session becomes unrecoverable during normal use
+- **THEN** the provider is removed from the enabled set so the toggle reads off
+- **AND** the re-enable path is the standard "toggle on while not authenticated" flow
+
+### Requirement: Mid-Session Unrecoverable Auth Failure
+
+When a provider's session becomes unrecoverable during normal use, the app SHALL log the provider out automatically, toggle the provider off in settings, and surface an informational "session expired" notification. The notification SHALL NOT carry a reconnect action button — re-enabling flows through the standard toggle path.
+
+#### Scenario: Provider returns terminal auth error during use
+- **WHEN** a provider reports an unrecoverable authentication failure during normal use
+- **THEN** the provider is logged out automatically
+- **AND** the provider is removed from the enabled set
+- **AND** an informational "session expired" notification is shown with no action button

--- a/openspec/changes/remove-reconnect-affordance/tasks.md
+++ b/openspec/changes/remove-reconnect-affordance/tasks.md
@@ -1,0 +1,22 @@
+## 1. Implementation
+
+- [x] 1.1 In `src/contexts/ProviderContext.tsx`, add `toggleProviderRef` and `enabledProviderIdsRef` and keep them current via per-deps `useEffect`s.
+- [x] 1.2 In `handleSessionExpired`, after dispatching `disconnectToast` and bumping `authRevision`, if `enabledProviderIdsRef.current.includes(providerId)` call `toggleProviderRef.current(providerId)`.
+- [x] 1.3 Delete `reconnectPrompt` state, `setReconnectPrompt`, `dismissReconnectPrompt`, `acceptReconnectPrompt`, and their entries on `ProviderContextValue` + the memoized context value.
+- [x] 1.4 Change the fallthrough notification copy from "Reconnect in Settings." to "Re-enable in Settings.".
+- [x] 1.5 In `src/components/AudioPlayer.tsx`, drop `reconnectPrompt`, `acceptReconnectPrompt`, `dismissReconnectPrompt` from the `useProviderContext()` destructure; delete the reconnect-toast `useEffect`; delete `RECONNECT_TOAST_ID`; remove the `|| reconnectPrompt` guard on the disconnect-toast effect.
+- [x] 1.6 In `src/components/AppSettingsMenu/SourcesSections.tsx`, remove `handleReconnect`, `needsReconnect`, the `'reconnect'` status branch, and the `Reconnect <name>` aria-label. Simplify `onCheckedChange` to two branches: `if (!isEnabled) handleToggleOn; else setDisconnectDialogProviderId`.
+- [x] 1.7 Narrow `ProviderStatusBadge` `$status` union to `'connected' | 'disabled'` in `src/components/AppSettingsMenu/styled.ts` and drop the reconnect color branch.
+
+## 2. Tests
+
+- [x] 2.1 Replace the `'token-expired reconnect flow'` test block in `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` with assertions that match the new behavior (toggle is unchecked when the provider is enabled-but-unauth after a SESSION_EXPIRED_EVENT propagates; no `"Reconnect needed"` text in DOM).
+- [x] 2.2 Remove the stale `"Reconnect needed" badge` test from `src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx`.
+- [x] 2.3 Add `src/contexts/__tests__/ProviderContext.test.tsx` asserting that dispatching `SESSION_EXPIRED_EVENT` removes the provider id from `enabledProviderIds`.
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc -b --noEmit` clean.
+- [x] 3.2 `npm run test:run` green.
+- [x] 3.3 `npm run build` green.
+- [x] 3.4 `grep -rn "reconnectPrompt\|acceptReconnectPrompt\|dismissReconnectPrompt\|handleReconnect\|'Reconnect needed'\|needsReconnect\|Tap to reconnect" src/` returns no production-code hits.

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/design.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`MusicSourcesSection` in `src/components/AppSettingsMenu/SourcesSections.tsx` exposes a single on/off `Switch` per provider. Toggling off currently calls `setDisconnectDialogProviderId(descriptor.id)` unconditionally, which opens `ProviderDisconnectDialog` and waits for the user to confirm or cancel. The dialog computes `affectedQueueCount` by filtering `tracks` for the pending provider id; the dialog body already hides its destructive-warning bar when that count is zero, so an empty-queue prompt asks the user "Are you sure?" with no destructive consequence shown.
+
+`handleConfirmDisconnect` performs the real work: pausing playback, removing the provider's tracks from `tracks` / `originalTracks`, fixing up `currentTrackIndex`, calling `descriptor.auth.logout()`, and finally `toggleProvider(id)`. Today it reads the target id from the dialog state (`disconnectDialogProviderId`).
+
+## Goals / Non-Goals
+
+**Goals**
+- Skip the confirmation dialog when the toggled-off provider has zero tracks in the queue.
+- Preserve current behavior when the provider has one or more tracks in the queue.
+- Update `auth-system` Requirement 3 to make the empty-queue path explicit in the spec.
+
+**Non-Goals**
+- Changing the destructive-cleanup logic (track removal, index fix-up, logout). The same cleanup runs in both branches.
+- Changing `ProviderDisconnectDialog.tsx`. Its warning-bar gating is already correct and stays.
+- Changing the reconnect path or the first-time-login (toggle-on) path.
+- Changing `descriptor.auth.logout()` semantics in Spotify or Dropbox adapters.
+- Adding an "undo" affordance — the spec explicitly rejects confirmation when there is nothing destructive to confirm.
+
+## Decisions
+
+### Decision 1: Gate the dialog on `affectedQueueCount > 0` in the toggle handler
+
+**What**: At toggle-off time, compute `tracks.filter(t => t.provider === descriptor.id).length`. If `> 0`, set `disconnectDialogProviderId` as today (opens the dialog). If `=== 0`, call the disconnect handler immediately with the provider id and skip the dialog.
+
+**Why**: Cheap (O(n) over the queue, which is bounded). Keeps the dialog state machine intact — the dialog is only opened when there is real destructive cleanup to confirm. Aligns with the existing dialog body, which already hides its warning bar in the empty-queue case.
+
+**Alternatives considered**:
+- _Always show the dialog with a generic "Are you sure?" copy._ Rejected: doesn't reduce friction, and the spec explicitly describes confirmation as a guard against destructive queue cleanup, not as a generic logout barrier.
+- _Move the gating into `ProviderDisconnectDialog` (auto-confirm on mount when count is 0)._ Rejected: violates the dialog's contract (it would still flash, would still emit `onConfirm` from inside the modal lifecycle). Cleaner to short-circuit at the call site.
+
+### Decision 2: Generalize `handleConfirmDisconnect` to accept the provider id
+
+**What**: Change `handleConfirmDisconnect` from a no-arg callback that reads `disconnectDialogProviderId` to a callback that accepts a `ProviderId` argument. The dialog's `onConfirm` wraps it as `() => handleConfirmDisconnect(disconnectDialogProviderId!)`, and the empty-queue branch calls `handleConfirmDisconnect(descriptor.id)` directly.
+
+**Why**: Avoids round-tripping through React state (`setDisconnectDialogProviderId` → effect → handler) when we already know the id at the call site. Keeps the cleanup logic in one place.
+
+**Alternatives considered**:
+- _Set `disconnectDialogProviderId` then immediately call the existing no-arg handler._ Rejected: relies on closure-over-stale-state and either needs a `useEffect` (overcomplication) or a `flushSync` (premature optimization workaround). The id-as-argument approach is the obvious React pattern.
+
+### Decision 3: Spec the empty-queue path explicitly under Requirement 3
+
+**What**: Add a new scenario to Requirement 3: _"Toggle off with no queued tracks → the provider is logged out, removed from the enabled set, and no confirmation prompt is shown."_ Soften the requirement statement to make the gating explicit: _"Disconnecting a provider SHALL prompt the user **when its tracks are in the queue**, and on confirmation (or immediately when no tracks are affected) SHALL log the provider out…"_.
+
+**Why**: The current Requirement 3 already implies the gating ("Disconnecting a provider SHALL prompt the user when its tracks are in the queue"), but only the queued-tracks scenario is documented. Adding the empty-queue scenario closes the gap so future implementations don't drift back to the unconditional-prompt behavior.
+
+## Risks / Trade-offs
+
+- **Risk**: A user expecting the existing prompt may be surprised when toggling off an empty-queue provider logs them out immediately. **Mitigation**: This is the documented behavior the spec was always written toward; the prompt's purpose is to guard against queue loss. Toggling back on requires reauth only when the token has also expired — usually it doesn't, so the user can flip back instantly.
+- **Risk**: If a future feature adds destructive cleanup beyond queue tracks (e.g. clearing cached art, signing out of Spotify SDK), the gating-on-queue-count check stops being a proxy for "is there anything destructive to confirm?". **Mitigation**: When that arrives, broaden the gate to a `hasDestructiveCleanup(providerId)` predicate; the current change keeps the gate narrowly scoped to the only destructive consequence today.
+
+## Migration Plan
+
+Single-step change; no migrations or feature flags required. The behavior is opt-out from the user's perspective (it removes a prompt step), not opt-in.
+
+## Open Questions
+
+None.

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/proposal.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The disconnect-confirmation dialog in `MusicSourcesSection` (`src/components/AppSettingsMenu/SourcesSections.tsx`) opens unconditionally when an enabled provider toggle is turned off, even when that provider has zero tracks in the queue. The dialog body in `src/components/ProviderDisconnectDialog.tsx` already gates the destructive-warning bar on `affectedQueueCount > 0`, so when the queue contribution is empty the user is asked "Are you sure?" without any destructive consequence to confirm.
+
+This diverges from `openspec/specs/auth-system/spec.md` Requirement 3 (Disconnect Confirmation and Cleanup), whose scenarios only describe the path "WHEN the user toggles off a provider **whose tracks are in the queue** THEN a confirmation prompt is shown stating the provider name and the count of tracks that will be removed". The spec does not require a prompt when there is no destructive cleanup to confirm; the implementation prompts anyway.
+
+Fixing the implementation is a one-line gate change, but the spec is currently silent on the empty-queue path. This change codifies the empty-queue behavior in the spec and aligns the implementation with it.
+
+## What Changes
+
+- In `SourcesSections.tsx`, compute `affectedQueueCount` for `descriptor.id` at the moment of toggle-off (currently it is only computed for the already-open dialog). If the count is zero, perform the logout + cleanup path directly without opening the confirmation dialog. If the count is greater than zero, keep the existing dialog-based flow.
+- Modify `openspec/specs/auth-system/spec.md` Requirement 3 (Disconnect Confirmation and Cleanup) to document the empty-queue path: when toggling off a provider with no tracks in the queue, the provider is logged out and state is cleaned up immediately, without a confirmation prompt.
+
+No public API changes. No change to `descriptor.auth.logout()` semantics or any provider implementation. No change to `ProviderDisconnectDialog.tsx` (its existing warning-bar gating remains correct). No change to other `AppSettingsMenu` sections or to the reconnect / first-time-login paths.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `auth-system`: Requirement 3 (Disconnect Confirmation and Cleanup) — clarifies that the confirmation prompt is gated on the presence of queued tracks for the disconnecting provider.
+
+## Impact
+
+- `src/components/AppSettingsMenu/SourcesSections.tsx` — toggle-off handler computes `affectedQueueCount` before deciding to open the dialog; existing `handleConfirmDisconnect` is generalized to accept the provider id directly so the empty-queue branch can call it without first setting dialog state.
+- `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` — add a Vitest case asserting that toggling off a provider with an empty queue performs logout + `toggleProvider` immediately and does not open `ProviderDisconnectDialog`. Existing cases for the queued-tracks confirmation path remain unchanged.
+- `openspec/specs/auth-system/spec.md` — Requirement 3 gains an "Toggle off with no queued tracks" scenario; existing scenarios are unchanged.
+- No effect on `src/components/ProviderDisconnectDialog.tsx`.
+- No effect on Spotify or Dropbox auth adapters (`logout()` semantics unchanged).
+- No effect on Playwright snapshots or visual capture.

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/specs/auth-system/spec.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/specs/auth-system/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Disconnect Confirmation and Cleanup
+
+Disconnecting a provider SHALL prompt the user for confirmation when its tracks are in the queue. On confirmation, or immediately when no tracks are affected, the app SHALL log the provider out, remove it from the enabled set, and remove its tracks from the queue and playback state.
+
+#### Scenario: Toggle off with queued tracks
+- **WHEN** the user toggles off a provider whose tracks are in the queue
+- **THEN** a confirmation prompt is shown stating the provider name and the count of tracks that will be removed
+
+#### Scenario: Toggle off with no queued tracks
+- **WHEN** the user toggles off a provider that has no tracks in the queue
+- **THEN** no confirmation prompt is shown
+- **AND** the provider is logged out, removed from the enabled set, and playback state is unchanged
+
+#### Scenario: Confirming disconnect
+- **WHEN** the user confirms the disconnect prompt
+- **THEN** the provider is logged out, removed from the enabled set, and its tracks are removed from the queue and playback state
+
+#### Scenario: Cancelling disconnect
+- **WHEN** the user cancels the disconnect prompt
+- **THEN** the enabled set, queue, and playback state are unchanged

--- a/openspec/changes/skip-disconnect-confirmation-empty-queue/tasks.md
+++ b/openspec/changes/skip-disconnect-confirmation-empty-queue/tasks.md
@@ -1,0 +1,23 @@
+## 1. Toggle-off gating
+
+- [x] 1.1 In `src/components/AppSettingsMenu/SourcesSections.tsx`, generalize `handleConfirmDisconnect` to accept a `ProviderId` argument (drop the dependency on `disconnectDialogProviderId` inside the handler body; clear the dialog state at the top of the body only if it is set).
+- [x] 1.2 In the `Switch` `onCheckedChange` toggle-off branch, compute `affectedQueueCount = tracks.filter(t => t.provider === descriptor.id).length`. If `> 0`, call `setDisconnectDialogProviderId(descriptor.id)` (existing behavior). If `=== 0`, call `handleConfirmDisconnect(descriptor.id)` directly and skip the dialog.
+- [x] 1.3 Update the dialog's `onConfirm` prop to wrap the generalized handler: `onConfirm={() => disconnectDialogProviderId && handleConfirmDisconnect(disconnectDialogProviderId)}`.
+
+## 2. Test coverage
+
+- [x] 2.1 Add a Vitest case in `src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx` under the `toggle-off: disconnect dialog flow` describe block: "performs logout and toggleProvider immediately without opening the dialog when the provider has no queued tracks". The test seeds `mockTracks` with only the other provider's tracks, clicks the disable toggle for the empty-queue provider, and asserts both `descriptor.auth.logout` and `mockToggleProvider` were called, and that the dialog title text does not appear.
+- [x] 2.2 Confirm the existing "opens ProviderDisconnectDialog when an enabled provider toggle is turned off" test still passes — that test seeds an empty queue today, so it will need to be reframed against a queue with at least one matching track to preserve its intent ("dialog opens when there is destructive cleanup to confirm"). Update the `#given` to add a matching track for that provider before clicking the toggle.
+- [x] 2.3 Confirm "calls descriptor.auth.logout() and toggleProvider when dialog is confirmed" still passes — same reframing applies (give the disconnecting provider a track in `mockTracks` so the dialog path is exercised).
+- [x] 2.4 Confirm "closes the dialog and leaves state unchanged when Cancel is clicked" still passes — same reframing.
+- [x] 2.5 Confirm "shows affected-track count in disconnect dialog when provider has queued tracks" still passes unchanged (it already seeds a non-empty queue).
+
+## 3. Verify
+
+- [x] 3.1 Run `npx tsc -b --noEmit` — clean.
+- [x] 3.2 Run `npm run test:run` — green.
+- [x] 3.3 Run `npm run build` — clean.
+
+## 4. Spec sync
+
+- [x] 4.1 On archive, ensure `openspec/specs/auth-system/spec.md` Requirement 3 is updated from the change's delta: requirement statement softened to make the gating explicit, and the new "Toggle off with no queued tracks" scenario merged in.

--- a/openspec/changes/spotify-api-401-retry/design.md
+++ b/openspec/changes/spotify-api-401-retry/design.md
@@ -1,0 +1,160 @@
+## Context
+
+The Spotify Web API layer (`src/services/spotify/api.ts`) currently has the shape:
+
+```ts
+async function executeApiRequest<T>(url, token, options) {
+  const response = await fetch(url, { ... });
+  handleRateLimitResponse(response);
+  if (!response.ok) {
+    throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
+  }
+  // ...
+}
+```
+
+The error is opaque — `status` is embedded in the message string. Two downstream sites in `spotifyPlaybackAdapter.ts` (lines 118 and 266) parse it back out with `message.includes('401')` to construct an `AuthExpiredError`. That's brittle and, more importantly, it skips the refresh-then-retry semantics that the Dropbox adapter implements (`dropboxApiClient.ts:74-82`):
+
+```ts
+let response = await makeRequest(token);
+if (response.status === 401) {
+  token = await this.auth.refreshAccessToken();
+  if (!token) throw new AuthExpiredError('dropbox');
+  response = await makeRequest(token);
+  if (response.status === 401) {
+    this.auth.reportUnauthorized();
+    throw new AuthExpiredError('dropbox');
+  }
+}
+```
+
+`reportUnauthorized()` on the Dropbox auth adapter logs out and dispatches the shared `SESSION_EXPIRED_EVENT`. Spotify's `notifySessionExpired()` exists in `src/services/spotify/auth.ts:193-198` but is private and only fires from `performRefresh()` on a 400/401 refresh failure — never from a downstream 401 in user-data requests.
+
+This change brings the Spotify API surface into parity with Dropbox on the auth-expiry contract while keeping the rest of `executeApiRequest`'s behavior (in-flight dedup, 429 backoff, single-flight refresh) untouched.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A structured `SpotifyApiError` carries the HTTP `status` (plus optional `statusText`) so downstream code can branch on `err.status` instead of `err.message.includes(...)`.
+- A single retry-after-refresh on 401: first 401 forces `spotifyAuth.refreshAccessToken()` and re-issues the request; second 401 throws `AuthExpiredError('spotify')` and calls a new public `spotifyAuth.reportUnauthorized()` (logs out + dispatches `SESSION_EXPIRED_EVENT`).
+- The two `.includes('401')` parse sites in `spotifyPlaybackAdapter.ts` use the structured error.
+- Behavior unchanged for non-401 errors: 5xx / network / unknown statuses still propagate as `SpotifyApiError` (i.e. transient, no logout).
+- `apiPlayTrack` / `apiPlayContext` / `apiPlayPlaylist` in `src/services/spotifyPlayerPlayback.ts` throw the same structured `SpotifyApiError` so the playback adapter sees the same type regardless of which code path produced the 401.
+
+**Non-Goals:**
+
+- Modifying Dropbox code. The Dropbox provider is the reference pattern, not the target.
+- Restructuring 403 / 429 handling in `spotifyPlaybackAdapter.playWithRetry`. Those `message.includes('403')` / `'429'` branches will get the same structured-error treatment in a follow-up change. This change is narrowly scoped to 401.
+- Adding a retry budget beyond `1`. Multiple refresh attempts during a single request would race with the auth singleton's `refreshInFlight` lock and would not improve recovery.
+- Changing the public function signature of `spotifyApiRequest<T>(url, token, options)`. Callers still pass the token explicitly; the wrapper re-acquires the token from `spotifyAuth.ensureValidToken()` only on the retry path.
+- Touching `useProviderPlayback.ts` / `useQueueManagement.ts` (other issues in this wave).
+
+## Decisions
+
+### Decision 1 — `SpotifyApiError extends Error` carries `status`
+
+**Choice:** Define and export `SpotifyApiError` from `src/services/spotify/api.ts`:
+
+```ts
+export class SpotifyApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  constructor(status: number, statusText: string) {
+    super(`Spotify API error: ${status} ${statusText}`);
+    this.name = 'SpotifyApiError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+```
+
+The `message` keeps the legacy format so existing log output / Sentry breadcrumbs are unchanged.
+
+**Why:**
+
+- A named subclass lets call sites use `instanceof SpotifyApiError` and `err.status` instead of regex/substring matching.
+- Keeping the legacy message text avoids invalidating any out-of-band log analysis or breadcrumb queries that match `Spotify API error:`.
+- Co-locating the class with `executeApiRequest` mirrors the pattern Dropbox uses (`AuthExpiredError` lives in `src/providers/errors.ts`; `dropboxApiClient.ts` throws plain `Error` for non-401s because Dropbox has no equivalent need for downstream `status` branching yet).
+
+**Alternatives considered:**
+
+- *Add a `status` field to `Error` directly.* Rejected — TypeScript doesn't allow augmenting the base `Error` cleanly without `as any` or a `// @ts-expect-error`, both blocked by project rules.
+- *Re-use `AuthExpiredError` for every non-OK response.* Rejected — conflates terminal auth failure with transient errors and would falsely log the user out on a 5xx.
+
+### Decision 2 — Use existing `AuthExpiredError` for the terminal-401 signal
+
+**Choice:** When the second 401 happens (after refresh), throw `AuthExpiredError('spotify')` from `@/providers/errors`. Do not introduce a `SpotifyAuthExpiredError` subclass.
+
+**Why:**
+
+- `AuthExpiredError` is already the cross-provider terminal-auth signal: `spotifyPlaybackAdapter.ts:119, 266`, `useSpotifyPlaylistManager.ts:218`, `dropboxApiClient.ts:80`, etc. all branch on it.
+- Adding a Spotify-specific subclass would force every consumer to widen its `catch` block; a flat single error type keeps the contract simple.
+- The `providerId` field on `AuthExpiredError` already distinguishes the two providers when needed.
+
+### Decision 3 — Single retry-after-refresh, force-refresh via `refreshAccessToken()`
+
+**Choice:** On the first 401, call `spotifyAuth.refreshAccessToken()` (not `ensureValidToken`), then read the fresh access token via `spotifyAuth.getAccessToken()` and re-issue the request with it. If still 401, throw `AuthExpiredError('spotify')` and call `spotifyAuth.reportUnauthorized()`.
+
+**Why:**
+
+- `ensureValidToken()` only refreshes when the token is within the 5-minute expiry buffer. A token that's been server-side revoked but not yet near expiry would short-circuit through `ensureValidToken` without refreshing, and the retry would re-use the same dead token. Forcing `refreshAccessToken()` bypasses that.
+- The Spotify auth singleton already has a single-flight guard (`refreshInFlight`) inside `refreshAccessToken`, so concurrent 401 retries from different requests collapse onto one network refresh — same shape as Dropbox.
+- Capping the retry at one mirrors Dropbox, prevents infinite refresh loops, and aligns with HTTP best practices for stale-token replay.
+
+**Alternatives considered:**
+
+- *Retry indefinitely with exponential backoff.* Rejected — a persistent 401 means the refresh token has been revoked; further retries waste battery and never recover.
+- *Skip the retry when `refreshAccessToken()` itself fails.* Already handled: `refreshAccessToken` throws when no refresh token exists or the refresh endpoint returns 400/401; the wrapper catches and re-raises as `AuthExpiredError('spotify')` after calling `reportUnauthorized()`.
+
+### Decision 4 — Promote `notifySessionExpired()` to a public `reportUnauthorized()` method
+
+**Choice:** Add a public `reportUnauthorized(): void` on the `spotifyAuth` singleton that performs `logout()` then dispatches `SESSION_EXPIRED_EVENT` (i.e. the existing `notifySessionExpired` private). The private `notifySessionExpired()` is removed; its single internal call site in `performRefresh()` is updated to call `reportUnauthorized()` instead.
+
+**Why:**
+
+- Mirrors `DropboxAuthAdapter.reportUnauthorized()` — same name, same semantics (clear tokens + notify).
+- Encapsulates "session is unrecoverable" in one place: callers don't need to remember to `logout()` + `notifySessionExpired()` in the right order.
+- Avoids exposing `notifySessionExpired` as public on its own, which would be a footgun (dispatching the event without clearing tokens leaves the app in an inconsistent state).
+
+**Alternatives considered:**
+
+- *Just make `notifySessionExpired` public.* Rejected — callers would have to remember to call `logout()` first or risk leaving stale tokens in `localStorage`.
+
+### Decision 5 — Wrap the retry inside `spotifyApiRequest`, not `executeApiRequest`
+
+**Choice:** Keep `executeApiRequest` as the low-level fetch + status-check that throws `SpotifyApiError`. Add the 401 retry-after-refresh logic inside `spotifyApiRequest`, which already owns rate-limit gating and request dedup.
+
+**Why:**
+
+- `executeApiRequest` is also called from inside the dedup `Promise` cached in `inflightRequests`. If we put the retry there, two concurrent GETs to the same URL would dedup into the same retry, which is fine — but the first 401 retry would re-enter `executeApiRequest` with the stale `token` parameter. Keeping the retry one level up lets us recompute the token for the retry call cleanly.
+- Single-flight: when `refreshAccessToken()` is in flight, all concurrent 401 retries await the same refresh and re-fire with the same fresh token. The dedup map in `spotifyApiRequest` continues to work because the retry uses a different `token`-bearing closure but the same URL/method key — the dedup logic still returns the in-flight promise to a second caller hitting the same URL.
+
+### Decision 6 — `apiPlayTrack` and friends throw `SpotifyApiError` too
+
+**Choice:** `apiPlayTrack`, `apiPlayContext`, and `apiPlayPlaylist` in `src/services/spotifyPlayerPlayback.ts` change their `throw new Error(...)` to `throw new SpotifyApiError(status, ...)`. The `parsePlayError` helper continues to format the rich message (including `error.reason`, `Retry-After`, etc.) but the thrown object now carries the structured `status` field.
+
+**Why:**
+
+- The 401 path the issue calls out (line 118 in `spotifyPlaybackAdapter.ts`) actually comes from `spotifyPlayer.playTrack()` → `apiPlayTrack()`, not from `spotifyApiRequest`. If `apiPlayTrack` keeps throwing a plain `Error`, line 118's `instanceof SpotifyApiError` check fails and we'd still need `.includes('401')` parsing as a fallback.
+- `apiPlayTrack` does not get the retry-after-refresh treatment (the play endpoint is more sensitive to replay, and the existing `playWithRetry` already retries with its own state machine). It only adopts the structured error type — the retry path stays in `playWithRetry`.
+
+**Alternatives considered:**
+
+- *Route `apiPlayTrack` through `spotifyApiRequest`.* Rejected — the request body, headers, and play-error message formatting are specific to the play endpoint, and routing through the generic helper would lose the `parsePlayError` shape that surfaces `error.reason` and `Retry-After` to logs.
+
+## Risks / Trade-offs
+
+- **Risk:** A 401 occurring inside the dedup window for a GET request would refresh once and retry; if the second 401 fires for one caller while another concurrent caller is mid-flight on the original token, only one of them will see `AuthExpiredError`. **Mitigation:** the dedup map keys by URL+method, so both concurrent callers share the *same* promise — the retry happens once and both callers receive the same outcome (success or `AuthExpiredError`). Verified by reading the dedup logic: `inflightRequests.get(key)` returns the existing promise, including its rejection.
+
+- **Risk:** `reportUnauthorized()` calls `logout()` which clears `localStorage.spotify_token`. If a refresh-then-retry sequence is racing a user-initiated re-auth (e.g. the user re-clicked the Spotify toggle mid-401), we could clear a token the user just set. **Mitigation:** `reportUnauthorized` only fires when the *second* 401 happens, by which point the post-refresh token was rejected — so any token in storage at that point is dead. The user-initiated re-auth would write a fresh token *after* the clear, so the worst case is a momentarily empty `localStorage` slot, not a lost session.
+
+- **Risk:** Existing callers that catch `Error` and inspect `err.message` to display a toast would still see the same message, but cosmetic differences (e.g. `SpotifyApiError` vs `Error` in console traces) might surprise reviewers. **Mitigation:** `SpotifyApiError` extends `Error`, sets `name = 'SpotifyApiError'`, and uses the same `message` format. Existing `instanceof Error` checks continue to work.
+
+- **Trade-off:** This change focuses on 401 only; the 403 / 429 parsing in `spotifyPlaybackAdapter.playWithRetry` remains string-based. The structured `SpotifyApiError` makes that follow-up cleanup trivial (`err.status === 429` instead of `message.includes('429')`), but is deferred to keep this change focused.
+
+## Spec strategy
+
+The behavioral contract this change codifies — Spotify Web API requests retry once after a forced token refresh on 401 and surface a terminal 401 as a structured `AuthExpiredError` plus a session-expired notification — is already captured in `openspec/specs/auth-system/spec.md` Requirements 5 ("Transient vs Terminal Failure Handling") and 6 ("Mid-Session Unrecoverable Auth Failure"), but only at the *general* provider level. Today neither requirement names a Spotify-specific scenario, so the Spotify implementation drifted (no retry, message-string parsing) without violating the literal text.
+
+The delta adds one **MODIFIED Requirement** block for each of these two requirements, keeping the existing language and adding Spotify-specific scenarios that pin down the one-shot retry-after-refresh contract and the terminal-401 handling. The general transient-vs-terminal language stays intact and continues to govern Dropbox.

--- a/openspec/changes/spotify-api-401-retry/proposal.md
+++ b/openspec/changes/spotify-api-401-retry/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Spotify Web API calls in `src/services/spotify/api.ts` (`executeApiRequest`, lines 43-72) throw a generic `Error("Spotify API error: <status> <text>")` on every non-OK response. There is no 401 retry-after-refresh, no terminal-vs-transient distinction, and no path that surfaces a persistent 401 to the auth layer. Downstream code (`src/providers/spotify/spotifyPlaybackAdapter.ts:118, 266`) is forced to parse the status out of the error message string with `.includes('401')` — brittle and easy to break when the message format changes.
+
+Compare with the Dropbox provider (`src/providers/dropbox/dropboxApiClient.ts:74-82`, `dropboxContentApiClient.ts:29-37`): a 401 forces one refresh, retries once, and on a second 401 calls `reportUnauthorized()` which logs out and notifies the UI via the shared `SESSION_EXPIRED_EVENT`.
+
+This gap violates [`openspec/specs/auth-system/spec.md`](../../specs/auth-system/spec.md) Requirements 5 (Transient vs Terminal Failure Handling) and 6 (Mid-Session Unrecoverable Auth Failure): the Spotify provider currently fails an expired-token request once and surfaces a generic error, instead of forcing a refresh, retrying, and — only when the refreshed token is still rejected — performing a terminal logout + session-expired notification.
+
+Tracks issue #1553.
+
+## What Changes
+
+- Export a structured `SpotifyApiError extends Error` from `src/services/spotify/api.ts` carrying `status: number` (and the response status text). Existing call sites that catch generic `Error` continue to work.
+- Reuse the existing `AuthExpiredError` (`src/providers/errors.ts`) as the terminal-401 signal so the rest of the provider/playback layer keeps a single auth-expired contract across providers.
+- Wrap the public `spotifyApiRequest` with a single retry-after-refresh on 401: on the first 401, force a token refresh via `spotifyAuth.refreshAccessToken()`, re-issue the request with the fresh token; on a second 401 throw `AuthExpiredError('spotify')` and trigger session-expired notification + logout via a new public `spotifyAuth.reportUnauthorized()` (mirroring the Dropbox adapter).
+- Promote `notifySessionExpired()` to a public `reportUnauthorized()` on the auth singleton so the api layer can call it without reaching into a private method.
+- Replace the brittle `message.includes('401')` checks in `spotifyPlaybackAdapter.ts:118, 266` with `instanceof AuthExpiredError` / `instanceof SpotifyApiError && err.status === 401` checks. Update `apiPlayTrack` in `src/services/spotifyPlayerPlayback.ts` to throw the same `SpotifyApiError` so the structured-error contract reaches the playback adapter.
+
+No public-component change, no UI change, no keyboard shortcut change. The Dropbox provider is not touched.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `auth-system` — Requirement 5 (Transient vs Terminal Failure Handling) and Requirement 6 (Mid-Session Unrecoverable Auth Failure) gain Spotify-specific scenarios that pin down the one-shot retry-after-refresh contract and the terminal-401 handling. The general transient/terminal language stays unchanged.
+
+### New Capabilities
+
+None.
+
+## Impact
+
+- `src/services/spotify/api.ts` — adds `SpotifyApiError`, retry-after-refresh wrapper around `executeApiRequest`, calls `spotifyAuth.refreshAccessToken()` and `spotifyAuth.reportUnauthorized()`.
+- `src/services/spotify/auth.ts` — adds public `reportUnauthorized()` (logs out + notifies session expired); existing private `notifySessionExpired()` is now invoked from this public method only.
+- `src/services/spotifyPlayerPlayback.ts` — `apiPlayTrack` (and the other `apiPlay*` helpers) throw `SpotifyApiError` instead of a generic `Error` so the structured-error contract reaches `SpotifyPlaybackAdapter`.
+- `src/providers/spotify/spotifyPlaybackAdapter.ts` — replaces `.includes('401')` parsing at lines 118 and 266 with `instanceof AuthExpiredError` / `SpotifyApiError && status === 401` checks. Continues to parse 403 / 429 strings until those errors also reach the adapter as structured types (out of scope for this change).
+- `openspec/specs/auth-system/spec.md` — adds two Spotify-specific scenarios under Requirements 5 and 6.
+- `src/services/spotify/__tests__/` — new test covering `executeApiRequest` retry-after-refresh, terminal-401 logout, and structured-error fields.
+- `src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts` — existing 401 test (`probePlayable`) keeps passing under the new error contract.
+
+Out of scope:
+- Dropbox provider (`src/providers/dropbox/`): not touched.
+- `useProviderPlayback.ts`, `useQueueManagement.ts`: belong to other issues in the same wave.
+- 403 / 429 structured-error promotion in the playback adapter: tracked separately; this change only flips 401 to structured.

--- a/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
+++ b/openspec/changes/spotify-api-401-retry/specs/auth-system/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Transient vs Terminal Failure Handling
+
+A provider SHALL distinguish transient failures from terminal authentication failures so that refresh tokens are preserved across retryable network errors and the user is logged out only on terminal failures.
+
+#### Scenario: Transient failure
+
+- **WHEN** a provider request fails with a transient error (network failure or server-side error)
+- **THEN** the refresh token is preserved and the user is not logged out
+
+#### Scenario: Terminal authentication failure
+
+- **WHEN** a provider request fails with a terminal authentication error
+- **THEN** the provider performs a full logout
+
+#### Scenario: Spotify Web API request receives a 401 with a non-expired refresh token
+
+- **WHEN** a `spotifyApiRequest`-based catalog/library request (i.e. requests routed through the shared API wrapper, excluding the player-playback control endpoints in `spotifyPlayerPlayback.ts`) returns HTTP 401 and the auth singleton holds a refresh token
+- **THEN** the provider forces a token refresh, retries the request once with the fresh access token, and treats the result as success if the retry returns a 2xx
+- **AND** the user is NOT logged out
+- **AND** if the refresh endpoint itself fails with a transient error (network blip, 5xx), the original `SpotifyApiError` carrying `status: 401` is rethrown — the user is NOT logged out and the refresh token is preserved
+
+#### Scenario: Spotify Web API exposes status via structured error
+
+- **WHEN** a Spotify Web API request fails with a non-OK HTTP status (other than the 401-then-refreshed-then-OK path)
+- **THEN** the thrown error carries the HTTP `status` (and `statusText`) as structured fields rather than only embedding them in the message string
+- **AND** downstream consumers branch on the structured `status` rather than parsing the error message
+
+### Requirement: Mid-Session Unrecoverable Auth Failure
+
+When a provider's session becomes unrecoverable during normal use, the app SHALL log the provider out automatically and notify the user.
+
+#### Scenario: Provider returns terminal auth error during use
+
+- **WHEN** a provider reports an unrecoverable authentication failure during normal use
+- **THEN** the provider is logged out automatically and a "session expired" notification is shown
+
+#### Scenario: Spotify Web API returns 401 after a forced refresh
+
+- **WHEN** a Spotify Web API request returns HTTP 401, the auth singleton forces a refresh, and the retried request still returns HTTP 401
+- **THEN** the Spotify provider performs a full logout
+- **AND** a "session expired" notification is dispatched on the shared `SESSION_EXPIRED_EVENT` bus
+- **AND** the call site receives an `AuthExpiredError` carrying `providerId: 'spotify'`

--- a/openspec/changes/spotify-api-401-retry/tasks.md
+++ b/openspec/changes/spotify-api-401-retry/tasks.md
@@ -1,0 +1,41 @@
+## 1. Structured error type
+
+- [x] 1.1 In `src/services/spotify/api.ts`, define and export `SpotifyApiError extends Error` carrying `status: number` and `statusText: string`. Keep the legacy message format (`Spotify API error: <status> <statusText>`).
+- [x] 1.2 Update `executeApiRequest` to throw `SpotifyApiError` instead of generic `Error`.
+
+## 2. Public reportUnauthorized on auth singleton
+
+- [x] 2.1 In `src/services/spotify/auth.ts`, add a public `reportUnauthorized(): void` that performs `this.logout()` then dispatches `SESSION_EXPIRED_EVENT`.
+- [x] 2.2 Update `performRefresh()` to call `this.reportUnauthorized()` instead of `this.logout() + this.notifySessionExpired()`.
+- [x] 2.3 Remove the now-redundant private `notifySessionExpired()` if its only call site was `performRefresh()`.
+
+## 3. Retry-after-refresh in spotifyApiRequest
+
+- [x] 3.1 Refactor `spotifyApiRequest` so its non-dedup return path goes through a single wrapper that catches `SpotifyApiError` with `status === 401`, forces a refresh via `spotifyAuth.refreshAccessToken()`, re-issues the request with the fresh token, and on a second 401 throws `AuthExpiredError('spotify')` after calling `spotifyAuth.reportUnauthorized()`.
+- [x] 3.2 Ensure the dedup map still keys correctly across the retry — the retry should not create a duplicate entry.
+- [x] 3.3 Verify the 429 backoff and `inflightRequests` cleanup still work after the refactor.
+
+## 4. apiPlayTrack and friends throw SpotifyApiError
+
+- [x] 4.1 In `src/services/spotifyPlayerPlayback.ts`, change `apiPlayTrack`, `apiPlayContext`, and `apiPlayPlaylist` to throw `SpotifyApiError` (preserving the rich `parsePlayError` message).
+- [x] 4.2 Do **not** add retry-after-refresh inside `apiPlayTrack`; only the error type changes. The existing `playWithRetry` state machine continues to handle 403 / 429 retries.
+
+## 5. Update spotifyPlaybackAdapter parse sites
+
+- [x] 5.1 In `src/providers/spotify/spotifyPlaybackAdapter.ts` (`playWithRetry`, around line 118), replace the `message.includes('401') || message.toLowerCase().includes('unauthorized')` branch with `error instanceof AuthExpiredError ? rethrow : error instanceof SpotifyApiError && error.status === 401 ? throw new AuthExpiredError('spotify') : ...`.
+- [x] 5.2 In `probePlayable` (around line 266), replace `message.includes('401') ? throw new AuthExpiredError(...)` with `err instanceof SpotifyApiError && err.status === 401 ? throw new AuthExpiredError('spotify') : ...`. Keep the `404 → false` branch but route it through `err.status === 404` instead of `message.includes('404')`.
+
+## 6. Tests
+
+- [x] 6.1 Add `src/services/spotify/__tests__/api.test.ts` (or extend an existing one) covering:
+  - `executeApiRequest` throws `SpotifyApiError` with `status === 500` on a transient 5xx (the user is not logged out).
+  - `spotifyApiRequest` retries once on 401: first 401 triggers `spotifyAuth.refreshAccessToken()`, second call succeeds, no `AuthExpiredError` thrown.
+  - `spotifyApiRequest` throws `AuthExpiredError('spotify')` on a second 401 after refresh and calls `spotifyAuth.reportUnauthorized()`.
+- [x] 6.2 Confirm the existing `spotifyPlaybackAdapterPrepareTrack.test.ts` 401 case (`probePlayable`) still passes under the new error contract.
+- [x] 6.3 Run `npm run test:run` and confirm zero new failures.
+
+## 7. Verify
+
+- [x] 7.1 `npx tsc -b --noEmit` clean.
+- [x] 7.2 `npm run test:run` green.
+- [x] 7.3 `npm run build` green.

--- a/openspec/changes/spotify-logout-cache-clear/specs/auth-system/spec.md
+++ b/openspec/changes/spotify-logout-cache-clear/specs/auth-system/spec.md
@@ -1,0 +1,27 @@
+# auth-system — Delta Spec: Logout Cache Clearing
+
+## Change
+
+Extends **Requirement: Disconnect Confirmation and Cleanup** to require that provider
+logout clears all provider-derived cached data, not only queue and playback state.
+
+## New Requirement: Provider Logout Clears All Derived Caches
+
+On logout, a provider adapter SHALL clear all cached data it wrote during the session,
+including in-memory caches and IndexedDB stores.
+
+**Rationale**: without this, playlist, track, and search data from a previous account
+persist into the next session on the same device — a data-hygiene leak. Dropbox already
+satisfies this requirement; this delta brings Spotify to parity.
+
+### Scenario: Spotify logout clears in-memory caches
+
+- **WHEN** the Spotify provider is logged out
+- **THEN** the in-memory track-saved, album-saved, and track-list caches are cleared
+- **AND** the in-memory liked-songs count and liked-songs list caches are cleared
+
+### Scenario: Spotify logout clears IndexedDB library cache
+
+- **WHEN** the Spotify provider is logged out
+- **THEN** the IndexedDB library cache (playlists, albums, track lists, meta stores)
+  is cleared so no data from the previous account leaks into the next session

--- a/playwright/capture/fixtures.ts
+++ b/playwright/capture/fixtures.ts
@@ -27,7 +27,7 @@ function hasSnapshotContent(): boolean {
 }
 
 export const test = base.extend<{ capturePage: Page }>({
-  capturePage: async (_fixtures, runFixture, testInfo) => {
+  capturePage: async ({}, runFixture, testInfo) => {
     if (!hasSnapshotContent()) {
       testInfo.skip(
         true,

--- a/playwright/specs/provider-auth-reauth.spec.ts
+++ b/playwright/specs/provider-auth-reauth.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '../fixtures/auth-state';
+import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type: 'json' };
+
+/**
+ * Re-prime after re-authentication
+ *
+ * See openspec/changes/reload-track-after-provider-reauth/. When a provider
+ * transitions from `not authenticated` to `authenticated` while the queue's
+ * current track belongs to that provider, the playback engine re-primes the
+ * current track at the persisted SessionSnapshot.playbackPosition (or 0 if
+ * the snapshot's trackId does not match).
+ *
+ * The spec seeds a non-zero playback position via the existing
+ * `?mock-session=` URL param (which writes SessionSnapshot.playbackPosition
+ * to localStorage), waits for `useSessionPersistence` to debounce-save the
+ * post-hydrate snapshot so the in-memory state and on-disk snapshot agree,
+ * then expires the spotify mock auth adapter and restores it. The seek bar
+ * SHALL return to ~45_000ms after the re-prime, not snap back to 0.
+ */
+
+const SEEK_TIMELINE_LABEL = 'Seek timeline';
+const SEED_POSITION_MS = 45_000;
+// useSessionPersistence DEBOUNCE_MS=1000; wait a hair longer to be safe.
+const SESSION_DEBOUNCE_SETTLE_MS = 1_500;
+
+type SnapshotTrack = (typeof spotifySnapshot)['tracks'][keyof (typeof spotifySnapshot)['tracks']];
+
+function pickSeedTrack(): SnapshotTrack | null {
+  const entries = Object.entries(spotifySnapshot.tracks as Record<string, SnapshotTrack>);
+  const sorted = entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const [, track] of sorted) {
+    if (track.durationMs > 60_000) return track;
+  }
+  return null;
+}
+
+const seedTrack = pickSeedTrack();
+
+function encodeSeed(trackId: string, positionMs: number): string {
+  const json = JSON.stringify({ trackId, positionMs });
+  return Buffer.from(json, 'utf8').toString('base64');
+}
+
+test.describe('Provider re-authentication — re-prime current track at saved position', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !seedTrack,
+      'Spec requires a fixture track with durationMs > 60_000. Run `npm run snapshot:spotify`.',
+    );
+  });
+
+  test('seek bar updates from zeroed placeholder to seeded position after re-auth', async ({ page }) => {
+    if (!seedTrack) return;
+
+    // #given — seed a session 45s into a spotify fixture track. mockProvider's
+    // seedSessionFromUrlParam writes the full SessionSnapshot to localStorage
+    // before React mounts, so the hydrate path primes the seek bar at 45s.
+    const seed = encodeSeed(seedTrack.id, SEED_POSITION_MS);
+    await page.goto(`/?mock-session=${seed}`);
+
+    const sliderLocator = page.locator(`[aria-label="${SEEK_TIMELINE_LABEL}"] [role="slider"]`);
+    await sliderLocator.waitFor({ state: 'attached', timeout: 15_000 });
+
+    // Wait for the hydrate path to settle so the slider reflects the seeded
+    // duration (not the disabled aria-valuemax=1 placeholder).
+    await expect(sliderLocator).not.toHaveAttribute('aria-valuemax', '1', { timeout: 10_000 });
+
+    // useSessionPersistence debounces saves by 1s — wait long enough that the
+    // post-hydrate snapshot (with playbackPosition=45000) is committed to
+    // localStorage. The re-prime handler reads via loadSession(), so the
+    // on-disk value must reflect the in-memory state before we re-auth.
+    await page.waitForTimeout(SESSION_DEBOUNCE_SETTLE_MS);
+
+    // #when — expire the spotify mock auth adapter, then restore it. The
+    // ProviderContext diff detects spotify transitioning `unauthed → authed`
+    // and dispatches PROVIDER_RECONNECTED_EVENT; useProviderPlayback's
+    // listener re-primes the current track at SessionSnapshot.playbackPosition.
+    await page.evaluate(async () => {
+      await window.__mockTest!.expireAuth('spotify');
+    });
+
+    // Yield once so React processes the AUTH_STATE_CHANGED_EVENT and the
+    // ProviderContext effect commits previousConnectedRef = { dropbox } before
+    // the restore flips it back — otherwise the diff sees no `false` baseline
+    // for spotify and the restoration is a no-op.
+    await page.waitForTimeout(50);
+
+    await page.evaluate(async () => {
+      await window.__mockTest!.restoreAuth('spotify');
+    });
+
+    // #then — aria-valuemax remains > 1 (real duration painted) and
+    // aria-valuenow is within ±2s of the seeded position (the re-prime
+    // restored the cursor to where the user left off, not 0:00).
+    await expect(sliderLocator).not.toHaveAttribute('aria-valuemax', '1', { timeout: 5_000 });
+
+    const valueMaxAttr = await sliderLocator.getAttribute('aria-valuemax');
+    const valueNowAttr = await sliderLocator.getAttribute('aria-valuenow');
+    const valueMax = valueMaxAttr !== null ? Number(valueMaxAttr) : NaN;
+    const valueNow = valueNowAttr !== null ? Number(valueNowAttr) : NaN;
+
+    expect(valueMax, 'aria-valuemax must reflect real duration after re-prime').toBeGreaterThan(1);
+    expect(
+      valueNow,
+      'aria-valuenow must restore to the seeded playback position after re-auth re-prime',
+    ).toBeGreaterThanOrEqual(SEED_POSITION_MS - 2_000);
+    expect(
+      valueNow,
+      'aria-valuenow must not exceed the seeded position by more than a few seconds',
+    ).toBeLessThanOrEqual(SEED_POSITION_MS + 5_000);
+  });
+});

--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -114,15 +114,6 @@ export const MusicSourcesSection = memo(() => {
     [openLoginPopup, toggleProvider],
   );
 
-  const handleReconnect = useCallback(
-    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
-      openLoginPopup(descriptor, () => {
-        // Provider is already in enabledProviderIds — no toggleProvider call needed.
-      });
-    },
-    [openLoginPopup],
-  );
-
   useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
 
   const performDisconnect = useCallback((id: ProviderId) => {
@@ -202,27 +193,24 @@ export const MusicSourcesSection = memo(() => {
         {providers.map((descriptor) => {
           const isEnabled = enabledProviderIds.includes(descriptor.id);
           const isConnected = descriptor.auth.isAuthenticated();
-          const needsReconnect = isEnabled && !isConnected;
           const isLastEnabled = enabledProviderIds.length <= 1 && isEnabled;
-          const status = isEnabled && isConnected ? 'connected' : needsReconnect ? 'reconnect' : 'disabled';
+          const status: 'connected' | 'disabled' = isEnabled && isConnected ? 'connected' : 'disabled';
           return (
             <ProviderRow key={descriptor.id}>
               <ProviderName>{descriptor.name}</ProviderName>
               <ProviderStatusBadge $status={status}>
-                {status === 'connected' ? 'Connected' : status === 'reconnect' ? 'Reconnect needed' : ''}
+                {status === 'connected' ? 'Connected' : ''}
               </ProviderStatusBadge>
               <Switch
                 checked={isEnabled}
                 onCheckedChange={() => {
                   if (!isEnabled) {
                     handleToggleOn(descriptor);
-                  } else if (needsReconnect) {
-                    handleReconnect(descriptor);
                   } else {
                     handleToggleOff(descriptor);
                   }
                 }}
-                aria-label={needsReconnect ? `Reconnect ${descriptor.name}` : isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}
+                aria-label={isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}
                 disabled={isLastEnabled}
                 variant="neutral"
               />

--- a/src/components/AppSettingsMenu/SourcesSections.tsx
+++ b/src/components/AppSettingsMenu/SourcesSections.tsx
@@ -125,10 +125,7 @@ export const MusicSourcesSection = memo(() => {
 
   useEffect(() => () => clearPendingPopup(), [clearPendingPopup]);
 
-  const handleConfirmDisconnect = useCallback(() => {
-    const id = disconnectDialogProviderId;
-    if (!id) return;
-
+  const performDisconnect = useCallback((id: ProviderId) => {
     setDisconnectDialogProviderId(null);
 
     const descriptor = registry.get(id);
@@ -163,7 +160,6 @@ export const MusicSourcesSection = memo(() => {
     descriptor?.auth.logout();
     toggleProvider(id);
   }, [
-    disconnectDialogProviderId,
     registry,
     tracks,
     currentTrackIndex,
@@ -172,6 +168,23 @@ export const MusicSourcesSection = memo(() => {
     setCurrentTrackIndex,
     toggleProvider,
   ]);
+
+  const handleConfirmDisconnect = useCallback(() => {
+    if (!disconnectDialogProviderId) return;
+    performDisconnect(disconnectDialogProviderId);
+  }, [disconnectDialogProviderId, performDisconnect]);
+
+  const handleToggleOff = useCallback(
+    (descriptor: ReturnType<typeof registry.getAll>[number]) => {
+      const affectedQueueCount = tracks.filter(t => t.provider === descriptor.id).length;
+      if (affectedQueueCount > 0) {
+        setDisconnectDialogProviderId(descriptor.id);
+      } else {
+        performDisconnect(descriptor.id);
+      }
+    },
+    [tracks, performDisconnect],
+  );
 
   if (providers.length < 2) return null;
 
@@ -206,7 +219,7 @@ export const MusicSourcesSection = memo(() => {
                   } else if (needsReconnect) {
                     handleReconnect(descriptor);
                   } else {
-                    setDisconnectDialogProviderId(descriptor.id);
+                    handleToggleOff(descriptor);
                   }
                 }}
                 aria-label={needsReconnect ? `Reconnect ${descriptor.name}` : isEnabled ? `Disable ${descriptor.name}` : `Enable ${descriptor.name}`}

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -93,8 +93,9 @@ describe('MusicSourcesSection', () => {
   });
 
   describe('toggle-off: disconnect dialog flow', () => {
-    it('opens ProviderDisconnectDialog when an enabled provider toggle is turned off', () => {
+    it('opens ProviderDisconnectDialog when an enabled provider with queued tracks is toggled off', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -113,6 +114,7 @@ describe('MusicSourcesSection', () => {
 
     it('calls descriptor.auth.logout() and toggleProvider when dialog is confirmed', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -133,6 +135,7 @@ describe('MusicSourcesSection', () => {
 
     it('closes the dialog and leaves state unchanged when Cancel is clicked', () => {
       // #given
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'spotify' })];
       const spotifyDesc = makeSpotifyDescriptor();
       const dropboxDesc = makeDropboxDescriptor();
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
@@ -147,6 +150,26 @@ describe('MusicSourcesSection', () => {
       expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
       expect(spotifyDesc.auth.logout).not.toHaveBeenCalled();
       expect(mockToggleProvider).not.toHaveBeenCalled();
+    });
+
+    it('performs logout and toggleProvider immediately without opening the dialog when the provider has no queued tracks', () => {
+      // #given — only dropbox has queued tracks; toggling off spotify should skip the prompt
+      mockTracks = [makeMediaTrack({ id: 'track-1', provider: 'dropbox' as 'spotify' })];
+      const spotifyDesc = makeSpotifyDescriptor();
+      const dropboxDesc = makeDropboxDescriptor();
+      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
+      mockRegistry.get.mockImplementation((id: string) =>
+        id === 'spotify' ? spotifyDesc : dropboxDesc,
+      );
+      render(<Wrapper><MusicSourcesSection /></Wrapper>);
+
+      // #when
+      fireEvent.click(screen.getByLabelText('Disable Spotify'));
+
+      // #then
+      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
+      expect(spotifyDesc.auth.logout).toHaveBeenCalledOnce();
+      expect(mockToggleProvider).toHaveBeenCalledWith('spotify');
     });
 
     it('shows affected-track count in disconnect dialog when provider has queued tracks', () => {

--- a/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
+++ b/src/components/AppSettingsMenu/__tests__/SourcesSections.test.tsx
@@ -365,8 +365,8 @@ describe('MusicSourcesSection', () => {
     });
   });
 
-  describe('token-expired reconnect flow', () => {
-    it('shows "Reconnect needed" badge when provider is enabled but auth has expired', () => {
+  describe('session-expired: provider toggles off (no reconnect affordance)', () => {
+    it('does not render a "Reconnect needed" badge when a provider is enabled but auth has expired', () => {
       // #given — Spotify is enabled but its auth token has expired
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       const dropboxDesc = makeDropboxDescriptor();
@@ -376,30 +376,36 @@ describe('MusicSourcesSection', () => {
       // #when
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #then
-      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+      // #then — the third "reconnect" state is gone
+      expect(screen.queryByText('Reconnect needed')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Reconnect Spotify')).not.toBeInTheDocument();
     });
 
-    it('sets aria-label to "Reconnect <name>" when provider is enabled but auth has expired', () => {
-      // #given — Spotify is enabled but its auth token has expired
+    it('shows Spotify toggle as unchecked once SESSION_EXPIRED has removed it from enabledProviderIds', () => {
+      // #given — SESSION_EXPIRED handler in ProviderContext has already removed Spotify
+      // from the enabled set; Dropbox stays enabled+connected
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockEnabledProviderIds = ['dropbox'];
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
 
       // #when
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #then — screen readers hear "Reconnect Spotify", not "Disable Spotify"
-      expect(screen.getByLabelText('Reconnect Spotify')).toBeInTheDocument();
+      // #then — Spotify toggle reads "Enable Spotify" (i.e. off) and is unchecked
+      const spotifyToggle = screen.getByLabelText('Enable Spotify');
+      expect(spotifyToggle).toHaveAttribute('aria-checked', 'false');
+      // Dropbox toggle stays on
+      const dropboxToggle = screen.getByLabelText('Disable Dropbox');
+      expect(dropboxToggle).toHaveAttribute('aria-checked', 'true');
     });
 
-    it('does not open ProviderDisconnectDialog when clicking the toggle on an expired provider', async () => {
-      // #given — Spotify is enabled but its auth token has expired
+    it('routes a re-enable click on the expired provider through the standard OAuth flow', async () => {
+      // #given — Spotify has been toggled off (session expired); user is about to flip it back on
       const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
       vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
       const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
+      mockEnabledProviderIds = ['dropbox'];
       mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
       mockRegistry.get.mockImplementation((id: string) =>
         id === 'spotify' ? spotifyDesc : dropboxDesc,
@@ -409,83 +415,13 @@ describe('MusicSourcesSection', () => {
 
       render(<Wrapper><MusicSourcesSection /></Wrapper>);
 
-      // #when
-      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
+      // #when — user flips the off toggle back on
+      fireEvent.click(screen.getByLabelText('Enable Spotify'));
 
-      // #then — disconnect dialog must NOT appear
-      expect(screen.queryByText('Disconnect Spotify')).not.toBeInTheDocument();
-    });
-
-    it('calls descriptor.auth.beginLogin when clicking the toggle on an expired provider', async () => {
-      // #given — Spotify is enabled but its auth token has expired
-      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated: vi.fn().mockReturnValue(false) });
-      vi.mocked(spotifyDesc.auth.beginLogin).mockResolvedValue(undefined);
-      const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
-      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
-      mockRegistry.get.mockImplementation((id: string) =>
-        id === 'spotify' ? spotifyDesc : dropboxDesc,
-      );
-      const mockPopup = { closed: false } as Window;
-      vi.spyOn(window, 'open').mockReturnValue(mockPopup);
-
-      render(<Wrapper><MusicSourcesSection /></Wrapper>);
-
-      // #when
-      fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
-
-      // #then — OAuth popup must be initiated
+      // #then — standard "toggle on while not authenticated" flow kicks off OAuth
       await waitFor(() => {
         expect(spotifyDesc.auth.beginLogin).toHaveBeenCalledWith({ popup: true });
       });
-    });
-
-    it('does not call toggleProvider after a successful reconnect (provider already enabled)', async () => {
-      // #given — Spotify is enabled but its auth token has expired; reconnect completes successfully
-      const isAuthenticated = vi.fn().mockReturnValue(false);
-      const spotifyDesc = makeSpotifyDescriptor({ isAuthenticated });
-      const dropboxDesc = makeDropboxDescriptor();
-      mockEnabledProviderIds = ['spotify', 'dropbox'];
-      mockRegistry.getAll.mockReturnValue([spotifyDesc, dropboxDesc]);
-      mockRegistry.get.mockImplementation((id: string) =>
-        id === 'spotify' ? spotifyDesc : dropboxDesc,
-      );
-
-      // beginLogin opens a popup that is already closed (immediate dismiss).
-      // isAuthenticated stays false until after the popup reference is captured,
-      // then switches to true so the poll detects a successful reconnect.
-      const mockPopupObj = { closed: true };
-      vi.mocked(spotifyDesc.auth.beginLogin).mockImplementation(async () => {
-        // Switch auth to "succeeded" before window.open fires so the poll sees it
-        isAuthenticated.mockReturnValue(true);
-        window.open('https://accounts.spotify.com/authorize', '_blank');
-      });
-      const originalOpenDescriptor = Object.getOwnPropertyDescriptor(window, 'open');
-      Object.defineProperty(window, 'open', {
-        value: () => mockPopupObj,
-        writable: true,
-        configurable: true,
-      });
-
-      try {
-        render(<Wrapper><MusicSourcesSection /></Wrapper>);
-
-        // #when
-        fireEvent.click(screen.getByLabelText('Reconnect Spotify'));
-        await waitFor(() => expect(spotifyDesc.auth.beginLogin).toHaveBeenCalled());
-
-        // #then — toggleProvider must NOT be called (provider is already enabled)
-        await waitFor(
-          () => {
-            expect(mockToggleProvider).not.toHaveBeenCalled();
-          },
-          { timeout: 2000 },
-        );
-      } finally {
-        if (originalOpenDescriptor) {
-          Object.defineProperty(window, 'open', originalOpenDescriptor);
-        }
-      }
     });
   });
 });

--- a/src/components/AppSettingsMenu/styled.ts
+++ b/src/components/AppSettingsMenu/styled.ts
@@ -181,15 +181,13 @@ export const ProviderName = styled.span`
   flex-shrink: 0;
 `;
 
-export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' | 'reconnect' }>`
+export const ProviderStatusBadge = styled.span<{ $status: 'connected' | 'disabled' }>`
   font-size: 0.6875rem;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   color: ${({ $status, theme }) =>
     $status === 'connected'
       ? theme.colors.success
-      : $status === 'reconnect'
-        ? theme.colors.warning
-        : theme.colors.muted.foreground};
+      : theme.colors.muted.foreground};
   flex: 1;
 `;
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -41,7 +41,6 @@ const LibraryRoute = lazy(() => import('./LibraryRoute'));
 
 const RESUME_TOAST_ID = 'resume-toast';
 const FALLTHROUGH_TOAST_ID = 'fallthrough-toast';
-const RECONNECT_TOAST_ID = 'reconnect-toast';
 const DISCONNECT_TOAST_ID = 'disconnect-toast';
 
 const Container = styled.div`
@@ -356,7 +355,7 @@ const AudioPlayerComponent = () => {
     withResumeDismiss,
   ]);
 
-  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast } = useProviderContext();
+  const { chosenProviderId, activeDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, disconnectToast, dismissDisconnectToast } = useProviderContext();
 
   useEffect(() => {
     if (!fallthroughNotification) return;
@@ -368,26 +367,13 @@ const AudioPlayerComponent = () => {
   }, [fallthroughNotification, dismissFallthroughNotification]);
 
   useEffect(() => {
-    if (!reconnectPrompt) {
-      toast.dismiss(RECONNECT_TOAST_ID);
-      return;
-    }
-    toast(reconnectPrompt.message, {
-      id: RECONNECT_TOAST_ID,
-      duration: Infinity,
-      action: { label: 'Reconnect', onClick: acceptReconnectPrompt },
-      onDismiss: dismissReconnectPrompt,
-    });
-  }, [reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt]);
-
-  useEffect(() => {
-    if (!disconnectToast || reconnectPrompt) return;
+    if (!disconnectToast) return;
     toast(disconnectToast, {
       id: DISCONNECT_TOAST_ID,
       onDismiss: dismissDisconnectToast,
       onAutoClose: dismissDisconnectToast,
     });
-  }, [disconnectToast, reconnectPrompt, dismissDisconnectToast]);
+  }, [disconnectToast, dismissDisconnectToast]);
 
   // Setup is needed when no provider has been chosen yet and none are connected,
   // or when the active provider isn't authenticated and no other enabled provider is either.

--- a/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/SourcesSection.test.tsx
@@ -198,9 +198,10 @@ describe('SettingsV2 SourcesSection', () => {
     });
   });
 
-  describe('token-expired reconnect state', () => {
-    it('shows "Reconnect needed" badge when a provider is enabled but isAuthenticated returns false', () => {
-      // #given — Spotify is enabled but its auth token has expired
+  describe('session-expired: no reconnect affordance', () => {
+    it('does not render a "Reconnect needed" badge when a provider is enabled but isAuthenticated returns false', () => {
+      // #given — Spotify is enabled but its auth token has expired; the session-expired
+      // handler in ProviderContext will toggle it off, so the reconnect state never surfaces
       const spotify = makeDescriptor('spotify', 'Spotify', { isAuthenticated: false });
       const dropbox = makeDescriptor('dropbox', 'Dropbox');
       mockEnabledProviderIds = ['spotify', 'dropbox'];
@@ -215,7 +216,7 @@ describe('SettingsV2 SourcesSection', () => {
       );
 
       // #then
-      expect(screen.getByText('Reconnect needed')).toBeInTheDocument();
+      expect(screen.queryByText('Reconnect needed')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/controls/QuickEffectsRow.tsx
+++ b/src/components/controls/QuickEffectsRow.tsx
@@ -73,7 +73,7 @@ const SwatchButton = styled.button<{ $color: string; $isActive: boolean }>`
   border-radius: 50%;
   background: ${({ $color }) => $color};
   border: 1px solid ${({ theme }) => theme.colors.control.border};
-  outline: ${({ theme, $isActive }) => ($isActive ? `2px solid ${theme.colors.selection}` : 'none')};
+  outline: ${({ $isActive }) => ($isActive ? '2px solid var(--accent-contrast-color)' : 'none')};
   cursor: pointer;
   padding: 0;
   flex-shrink: 0;

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -8,3 +8,18 @@ export const AUTH_COMPLETE_EVENT = 'vorbis-auth-complete';
  * Event `detail` is `{ providerId: ProviderId }`.
  */
 export const SESSION_EXPIRED_EVENT = 'vorbis-session-expired';
+
+/**
+ * Dispatched on `window` when a provider transitions from `not authenticated`
+ * to `authenticated` (e.g., the user re-toggles a previously-expired provider
+ * on in Settings and OAuth completes). The playback layer listens to
+ * re-prime the queue's current track at the user's last known position when
+ * the current track belongs to the reconnected provider.
+ *
+ * Not dispatched on the initial render for providers that are already
+ * authenticated at mount — the persisted-session hydrate path owns the
+ * initial primed state. See `openspec/changes/reload-track-after-provider-reauth/`.
+ *
+ * Event `detail` is `{ providerId: ProviderId }`.
+ */
+export const PROVIDER_RECONNECTED_EVENT = 'vorbis-provider-reconnected';

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -56,13 +56,6 @@ interface ProviderContextValue {
   /** Dismiss the fallthrough notification. */
   dismissFallthroughNotification: () => void;
 
-  /** Reconnect prompt shown when a provider's refresh token is rejected (400/401). Persists until acted upon. */
-  reconnectPrompt: { providerId: ProviderId; message: string } | null;
-  /** Trigger the OAuth flow for the provider with a pending reconnect prompt. */
-  acceptReconnectPrompt: () => void;
-  /** Dismiss the reconnect prompt without reconnecting. */
-  dismissReconnectPrompt: () => void;
-
   /** Auto-dismiss toast shown immediately when a provider is disconnected due to an unrecoverable 401. */
   disconnectToast: string | null;
   /** Dismiss the disconnect toast. */
@@ -111,29 +104,31 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   // ── Enabled providers (multi-toggle) ───────────────────────────────────
-  const [storedEnabledIds, setStoredEnabledIds] = useLocalStorage<ProviderId[]>(
+  // Stored value uses `null` as the "uninitialized" sentinel (default to all
+  // registered providers). An explicit `[]` means the user — or a forced
+  // session-expired toggle-off — has emptied the set, and we must honor it
+  // rather than re-defaulting.
+  const [storedEnabledIds, setStoredEnabledIds] = useLocalStorage<ProviderId[] | null>(
     STORAGE_KEYS.ENABLED_PROVIDERS,
-    [],
+    null,
   );
 
-  // Validate stored enabled IDs — only keep those that are actually registered.
-  // If nothing is stored yet, default to all registered providers.
   const enabledProviderIds = useMemo(() => {
-    const valid = storedEnabledIds.filter(id => providerRegistry.has(id));
-    if (valid.length > 0) return valid;
-    // Default: enable all registered providers
-    return allProviderIds;
+    if (storedEnabledIds === null) return allProviderIds;
+    return storedEnabledIds.filter(id => providerRegistry.has(id));
   }, [storedEnabledIds, allProviderIds]);
 
   const toggleProvider = useCallback(
     (id: ProviderId) => {
       if (!providerRegistry.has(id)) return;
       setStoredEnabledIds(prev => {
-        const validPrev = prev.filter(pid => providerRegistry.has(pid));
-        const current = validPrev.length > 0 ? validPrev : allProviderIds;
+        const current =
+          prev === null ? allProviderIds : prev.filter(pid => providerRegistry.has(pid));
         const isCurrentlyEnabled = current.includes(id);
         if (isCurrentlyEnabled) {
-          // Don't disable the last remaining provider
+          // Don't disable the last remaining provider via the user-facing
+          // toggle. Session-expired bypasses this guard by writing through
+          // `setStoredEnabledIds` directly (see handleSessionExpired below).
           if (current.length <= 1) return current;
           return current.filter(pid => pid !== id);
         } else {
@@ -166,12 +161,33 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
   const [fallthroughNotification, setFallthroughNotification] = useState<string | null>(null);
   const dismissFallthroughNotification = useCallback(() => setFallthroughNotification(null), []);
 
-  // ── Session-expired reconnect prompt ─────────────────────────────────
-  const [reconnectPrompt, setReconnectPrompt] = useState<{ providerId: ProviderId; message: string } | null>(null);
-
   // ── Disconnect toast (auto-dismiss) ──────────────────────────────────
   const [disconnectToast, setDisconnectToast] = useState<string | null>(null);
   const dismissDisconnectToast = useCallback(() => setDisconnectToast(null), []);
+
+  // Latest-value refs so the SESSION_EXPIRED_EVENT listener (attached once,
+  // []-deps) can read the current state setters without re-binding on every
+  // render. Re-binding would race user-driven toggles and risk dropping events
+  // fired during a re-render.
+  //
+  // Session-expired uses `setStoredEnabledIds` directly instead of going
+  // through `toggleProvider` so it can bypass the "do not disable the last
+  // remaining provider" guard. That guard exists to prevent accidental
+  // user-initiated zero-provider states; a forced session-expired toggle-off
+  // must accurately reflect that the underlying auth has failed, regardless
+  // of how many providers remain enabled.
+  const setStoredEnabledIdsRef = useRef(setStoredEnabledIds);
+  const enabledProviderIdsRef = useRef(enabledProviderIds);
+  const allProviderIdsRef = useRef(allProviderIds);
+  useEffect(() => {
+    setStoredEnabledIdsRef.current = setStoredEnabledIds;
+  }, [setStoredEnabledIds]);
+  useEffect(() => {
+    enabledProviderIdsRef.current = enabledProviderIds;
+  }, [enabledProviderIds]);
+  useEffect(() => {
+    allProviderIdsRef.current = allProviderIds;
+  }, [allProviderIds]);
 
   useEffect(() => {
     const handleSessionExpired = (event: Event) => {
@@ -180,32 +196,22 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       if (!providerId) return;
       const descriptor = providerRegistry.get(providerId);
       const name = descriptor?.name ?? providerId;
-      setReconnectPrompt(prev => {
-        if (prev?.providerId === providerId) return prev;
-        return {
-          providerId,
-          message: `Your ${name} session has expired. Tap to reconnect.`,
-        };
-      });
       setDisconnectToast(`${name} disconnected — session expired.`);
       setAuthRevision(prev => prev + 1);
+      if (enabledProviderIdsRef.current.includes(providerId)) {
+        setStoredEnabledIdsRef.current(prev => {
+          const current =
+            prev === null
+              ? allProviderIdsRef.current
+              : prev.filter(pid => providerRegistry.has(pid));
+          if (!current.includes(providerId)) return current;
+          return current.filter(pid => pid !== providerId);
+        });
+      }
     };
 
     window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
     return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
-  }, []);
-
-  const dismissReconnectPrompt = useCallback(() => setReconnectPrompt(null), []);
-
-  const acceptReconnectPrompt = useCallback(() => {
-    setReconnectPrompt(current => {
-      if (!current) return null;
-      const descriptor = providerRegistry.get(current.providerId);
-      descriptor?.auth.beginLogin({ popup: true }).catch(error => {
-        console.warn('[ProviderContext] Failed to begin login for reconnect:', error);
-      });
-      return null;
-    });
   }, []);
 
   // ── Active provider (for playback) ─────────────────────────────────────
@@ -267,12 +273,25 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     activeDescriptor?.playback.pause().catch(() => {});
     setStoredProviderId(fallback);
 
+    // Toggle the expired provider off so the settings UI reflects its
+    // not-connected state. Mirrors handleSessionExpired and bypasses
+    // toggleProvider's "last enabled" guard by writing setStoredEnabledIds
+    // directly — the underlying auth has failed and the toggle must
+    // accurately reflect that regardless of how many providers remain.
+    const expiredId = storedProviderId;
+    setStoredEnabledIds(prev => {
+      const current =
+        prev === null ? allProviderIds : prev.filter(pid => providerRegistry.has(pid));
+      if (!current.includes(expiredId)) return current;
+      return current.filter(pid => pid !== expiredId);
+    });
+
     // Notify the user
     const expiredName = activeDescriptor?.name ?? storedProviderId;
     setFallthroughNotification(
-      `${expiredName} session expired — switched to ${fallbackDesc.name}. Reconnect in Settings.`,
+      `${expiredName} session expired — switched to ${fallbackDesc.name}. Re-enable in Settings.`,
     );
-  }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId]);
+  }, [storedProviderId, activeDescriptor, enabledProviderIds, validProviderId, setStoredProviderId, setStoredEnabledIds, allProviderIds]);
 
   // ── Auto-switch when active provider is disabled ──────────────────────
   useEffect(() => {
@@ -310,15 +329,12 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
       connectedProviderIds,
       fallthroughNotification,
       dismissFallthroughNotification,
-      reconnectPrompt,
-      acceptReconnectPrompt,
-      dismissReconnectPrompt,
       disconnectToast,
       dismissDisconnectToast,
     }),
     // authRevision triggers re-evaluation when a popup completes OAuth
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, reconnectPrompt, acceptReconnectPrompt, dismissReconnectPrompt, disconnectToast, dismissDisconnectToast, authRevision],
+    [storedProviderId, validProviderId, activeDescriptor, setActiveProviderId, setProviderSwitchInterceptor, needsProviderSelection, enabledProviderIds, toggleProvider, isProviderEnabled, allProviders.length, getDescriptor, connectedProviderIds, fallthroughNotification, dismissFallthroughNotification, disconnectToast, dismissDisconnectToast, authRevision],
   );
 
   return (

--- a/src/contexts/ProviderContext.tsx
+++ b/src/contexts/ProviderContext.tsx
@@ -10,7 +10,7 @@ import '@/providers/spotify/spotifyProvider';
 import '@/providers/dropbox/dropboxProvider'; // conditionally registers if VITE_DROPBOX_CLIENT_ID is set
 import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 import { DROPBOX_AUTH_ERROR_EVENT } from '@/providers/dropbox/dropboxAuthAdapter';
-import { AUTH_COMPLETE_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { AUTH_COMPLETE_EVENT, PROVIDER_RECONNECTED_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { STORAGE_KEYS } from '@/constants/storage';
 import { NOTIFICATION_DISMISS_MS } from '@/constants/timing';
 
@@ -156,6 +156,26 @@ export function ProviderProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [enabledProviderIds, authRevision],
   );
+
+  // ── Detect `not authenticated → authenticated` transitions ─────────────
+  // The first render seeds previousConnectedRef without dispatching, so
+  // providers that are already authenticated at mount are not treated as a
+  // transition (the persisted-session hydrate path owns the initial primed
+  // state). On subsequent renders, every provider newly present in
+  // connectedProviderIds emits PROVIDER_RECONNECTED_EVENT exactly once.
+  const previousConnectedRef = useRef<Set<ProviderId> | null>(null);
+  useEffect(() => {
+    const current = new Set(connectedProviderIds);
+    const previous = previousConnectedRef.current;
+    previousConnectedRef.current = current;
+    if (previous === null) return;
+    for (const providerId of current) {
+      if (previous.has(providerId)) continue;
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId } }),
+      );
+    }
+  }, [connectedProviderIds]);
 
   // ── Auto-fallthrough notification ─────────────────────────────────────
   const [fallthroughNotification, setFallthroughNotification] = useState<string | null>(null);

--- a/src/contexts/__tests__/ProviderContext.test.tsx
+++ b/src/contexts/__tests__/ProviderContext.test.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { STORAGE_KEYS } from '@/constants/storage';
+import type { ProviderDescriptor } from '@/types/providers';
+import { makeProviderDescriptor } from '@/test/fixtures';
+
+vi.mock('@/providers/spotify/spotifyProvider', () => ({}));
+vi.mock('@/providers/dropbox/dropboxProvider', () => ({}));
+
+import { providerRegistry } from '@/providers/registry';
+import { ProviderProvider, useProviderContext } from '@/contexts/ProviderContext';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <ProviderProvider>{children}</ProviderProvider>;
+}
+
+function registerProvider(overrides: Partial<ProviderDescriptor>): ProviderDescriptor {
+  const descriptor = makeProviderDescriptor(overrides);
+  providerRegistry.register(descriptor);
+  return descriptor;
+}
+
+function resetRegistry() {
+  for (const descriptor of providerRegistry.getAll()) {
+    (providerRegistry as unknown as { providers: Map<string, ProviderDescriptor> }).providers.delete(
+      descriptor.id,
+    );
+  }
+}
+
+function stubLocalStorage(entries: Record<string, string>): void {
+  const store: Record<string, string> = { ...entries };
+  vi.mocked(window.localStorage.getItem).mockImplementation((key: string) =>
+    Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
+  );
+  vi.mocked(window.localStorage.setItem).mockImplementation((key: string, value: string) => {
+    store[key] = value;
+  });
+  vi.mocked(window.localStorage.removeItem).mockImplementation((key: string) => {
+    delete store[key];
+  });
+}
+
+describe('ProviderContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRegistry();
+  });
+
+  describe('SESSION_EXPIRED_EVENT', () => {
+    it('removes the provider from enabledProviderIds when its session expires', () => {
+      // #given — Spotify + Dropbox are both registered and enabled
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['spotify', 'dropbox']);
+
+      // #when — Spotify's session is reported as expired
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(false);
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Spotify is removed from the enabled set; Dropbox stays
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+    });
+
+    it('does not toggle a provider that is already disabled', () => {
+      // #given — Spotify is registered but disabled; only Dropbox is enabled
+      registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+
+      // #when — a stray SESSION_EXPIRED for the already-disabled Spotify fires
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Dropbox is not re-toggled and remains the sole enabled provider
+      expect(result.current.enabledProviderIds).toEqual(['dropbox']);
+    });
+
+    it('removes the sole enabled provider on session expiry, bypassing the "last enabled" guard', () => {
+      // #given — only Spotify is enabled (Dropbox registered but disabled)
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+      expect(result.current.enabledProviderIds).toEqual(['spotify']);
+
+      // #when — Spotify's session expires while it is the sole enabled provider
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(false);
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then — Spotify is removed even though it was the last enabled provider
+      expect(result.current.enabledProviderIds).toEqual([]);
+      // #then — the disconnect toast still surfaces so the user knows why
+      expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+
+    it('surfaces the disconnect toast', () => {
+      // #given
+      registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+
+      const { result } = renderHook(() => useProviderContext(), { wrapper });
+
+      // #when
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+        );
+      });
+
+      // #then
+      expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+  });
+});

--- a/src/contexts/__tests__/ProviderContext.test.tsx
+++ b/src/contexts/__tests__/ProviderContext.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { PROVIDER_RECONNECTED_EVENT, SESSION_EXPIRED_EVENT } from '@/constants/events';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
 import { STORAGE_KEYS } from '@/constants/storage';
 import type { ProviderDescriptor } from '@/types/providers';
+import type { ProviderId } from '@/types/domain';
 import { makeProviderDescriptor } from '@/test/fixtures';
 
 vi.mock('@/providers/spotify/spotifyProvider', () => ({}));
@@ -200,6 +202,127 @@ describe('ProviderContext', () => {
 
       // #then
       expect(result.current.disconnectToast).toBe('Spotify disconnected — session expired.');
+    });
+  });
+
+  describe('PROVIDER_RECONNECTED_EVENT dispatch', () => {
+    function collectReconnects(): {
+      events: Array<{ providerId: ProviderId }>;
+      detach: () => void;
+    } {
+      const events: Array<{ providerId: ProviderId }> = [];
+      const listener = (e: Event) => {
+        events.push((e as CustomEvent<{ providerId: ProviderId }>).detail);
+      };
+      window.addEventListener(PROVIDER_RECONNECTED_EVENT, listener);
+      return {
+        events,
+        detach: () => window.removeEventListener(PROVIDER_RECONNECTED_EVENT, listener),
+      };
+    }
+
+    it('does NOT dispatch PROVIDER_RECONNECTED_EVENT on initial mount for already-authenticated providers', () => {
+      // #given — dropbox is already authenticated at mount
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+
+      // #when — mount
+      renderHook(() => useProviderContext(), { wrapper });
+
+      // #then — the initial-render snapshot was seeded into previousConnectedRef
+      // so dropbox (already authed) is NOT reported as a transition.
+      expect(events).toEqual([]);
+      detach();
+    });
+
+    it('dispatches PROVIDER_RECONNECTED_EVENT exactly once when a provider transitions to authenticated', () => {
+      // #given — spotify starts unauthenticated, dropbox is already authed
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+      renderHook(() => useProviderContext(), { wrapper });
+
+      // #when — spotify auth flips to true, then AUTH_STATE_CHANGED_EVENT fires
+      // (production flow: usePopupAuth posts the event after a successful OAuth
+      // popup, which bumps authRevision and recomputes connectedProviderIds).
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(true);
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+
+      // #then — exactly one event for the newly-connected provider
+      expect(events).toEqual([{ providerId: 'spotify' }]);
+      detach();
+    });
+
+    it('does NOT re-dispatch on subsequent renders if no new provider is newly connected', () => {
+      // #given — spotify already transitioned once
+      const spotify = registerProvider({
+        id: 'spotify',
+        name: 'Spotify',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          isAuthenticated: vi.fn().mockReturnValue(false),
+        },
+      });
+      registerProvider({
+        id: 'dropbox' as ProviderDescriptor['id'],
+        name: 'Dropbox',
+        auth: {
+          ...makeProviderDescriptor().auth,
+          providerId: 'dropbox' as ProviderDescriptor['id'],
+          isAuthenticated: vi.fn().mockReturnValue(true),
+        },
+      });
+      stubLocalStorage({
+        [STORAGE_KEYS.ENABLED_PROVIDERS]: JSON.stringify(['spotify', 'dropbox']),
+      });
+      const { events, detach } = collectReconnects();
+      renderHook(() => useProviderContext(), { wrapper });
+
+      act(() => {
+        spotify.auth.isAuthenticated = vi.fn().mockReturnValue(true);
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+      expect(events).toHaveLength(1);
+
+      // #when — another auth-state change fires but no provider newly connects
+      act(() => {
+        window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      });
+
+      // #then — no additional dispatches
+      expect(events).toHaveLength(1);
+      detach();
     });
   });
 });

--- a/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tests for the onAuthExpired handler in usePlayerLogic.
+ * Verifies that an AuthExpiredError from playback triggers reportUnauthorized()
+ * on the affected provider and updates authExpired state.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { usePlayerLogic } from '../usePlayerLogic';
+import { TrackProvider } from '@/contexts/TrackContext';
+import { VisualEffectsProvider } from '@/contexts/visualEffects';
+import { ColorProvider } from '@/contexts/ColorContext';
+import { ProviderProvider } from '@/contexts/ProviderContext';
+import type { ProviderId } from '@/types/domain';
+
+let capturedOnAuthExpired: ((providerId: ProviderId) => void) | undefined;
+
+vi.mock('@/hooks/useProviderPlayback', () => ({
+  useProviderPlayback: vi.fn((props: { onAuthExpired?: (id: ProviderId) => void }) => {
+    capturedOnAuthExpired = props.onAuthExpired;
+    return {
+      playTrack: vi.fn(),
+      currentPlaybackProviderRef: { current: null },
+    };
+  }),
+}));
+
+vi.mock('@/hooks/usePlaylistManager', () => ({
+  usePlaylistManager: vi.fn(() => ({ handlePlaylistSelect: vi.fn() })),
+}));
+
+vi.mock('@/hooks/useAutoAdvance', () => ({
+  useAutoAdvance: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAccentColor', () => ({
+  useAccentColor: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
+  useUnifiedLikedTracks: vi.fn(() => ({ isUnifiedLikedActive: false })),
+}));
+
+vi.mock('@/hooks/useRadio', () => ({
+  useRadio: vi.fn(() => ({
+    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    startRadio: vi.fn(),
+    stopRadio: vi.fn(),
+    isRadioAvailable: true,
+  })),
+}));
+
+const reportUnauthorizedSpy = vi.fn();
+
+const mockDescriptor = {
+  id: 'spotify' as const,
+  name: 'Spotify',
+  catalog: { listTracks: vi.fn().mockResolvedValue([]) },
+  auth: {
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    logout: vi.fn(),
+    reportUnauthorized: reportUnauthorizedSpy,
+  },
+  playback: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn().mockResolvedValue(undefined),
+    resume: vi.fn(),
+    playTrack: vi.fn(),
+    getState: vi.fn().mockResolvedValue(null),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+  capabilities: { hasSaveTrack: true, hasExternalLink: true, hasLikedCollection: true },
+};
+
+vi.mock('@/contexts/ProviderContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/contexts/ProviderContext')>();
+  return {
+    ...actual,
+    useProviderContext: vi.fn(() => ({
+      activeDescriptor: mockDescriptor,
+      setActiveProviderId: vi.fn(),
+      getDescriptor: vi.fn((id: string) => (id === 'spotify' ? mockDescriptor : undefined)),
+      connectedProviderIds: ['spotify'],
+      chosenProviderId: 'spotify',
+      activeProviderId: 'spotify',
+      setProviderSwitchInterceptor: vi.fn(),
+      registry: {},
+      needsProviderSelection: false,
+      enabledProviderIds: ['spotify'],
+      toggleProvider: vi.fn(),
+      isProviderEnabled: vi.fn(() => true),
+      hasMultipleProviders: false,
+      fallthroughNotification: null,
+      dismissFallthroughNotification: vi.fn(),
+      disconnectToast: null,
+      dismissDisconnectToast: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('@/services/spotify', () => ({
+  spotifyAuth: {
+    handleRedirect: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated: vi.fn().mockReturnValue(false),
+    getAccessToken: vi.fn().mockReturnValue('test-token'),
+    ensureValidToken: vi.fn().mockResolvedValue('test-token'),
+    redirectToAuth: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/spotifyPlayer', () => ({
+  spotifyPlayer: {
+    onPlayerStateChanged: vi.fn(() => vi.fn()),
+    getCurrentState: vi.fn().mockResolvedValue(null),
+    resume: vi.fn(),
+    pause: vi.fn(),
+    setVolume: vi.fn().mockResolvedValue(undefined),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    playTrack: vi.fn().mockResolvedValue(undefined),
+    getDeviceId: vi.fn().mockReturnValue(null),
+    getIsReady: vi.fn().mockReturnValue(false),
+  },
+}));
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn((id: string) => (id === 'spotify' ? mockDescriptor : undefined)),
+    getAll: vi.fn(() => []),
+    has: vi.fn(() => true),
+    register: vi.fn(),
+  },
+}));
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => (
+  <ProviderProvider>
+    <TrackProvider>
+      <VisualEffectsProvider>
+        <ColorProvider>
+          {children}
+        </ColorProvider>
+      </VisualEffectsProvider>
+    </TrackProvider>
+  </ProviderProvider>
+);
+
+describe('usePlayerLogic — onAuthExpired handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnAuthExpired = undefined;
+  });
+
+  it('calls reportUnauthorized on the provider when auth expires during playback', async () => {
+    // #given
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when — simulate AuthExpiredError surfacing from playback adapter
+    await act(async () => {
+      capturedOnAuthExpired?.('spotify');
+    });
+
+    // #then
+    expect(reportUnauthorizedSpy).toHaveBeenCalledOnce();
+  });
+
+  it('sets authExpired state to the affected provider id', async () => {
+    // #given
+    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when
+    await act(async () => {
+      capturedOnAuthExpired?.('spotify');
+    });
+
+    // #then
+    expect(result.current.radio.authExpired).toBe('spotify');
+  });
+
+  it('does not call reportUnauthorized when provider has no auth adapter', async () => {
+    // #given — provider id that has no registered descriptor
+    const { result: _ } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+
+    // #when — unknown provider id
+    await act(async () => {
+      capturedOnAuthExpired?.('dropbox');
+    });
+
+    // #then — reportUnauthorized not called (no descriptor for 'dropbox' in this mock)
+    expect(reportUnauthorizedSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useProviderPlayback.reauth.test.ts
+++ b/src/hooks/__tests__/useProviderPlayback.reauth.test.ts
@@ -1,0 +1,191 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { PROVIDER_RECONNECTED_EVENT } from '@/constants/events';
+
+const mockPrepareTrack = vi.fn();
+const mockPlayTrack = vi.fn().mockResolvedValue(undefined);
+const mockPause = vi.fn().mockResolvedValue(undefined);
+const mockResume = vi.fn().mockResolvedValue(undefined);
+const mockInitialize = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn((id: string) => ({
+      id,
+      playback: {
+        providerId: id,
+        playTrack: mockPlayTrack,
+        pause: mockPause,
+        resume: mockResume,
+        prepareTrack: mockPrepareTrack,
+        initialize: mockInitialize,
+        seek: vi.fn(),
+        next: vi.fn(),
+        previous: vi.fn(),
+        setVolume: vi.fn(),
+        getState: vi.fn(),
+        subscribe: vi.fn(),
+      },
+    })),
+  },
+}));
+
+const mockLoadSession = vi.fn();
+vi.mock('@/services/sessionPersistence', () => ({
+  loadSession: () => mockLoadSession(),
+}));
+
+import { useProviderPlayback } from '../useProviderPlayback';
+
+function makeMediaTrack(overrides?: Partial<MediaTrack>): MediaTrack {
+  return {
+    id: 'track-1',
+    provider: 'spotify' as ProviderId,
+    playbackRef: { provider: 'spotify' as ProviderId, ref: 'spotify:track:track-1' },
+    name: 'Test Track',
+    artists: 'Test Artist',
+    album: 'Test Album',
+    durationMs: 210000,
+    image: '',
+    ...overrides,
+  };
+}
+
+describe('useProviderPlayback — PROVIDER_RECONNECTED_EVENT re-prime', () => {
+  const setCurrentTrackIndex = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockLoadSession.mockReset();
+  });
+
+  it('calls prepareTrack with the persisted playbackPosition when the snapshot trackId matches', () => {
+    // #given — current track is a spotify track, snapshot points at the same id
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue({
+      collectionId: 'c1',
+      collectionName: 'C',
+      trackIndex: 0,
+      trackId: 'sp-1',
+      playbackPosition: 45_000,
+    });
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when — dispatch the reconnect event for spotify
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledTimes(1);
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 45_000 });
+  });
+
+  it('falls back to positionMs=0 when the snapshot trackId does not match', () => {
+    // #given
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue({
+      collectionId: 'c1',
+      collectionName: 'C',
+      trackIndex: 0,
+      trackId: 'different-track',
+      playbackPosition: 45_000,
+    });
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 0 });
+  });
+
+  it('falls back to positionMs=0 when no snapshot is persisted', () => {
+    // #given
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue(null);
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).toHaveBeenCalledWith(currentTrack, { positionMs: 0 });
+  });
+
+  it('does NOT call prepareTrack when the reconnected provider is not the current track provider', () => {
+    // #given — current track is spotify, but dropbox just reconnected
+    const currentTrack = makeMediaTrack({ id: 'sp-1', provider: 'spotify' });
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [currentTrack] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: 0 };
+
+    mockLoadSession.mockReturnValue(null);
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'dropbox' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call prepareTrack when there is no current track', () => {
+    // #given — empty queue
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [] };
+    const currentTrackIndexRef: React.MutableRefObject<number> = { current: -1 };
+
+    renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef, currentTrackIndexRef })
+    );
+
+    // #when
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_RECONNECTED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+    });
+
+    // #then
+    expect(mockPrepareTrack).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -30,6 +30,7 @@ describe('useQueueManagement', () => {
   let mockGetDescriptor: ReturnType<typeof vi.fn>;
   let mockActiveDescriptor: { id: string; [key: string]: unknown };
   let mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  let mockGetDrivingProviderDescriptor: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockHandlePlaylistSelect = vi.fn();
@@ -40,6 +41,9 @@ describe('useQueueManagement', () => {
     mockGetDescriptor = vi.fn();
     mockActiveDescriptor = { id: 'spotify' };
     mediaTracksRef = { current: [] };
+    // Default: no driving descriptor (notify is a no-op). Tests covering native-sync
+    // override this with a descriptor that declares `hasNativeQueueSync`.
+    mockGetDrivingProviderDescriptor = vi.fn(() => undefined);
     vi.mocked(toast).mockClear();
   });
 
@@ -55,6 +59,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -81,6 +86,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -116,6 +122,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -143,6 +150,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -174,6 +182,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: dropboxDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -213,6 +222,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: dropboxDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -248,6 +258,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -286,6 +297,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -309,6 +321,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: undefined,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -340,6 +353,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -372,6 +386,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -404,6 +419,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -438,6 +454,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -471,6 +488,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -501,6 +519,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -530,6 +549,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -561,6 +581,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -594,6 +615,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 
@@ -625,6 +647,7 @@ describe('useQueueManagement', () => {
       handleBackToLibrary: mockHandleBackToLibrary,
       activeDescriptor: mockActiveDescriptor,
       getDescriptor: mockGetDescriptor,
+      getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
     };
 
     const { result, rerender } = renderHook((p: typeof props) => useQueueManagement(p), {
@@ -648,6 +671,347 @@ describe('useQueueManagement', () => {
     expect(result.current.handleAddToQueue).toBe(initialAdd);
   });
 
+  describe('native-queue-sync notifications', () => {
+    function makeDrivingDescriptor(opts: { hasNativeQueueSync: boolean }): {
+      descriptor: { id: 'spotify'; capabilities: { hasNativeQueueSync: boolean }; playback: { onQueueChanged: ReturnType<typeof vi.fn>; pause: ReturnType<typeof vi.fn> } };
+      onQueueChanged: ReturnType<typeof vi.fn>;
+    } {
+      const onQueueChanged = vi.fn();
+      return {
+        descriptor: {
+          id: 'spotify',
+          capabilities: { hasNativeQueueSync: opts.hasNativeQueueSync },
+          playback: { onQueueChanged, pause: vi.fn() },
+        },
+        onQueueChanged,
+      };
+    }
+
+    it('handleAddToQueue notifies the driving provider with the post-append tracks and unchanged index', async () => {
+      // #given — non-empty queue, driving provider declares native-queue-sync
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('3'), makeMediaTrack('4')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2', '3', '4']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('handleRemoveFromQueue notifies with the post-removal tracks and adjusted index', () => {
+      // #given — currently playing index 2; remove index 0 → adjusted to 1
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2'), makeMediaTrack('3')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' }), makeTrack({ id: '3' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 2,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleRemoveFromQueue(0);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['2', '3']);
+      expect(notifiedIndex).toBe(1);
+    });
+
+    it('handleReorderQueue notifies with the reordered tracks and the followed-current index', () => {
+      // #given — playing index 0 ('a'); reorder 0→2 follows the playing track to index 2
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleReorderQueue(0, 2);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['b', 'c', 'a']);
+      expect(notifiedIndex).toBe(2);
+    });
+
+    it('insertTracksNext notifies with the spliced tracks and unchanged current index', () => {
+      // #given — playing index 1 of 4; insert one track at index 2
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c'), makeMediaTrack('d')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' }), makeTrack({ id: 'd' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 1,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'b', 'x', 'c', 'd']);
+      expect(notifiedIndex).toBe(1);
+    });
+
+    it('insertTracksNext notifies with index 0 when the queue starts empty', () => {
+      // #given — empty queue; fall-through path treats inserted tracks as the new queue
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks: [],
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('queueTracksDirectly notifies with the post-append tracks and unchanged index', () => {
+      // #given — non-empty queue, driving provider declares native-queue-sync
+      mediaTracksRef.current = [makeMediaTrack('1')];
+      const tracks = [makeTrack({ id: '1' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('2'), makeMediaTrack('3')]);
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2', '3']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('insertCollectionNext notifies through insertTracksNext on the non-empty path', async () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const fetched = [makeMediaTrack('p1'), makeMediaTrack('p2')];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue(fetched) };
+      mockActiveDescriptor.catalog = mockCatalog;
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.insertCollectionNext('p1');
+      });
+
+      // #then
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+      const [notifiedTracks, notifiedIndex] = onQueueChanged.mock.calls[0];
+      expect((notifiedTracks as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'p1', 'p2', 'b']);
+      expect(notifiedIndex).toBe(0);
+    });
+
+    it('does not notify when the driving provider lacks the native-queue-sync capability', () => {
+      // #given — driving descriptor without the capability flag
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: false });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.handleReorderQueue(0, 2);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when a mutation bails before committing new state', () => {
+      // #given — removing the currently playing index is a no-op
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 1,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when — attempt to remove the playing track (bails)
+      act(() => {
+        result.current.handleRemoveFromQueue(1);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when insertTracksNext dedups to zero new tracks', () => {
+      // #given — every incoming track is already in the queue
+      mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
+      const tracks = [makeTrack({ id: '1' }), makeTrack({ id: '2' })];
+      const { descriptor, onQueueChanged } = makeDrivingDescriptor({ hasNativeQueueSync: true });
+      mockGetDrivingProviderDescriptor.mockReturnValue(descriptor);
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')]);
+      });
+
+      // #then
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];
@@ -663,6 +1027,7 @@ describe('useQueueManagement', () => {
         handleBackToLibrary: mockHandleBackToLibrary,
         activeDescriptor: mockActiveDescriptor,
         getDescriptor: mockGetDescriptor,
+        getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
       })
     );
 

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -462,6 +462,7 @@ export function usePlayerLogic() {
     handleBackToLibrary,
     activeDescriptor,
     getDescriptor,
+    getDrivingProviderDescriptor,
   });
 
   const dismissRadioProgress = useCallback(() => setRadioProgress(null), []);

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -111,6 +111,7 @@ export function usePlayerLogic() {
     setCurrentTrackIndex,
     activeDescriptor,
     mediaTracksRef,
+    currentTrackIndexRef,
     onAuthExpired: (providerId: ProviderId) => setAuthExpired(providerId),
     expectedTrackIdRef,
   });

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -107,12 +107,17 @@ export function usePlayerLogic() {
   // Radio generation progress panel state
   const [radioProgress, setRadioProgress] = useState<RadioProgress | null>(null);
 
+  const handleAuthExpired = useCallback((providerId: ProviderId) => {
+    providerRegistry.get(providerId)?.auth.reportUnauthorized?.();
+    setAuthExpired(providerId);
+  }, []);
+
   const providerPlayback = useProviderPlayback({
     setCurrentTrackIndex,
     activeDescriptor,
     mediaTracksRef,
     currentTrackIndexRef,
-    onAuthExpired: (providerId: ProviderId) => setAuthExpired(providerId),
+    onAuthExpired: handleAuthExpired,
     expectedTrackIdRef,
   });
   const providerPlayTrack = providerPlayback.playTrack;

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -1,15 +1,22 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import { providerRegistry } from '@/providers/registry';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { logQueue, logArtRace } from '@/lib/debugLog';
 import { SKIP_ON_ERROR_DELAY_MS } from '@/constants/timing';
+import { PROVIDER_RECONNECTED_EVENT } from '@/constants/events';
+import { loadSession } from '@/services/sessionPersistence';
 
 interface UseProviderPlaybackProps {
   setCurrentTrackIndex: (index: number) => void;
   activeDescriptor?: ProviderDescriptor | null;
   mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
+  /**
+   * Ref tracking the current track index. Used by the re-prime listener so
+   * the handler reads the live index without re-binding on every change.
+   */
+  currentTrackIndexRef?: React.MutableRefObject<number>;
   onAuthExpired?: (providerId: ProviderId) => void;
   /**
    * Shared guard ref used by `usePlaybackSubscription` to ignore stale provider
@@ -25,11 +32,49 @@ export const useProviderPlayback = ({
   setCurrentTrackIndex,
   activeDescriptor,
   mediaTracksRef,
+  currentTrackIndexRef,
   onAuthExpired,
   expectedTrackIdRef,
 }: UseProviderPlaybackProps) => {
 
   const currentPlaybackProviderRef = useRef<ProviderId | null>(null);
+
+  // Re-prime the current track when its provider re-authenticates after a
+  // session expiry. The dispatcher (ProviderContext) skips the initial mount,
+  // so this only fires on genuine `not authenticated → authenticated`
+  // transitions. The handler is silent — no auto-play, no queue mutation.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
+      const providerId = detail?.providerId;
+      if (!providerId) return;
+
+      const tracks = mediaTracksRef.current;
+      const index = currentTrackIndexRef?.current ?? -1;
+      const currentTrack = index >= 0 ? tracks[index] : undefined;
+      if (!currentTrack) return;
+      if (currentTrack.provider !== providerId) return;
+
+      const descriptor = providerRegistry.get(providerId);
+      if (!descriptor?.playback.prepareTrack) return;
+
+      const snapshot = loadSession();
+      const resolvedPosition =
+        snapshot?.trackId === currentTrack.id &&
+        typeof snapshot.playbackPosition === 'number'
+          ? snapshot.playbackPosition
+          : 0;
+
+      try {
+        descriptor.playback.prepareTrack(currentTrack, { positionMs: resolvedPosition });
+      } catch (error) {
+        logQueue('PROVIDER_RECONNECTED re-prime failed: %o', error);
+      }
+    };
+
+    window.addEventListener(PROVIDER_RECONNECTED_EVENT, handler);
+    return () => window.removeEventListener(PROVIDER_RECONNECTED_EVENT, handler);
+  }, [mediaTracksRef, currentTrackIndexRef]);
 
   const resolveTrackProvider = useCallback((mediaTrack?: MediaTrack): ProviderId | undefined => (
     mediaTrack?.provider

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -93,12 +93,12 @@ export const useProviderPlayback = ({
       return;
     }
 
-    // Sync the queue to the provider synchronously before playTrack so the
-    // adapter sees the current track list. The persistent useEffect-based
-    // onQueueChanged in usePlayerLogic only fires after React commits new
-    // state — too late for the playTrack we're about to await, which would
-    // otherwise hand Spotify a stale upcomingUris list (or no list at all
-    // on cold start) and let the SDK auto-advance into the wrong tracks.
+    // Push the latest queue snapshot to the driving provider before invoking
+    // playTrack so adapters that build their native queue from this signal
+    // (Spotify's upcomingUris) see the current list for the imminent
+    // playback call. User-driven queue mutations notify separately via
+    // useQueueManagement.ts; this call covers track transitions
+    // (next/previous/hydrate/auto-advance) that bypass that hook.
     descriptor.playback.onQueueChanged?.(tracks, index);
 
     try {

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -31,6 +31,13 @@ interface UseQueueManagementProps {
   handleBackToLibrary: () => void;
   activeDescriptor: ProviderDescriptor | undefined;
   getDescriptor: (providerId: ProviderId) => ProviderDescriptor | undefined;
+  /**
+   * Resolves the **driving** provider descriptor — the one producing audio, which
+   * may differ from `activeDescriptor` for cross-provider queues. Native-queue-sync
+   * notifications must target this descriptor so the SDK whose queue we are mirroring
+   * receives the update.
+   */
+  getDrivingProviderDescriptor: () => ProviderDescriptor | undefined;
 }
 
 interface UseQueueManagementReturn {
@@ -51,10 +58,21 @@ export function useQueueManagement({
   handleBackToLibrary,
   activeDescriptor,
   getDescriptor,
+  getDrivingProviderDescriptor,
 }: UseQueueManagementProps): UseQueueManagementReturn {
   const { setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef } = trackOps;
   const tracksRef = useRef(tracks);
   tracksRef.current = tracks;
+
+  const notifyQueueChanged = useCallback(
+    (nextTracks: MediaTrack[], nextIndex: number): void => {
+      const driving = getDrivingProviderDescriptor();
+      if (!driving) return;
+      if (!driving.capabilities?.hasNativeQueueSync) return;
+      driving.playback.onQueueChanged?.(nextTracks, nextIndex);
+    },
+    [getDrivingProviderDescriptor],
+  );
 
   /**
    * Fetch tracks from a collection (album/playlist) and append them to the
@@ -115,9 +133,11 @@ export function useQueueManagement({
           tracksRef.current.length,
           mediaTracksRef.current.length,
         );
+        const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-        setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+        setOriginalTracks(nextTracks);
         setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+        notifyQueueChanged(nextTracks, currentTrackIndex);
         logQueue(
           'handleAddToQueue — after append: mediaRef=%d, newTracks added: %s',
           mediaTracksRef.current.length,
@@ -131,7 +151,7 @@ export function useQueueManagement({
       }
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex]
   );
 
   const handleRemoveFromQueue = useCallback(
@@ -153,17 +173,21 @@ export function useQueueManagement({
       setOriginalTracks((prev) => prev.filter((t) => t.id !== removedTrack.id));
 
       // Adjust currentTrackIndex if removing before current
+      const adjustedIndex = index < currentTrackIndex ? currentTrackIndex - 1 : currentTrackIndex;
       if (index < currentTrackIndex) {
         setCurrentTrackIndex(prev => prev - 1);
       }
 
       // Remove from tracks by index
+      const nextTracks = tracks.filter((_, i) => i !== index);
       setTracks(prev => prev.filter((_, i) => i !== index));
+
+      notifyQueueChanged(nextTracks, adjustedIndex);
 
       logQueue('handleRemoveFromQueue — done, new queueLen=%d', tracks.length - 1);
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
+    [tracks, currentTrackIndex, handleBackToLibrary, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef, notifyQueueChanged]
   );
 
   const handleReorderQueue = useCallback(
@@ -199,13 +223,16 @@ export function useQueueManagement({
         setOriginalTracks(newTracks);
       }
 
-      setCurrentTrackIndex(newCurrentIndex >= 0 ? newCurrentIndex : 0);
+      const finalIndex = newCurrentIndex >= 0 ? newCurrentIndex : 0;
+      setCurrentTrackIndex(finalIndex);
       setTracks(newTracks);
+
+      notifyQueueChanged(newTracks, finalIndex);
 
       logQueue('handleReorderQueue — done, currentIndex=%d', newCurrentIndex);
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef]
+    [tracks, currentTrackIndex, shuffleEnabled, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef, notifyQueueChanged]
   );
 
   const queueTracksDirectly = useCallback(
@@ -226,12 +253,14 @@ export function useQueueManagement({
         tracksRef.current.length,
         mediaTracksRef.current.length,
       );
+      const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
       mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-      setOriginalTracks([...tracksRef.current, ...uniqueNewTracks]);
+      setOriginalTracks(nextTracks);
       setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
+      notifyQueueChanged(nextTracks, currentTrackIndex);
       return { added: uniqueNewTracks.length, collectionName };
     },
-    [mediaTracksRef, setOriginalTracks, setTracks]
+    [mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
   );
 
   /**
@@ -256,6 +285,7 @@ export function useQueueManagement({
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
         setOriginalTracks([...uniqueNewTracks]);
         setTracks([...uniqueNewTracks]);
+        notifyQueueChanged([...uniqueNewTracks], 0);
         return { added: uniqueNewTracks.length, collectionName };
       }
 
@@ -274,6 +304,8 @@ export function useQueueManagement({
       setOriginalTracks(nextTracks);
       setTracks(nextTracks);
 
+      notifyQueueChanged(nextTracks, currentTrackIndex);
+
       logQueue(
         'insertTracksNext — after insert: mediaRef=%d, newTracks added: %s',
         mediaTracksRef.current.length,
@@ -281,7 +313,7 @@ export function useQueueManagement({
       );
       return { added: uniqueNewTracks.length, collectionName };
     },
-    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks],
+    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
   );
 
   /**

--- a/src/providers/__tests__/dropboxAdapters.test.ts
+++ b/src/providers/__tests__/dropboxAdapters.test.ts
@@ -98,10 +98,18 @@ describe('DropboxPlaybackAdapter', () => {
       currentTime: 0,
       duration: 180,
       volume: 1,
-      play: vi.fn().mockResolvedValue(undefined),
+      play: vi.fn().mockImplementation(() => {
+        queueMicrotask(() => audioListeners['playing']?.({} as Event));
+        return Promise.resolve();
+      }),
       pause: vi.fn(),
       addEventListener: vi.fn((event: string, handler: EventListener) => {
         audioListeners[event] = handler;
+      }),
+      removeEventListener: vi.fn((event: string, handler: EventListener) => {
+        if (audioListeners[event] === handler) {
+          delete audioListeners[event];
+        }
       }),
     };
 

--- a/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
+++ b/src/providers/dropbox/__tests__/dropboxPlaybackAdapter.test.ts
@@ -8,6 +8,7 @@ import { DropboxPlaybackAdapter } from '../dropboxPlaybackAdapter';
 import type { DropboxCatalogAdapter } from '../dropboxCatalogAdapter';
 import { makeMediaTrack } from '@/test/fixtures';
 import type { PlaybackState } from '@/types/domain';
+import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 
 // Mock DropboxCatalogAdapter
 const mockCatalog: Partial<DropboxCatalogAdapter> = {
@@ -97,6 +98,14 @@ describe('DropboxPlaybackAdapter', () => {
       if (eventListeners[event]) {
         eventListeners[event] = eventListeners[event].filter((l) => l !== listener);
       }
+    });
+
+    // Default play() behavior: resolve immediately and asynchronously fire
+    // the `playing` event so awaitInitialPlay settles. Individual tests
+    // override this to simulate error or supersession scenarios.
+    mockAudio.play.mockImplementation(() => {
+      queueMicrotask(() => mockAudio.__triggerEvent?.('playing'));
+      return Promise.resolve();
     });
 
     adapter = new DropboxPlaybackAdapter(mockCatalog as DropboxCatalogAdapter);
@@ -498,6 +507,91 @@ describe('DropboxPlaybackAdapter', () => {
 
       // #when / #then
       await expect(adapter.probePlayable(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+  });
+
+  describe('playTrack error recovery', () => {
+    it('rejects with UnavailableTrackError when the audio element fires error during initial play', async () => {
+      // #given — audio element fails to decode/load; play() resolves but error event fires
+      const track = makeMediaTrack({
+        id: 'track-broken',
+        name: 'Broken Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/broken.mp3' },
+      });
+      await adapter.initialize();
+      mockAudio.play.mockImplementation(() => {
+        queueMicrotask(() => mockAudio.__triggerEvent?.('error'));
+        return Promise.resolve();
+      });
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(UnavailableTrackError);
+    });
+
+    it('rejects with UnavailableTrackError when audio.play() itself rejects', async () => {
+      // #given — autoplay policy blocks play, or some other terminal play() rejection
+      const track = makeMediaTrack({
+        id: 'track-blocked',
+        name: 'Blocked Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/blocked.mp3' },
+      });
+      await adapter.initialize();
+      mockAudio.play.mockImplementation(() => Promise.reject(new Error('NotAllowedError')));
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(UnavailableTrackError);
+    });
+
+    it('rethrows AuthExpiredError from catalog.getTemporaryLink unchanged', async () => {
+      // #given — Dropbox refresh-token exchange failed before audio src is assigned
+      const track = makeMediaTrack({
+        id: 'track-auth',
+        name: 'Auth Track',
+        playbackRef: { provider: 'dropbox', ref: '/Music/auth.mp3' },
+      });
+      await adapter.initialize();
+      vi.mocked(mockCatalog.getTemporaryLink!).mockRejectedValueOnce(
+        new AuthExpiredError('dropbox'),
+      );
+
+      // #when / #then
+      await expect(adapter.playTrack(track)).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+
+    it('ignores a stale error event after a superseding playTrack', async () => {
+      // #given — first playTrack pending; a second playTrack supersedes it via prepareGeneration
+      const trackA = makeMediaTrack({
+        id: 'track-a',
+        name: 'Track A',
+        playbackRef: { provider: 'dropbox', ref: '/Music/a.mp3' },
+      });
+      const trackB = makeMediaTrack({
+        id: 'track-b',
+        name: 'Track B',
+        playbackRef: { provider: 'dropbox', ref: '/Music/b.mp3' },
+      });
+      vi.mocked(mockCatalog.getTemporaryLink!)
+        .mockResolvedValueOnce('https://example.com/a.mp3')
+        .mockResolvedValueOnce('https://example.com/b.mp3');
+      await adapter.initialize();
+
+      // First play: never fires playing or error itself; the test will fire error AFTER B settles
+      mockAudio.play.mockImplementationOnce(() => Promise.resolve());
+
+      // #when — start A but don't let it settle; immediately supersede with B (which fires playing)
+      const playA = adapter.playTrack(trackA);
+      // Yield so A reaches awaitInitialPlay and attaches listeners
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Default mock (set in beforeEach) auto-fires playing for B
+      await adapter.playTrack(trackB);
+
+      // Now fire a stale error from A's prior src — must NOT reject A (or anything)
+      mockAudio.__triggerEvent?.('error');
+
+      // #then — A resolves cleanly because generation moved past it; no rejection
+      await expect(playA).resolves.toBeUndefined();
     });
   });
 });

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -283,9 +283,15 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
   private async primeAudioForHydrate(track: MediaTrack, positionMs?: number): Promise<void> {
     this.ensureAudio();
     const audio = this.audio!;
-    // Only prime audio when nothing is loaded — during next-track pre-warm
-    // the current src is mid-playback and must not be replaced.
-    if (audio.src && this.currentTrack) {
+    // Skip when audio is mid-playback for a *different* track — that's the
+    // next-track pre-warm path; we must not clobber the playing src.
+    // Allow the prime to proceed when the call targets the current track AND
+    // explicitly carries a positionMs (re-prime after re-authentication: the
+    // existing audio src holds an expired temporary link, so we want to fetch
+    // a fresh one and re-seat the seek bar at the saved position).
+    const isCurrentTrackReprime =
+      this.currentTrack?.id === track.id && positionMs !== undefined;
+    if (audio.src && this.currentTrack && !isCurrentTrackReprime) {
       logArtRace('dropbox.prepareTrack: skip emit (audio already loaded for current track) id=%s',
         track.id.slice(0, 8));
       return;

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -5,7 +5,7 @@
 
 import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
-import { AuthExpiredError } from '@/providers/errors';
+import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { DropboxCatalogAdapter } from './dropboxCatalogAdapter';
 import { parseID3 } from '@/utils/id3Parser';
 import { bytesToDataUrl } from '@/utils/bytesToDataUrl';
@@ -98,7 +98,8 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
     this.hydrateHint = null;
     this.audio!.pause();
     this.audio!.src = streamUrl;
-    await this.audio!.play();
+
+    await this.awaitInitialPlay(track, this.prepareGeneration);
 
     if (options?.positionMs) {
       this.audio!.currentTime = options.positionMs / 1000;
@@ -106,6 +107,58 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
 
     this.startUpdateInterval();
     this.enrichMetadataInBackground(track, streamUrl);
+  }
+
+  private awaitInitialPlay(track: MediaTrack, generation: number): Promise<void> {
+    const audio = this.audio!;
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = () => {
+        audio.removeEventListener('playing', onPlaying);
+        audio.removeEventListener('error', onError);
+      };
+
+      const onPlaying = () => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve();
+      };
+
+      const onError = () => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(new UnavailableTrackError(track.name));
+      };
+
+      audio.addEventListener('playing', onPlaying);
+      audio.addEventListener('error', onError);
+
+      audio.play().catch((err) => {
+        if (settled) return;
+        if (generation !== this.prepareGeneration) {
+          cleanup();
+          resolve();
+          return;
+        }
+        settled = true;
+        cleanup();
+        logCaughtError('dropboxPlaybackAdapter.awaitInitialPlay.audioPlay', err);
+        reject(new UnavailableTrackError(track.name));
+      });
+    });
   }
 
   private hydrateAlbumArtFromCache(track: MediaTrack): void {

--- a/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
+++ b/src/providers/mock/__tests__/mockPlaybackAdapter.test.ts
@@ -201,6 +201,20 @@ describe('MockPlaybackAdapter', () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
+    it('preserves audio.src when pre-warming against an already-playing track', () => {
+      // #given an audio element already loaded with a clip (mid-playback)
+      const originalSrc = 'blob:mock/currently-playing-clip';
+      mockAudio.src = originalSrc;
+      // #when prepareTrack is called without positionMs (pre-warm intent) —
+      // this happens in single-provider queues where nextDescriptor ===
+      // currentDescriptor at the pre-warm call site
+      adapter.prepareTrack(makeTrack('seed-track'));
+      // #then audio.src is unchanged and load() is not invoked, so the
+      // currently-playing audio is not interrupted
+      expect(mockAudio.src).toBe(originalSrc);
+      expect(mockAudio.load).not.toHaveBeenCalled();
+    });
+
     it('does not emit state when positionMs is undefined', () => {
       // #given a subscribed listener
       const listener = vi.fn();

--- a/src/providers/mock/__tests__/test-control.test.ts
+++ b/src/providers/mock/__tests__/test-control.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { installMockTestApi } from '../test-control';
+import { MockAuthAdapter } from '../mockAuthAdapter';
 import type { MockCatalogAdapter } from '../mockCatalogAdapter';
 import type { MockPlaybackAdapter } from '../mockPlaybackAdapter';
 import type { MediaTrack } from '@/types/domain';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 
 function makeTrack(overrides: Partial<MediaTrack> & Pick<MediaTrack, 'id' | 'provider'>): MediaTrack {
   return {
@@ -37,16 +40,22 @@ const dropboxTrack = makeTrack({ id: 'db-1', provider: 'dropbox' });
 describe('installMockTestApi', () => {
   let spotifyPlayback: MockPlaybackAdapter;
   let dropboxPlayback: MockPlaybackAdapter;
+  let spotifyAuth: MockAuthAdapter;
+  let dropboxAuth: MockAuthAdapter;
 
   beforeEach(() => {
     delete window.__mockTest;
     spotifyPlayback = makePlaybackStub();
     dropboxPlayback = makePlaybackStub();
+    spotifyAuth = new MockAuthAdapter('spotify');
+    dropboxAuth = new MockAuthAdapter('dropbox');
     installMockTestApi({
       spotifyCatalog: makeCatalogStub([spotifyTrack]),
       dropboxCatalog: makeCatalogStub([dropboxTrack]),
       spotifyPlayback,
       dropboxPlayback,
+      spotifyAuth,
+      dropboxAuth,
     });
   });
 
@@ -65,6 +74,8 @@ describe('installMockTestApi', () => {
       dropboxCatalog: makeCatalogStub([]),
       spotifyPlayback: makePlaybackStub(),
       dropboxPlayback: makePlaybackStub(),
+      spotifyAuth: new MockAuthAdapter('spotify'),
+      dropboxAuth: new MockAuthAdapter('dropbox'),
     });
 
     // #then
@@ -141,6 +152,62 @@ describe('installMockTestApi', () => {
       await expect(
         window.__mockTest!.setPlaybackState({ trackId: 'no-such-track' }),
       ).rejects.toThrow('Track id "no-such-track" not found in snapshots.');
+    });
+  });
+
+  describe('expireAuth / restoreAuth', () => {
+    it('expireAuth flips the adapter to unauthenticated and dispatches AUTH_STATE_CHANGED_EVENT', async () => {
+      // #given
+      let fired = 0;
+      window.addEventListener(AUTH_STATE_CHANGED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify');
+
+      // #then
+      expect(spotifyAuth.isAuthenticated()).toBe(false);
+      expect(fired).toBe(1);
+    });
+
+    it('expireAuth does NOT dispatch SESSION_EXPIRED_EVENT by default', async () => {
+      // #given
+      let fired = 0;
+      window.addEventListener(SESSION_EXPIRED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify');
+
+      // #then
+      expect(fired).toBe(0);
+    });
+
+    it('expireAuth dispatches SESSION_EXPIRED_EVENT when alsoDispatchSessionExpired is true', async () => {
+      // #given
+      const events: Array<{ providerId: string }> = [];
+      window.addEventListener(SESSION_EXPIRED_EVENT, (e) => {
+        events.push((e as CustomEvent<{ providerId: string }>).detail);
+      });
+
+      // #when
+      await window.__mockTest!.expireAuth('spotify', { alsoDispatchSessionExpired: true });
+
+      // #then
+      expect(events).toEqual([{ providerId: 'spotify' }]);
+      expect(spotifyAuth.isAuthenticated()).toBe(false);
+    });
+
+    it('restoreAuth flips the adapter back to authenticated and dispatches AUTH_STATE_CHANGED_EVENT', async () => {
+      // #given
+      spotifyAuth.__testExpire();
+      let fired = 0;
+      window.addEventListener(AUTH_STATE_CHANGED_EVENT, () => { fired += 1; });
+
+      // #when
+      await window.__mockTest!.restoreAuth('spotify');
+
+      // #then
+      expect(spotifyAuth.isAuthenticated()).toBe(true);
+      expect(fired).toBe(1);
     });
   });
 

--- a/src/providers/mock/mockAuthAdapter.ts
+++ b/src/providers/mock/mockAuthAdapter.ts
@@ -3,29 +3,42 @@ import type { ProviderId } from '@/types/domain';
 
 export class MockAuthAdapter implements AuthProvider {
   readonly providerId: ProviderId;
+  private authenticated = true;
 
   constructor(providerId: ProviderId) {
     this.providerId = providerId;
   }
 
   isAuthenticated(): boolean {
-    return true;
+    return this.authenticated;
   }
 
   getAccessToken(): Promise<string | null> {
-    return Promise.resolve('mock-access-token');
+    return Promise.resolve(this.authenticated ? 'mock-access-token' : null);
   }
 
   beginLogin(): Promise<void> {
+    this.authenticated = true;
     return Promise.resolve();
   }
 
   handleCallback(url: URL): Promise<boolean> {
     void url;
+    this.authenticated = true;
     return Promise.resolve(true);
   }
 
   logout(): void {
-    // no-op
+    this.authenticated = false;
+  }
+
+  /** Test-only: flip the adapter back into the authenticated state. */
+  __testRestoreAuth(): void {
+    this.authenticated = true;
+  }
+
+  /** Test-only: force the adapter into the expired/unauthenticated state. */
+  __testExpire(): void {
+    this.authenticated = false;
   }
 }

--- a/src/providers/mock/mockPlaybackAdapter.ts
+++ b/src/providers/mock/mockPlaybackAdapter.ts
@@ -167,15 +167,24 @@ export class MockPlaybackAdapter implements PlaybackProvider {
 
   prepareTrack(track: MediaTrack, options?: { positionMs?: number }): void {
     const audio = this.ensureAudio();
-    audio.src = clipUrlForTrack(track.id);
-    audio.load();
 
     if (options?.positionMs !== undefined) {
+      // Hydrate intent: load the requested clip and emit staged state. Skip
+      // the load when the audio element already holds the same track to avoid
+      // restarting a mid-flight playback.
+      if (!(audio.src && this.currentTrack?.id === track.id)) {
+        audio.src = clipUrlForTrack(track.id);
+        audio.load();
+      }
       this.currentTrack = track;
       this.startedAtPositionMs = options.positionMs;
       this.startedAtMs = Date.now();
       this.notifyListeners();
     }
+    // Pre-warm intent (options omitted / positionMs undefined): no-op. The
+    // real providers do not mutate the audio element during pre-warm, so the
+    // mock must preserve the currently-playing src — see Dropbox's
+    // primeAudioForHydrate guard at dropboxPlaybackAdapter.ts:235.
   }
 
   probePlayable(track: MediaTrack): Promise<boolean> {

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -93,5 +93,7 @@ if (shouldUseMockProvider()) {
     dropboxCatalog: dropboxDescriptor.catalog as MockCatalogAdapter,
     spotifyPlayback: spotifyDescriptor.playback as MockPlaybackAdapter,
     dropboxPlayback: dropboxDescriptor.playback as MockPlaybackAdapter,
+    spotifyAuth: spotifyDescriptor.auth as MockAuthAdapter,
+    dropboxAuth: dropboxDescriptor.auth as MockAuthAdapter,
   });
 }

--- a/src/providers/mock/test-control.ts
+++ b/src/providers/mock/test-control.ts
@@ -9,11 +9,31 @@
 // `shouldUseMockProvider()` is true, so it is a no-op in production.
 import type { MockCatalogAdapter } from './mockCatalogAdapter';
 import type { MockPlaybackAdapter } from './mockPlaybackAdapter';
-import type { MediaTrack } from '@/types/domain';
+import type { MockAuthAdapter } from './mockAuthAdapter';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { AUTH_STATE_CHANGED_EVENT } from '@/hooks/usePopupAuth';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
+
+export interface ExpireAuthOptions {
+  /**
+   * When true, ALSO dispatch SESSION_EXPIRED_EVENT alongside the
+   * AUTH_STATE_CHANGED_EVENT. Defaults to false — the narrower simulation
+   * mirrors the legacy behavior and keeps existing Playwright specs stable.
+   *
+   * Real expiry in production dispatches both events (the refresh-token
+   * rejection path fires SESSION_EXPIRED; the resulting state flip fires
+   * AUTH_STATE_CHANGED). Opt in to this flag when an end-to-end test needs
+   * the SESSION_EXPIRED handler in the SpotifyPlaybackAdapter (and other
+   * listeners) to run ahead of the reconnect.
+   */
+  alsoDispatchSessionExpired?: boolean;
+}
 
 export interface MockTestApi {
   setQueue(trackIds: string[]): Promise<void>;
   setPlaybackState(state: { trackId: string; positionMs?: number; isPlaying?: boolean }): Promise<void>;
+  expireAuth(providerId: ProviderId, opts?: ExpireAuthOptions): Promise<void>;
+  restoreAuth(providerId: ProviderId): Promise<void>;
   reset(): Promise<void>;
 }
 
@@ -22,13 +42,28 @@ export interface InstallOptions {
   dropboxCatalog: MockCatalogAdapter;
   spotifyPlayback: MockPlaybackAdapter;
   dropboxPlayback: MockPlaybackAdapter;
+  spotifyAuth: MockAuthAdapter;
+  dropboxAuth: MockAuthAdapter;
 }
 
 export function installMockTestApi(opts: InstallOptions): void {
   if (typeof window === 'undefined') return;
   if (window.__mockTest) return;
 
-  const { spotifyCatalog, dropboxCatalog, spotifyPlayback, dropboxPlayback } = opts;
+  const {
+    spotifyCatalog,
+    dropboxCatalog,
+    spotifyPlayback,
+    dropboxPlayback,
+    spotifyAuth,
+    dropboxAuth,
+  } = opts;
+
+  function resolveAuth(providerId: ProviderId): MockAuthAdapter {
+    if (providerId === 'spotify') return spotifyAuth;
+    if (providerId === 'dropbox') return dropboxAuth;
+    throw new Error(`[MockTestApi] Unknown providerId "${providerId}"`);
+  }
 
   function resolveTrack(id: string): MediaTrack {
     const track =
@@ -53,6 +88,21 @@ export function installMockTestApi(opts: InstallOptions): void {
       if (!isPlaying) {
         await adapter.pause();
       }
+    },
+
+    async expireAuth(providerId, opts) {
+      resolveAuth(providerId).__testExpire();
+      window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
+      if (opts?.alsoDispatchSessionExpired) {
+        window.dispatchEvent(
+          new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId } }),
+        );
+      }
+    },
+
+    async restoreAuth(providerId) {
+      resolveAuth(providerId).__testRestoreAuth();
+      window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGED_EVENT));
     },
 
     async reset() {

--- a/src/providers/spotify/__tests__/spotifyAuthAdapter.test.ts
+++ b/src/providers/spotify/__tests__/spotifyAuthAdapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockSpotifyLogout,
+  mockSpotifyIsAuthenticated,
+  mockClearLikedCountSnapshot,
+  mockClearAllSpotifyInMemoryCaches,
+  mockClearLibraryCache,
+} = vi.hoisted(() => ({
+  mockSpotifyLogout: vi.fn(),
+  mockSpotifyIsAuthenticated: vi.fn().mockReturnValue(true),
+  mockClearLikedCountSnapshot: vi.fn(),
+  mockClearAllSpotifyInMemoryCaches: vi.fn(),
+  mockClearLibraryCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/spotify', () => ({
+  spotifyAuth: {
+    isAuthenticated: mockSpotifyIsAuthenticated,
+    logout: mockSpotifyLogout,
+    ensureValidToken: vi.fn().mockResolvedValue('tok'),
+    getAccessToken: vi.fn().mockReturnValue('tok'),
+    getAuthUrl: vi.fn().mockResolvedValue('https://accounts.spotify.com/authorize'),
+    redirectToAuth: vi.fn().mockResolvedValue(undefined),
+    handleRedirect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/services/cache/likedCountSnapshot', () => ({
+  clearLikedCountSnapshot: mockClearLikedCountSnapshot,
+}));
+
+vi.mock('@/services/spotify/cache', () => ({
+  clearAllSpotifyInMemoryCaches: mockClearAllSpotifyInMemoryCaches,
+}));
+
+vi.mock('@/services/cache/libraryCache', () => ({
+  clearAll: mockClearLibraryCache,
+}));
+
+import { SpotifyAuthAdapter } from '@/providers/spotify/spotifyAuthAdapter';
+
+describe('SpotifyAuthAdapter.logout', () => {
+  let adapter: SpotifyAuthAdapter;
+
+  beforeEach(() => {
+    adapter = new SpotifyAuthAdapter();
+    vi.clearAllMocks();
+    mockClearLibraryCache.mockResolvedValue(undefined);
+  });
+
+  it('calls spotifyAuth.logout', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockSpotifyLogout).toHaveBeenCalledOnce();
+  });
+
+  it('clears liked count snapshot', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearLikedCountSnapshot).toHaveBeenCalledWith('spotify');
+  });
+
+  it('clears all in-memory Spotify caches', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearAllSpotifyInMemoryCaches).toHaveBeenCalledOnce();
+  });
+
+  it('fires IDB library cache clear', () => {
+    // #when
+    adapter.logout();
+
+    // #then
+    expect(mockClearLibraryCache).toHaveBeenCalledOnce();
+  });
+});

--- a/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
+++ b/src/providers/spotify/__tests__/spotifyPlaybackAdapterPrepareTrack.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SpotifyPlaybackAdapter } from '@/providers/spotify/spotifyPlaybackAdapter';
 import { spotifyPlayer, waitForSpotifyReady } from '@/services/spotifyPlayer';
 import { AuthExpiredError } from '@/providers/errors';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 import type { MediaTrack, PlaybackState } from '@/types/domain';
 
 vi.mock('@/services/spotifyPlayer', () => ({
@@ -367,5 +368,65 @@ describe('SpotifyPlaybackAdapter.prepareTrack', () => {
 
     // A's emission count stays at 1 (only the synchronous emit; no post-transfer re-emit)
     expect(stageEmissions.filter((s) => s?.currentTrackId === 'a')).toHaveLength(1);
+  });
+
+  describe('SESSION_EXPIRED re-prime', () => {
+    it('re-emits state on a same-track prepareTrack after SESSION_EXPIRED resets the guard', async () => {
+      // #given — adapter has staged track-1 once already; without the
+      // SESSION_EXPIRED reset, the `preparedTrackRef === uri` guard would
+      // silently drop a same-track re-prime fired by `PROVIDER_RECONNECTED`,
+      // and the seek bar would remain stuck at 0:00 / 0:00 after re-auth
+      // (issue #1571).
+      const track = makeTrack();
+      const stageEmissions: PlaybackState[] = [];
+      adapter.subscribe((state) => {
+        if (state?.currentTrackId === track.id && !state.isPlaying) {
+          stageEmissions.push(state);
+        }
+      });
+
+      adapter.prepareTrack(track, { positionMs: 15_000 });
+      await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+      await vi.waitFor(() =>
+        expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(1),
+      );
+
+      // #when — simulate provider session expiry, then re-prime same track
+      window.dispatchEvent(
+        new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),
+      );
+      adapter.prepareTrack(track, { positionMs: 15_000 });
+
+      // #then — second prepareTrack must re-emit (guard cleared) and trigger
+      // another Connect transfer.
+      expect(stageEmissions).toHaveLength(2);
+      await vi.waitFor(() =>
+        expect(vi.mocked(spotifyPlayer.transferPlaybackToDevice)).toHaveBeenCalledTimes(2),
+      );
+    });
+
+    it('ignores SESSION_EXPIRED events for other providers', async () => {
+      // #given — only Spotify's preparedTrackRef should reset; a Dropbox
+      // session-expiry event should not clear Spotify's guard.
+      const track = makeTrack();
+      const stageEmissions: PlaybackState[] = [];
+      adapter.subscribe((state) => {
+        if (state?.currentTrackId === track.id && !state.isPlaying) {
+          stageEmissions.push(state);
+        }
+      });
+
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+      await vi.waitFor(() => expect(stageEmissions).toHaveLength(1));
+
+      // #when
+      window.dispatchEvent(
+        new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'dropbox' } }),
+      );
+      adapter.prepareTrack(track, { positionMs: 10_000 });
+
+      // #then — Spotify guard still set → second prepare is a no-op
+      expect(stageEmissions).toHaveLength(1);
+    });
   });
 });

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -62,4 +62,8 @@ export class SpotifyAuthAdapter implements AuthProvider {
     spotifyAuth.logout();
     clearLikedCountSnapshot('spotify');
   }
+
+  reportUnauthorized(): void {
+    spotifyAuth.reportUnauthorized();
+  }
 }

--- a/src/providers/spotify/spotifyAuthAdapter.ts
+++ b/src/providers/spotify/spotifyAuthAdapter.ts
@@ -7,6 +7,8 @@ import type { AuthProvider } from '@/types/providers';
 import type { ProviderId } from '@/types/domain';
 import { spotifyAuth } from '@/services/spotify';
 import { clearLikedCountSnapshot } from '@/services/cache/likedCountSnapshot';
+import { clearAllSpotifyInMemoryCaches } from '@/services/spotify/cache';
+import { clearAll as clearLibraryCache } from '@/services/cache/libraryCache';
 import { logCaughtError } from '@/utils/logCaughtError';
 
 export class SpotifyAuthAdapter implements AuthProvider {
@@ -61,6 +63,8 @@ export class SpotifyAuthAdapter implements AuthProvider {
   logout(): void {
     spotifyAuth.logout();
     clearLikedCountSnapshot('spotify');
+    clearAllSpotifyInMemoryCaches();
+    void clearLibraryCache();
   }
 
   reportUnauthorized(): void {

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -11,6 +11,7 @@ import { spotifyApiRequest, SpotifyApiError } from '@/services/spotify/api';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
+import { SESSION_EXPIRED_EVENT } from '@/constants/events';
 import { AuthExpiredError, UnavailableTrackError } from '@/providers/errors';
 import { spotifyQueueSync } from './spotifyQueueSync';
 import { logSpotify, logArtRace } from '@/lib/debugLog';
@@ -43,6 +44,30 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
   private sdkUnsubscribe: (() => void) | null = null;
   /** Ref of the track most recently staged by prepareTrack; used for idempotency. */
   private preparedTrackRef: string | null = null;
+  /**
+   * Listener that resets `preparedTrackRef` when the Spotify session expires.
+   *
+   * Why: `prepareTrack` short-circuits when `preparedTrackRef === uri` to keep
+   * back-to-back hydrate calls cheap. Across a session boundary that guard
+   * becomes a bug — after SESSION_EXPIRED + reconnect, the SDK has detached
+   * and emitted no state, so a same-track re-prime is the only thing that
+   * repaints the seek bar (issue #1571). Resetting on SESSION_EXPIRED lets
+   * the next `prepareTrack(currentTrack, { positionMs })` from
+   * `useProviderPlayback`'s `PROVIDER_RECONNECTED_EVENT` handler stage state
+   * again.
+   */
+  private readonly handleSessionExpired = (event: Event): void => {
+    const detail = (event as CustomEvent<{ providerId: ProviderId }>).detail;
+    if (detail?.providerId !== 'spotify') return;
+    this.preparedTrackRef = null;
+    this.playbackSessionActive = false;
+  };
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      window.addEventListener(SESSION_EXPIRED_EVENT, this.handleSessionExpired);
+    }
+  }
 
   private async ensurePlaybackReady(): Promise<void> {
     await spotifyPlayer.initialize();

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -7,7 +7,7 @@ import type { PlaybackProvider } from '@/types/providers';
 import type { ProviderId, MediaTrack, PlaybackState, CollectionRef } from '@/types/domain';
 import { spotifyPlayer, waitForSpotifyReady } from '@/services/spotifyPlayer';
 import { spotifyAuth } from '@/services/spotify';
-import { spotifyApiRequest } from '@/services/spotify/api';
+import { spotifyApiRequest, SpotifyApiError } from '@/services/spotify/api';
 import { isAlbumId, extractAlbumId } from '@/constants/playlist';
 import { SPOTIFY_MAX_RETRIES, SPOTIFY_BASE_BACKOFF_MS } from '@/constants/spotify';
 import { SPOTIFY_DEVICE_ACTIVATE_RETRIES, SPOTIFY_DEVICE_ACTIVATE_DELAY_MS } from '@/constants/timing';
@@ -113,17 +113,24 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
     try {
       await spotifyPlayer.playTrack(uri, upcomingUris, positionMs);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      if (message.includes('401') || message.toLowerCase().includes('unauthorized')) {
+      if (error instanceof AuthExpiredError) {
+        throw error;
+      }
+      if (error instanceof SpotifyApiError && error.status === 401) {
         throw new AuthExpiredError('spotify');
       }
+
+      const message = error instanceof Error ? error.message : String(error);
 
       if (retryCount >= SPOTIFY_MAX_RETRIES) {
         throw error;
       }
 
-      if (message.includes('429')) {
+      const status = error instanceof SpotifyApiError ? error.status : null;
+      const is429 = status === 429 || (status === null && message.includes('429'));
+      const is403 = status === 403 || (status === null && message.includes('403'));
+
+      if (is429) {
         const retryAfterMatch = message.match(/retry.?after[:\s]+(\d+)/i);
         const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1], 10) : 0;
         const backoffMs = retryAfterSec > 0
@@ -134,7 +141,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
         return this.playWithRetry(uri, trackName, upcomingUris, retryCount + 1, positionMs);
       }
 
-      if (message.includes('403')) {
+      if (is403) {
         if (message.includes('Restriction violated')) {
           throw new UnavailableTrackError(trackName);
         }
@@ -262,9 +269,11 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
       );
       return body.is_playable !== false;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('401')) throw new AuthExpiredError('spotify');
-      if (message.includes('404')) return false;
+      if (err instanceof AuthExpiredError) throw err;
+      if (err instanceof SpotifyApiError) {
+        if (err.status === 401) throw new AuthExpiredError('spotify');
+        if (err.status === 404) return false;
+      }
       throw err;
     }
   }

--- a/src/services/__tests__/spotifyAuth.test.ts
+++ b/src/services/__tests__/spotifyAuth.test.ts
@@ -405,4 +405,46 @@ describe('SpotifyAuth', () => {
       expect(window.history.replaceState).toHaveBeenCalled();
     });
   });
+
+  describe('reportUnauthorized', () => {
+    it('dispatches SESSION_EXPIRED_EVENT even when tokenData is already null', async () => {
+      // #given — no token in storage, so tokenData starts as null
+      const auth = await freshAuth();
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      auth.reportUnauthorized();
+
+      // #then — the event still fires; the absent-tokenData branch no longer
+      // silently suppresses the toast for callers invoking after logout().
+      const dispatchedEvents = dispatchSpy.mock.calls.map(call => (call[0] as Event).type);
+      expect(dispatchedEvents).toContain('vorbis-session-expired');
+      dispatchSpy.mockRestore();
+    });
+
+    it('does not double-dispatch when called twice in the same session', async () => {
+      // #given — token present, then reportUnauthorized twice (simulates
+      // performRefresh 400/401 → reportUnauthorized → executeWithAuthRetry
+      // catch → reportUnauthorized again).
+      const token = {
+        access_token: 'old-token',
+        refresh_token: 'my-refresh',
+        expires_at: Date.now() + 30 * 60 * 1000,
+      };
+      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(token));
+      const auth = await freshAuth();
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+      // #when
+      auth.reportUnauthorized();
+      auth.reportUnauthorized();
+
+      // #then — exactly one session-expired event reaches listeners
+      const sessionExpiredEvents = dispatchSpy.mock.calls.filter(
+        call => (call[0] as Event).type === 'vorbis-session-expired',
+      );
+      expect(sessionExpiredEvents).toHaveLength(1);
+      dispatchSpy.mockRestore();
+    });
+  });
 });

--- a/src/services/__tests__/spotifyPlayer.test.ts
+++ b/src/services/__tests__/spotifyPlayer.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/services/spotify', () => ({
     isAuthenticated: vi.fn().mockReturnValue(true),
     ensureValidToken: vi.fn().mockResolvedValue('token'),
     redirectToAuth: vi.fn(),
+    reportUnauthorized: vi.fn(),
   },
 }));
 

--- a/src/services/spotify/__tests__/api.test.ts
+++ b/src/services/spotify/__tests__/api.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const refreshAccessToken = vi.fn();
+const getAccessToken = vi.fn();
+const reportUnauthorized = vi.fn();
+
+vi.mock('../auth', () => ({
+  spotifyAuth: {
+    refreshAccessToken: (...args: unknown[]) => refreshAccessToken(...args),
+    getAccessToken: (...args: unknown[]) => getAccessToken(...args),
+    reportUnauthorized: (...args: unknown[]) => reportUnauthorized(...args),
+  },
+}));
+
+import { spotifyApiRequest, SpotifyApiError } from '../api';
+import { AuthExpiredError } from '@/providers/errors';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function emptyResponse(status: number, statusText = ''): Response {
+  return new Response(null, { status, statusText });
+}
+
+describe('spotifyApiRequest — structured errors and retry-after-refresh', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    refreshAccessToken.mockReset();
+    getAccessToken.mockReset();
+    reportUnauthorized.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws SpotifyApiError carrying status on a 5xx (transient — no refresh, no logout)', async () => {
+    // #given — server returns 500
+    fetchMock.mockResolvedValueOnce(emptyResponse(500, 'Internal Server Error'));
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 500 });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('forces a refresh and retries once on first 401, succeeding on the retry', async () => {
+    // #given — first call 401, second call (after refresh) 200
+    fetchMock
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'))
+      .mockResolvedValueOnce(jsonResponse({ id: 'me-1' }));
+    refreshAccessToken.mockResolvedValue(undefined);
+    getAccessToken.mockReturnValue('token-2-fresh');
+
+    // #when
+    const result = await spotifyApiRequest<{ id: string }>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+
+    // #then
+    expect(result).toEqual({ id: 'me-1' });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+
+    // #and the retry used the freshly-refreshed token
+    const retryInit = fetchMock.mock.calls[1][1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>).Authorization).toBe(
+      'Bearer token-2-fresh',
+    );
+  });
+
+  it('throws AuthExpiredError and calls reportUnauthorized on a second 401 after refresh', async () => {
+    // #given — both calls 401; refresh succeeds but the freshly-minted token is also rejected
+    fetchMock
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'))
+      .mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockResolvedValue(undefined);
+    getAccessToken.mockReturnValue('token-2-fresh-but-dead');
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(AuthExpiredError);
+    await expect(promise).rejects.toMatchObject({ providerId: 'spotify' });
+    expect(reportUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws AuthExpiredError when refresh fails terminally (auth cleared by performRefresh)', async () => {
+    // #given — first call 401, refresh throws AND performRefresh cleared tokenData
+    //          (i.e. accounts.spotify.com/api/token returned 400/401 and the auth
+    //          singleton already invoked reportUnauthorized → logout → getAccessToken null)
+    fetchMock.mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockRejectedValue(new Error('Token refresh failed: Bad Request'));
+    getAccessToken.mockReturnValue(null);
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(AuthExpiredError);
+    // reportUnauthorized was called by performRefresh itself, not by the wrapper —
+    // the wrapper relies on the cleared-token signal and does not re-invoke it.
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows original SpotifyApiError(401) on transient refresh failure (network blip / 5xx)', async () => {
+    // #given — first call 401, refresh throws a transient error (network blip),
+    //          and the auth singleton still has its tokenData (getAccessToken returns the stale token)
+    fetchMock.mockResolvedValueOnce(emptyResponse(401, 'Unauthorized'));
+    refreshAccessToken.mockRejectedValue(new Error('network blip'));
+    getAccessToken.mockReturnValue('token-1-stale');
+
+    // #when / #then — caller sees the original 401, not AuthExpiredError; user is NOT logged out
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me',
+      'token-1-stale',
+      { method: 'POST' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 401 });
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on non-401 errors (e.g. 403)', async () => {
+    // #given — server returns 403
+    fetchMock.mockResolvedValueOnce(emptyResponse(403, 'Forbidden'));
+
+    // #when / #then
+    const promise = spotifyApiRequest<unknown>(
+      'https://api.spotify.com/v1/me/player',
+      'token-1',
+      { method: 'PUT' },
+    );
+    await expect(promise).rejects.toBeInstanceOf(SpotifyApiError);
+    await expect(promise).rejects.toMatchObject({ status: 403 });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(reportUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -1,5 +1,25 @@
 import type { PaginatedResponse } from './types';
 import { SPOTIFY_RATE_LIMIT_WAIT_S } from '@/constants/spotify';
+import { spotifyAuth } from './auth';
+import { AuthExpiredError } from '@/providers/errors';
+
+/**
+ * Structured error thrown for any non-OK Spotify Web API response.
+ * Carries the HTTP `status` so downstream consumers can branch on the status
+ * code without parsing the error message string. The message format is kept
+ * stable (`Spotify API error: <status> <statusText>`) so log/breadcrumb queries
+ * targeting the legacy generic-Error message continue to match.
+ */
+export class SpotifyApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  constructor(status: number, statusText: string, message?: string) {
+    super(message ?? `Spotify API error: ${status} ${statusText}`);
+    this.name = 'SpotifyApiError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
 
 // =============================================================================
 // Rate Limiting & Request Deduplication
@@ -57,7 +77,7 @@ async function executeApiRequest<T>(
   handleRateLimitResponse(response);
 
   if (!response.ok) {
-    throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
+    throw new SpotifyApiError(response.status, response.statusText);
   }
 
   if (response.status === 204) {
@@ -69,6 +89,66 @@ async function executeApiRequest<T>(
     return undefined as T;
   }
   return JSON.parse(text);
+}
+
+/**
+ * Wrap a single `executeApiRequest` call with one-shot retry-after-refresh on
+ * 401: on the first 401 we force a token refresh and re-issue the request with
+ * the freshly-minted access token; on a second 401 we throw `AuthExpiredError`
+ * and notify the auth layer via `reportUnauthorized()`, which logs out and
+ * dispatches `SESSION_EXPIRED_EVENT`.
+ *
+ * Refresh-endpoint failures are split: a terminal 400/401 from
+ * `accounts.spotify.com/api/token` (`performRefresh` already cleared
+ * `tokenData` and called `reportUnauthorized()`) escalates to
+ * `AuthExpiredError`. Any other refresh exception (network blip, 5xx) is
+ * treated as transient — we rethrow the original `SpotifyApiError(401)` so
+ * the caller can retry later without the user being logged out. This mirrors
+ * `performRefresh`'s policy of only treating 400/401 from the refresh
+ * endpoint as terminal.
+ *
+ * Non-401 errors from the resource request propagate as `SpotifyApiError`
+ * (transient — no logout).
+ */
+async function executeWithAuthRetry<T>(
+  url: string,
+  token: string,
+  options: RequestInit,
+): Promise<T> {
+  try {
+    return await executeApiRequest<T>(url, token, options);
+  } catch (err) {
+    if (!(err instanceof SpotifyApiError) || err.status !== 401) {
+      throw err;
+    }
+
+    let refreshedToken: string;
+    try {
+      await spotifyAuth.refreshAccessToken();
+      const next = spotifyAuth.getAccessToken();
+      if (!next) {
+        spotifyAuth.reportUnauthorized();
+        throw new AuthExpiredError('spotify');
+      }
+      refreshedToken = next;
+    } catch (refreshErr) {
+      if (refreshErr instanceof AuthExpiredError) throw refreshErr;
+      if (spotifyAuth.getAccessToken() === null) {
+        throw new AuthExpiredError('spotify');
+      }
+      throw err;
+    }
+
+    try {
+      return await executeApiRequest<T>(url, refreshedToken, options);
+    } catch (retryErr) {
+      if (retryErr instanceof SpotifyApiError && retryErr.status === 401) {
+        spotifyAuth.reportUnauthorized();
+        throw new AuthExpiredError('spotify');
+      }
+      throw retryErr;
+    }
+  }
 }
 
 export async function spotifyApiRequest<T>(
@@ -93,14 +173,14 @@ export async function spotifyApiRequest<T>(
       return existing as Promise<T>;
     }
 
-    const promise = executeApiRequest<T>(url, token, options).finally(() => {
+    const promise = executeWithAuthRetry<T>(url, token, options).finally(() => {
       inflightRequests.delete(key);
     });
     inflightRequests.set(key, promise);
     return promise;
   }
 
-  return executeApiRequest<T>(url, token, options);
+  return executeWithAuthRetry<T>(url, token, options);
 }
 
 export async function fetchAllPaginated<TItem, TResult>(

--- a/src/services/spotify/auth.ts
+++ b/src/services/spotify/auth.ts
@@ -34,6 +34,7 @@ const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 class SpotifyAuth {
   private tokenData: TokenData | null = null;
   private refreshInFlight: Promise<void> | null = null;
+  private sessionExpiredNotified = false;
 
   constructor() {
     this.loadTokenFromStorage();
@@ -64,6 +65,7 @@ class SpotifyAuth {
 
   private saveTokenToStorage(tokenData: TokenData): void {
     this.tokenData = tokenData;
+    this.sessionExpiredNotified = false;
     localStorage.setItem('spotify_token', JSON.stringify(tokenData));
   }
 
@@ -176,8 +178,7 @@ class SpotifyAuth {
 
     if (!response.ok) {
       if (response.status === 400 || response.status === 401) {
-        this.logout();
-        this.notifySessionExpired();
+        this.reportUnauthorized();
       }
       throw new Error(`Token refresh failed: ${response.statusText}`);
     }
@@ -190,7 +191,25 @@ class SpotifyAuth {
     });
   }
 
-  private notifySessionExpired(): void {
+  /**
+   * Called by API consumers (and `performRefresh` itself on a 400/401 from the
+   * refresh endpoint) when the session is no longer recoverable. Clears any
+   * surviving tokens and dispatches `SESSION_EXPIRED_EVENT` once per session.
+   *
+   * Idempotent: a follow-up invocation after `logout()` (e.g. a wrapper catch
+   * path after `performRefresh` already cleared `tokenData`) re-dispatches
+   * nothing thanks to `sessionExpiredNotified`, but earlier we would have
+   * silently skipped the event entirely whenever `tokenData` was already null.
+   * The notification flag resets on the next successful `saveTokenToStorage`,
+   * so a fresh login can surface a future session-expired toast.
+   */
+  public reportUnauthorized(): void {
+    if (this.sessionExpiredNotified) return;
+    this.sessionExpiredNotified = true;
+    console.warn('[spotifyAuth] Persistent 401 — logging out');
+    if (this.tokenData) {
+      this.logout();
+    }
     if (typeof window === 'undefined') return;
     window.dispatchEvent(
       new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { providerId: 'spotify' } }),

--- a/src/services/spotify/cache.ts
+++ b/src/services/spotify/cache.ts
@@ -58,3 +58,15 @@ export function getLikedSongsCache(): { data: Track[]; limit: number; timestamp:
 export function setLikedSongsCache(value: { data: Track[]; limit: number; timestamp: number } | null): void {
   likedSongsCacheData = value;
 }
+
+/**
+ * Clear all in-memory Spotify caches. Called on logout so the next session
+ * starts with a clean slate instead of serving stale data from a previous account.
+ */
+export function clearAllSpotifyInMemoryCaches(): void {
+  trackSavedCache.clear();
+  albumSavedCache.clear();
+  trackListCache.clear();
+  likedSongsCountCacheData = null;
+  likedSongsCacheData = null;
+}

--- a/src/services/spotifyPlayer.ts
+++ b/src/services/spotifyPlayer.ts
@@ -102,7 +102,7 @@ class SpotifyPlayerService {
     this.player.addListener('authentication_error', ({ message }: { message: string }) => {
       console.error('Failed to authenticate', message);
       if (shouldUseMockProvider()) return;
-      spotifyAuth.redirectToAuth();
+      spotifyAuth.reportUnauthorized();
     });
 
     this.player.addListener('account_error', ({ message }: { message: string }) => {

--- a/src/services/spotifyPlayerPlayback.ts
+++ b/src/services/spotifyPlayerPlayback.ts
@@ -1,10 +1,11 @@
 import { spotifyAuth } from './spotify';
+import { SpotifyApiError } from './spotify/api';
 import { SPOTIFY_TRANSFER_RETRY_COUNT } from '@/constants/spotify';
 import { logSpotify } from '@/lib/debugLog';
 import { TRANSFER_RETRY_DELAY_MS } from '@/constants/timing';
 import { logCaughtError } from '@/utils/logCaughtError';
 
-async function parsePlayError(response: Response): Promise<string> {
+async function buildPlayApiError(response: Response): Promise<SpotifyApiError> {
   const errorText = await response.text();
   let reason = '';
   try {
@@ -12,14 +13,18 @@ async function parsePlayError(response: Response): Promise<string> {
     if (json.error?.message) reason = ` - ${json.error.message}`;
     if (json.error?.reason) reason += ` (${json.error.reason})`;
   } catch (err) {
-    logCaughtError('spotifyPlayerPlayback.parsePlayError', err);
+    logCaughtError('spotifyPlayerPlayback.buildPlayApiError', err);
     reason = errorText ? ` - ${errorText}` : '';
   }
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
     if (retryAfter) reason += ` Retry-After: ${retryAfter}`;
   }
-  return `Spotify API error: ${response.status}${reason}`;
+  return new SpotifyApiError(
+    response.status,
+    response.statusText,
+    `Spotify API error: ${response.status}${reason}`,
+  );
 }
 
 /**
@@ -80,7 +85,7 @@ export async function apiPlayTrack(
   logSpotify('Web API play track response status=%d ok=%s', response.status, response.ok);
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 
@@ -110,7 +115,7 @@ export async function apiPlayContext(
   });
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 
@@ -136,7 +141,7 @@ export async function apiPlayPlaylist(
   logSpotify('Web API play URIs response status=%d ok=%s', response.status, response.ok);
 
   if (!response.ok) {
-    throw new Error(await parsePlayError(response));
+    throw await buildPlayApiError(response);
   }
 }
 

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -19,6 +19,12 @@ export interface AuthProvider {
   /** Handle OAuth callback (e.g. parse URL and exchange code). */
   handleCallback(url: URL): Promise<boolean>;
   logout(): void;
+  /**
+   * Called when the provider encounters an unrecoverable auth failure during
+   * playback. Implementations should log out and dispatch SESSION_EXPIRED_EVENT.
+   * Optional — providers that don't implement this fall back to logout() + event dispatch.
+   */
+  reportUnauthorized?(): void;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ship the auth + playback hardening wave: Spotify 401 retry/refresh, session-expiry handled as a clean provider toggle (reconnect affordance removed), playback re-prime after re-auth, Dropbox skip-on-error, queue mutation native-sync, and a handful of mock/VFX/Playwright fixes.

## Release summary

**Built from**: `rc/2026-05-20.1`

### Release notes

**auth**
- fix(auth): clear all Spotify IDB and in-memory caches on logout
- fix(auth): wire AuthExpiredError from playback through to logout + session-expired flow
- fix(auth): use reportUnauthorized() for SDK authentication_error
- fix(auth): toggle provider off on session expiry; remove reconnect affordance
- fix(auth): skip disconnect confirmation when provider has no queued tracks

**dropbox**
- fix(dropbox): skip queue on unrecoverable playback error

**mock**
- fix(mock): guard pre-warm to avoid interrupting current audio

**playback**
- feat(playback): re-prime current track after provider re-authentication

**playwright**
- fix(playwright): use empty destructure to satisfy fixture-arg validator

**queue**
- fix(queue): notify native-sync provider on every queue mutation

**spotify**
- fix(spotify): retry 401 with refresh and surface terminal auth failures

**vfx-menu**
- fix(vfx-menu): reconcile flip-gesture spec with implementation
- fix(vfx-menu): tint active swatch outline with current accent color