### PR TITLE
refactor(types): tighten src/types/ foundation (#1582)

### DIFF
--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -135,11 +135,12 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
       return;
     }
     const isDone = radioProgress.phase === 'done';
+    const trackCount = isDone ? radioProgress.trackCount : undefined;
     toast.custom(
       (toastId: string | number) => (
         <RadioProgressContent
           phase={radioProgress.phase}
-          trackCount={radioProgress.trackCount}
+          trackCount={trackCount}
           onDismiss={() => {
             toast.dismiss(toastId);
             onDismissRadioProgress();

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -116,11 +116,11 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
 
     const getAlbumExternalUrl = (albumId: string, albumName: string): string | undefined => {
         if (trackDescriptor?.getExternalUrls) {
-            const urls = trackDescriptor.getExternalUrls({ type: 'album', name: albumName, artistName: track?.artists });
+            const urls = trackDescriptor.getExternalUrls({ type: 'album', name: albumName, artistName: track?.artists ?? '' });
             return urls?.[0]?.url;
         }
         if (trackDescriptor?.getExternalUrl) {
-            return trackDescriptor.getExternalUrl({ type: 'album', name: albumName, artistName: track?.artists });
+            return trackDescriptor.getExternalUrl({ type: 'album', name: albumName, artistName: track?.artists ?? '' });
         }
         if (trackDescriptor?.id === 'spotify' && albumId) {
             return `https://open.spotify.com/album/${albumId}`;
@@ -237,7 +237,7 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
             });
         }
         if (hasExternalLink) {
-            const externalUrls = trackDescriptor?.getExternalUrls?.({ type: 'album', name: popover.albumName, artistName: track?.artists });
+            const externalUrls = trackDescriptor?.getExternalUrls?.({ type: 'album', name: popover.albumName, artistName: track?.artists ?? '' });
             if (externalUrls) {
                 for (const entry of externalUrls) {
                     const IconComponent = ICON_MAP[entry.icon] ?? DiscogsIcon;

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -162,7 +162,7 @@ export class DropboxCatalogAdapter implements CatalogProvider {
           kind: 'album',
           name,
           trackCount: count,
-          ownerName: artistName ?? null,
+          ownerName: artistName,
           imageUrl: dirToImageUrl.get(dirPath),
           // Dropbox folder metadata does not include genre information
           genres: [],

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -123,6 +123,7 @@ function savedTrackToMediaTrack(track: SavedTrack): MediaTrack {
     durationMs: track.durationMs,
     externalUrl: track.externalUrl,
     image: track.image,
+    genres: [],
   };
 }
 
@@ -238,6 +239,7 @@ export async function listSavedPlaylists(
         kind: 'playlist',
         name: entry.name.replace(/\.json$/, ''),
         imageUrl: undefined,
+        genres: [],
       });
       filePaths.push(entry.path_lower);
     }

--- a/src/providers/dropbox/dropboxProvider.ts
+++ b/src/providers/dropbox/dropboxProvider.ts
@@ -59,8 +59,10 @@ if (DROPBOX_CLIENT_ID) {
       if (!result) return null;
       return { totalTracks: tracks.length, skippedTracks: 0 };
     },
-    getExternalUrls({ type, name, artistName }) {
-      const isArtist = type === 'artist';
+    getExternalUrls(info) {
+      const isArtist = info.type === 'artist';
+      const name = info.name;
+      const artistName = info.type === 'album' ? info.artistName : '';
       const query = isArtist ? name : (artistName ? `${artistName} ${name}` : name);
       const discogsType = isArtist ? 'artist' : 'release';
       const mbType = isArtist ? 'artist' : 'release';

--- a/src/providers/mock/mockCatalogAdapter.ts
+++ b/src/providers/mock/mockCatalogAdapter.ts
@@ -62,7 +62,8 @@ export class MockCatalogAdapter implements CatalogProvider {
         imageUrl: playlist.image?.url,
         trackCount: playlist.trackCount,
         ownerName: playlist.ownerName,
-        revision: playlist.revision,
+        revision: playlist.revision ?? undefined,
+        genres: [],
       });
     }
 
@@ -74,7 +75,7 @@ export class MockCatalogAdapter implements CatalogProvider {
         name: album.name,
         imageUrl: album.image?.url,
         trackCount: album.trackCount,
-        ownerName: album.artists[0]?.name ?? null,
+        ownerName: album.artists[0]?.name,
         releaseDate: album.releaseDate,
         genres: album.genres ?? [],
       });

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -50,8 +50,10 @@ const dropboxDescriptor: ProviderDescriptor = {
     hasExternalLink: true,
     externalLinkLabel: 'Search Discogs',
   },
-  getExternalUrls({ type, name, artistName }) {
-    const isArtist = type === 'artist';
+  getExternalUrls(info) {
+    const isArtist = info.type === 'artist';
+    const name = info.name;
+    const artistName = info.type === 'album' ? info.artistName : '';
     const query = isArtist ? name : (artistName ? `${artistName} ${name}` : name);
     const discogsType = isArtist ? 'artist' : 'release';
     const mbType = isArtist ? 'artist' : 'release';

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -47,6 +47,7 @@ function spotifyTrackToMediaTrack(track: Track): MediaTrack {
       ? `https://open.spotify.com/track/${track.id}`
       : undefined,
     addedAt: track.added_at,
+    genres: track.genres ?? [],
   };
 }
 
@@ -57,11 +58,13 @@ function spotifyPlaylistToMediaCollection(pl: PlaylistInfo): MediaCollection {
     provider: 'spotify',
     kind: 'playlist',
     name: pl.name,
-    description: pl.description,
+    description: pl.description ?? undefined,
     imageUrl: getLargestImage(pl.images),
     trackCount: pl.tracks?.total ?? undefined,
     ownerName: pl.owner?.display_name ?? undefined,
     revision: pl.snapshot_id,
+    // Spotify playlist API doesn't return genre information
+    genres: [],
   };
 }
 
@@ -76,7 +79,7 @@ function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
     imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
     // Genres come from the Spotify album object (may be empty for simplified library responses)
-    genres: album.genres,
+    genres: album.genres ?? [],
   };
 }
 

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -39,6 +39,7 @@ function buildTracksFromWindow(state: SpotifyPlaybackState): MediaTrack[] {
       albumId,
       durationMs: item.duration_ms ?? 0,
       image: getLargestImage(item.album?.images),
+      genres: [],
     };
   }
 

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -92,7 +92,7 @@ export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
     image: t.image,
     externalUrl: t.preview_url,
     addedAt: t.added_at,
