### PR TITLE
refactor(providers): tighten src/providers/ sweep (#1583)

### DIFF
--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -14,6 +14,8 @@ async function parseRetryAfterSeconds(response: Response): Promise<number> {
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   try {
+    // HTTP error-body boundary: shape isn't validated; only retry_after is read,
+    // and a wrong type falls through to the default below.
     const body = await response.clone().json() as { retry_after?: number };
     if (typeof body?.retry_after === 'number' && body.retry_after > 0) return body.retry_after;
   } catch (err) {

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -15,7 +15,7 @@
  */
 
 import type { CatalogProvider } from '@/types/providers';
-import type { ProviderId, MediaTrack, MediaCollection, CollectionRef } from '@/types/domain';
+import type { ArtistRef, ProviderId, MediaTrack, MediaCollection, CollectionRef } from '@/types/domain';
 import { DropboxAuthAdapter } from './dropboxAuthAdapter';
 import {
   getDurationsMap,
@@ -279,7 +279,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
             if (cached.name) t.name = cached.name;
             if (cached.artists) {
               t.artists = cached.artists;
-              t.artistsData = [{ name: cached.artists }];
+              const refs: ArtistRef[] = [{ name: cached.artists }];
+              t.artistsData = refs;
             }
             if (cached.album) t.album = cached.album;
           }

--- a/src/providers/dropbox/dropboxPlaybackAdapter.ts
+++ b/src/providers/dropbox/dropboxPlaybackAdapter.ts
@@ -220,6 +220,7 @@ export class DropboxPlaybackAdapter implements PlaybackProvider {
         offset += chunk.length;
       }
 
+      // WebAudio API boundary: parseID3 expects ArrayBuffer; combined.buffer is ArrayBufferLike under DOM lib typings.
       const { title, artist, album, coverArt, musicbrainzRecordingId, musicbrainzArtistId, isrc } = parseID3(combined.buffer as ArrayBuffer);
       const update: PlaybackState['trackMetadata'] = {};
       if (title && title !== track.name) update.name = title;

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -117,7 +117,6 @@ function savedTrackToMediaTrack(track: SavedTrack): MediaTrack {
     playbackRef: track.playbackRef,
     name: track.name,
     artists: track.artists,
-    artistsData: undefined,
     album: track.album,
     albumId: track.albumId,
     durationMs: track.durationMs,

--- a/src/providers/mock/mockProvider.ts
+++ b/src/providers/mock/mockProvider.ts
@@ -9,93 +9,114 @@ import { seedPinsFromSnapshots } from './pinSeeder';
 import { shouldUseMockProvider } from './shouldUseMockProvider';
 import { installMockTestApi } from './test-control';
 import { seedSessionFromUrlParam } from './sessionSeed';
-import { assertProviderSnapshot } from '../../../playwright/fixtures/data/snapshot.types';
+import { assertProviderSnapshot, type ProviderSnapshot } from '../../../playwright/fixtures/data/snapshot.types';
 import spotifySnapshotJson from '../../../playwright/fixtures/data/spotify-snapshot.json' with { type: 'json' };
 import dropboxSnapshotJson from '../../../playwright/fixtures/data/dropbox-snapshot.json' with { type: 'json' };
 
 assertProviderSnapshot(spotifySnapshotJson, 'spotify');
 assertProviderSnapshot(dropboxSnapshotJson, 'dropbox');
 
-const spotifyDescriptor: ProviderDescriptor = {
-  id: 'spotify',
-  name: 'Spotify',
-  color: '#1db954',
-  icon: SpotifyIcon,
-  subscriptionNote: 'Requires Spotify Premium.',
-  capabilities: {
-    hasLikedCollection: true,
-    hasSaveTrack: true,
-    hasSaveAlbum: true,
-    hasDeleteCollection: true,
-    hasExternalLink: true,
-    externalLinkLabel: 'Open in Spotify',
-    hasTrackSearch: true,
-    hasNativeQueueSync: false,
-  },
-  auth: new MockAuthAdapter('spotify'),
-  catalog: new MockCatalogAdapter(spotifySnapshotJson),
-  playback: new MockPlaybackAdapter('spotify'),
-};
+/**
+ * A constructed mock provider, exposing both its `ProviderDescriptor` (for
+ * registration) and the concrete adapter instances (for the test-control API
+ * and session seeding). Returning both eliminates the previous need to cast
+ * `descriptor.catalog as MockCatalogAdapter` etc. at every consumption site.
+ */
+interface MockProviderHandles {
+  descriptor: ProviderDescriptor;
+  auth: MockAuthAdapter;
+  catalog: MockCatalogAdapter;
+  playback: MockPlaybackAdapter;
+}
 
-const dropboxDescriptor: ProviderDescriptor = {
-  id: 'dropbox',
-  name: 'Dropbox',
-  color: '#0061FF',
-  icon: DropboxIcon,
-  likesChangedEvent: 'mock-dropbox-likes-changed',
-  capabilities: {
-    hasLikedCollection: true,
-    hasSaveTrack: true,
-    hasDeleteCollection: true,
-    hasExternalLink: true,
-    externalLinkLabel: 'Search Discogs',
+function createMockProvider(
+  base: Omit<ProviderDescriptor, 'auth' | 'catalog' | 'playback'>,
+  snapshot: ProviderSnapshot,
+): MockProviderHandles {
+  const auth = new MockAuthAdapter(base.id);
+  const catalog = new MockCatalogAdapter(snapshot);
+  const playback = new MockPlaybackAdapter(base.id);
+  const descriptor: ProviderDescriptor = { ...base, auth, catalog, playback };
+  return { descriptor, auth, catalog, playback };
+}
+
+const spotify = createMockProvider(
+  {
+    id: 'spotify',
+    name: 'Spotify',
+    color: '#1db954',
+    icon: SpotifyIcon,
+    subscriptionNote: 'Requires Spotify Premium.',
+    capabilities: {
+      hasLikedCollection: true,
+      hasSaveTrack: true,
+      hasSaveAlbum: true,
+      hasDeleteCollection: true,
+      hasExternalLink: true,
+      externalLinkLabel: 'Open in Spotify',
+      hasTrackSearch: true,
+      hasNativeQueueSync: false,
+    },
   },
-  getExternalUrls(info) {
-    const isArtist = info.type === 'artist';
-    const name = info.name;
-    const artistName = info.type === 'album' ? info.artistName : '';
-    const query = isArtist ? name : (artistName ? `${artistName} ${name}` : name);
-    const discogsType = isArtist ? 'artist' : 'release';
-    const mbType = isArtist ? 'artist' : 'release';
-    return [
-      {
-        label: 'Discogs',
-        url: `https://www.discogs.com/search/?q=${encodeURIComponent(query)}&type=${discogsType}`,
-        icon: 'discogs',
-      },
-      {
-        label: 'MusicBrainz',
-        url: `https://musicbrainz.org/search?query=${encodeURIComponent(query)}&type=${mbType}`,
-        icon: 'musicbrainz',
-      },
-    ];
+  spotifySnapshotJson,
+);
+
+const dropbox = createMockProvider(
+  {
+    id: 'dropbox',
+    name: 'Dropbox',
+    color: '#0061FF',
+    icon: DropboxIcon,
+    likesChangedEvent: 'mock-dropbox-likes-changed',
+    capabilities: {
+      hasLikedCollection: true,
+      hasSaveTrack: true,
+      hasDeleteCollection: true,
+      hasExternalLink: true,
+      externalLinkLabel: 'Search Discogs',
+    },
+    getExternalUrls(info) {
+      const isArtist = info.type === 'artist';
+      const name = info.name;
+      const artistName = info.type === 'album' ? info.artistName : '';
+      const query = isArtist ? name : (artistName ? `${artistName} ${name}` : name);
+      const discogsType = isArtist ? 'artist' : 'release';
+      const mbType = isArtist ? 'artist' : 'release';
+      return [
+        {
+          label: 'Discogs',
+          url: `https://www.discogs.com/search/?q=${encodeURIComponent(query)}&type=${discogsType}`,
+          icon: 'discogs',
+        },
+        {
+          label: 'MusicBrainz',
+          url: `https://musicbrainz.org/search?query=${encodeURIComponent(query)}&type=${mbType}`,
+          icon: 'musicbrainz',
+        },
+      ];
+    },
   },
-  auth: new MockAuthAdapter('dropbox'),
-  catalog: new MockCatalogAdapter(dropboxSnapshotJson),
-  playback: new MockPlaybackAdapter('dropbox'),
-};
+  dropboxSnapshotJson,
+);
 
 // `main.tsx` eager-imports this module in any dev build so `?provider=mock`
 // activation works without a restart. Gate the registry mutation so the real
 // Spotify/Dropbox descriptors survive in dev unless the user has actually
 // opted in (VITE_MOCK_PROVIDER=true or ?provider=mock).
 if (shouldUseMockProvider()) {
-  providerRegistry.register(spotifyDescriptor);
-  providerRegistry.register(dropboxDescriptor);
+  providerRegistry.register(spotify.descriptor);
+  providerRegistry.register(dropbox.descriptor);
 
   void seedPinsFromSnapshots(spotifySnapshotJson.pins, dropboxSnapshotJson.pins);
 
-  seedSessionFromUrlParam(
-    spotifyDescriptor.catalog as MockCatalogAdapter,
-    dropboxDescriptor.catalog as MockCatalogAdapter,
-  );
+  seedSessionFromUrlParam(spotify.catalog, dropbox.catalog);
 
   installMockTestApi({
-    spotifyCatalog: spotifyDescriptor.catalog as MockCatalogAdapter,
-    dropboxCatalog: dropboxDescriptor.catalog as MockCatalogAdapter,
-    spotifyPlayback: spotifyDescriptor.playback as MockPlaybackAdapter,
-    dropboxPlayback: dropboxDescriptor.playback as MockPlaybackAdapter,
-    spotifyAuth: spotifyDescriptor.auth as MockAuthAdapter,
-    dropboxAuth: dropboxDescriptor.auth as MockAuthAdapter,
+    spotifyCatalog: spotify.catalog,
+    dropboxCatalog: dropbox.catalog,
+    spotifyPlayback: spotify.playback,
+    dropboxPlayback: dropbox.playback,
+    spotifyAuth: spotify.auth,
+    dropboxAuth: dropbox.auth,
   });
 }

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -92,7 +92,7 @@ export class SpotifyCatalogAdapter implements CatalogProvider {
     await getUserLibraryInterleaved(
       (fetchedPlaylists, _isComplete) => {
         for (const p of fetchedPlaylists) {
-          collections.push(spotifyPlaylistToMediaCollection(p as PlaylistInfo));
+          collections.push(spotifyPlaylistToMediaCollection(p));
         }
       },
       (fetchedAlbums, _isComplete) => {


### PR DESCRIPTION
Phase:2 sweep for `src/providers/`. Removes the smuggled / redundant `as` casts the blueprint identified, leaves all legitimate boundary casts (IndexedDB, custom events, JSON.parse, WebAudio) untouched.

## Casts removed (9 total)

| Site | Before | Why removable | Fix |
|---|---|---|---|
| `src/providers/mock/mockProvider.ts:89-99` (8 casts) | `descriptor.catalog as MockCatalogAdapter`, etc. | Adapter instances were widened through `ProviderDescriptor` then cast back to their concrete mock types at every consumption site. | New `MockProviderHandles` shape returned by a `createMockProvider` factory: `{ descriptor, auth, catalog, playback }`. Test-control API and session seeder now consume the concrete adapters directly. |
| `src/providers/spotify/spotifyCatalogAdapter.ts:95` | `p as PlaylistInfo` | `getUserLibraryInterleaved`'s `PlaylistsIncrementalCallback` already types its argument as `PlaylistInfo[]`. | Delete. |

## Legitimate boundary casts retained (14 total, per blueprint)

All at deserialization / DOM-API boundaries the blueprint explicitly lists to keep:

- `dropboxLikesCache.ts` ×4 — IDB `req.result` boundary
- `dropboxArtCache.ts` ×3 — IDB open/get boundary
- `dropboxCatalogCache.ts` ×1 — IDB `req.result` boundary
- `dropboxPlaybackAdapter.ts` ×1 — WebAudio `ArrayBuffer` boundary (commented)
- `dropboxApiClient.ts` ×1 — HTTP error-body shape, only `retry_after` is read (commented)
- `dropboxPreferencesSync.ts` ×1 — `JSON.parse` boundary, guarded
- `mockCatalogAdapter.ts` ×1 — `JSON.parse` boundary
- `sessionSeed.ts` ×1 — `JSON.parse` boundary, structurally narrowed
- `spotifyPlaybackAdapter.ts` ×1 — `CustomEvent.detail` boundary

Per blueprint acceptance criterion, the two non-obvious-from-context boundaries (`dropboxPlaybackAdapter.ts:223`, `dropboxApiClient.ts:17`) now carry one-line `//` comments.

## Optional-field tightenings

| Site | Change | Why |
|---|---|---|
| `src/providers/dropbox/dropboxCatalogAdapter.ts:282` | Annotate the metadata-overlay artist array as `ArtistRef[]` using the named domain type instead of inline-shape inference. | Per blueprint — names the contract with `MediaTrack.artistsData`. |
| `src/providers/dropbox/dropboxPlaylistStorage.ts:120` | Drop `artistsData: undefined` from the saved-track mapper. | The field is optional; the explicit-undefined is redundant today and would conflict with `exactOptionalPropertyTypes` (phase:3, #1585). |

## Cross-area handoffs

None for this sweep — the foundation drive-bys for `services/spotify/{tracks,albums}.ts` already shipped in #1590; verified `genres` write-sites still use `?? []`. No spill into `services/` or `hooks/`.

## Verify

- `npx tsc -b --noEmit` ✅
- `npm run test:run` ✅ (2063/2063)
- `npm run build` ✅

## Acceptance checklist

- [x] No smuggled `as <Type>` in `src/providers/` (non-test)
- [x] `mockProvider.ts:89-99` reads cleanly without `as MockXxxAdapter` casts
- [x] `MockProviderHandles` shape introduced per blueprint
- [x] One-line `//` comments on the two non-obvious legitimate boundaries
- [x] tsc, test, build all green
- [x] PR targets `feature/typescript-strictness-audit-1589`

Part of #1589.