-    genres: t.genres,
+    genres: t.genres ?? [],
   }));
 }
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -13,6 +13,7 @@ export function makeTrack(overrides?: Partial<MediaTrack>): MediaTrack {
     albumId: 'album-1',
     durationMs: 210000,
     image: 'https://i.scdn.co/image/test',
+    genres: [],
     ...overrides,
   };
 }
@@ -29,6 +30,7 @@ export function makeMediaTrack(overrides?: Partial<MediaTrack>): MediaTrack {
     artists: 'Test Artist',
     album: 'Test Album',
     durationMs: 210000,
+    genres: [],
     ...overrides,
   };
 }

--- a/src/types/__tests__/domain.test.ts
+++ b/src/types/__tests__/domain.test.ts
@@ -19,7 +19,7 @@ describe('collectionRefToKey', () => {
   });
 
   it('serializes a spotify liked ref', () => {
-    const ref: CollectionRef = { provider: 'spotify', kind: 'liked', id: '' };
+    const ref: CollectionRef = { provider: 'spotify', kind: 'liked' };
     expect(collectionRefToKey(ref)).toBe('spotify:liked:');
   });
 });
@@ -81,7 +81,7 @@ describe('keyToCollectionRef', () => {
     const refs: CollectionRef[] = [
       { provider: 'spotify', kind: 'playlist', id: 'p1' },
       { provider: 'spotify', kind: 'album', id: 'a1' },
-      { provider: 'spotify', kind: 'liked', id: '' },
+      { provider: 'spotify', kind: 'liked' },
       { provider: 'dropbox', kind: 'folder', id: '/path/to/music' },
     ];
 
@@ -91,5 +91,13 @@ describe('keyToCollectionRef', () => {
       const parsed = keyToCollectionRef(key);
       expect(parsed).toEqual(ref);
     }
+  });
+
+  it('parses a spotify liked key (no id segment)', () => {
+    // #given a key with an empty id segment (the canonical 'liked' serialization)
+    // #when
+    const parsed = keyToCollectionRef('spotify:liked:');
+    // #then — must omit the id field, matching the 'liked' variant shape
+    expect(parsed).toEqual({ provider: 'spotify', kind: 'liked' });
   });
 });

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -13,6 +13,12 @@ export interface PlaybackItemRef {
   ref: string;
 }
 
+/** Structured artist reference used for display and external links. */
+export interface ArtistRef {
+  name: string;
+  url?: string;
+}
+
 /**
  * Normalized track for UI and queue. All providers map their native track to this shape.
  */
@@ -24,7 +30,7 @@ export interface MediaTrack {
   name: string;
   artists: string;
   /** Optional structured artist data for links/display. */
-  artistsData?: { name: string; url?: string }[];
+  artistsData?: ArtistRef[];
   album: string;
   albumId?: string;
   trackNumber?: number;
@@ -39,7 +45,7 @@ export interface MediaTrack {
   /** Epoch ms when the track was added/liked. Populated for liked tracks to enable cross-provider sorting. */
   addedAt?: number;
   /** Genre tags for the track (e.g. from album metadata). Empty array means unavailable. */
-  genres?: string[];
+  genres: string[];
 }
 
 /**
@@ -65,19 +71,33 @@ export interface MediaCollection {
   provider: ProviderId;
   kind: CollectionKind;
   name: string;
-  description?: string | null;
+  description?: string;
   imageUrl?: string;
   trackCount?: number;
-  ownerName?: string | null;
+  ownerName?: string;
   /** Revision/cursor for change detection (e.g. snapshot_id, cursor, hash). */
-  revision?: string | null;
+  revision?: string;
   /** Release date string (e.g. "2023", "2023-05-17") for sorting. */
   releaseDate?: string;
   /** Album paths for mosaic thumbnails (multi-album playlists). Resolved to art at render time via IndexedDB cache. */
   mosaicAlbumPaths?: string[];
   /** Genre tags for the collection (e.g. from album metadata). Empty array means unavailable. */
-  genres?: string[];
+  genres: string[];
 }
+
+/** Structured playback error reported by providers. */
+export interface PlaybackError {
+  code: number;
+  message: string;
+}
+
+/**
+ * Subset of `MediaTrack` fields that may be overlaid by enriched metadata
+ * (e.g. ID3 tags) over the values produced by the catalog adapter.
+ */
+export type TrackMetadataOverlay = Partial<Pick<MediaTrack,
+  'name' | 'artists' | 'album' | 'image' | 'durationMs'
+>>;
 
 /**
  * Playback state as seen by the app (provider-agnostic).
@@ -89,9 +109,9 @@ export interface PlaybackState {
   currentTrackId: string | null;
   currentPlaybackRef: PlaybackItemRef | null;
   /** Enriched metadata read from audio file tags (e.g. ID3). Overrides filename-derived values. */
-  trackMetadata?: Partial<Pick<MediaTrack, 'name' | 'artists' | 'album' | 'image' | 'durationMs'>>;
+  trackMetadata?: TrackMetadataOverlay;
   /** Set when the provider encounters a playback error; cleared after one notification cycle. */
-  playbackError?: { code: number; message: string };
+  playbackError?: PlaybackError;
 }
 
 /** Serializable form of CollectionRef for storage/URL (e.g. "spotify:playlist:xxx", "dropbox:folder:/Music"). */
@@ -109,13 +129,25 @@ export interface AddToQueueResult {
   collectionName?: string;
 }
 
+const COLLECTION_KINDS = ['playlist', 'album', 'folder', 'liked'] as const;
+type ParseableCollectionKind = typeof COLLECTION_KINDS[number];
+
+function isProviderId(x: string): x is ProviderId {
+  return x === 'spotify' || x === 'dropbox';
+}
+
+function isCollectionKind(x: string): x is ParseableCollectionKind {
+  return (COLLECTION_KINDS as readonly string[]).includes(x);
+}
+
 /** Parse a stored key back into CollectionRef if possible. */
 export function keyToCollectionRef(key: string): CollectionRef | null {
   const parts = key.split(':');
   if (parts.length < 3) return null;
   const [provider, kind, ...idParts] = parts;
+  if (!isProviderId(provider) || !isCollectionKind(kind)) return null;
+  if (kind === 'liked') return { provider, kind };
   const id = idParts.join(':');
-  if (provider !== 'spotify' && provider !== 'dropbox') return null;
-  if (!['playlist', 'album', 'folder', 'liked'].includes(kind)) return null;
-  return { provider: provider as ProviderId, kind: kind as CollectionRef['kind'], id };
+  if (!id) return null;
+  return { provider, kind, id };
 }

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -3,8 +3,49 @@
  * All music sources (Spotify, Dropbox, future) implement these interfaces.
  */
 
-import type { MediaTrack, MediaCollection, CollectionRef, PlaybackState, ProviderId } from './domain';
+import type {
+  MediaTrack,
+  MediaCollection,
+  CollectionRef,
+  CollectionKind,
+  PlaybackState,
+  ProviderId,
+} from './domain';
 import type { ComponentType } from 'react';
+
+// -----------------------------------------------------------------------------
+// External link helpers (provider-defined deep links / search URLs)
+// -----------------------------------------------------------------------------
+
+/**
+ * Request shape for building an external URL (Discogs search, Spotify deep link, etc.).
+ * `artistName` is required on the album variant so callers can construct
+ * artist-scoped album searches; the artist variant has no use for it.
+ */
+export type ExternalLinkRequest =
+  | { type: 'artist'; name: string }
+  | { type: 'album'; name: string; artistName: string };
+
+export interface ExternalLink {
+  label: string;
+  url: string;
+  icon: string;
+}
+
+// -----------------------------------------------------------------------------
+// Catalog mutation result shapes
+// -----------------------------------------------------------------------------
+
+export interface SavePlaylistResult {
+  url?: string;
+  totalTracks: number;
+  skippedTracks: number;
+}
+
+export interface RefreshLikedMetadataResult {
+  updated: number;
+  removed: number;
+}
 
 // -----------------------------------------------------------------------------
 // Auth
@@ -46,7 +87,7 @@ export interface CatalogProvider {
   setAlbumSaved?(albumId: string, saved: boolean): Promise<void>;
   isAlbumSaved?(albumId: string): Promise<boolean>;
   /** Optional: delete/unfollow a collection (playlist). */
-  deleteCollection?(collectionId: string, kind: import('./domain').CollectionKind): Promise<void>;
+  deleteCollection?(collectionId: string, kind: CollectionKind): Promise<void>;
   /** Optional: resolve missing duration for a track (e.g. probe audio metadata). */
   resolveDuration?(track: MediaTrack): Promise<number | null>;
   /** Optional: resolve missing artwork for an album. Returns image URL/data-URL or null. */
@@ -62,7 +103,7 @@ export interface CatalogProvider {
   /** Optional: import liked songs from JSON. Returns number of imported tracks. */
   importLikes?(json: string): Promise<number>;
   /** Optional: refresh metadata for liked tracks. */
-  refreshLikedMetadata?(): Promise<{ updated: number; removed: number }>;
+  refreshLikedMetadata?(): Promise<RefreshLikedMetadataResult>;
 }
 
 // -----------------------------------------------------------------------------
@@ -147,11 +188,11 @@ export interface ProviderDescriptor {
   /** Window event name dispatched when this provider's liked tracks change. */
   likesChangedEvent?: string;
   /** Build an external URL for an artist or album (e.g. Discogs search). */
-  getExternalUrl?(info: { type: 'artist' | 'album'; name: string; artistName?: string }): string;
+  getExternalUrl?(info: ExternalLinkRequest): string;
   /** Build multiple external URLs for an artist or album. Takes precedence over getExternalUrl. */
-  getExternalUrls?(info: { type: 'artist' | 'album'; name: string; artistName?: string }): Array<{ label: string; url: string; icon: string }>;
+  getExternalUrls?(info: ExternalLinkRequest): ExternalLink[];
   /** Optional: save a list of tracks as a new playlist. */
-  savePlaylist?(name: string, tracks: MediaTrack[]): Promise<{ url?: string; totalTracks: number; skippedTracks: number } | null>;
+  savePlaylist?(name: string, tracks: MediaTrack[]): Promise<SavePlaylistResult | null>;
 }
 
 /** Registry of available providers; used by app to resolve active provider by id. */

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -94,14 +94,14 @@ export interface RadioResult {
 
 // ── Radio state ──────────────────────────────────────────────────────
 
-// TODO(#1589): discriminate RadioState by `isActive` once #1582 lands.
-// Proposed shape:
-//   type RadioState =
-//     | { isActive: false; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
-//     | { isActive: true; seedDescription: string; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null };
-// Deferred because the flat → discriminated rewrite ripples through useRadio.ts,
-// 5+ test fixtures, and 3 UI components reading isGenerating/error without an
-// isActive narrowing. Will be picked up by the hooks/contexts phase:2 sweep (#1586).
+// TODO(#1589 / #1586): discriminate by isActive — see .claude/blueprints/issue-1582-foundation.md §3b (revised).
+// Canonical shape:
+//   | { isActive: false; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
+//   | { isActive: true;  seedDescription: string; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
+// Only seedDescription is variant-locked; lastMatchStats and error persist across
+// the active boundary ("last" + post-session semantics). Deferred from #1582
+// because the rewrite ripples through useRadio.ts, 3 UI consumers, and 6 inline
+// test fixtures — hooks/contexts phase:2 sweep (#1586) takes ownership.
 export interface RadioState {
   /** Whether a radio session is currently active. */
   isActive: boolean;

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -61,19 +61,32 @@ export interface UnmatchedSuggestion {
 // ── Radio progress ──────────────────────────────────────────────────
 
 export type RadioProgressPhase = 'fetching-catalog' | 'generating' | 'resolving' | 'done';
-export interface RadioProgress { phase: RadioProgressPhase; trackCount?: number; }
+
+/**
+ * Progress event emitted by the radio pipeline. `trackCount` is only carried
+ * by the `done` phase (the only emit site that knows the final queue length).
+ */
+export type RadioProgress =
+  | { phase: 'fetching-catalog' }
+  | { phase: 'generating' }
+  | { phase: 'resolving' }
+  | { phase: 'done'; trackCount: number };
+
+// ── Radio match stats ───────────────────────────────────────────────
+
+export interface RadioMatchStats {
+  lastfmCandidates: number;
+  matched: number;
+  byMbid: number;
+  byName: number;
+}
 
 // ── Radio result ────────────────────────────────────────────────────
 
 export interface RadioResult {
   queue: MediaTrack[];
   seedDescription: string;
-  matchStats: {
-    lastfmCandidates: number;
-    matched: number;
-    byMbid: number;
-    byName: number;
-  };
+  matchStats: RadioMatchStats;
   /** Last.fm suggestions that didn't match the local catalog, sorted by matchScore descending. */
   unmatchedSuggestions: UnmatchedSuggestion[];
 }
@@ -81,6 +94,14 @@ export interface RadioResult {
 
 // ── Radio state ──────────────────────────────────────────────────────
 
+// TODO(#1589): discriminate RadioState by `isActive` once #1582 lands.
+// Proposed shape:
+//   type RadioState =
+//     | { isActive: false; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
+//     | { isActive: true; seedDescription: string; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null };
+// Deferred because the flat → discriminated rewrite ripples through useRadio.ts,
+// 5+ test fixtures, and 3 UI components reading isGenerating/error without an
+// isActive narrowing. Will be picked up by the hooks/contexts phase:2 sweep (#1586).
 export interface RadioState {
   /** Whether a radio session is currently active. */
   isActive: boolean;
@@ -91,5 +112,5 @@ export interface RadioState {
   /** Error message from the last radio attempt. */
   error: string | null;
   /** Match stats from the last successful radio generation. */
-  lastMatchStats: RadioResult['matchStats'] | null;
+  lastMatchStats: RadioMatchStats | null;
 }


### PR DESCRIPTION
Phase:1 foundation for the TypeScript strictness audit epic. Establishes the canonical type shapes that all phase:2 sweeps will consume.

## Lifted shapes

| Type | Home | Notes |
|---|---|---|
| `ArtistRef` | `domain.ts` | Replaces inline `MediaTrack.artistsData?: { name: string; url?: string }[]` |
| `PlaybackError` | `domain.ts` | Replaces inline `PlaybackState.playbackError` |
| `TrackMetadataOverlay` | `domain.ts` | Replaces inline `PlaybackState.trackMetadata` Partial<Pick<…>> |
| `ExternalLinkRequest` | `providers.ts` | **Discriminated union** — album variant requires `artistName` |
| `ExternalLink` | `providers.ts` | Replaces inline `Array<{ label; url; icon }>` |
| `SavePlaylistResult` | `providers.ts` | Replaces inline `Promise<{ url?; totalTracks; skippedTracks } \| null>` |
| `RefreshLikedMetadataResult` | `providers.ts` | Replaces inline `Promise<{ updated; removed }>` |
| `RadioMatchStats` | `radio.ts` | Replaces inline `matchStats` + indexed `RadioResult['matchStats']` reads |

`providers.ts` also drops the inline `import('./domain').CollectionKind` in favor of a named import.

## Tightened shapes

- **`MediaCollection`**: `description?: string | null` → `description?: string` (same for `ownerName`, `revision`). Forbidden three-way `missing | null | T` shapes removed.
- **`MediaTrack.genres` / `MediaCollection.genres`**: now required `string[]` (empty array = unavailable). Eliminates the `undefined | []` ambiguity.
- **`keyToCollectionRef`**: rewritten with `is*` narrowing guards (no `as` casts); the `liked` variant no longer carries a phantom `id`. Test fixture corrected to match.
- **`RadioProgress`**: discriminated union by `phase`. Only `'done'` carries `trackCount`, matching what `radioPipeline.ts` actually emits.

## Drive-by call-site fixes (per blueprint § Build-green strategy #1)

Phase:2 sweeps should not need to retouch these:

- `src/providers/{spotify,dropbox,mock}/*Adapter.ts`, `dropboxPlaylistStorage.ts`, `mockProvider.ts`, `dropboxProvider.ts`, `useSpotifyPlaylistManager.ts`, `src/services/spotify/tracks.ts` — `genres: []` / `?? []` on every track + collection mapper, `null`-assignments converted to omissions or `?? undefined`, `ExternalLinkRequest` callers narrow before reading `artistName`.
- `src/components/controls/TrackInfo.tsx` — `artistName: track?.artists ?? ''` on the three album-variant call sites.
- `src/components/PlayerContent/DrawerOrchestrator.tsx` — narrows `radioProgress.trackCount` through the `'done'` phase check before passing it to `RadioProgressContent`.

## Deferred

- **`RadioState` discrimination by `isActive` (3b in the blueprint)** — left a `// TODO(#1589):` block at the type definition with the proposed shape. Rationale: rewriting the flat interface forces touching `useRadio.ts` (5 `setState` call sites), 3 UI consumers (`AudioPlayer`, `PlayerControlsSection`, `DrawerOrchestrator`) reading `isGenerating`/`error` without an `isActive` narrowing, plus 6 inline test fixtures that hard-code `{ isActive: false, ..., isGenerating: false, error: null, lastMatchStats: null }`. That exceeds the blueprint's "> 6 non-test files" defer threshold. Phase:2 hooks+contexts sweep (#1586) will own this discrimination together with the consumer refactor.

## Verify

- `npx tsc -b --noEmit` ✅
- `npm run test:run` ✅ (2063/2063)
- `npm run build` ✅

## Acceptance checklist

- [x] Lifted types exported and inline shapes replaced
- [x] No `field?: T | null` shapes in `src/types/`
- [x] `keyToCollectionRef` casts eliminated; `liked` variant correct
- [x] Discriminated unions added per blueprint (or deferred with TODO)
- [x] tsc, test, build all green
- [x] PR targets `feature/typescript-strictness-audit-1589`

Part of #1589.