### PR TITLE
refactor(services): sweep `as` casts, headlined by lastfm 21->1

### DIFF
--- a/src/services/cache/libraryCacheLifecycle.ts
+++ b/src/services/cache/libraryCacheLifecycle.ts
@@ -6,11 +6,7 @@
  */
 
 import type { AlbumInfo } from '../spotify';
-import type {
-  CachedPlaylistInfo,
-  CachedTrackList,
-  LibraryCacheMeta,
-} from './cacheTypes';
+import type { CachedPlaylistInfo, LibraryCacheMeta } from './cacheTypes';
 import { STORAGE_KEYS } from '@/constants/storage';
 
 const DB_NAME = 'vorbis-player-library';
@@ -21,18 +17,19 @@ export const STORE_ALBUMS = 'albums';
 export const STORE_TRACK_LISTS = 'trackLists';
 export const STORE_META = 'meta';
 
-export interface FallbackStores {
-  playlists: Map<string, CachedPlaylistInfo>;
-  albums: Map<string, AlbumInfo>;
-  trackLists: Map<string, CachedTrackList>;
-  meta: Map<string, LibraryCacheMeta>;
-}
+/**
+ * In-memory fallback stores keyed by store name (matches the IDB store names).
+ * Values are typed as `unknown` because the consumer-facing `getFallbackMap`
+ * API has to serve any store, and IDB itself persists structured-cloneable
+ * data without per-store typing.
+ */
+export type FallbackStores = Record<string, Map<string, unknown>>;
 
 export const fallbackStores: FallbackStores = {
-  playlists: new Map(),
-  albums: new Map(),
-  trackLists: new Map(),
-  meta: new Map(),
+  [STORE_PLAYLISTS]: new Map(),
+  [STORE_ALBUMS]: new Map(),
+  [STORE_TRACK_LISTS]: new Map(),
+  [STORE_META]: new Map(),
 };
 
 let db: IDBDatabase | null = null;
@@ -48,18 +45,9 @@ export function isFallback(): boolean {
 }
 
 export function getFallbackMap(storeName: string): Map<string, unknown> {
-  switch (storeName) {
-    case STORE_PLAYLISTS:
-      return fallbackStores.playlists as Map<string, unknown>;
-    case STORE_ALBUMS:
-      return fallbackStores.albums as Map<string, unknown>;
-    case STORE_TRACK_LISTS:
-      return fallbackStores.trackLists as Map<string, unknown>;
-    case STORE_META:
-      return fallbackStores.meta as Map<string, unknown>;
-    default:
-      throw new Error(`[libraryCache] Unknown store: ${storeName}`);
-  }
+  const store = fallbackStores[storeName];
+  if (!store) throw new Error(`[libraryCache] Unknown store: ${storeName}`);
+  return store;
 }
 
 function openIDB(): Promise<IDBDatabase> {
@@ -121,10 +109,9 @@ export function closeCache(): void {
   }
   fallbackMode = false;
   initPromise = null;
-  fallbackStores.playlists.clear();
-  fallbackStores.albums.clear();
-  fallbackStores.trackLists.clear();
-  fallbackStores.meta.clear();
+  for (const store of Object.values(fallbackStores)) {
+    store.clear();
+  }
 }
 
 interface LocalStorageCacheEntry<T> {

--- a/src/services/cache/libraryDiffEngine.ts
+++ b/src/services/cache/libraryDiffEngine.ts
@@ -85,8 +85,7 @@ async function syncPlaylists(newTotal: number, signal: AbortSignal): Promise<Cac
 
   if (signal.aborted) throw new DOMException('Request aborted', 'AbortError');
 
-  const playlists = await getAllUserPlaylists(signal);
-  const allFetched = playlists as CachedPlaylistInfo[];
+  const allFetched: CachedPlaylistInfo[] = await getAllUserPlaylists(signal);
 
   for (let i = 0; i < allFetched.length; i++) {
     const p = allFetched[i];

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -250,7 +250,7 @@ export class SpotifyLibrarySyncEngine {
     let allAlbums: AlbumInfo[] = [];
 
     const onPlaylistsUpdate: PlaylistsUpdateCallback = (playlists, isComplete) => {
-      allPlaylists = playlists as CachedPlaylistInfo[];
+      allPlaylists = playlists;
       this.notifyListeners(allPlaylists, allAlbums);
       if (isComplete) {
         cache.putAllPlaylists(allPlaylists).catch(() => {});

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -65,32 +65,81 @@ async function lastfmGet(params: Record<string, string>): Promise<unknown> {
   return data;
 }
 
+// ── Structural narrowers ────────────────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function readNullableString(obj: Record<string, unknown>, key: string): string | null {
+  const v = obj[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function readNumber(obj: Record<string, unknown>, key: string): number {
+  const v = obj[key];
+  if (typeof v === 'number') return Number.isFinite(v) ? v : 0;
+  if (typeof v === 'string') {
+    const parsed = parseFloat(v);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function readObject(obj: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const v = obj[key];
+  return isPlainObject(v) ? v : null;
+}
+
+function readArray(obj: Record<string, unknown>, key: string): unknown[] {
+  const v = obj[key];
+  return Array.isArray(v) ? v : [];
+}
+
 // ── Response parsers ────────────────────────────────────────────────
 
-function parseSimilarTrack(raw: Record<string, unknown>): LastFmSimilarTrack {
-  const artist =
-    typeof raw.artist === 'object' && raw.artist !== null
-      ? ((raw.artist as Record<string, unknown>).name as string) ?? ''
-      : (raw.artist as string) ?? '';
-
+function parseSimilarTrack(raw: unknown): LastFmSimilarTrack | null {
+  if (!isPlainObject(raw)) return null;
+  const artistObj = readObject(raw, 'artist');
+  const artist = artistObj ? readString(artistObj, 'name') : readString(raw, 'artist');
   return {
-    name: (raw.name as string) ?? '',
+    name: readString(raw, 'name'),
     artist,
-    artistMbid:
-      typeof raw.artist === 'object' && raw.artist !== null
-        ? ((raw.artist as Record<string, unknown>).mbid as string) || null
-        : null,
-    trackMbid: (raw.mbid as string) || null,
-    matchScore: parseFloat(raw.match as string) || 0,
+    artistMbid: artistObj ? readNullableString(artistObj, 'mbid') : null,
+    trackMbid: readNullableString(raw, 'mbid'),
+    matchScore: readNumber(raw, 'match'),
   };
 }
 
-function parseSimilarArtist(raw: Record<string, unknown>): LastFmSimilarArtist {
+function parseSimilarArtist(raw: unknown): LastFmSimilarArtist | null {
+  if (!isPlainObject(raw)) return null;
   return {
-    name: (raw.name as string) ?? '',
-    mbid: (raw.mbid as string) || null,
-    matchScore: parseFloat(raw.match as string) || 0,
+    name: readString(raw, 'name'),
+    mbid: readNullableString(raw, 'mbid'),
+    matchScore: readNumber(raw, 'match'),
   };
+}
+
+function parseAlbumTrack(raw: unknown, fallbackArtist: string): { name: string; artist: string } | null {
+  if (!isPlainObject(raw)) return null;
+  const artistObj = readObject(raw, 'artist');
+  return {
+    name: readString(raw, 'name'),
+    artist: artistObj ? readString(artistObj, 'name') || fallbackArtist : fallbackArtist,
+  };
+}
+
+function isNotNull<T>(value: T | null): value is T {
+  return value !== null;
+}
+
+function asObject(data: unknown): Record<string, unknown> {
+  return isPlainObject(data) ? data : {};
 }
 
 // ── Public API ──────────────────────────────────────────────────────
@@ -100,93 +149,85 @@ export async function getSimilarTracks(
   track: string,
   limit = SIMILAR_TRACKS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarTrack[]> {
-  const data = (await lastfmGet({
-    method: 'track.getsimilar',
-    artist,
-    track,
-    limit: String(limit),
-    autocorrect: '1',
-  })) as Record<string, unknown>;
+  const data = asObject(
+    await lastfmGet({
+      method: 'track.getsimilar',
+      artist,
+      track,
+      limit: String(limit),
+      autocorrect: '1',
+    }),
+  );
 
-  const container = data.similartracks as Record<string, unknown> | undefined;
+  const container = readObject(data, 'similartracks');
   if (!container) return [];
 
-  const rawTracks = container.track;
-  if (!Array.isArray(rawTracks)) return [];
-
-  return rawTracks.map((t: Record<string, unknown>) => parseSimilarTrack(t));
+  return readArray(container, 'track').map(parseSimilarTrack).filter(isNotNull);
 }
 
 export async function getSimilarArtists(
   artist: string,
   limit = SIMILAR_ARTISTS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarArtist[]> {
-  const data = (await lastfmGet({
-    method: 'artist.getsimilar',
-    artist,
-    limit: String(limit),
-    autocorrect: '1',
-  })) as Record<string, unknown>;
+  const data = asObject(
+    await lastfmGet({
+      method: 'artist.getsimilar',
+      artist,
+      limit: String(limit),
+      autocorrect: '1',
+    }),
+  );
 
-  const container = data.similarartists as Record<string, unknown> | undefined;
+  const container = readObject(data, 'similarartists');
   if (!container) return [];
 
-  const rawArtists = container.artist;
-  if (!Array.isArray(rawArtists)) return [];
-
-  return rawArtists.map((a: Record<string, unknown>) => parseSimilarArtist(a));
+  return readArray(container, 'artist').map(parseSimilarArtist).filter(isNotNull);
 }
 
 export async function getArtistTopTracks(
   artist: string,
   limit = TOP_TRACKS_DEFAULT_LIMIT,
 ): Promise<LastFmSimilarTrack[]> {
-  const data = (await lastfmGet({
-    method: 'artist.gettoptracks',
-    artist,
-    limit: String(limit),
-    autocorrect: '1',
-  })) as Record<string, unknown>;
+  const data = asObject(
+    await lastfmGet({
+      method: 'artist.gettoptracks',
+      artist,
+      limit: String(limit),
+      autocorrect: '1',
+    }),
+  );
 
-  const container = data.toptracks as Record<string, unknown> | undefined;
+  const container = readObject(data, 'toptracks');
   if (!container) return [];
 
-  const rawTracks = container.track;
-  if (!Array.isArray(rawTracks)) return [];
-
-  return rawTracks.map((t: Record<string, unknown>) => ({
-    ...parseSimilarTrack(t),
-    matchScore: 1.0,
-  }));
+  return readArray(container, 'track')
+    .map(parseSimilarTrack)
+    .filter(isNotNull)
+    .map((t) => ({ ...t, matchScore: 1.0 }));
 }
 
 export async function getAlbumTracks(
   artist: string,
   album: string,
 ): Promise<{ name: string; artist: string }[]> {
-  const data = (await lastfmGet({
-    method: 'album.getinfo',
-    artist,
-    album,
-    autocorrect: '1',
-  })) as Record<string, unknown>;
+  const data = asObject(
+    await lastfmGet({
+      method: 'album.getinfo',
+      artist,
+      album,
+      autocorrect: '1',
+    }),
+  );
 
-  const albumInfo = data.album as Record<string, unknown> | undefined;
+  const albumInfo = readObject(data, 'album');
   if (!albumInfo) return [];
 
-  const tracksContainer = albumInfo.tracks as Record<string, unknown> | undefined;
+  const tracksContainer = readObject(albumInfo, 'tracks');
   if (!tracksContainer) return [];
 
-  const rawTracks = tracksContainer.track;
-  if (!Array.isArray(rawTracks)) return [];
-
-  return rawTracks.map((t: Record<string, unknown>) => ({
-    name: (t.name as string) ?? '',
-    artist:
-      typeof t.artist === 'object' && t.artist !== null
-        ? ((t.artist as Record<string, unknown>).name as string) ?? artist
-        : artist,
-  }));
+  return readArray(tracksContainer, 'track')
+    .map((raw) => parseAlbumTrack(raw, artist))
+    .filter(isNotNull);
 }
 
 /** Returns true if the Last.fm API key is configured. */

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -42,21 +42,26 @@ export function saveSession(snapshot: SessionSnapshot): void {
   }
 }
 
+/**
+ * Structural check on the three required fields (collectionId, collectionName, trackIndex).
+ * Optional fields (queueTracks, trackTitle, savedAt, …) are trusted as-shaped without per-element validation.
+ */
+function isSessionSnapshot(value: unknown): value is SessionSnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.collectionId === 'string' &&
+    typeof obj.collectionName === 'string' &&
+    typeof obj.trackIndex === 'number'
+  );
+}
+
 export function loadSession(): SessionSnapshot | null {
   try {
     const raw = localStorage.getItem(SESSION_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      typeof (parsed as SessionSnapshot).collectionId === 'string' &&
-      typeof (parsed as SessionSnapshot).collectionName === 'string' &&
-      typeof (parsed as SessionSnapshot).trackIndex === 'number'
-    ) {
-      return parsed as SessionSnapshot;
-    }
-    return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isSessionSnapshot(parsed) ? parsed : null;
   } catch (err) {
     logCaughtError('sessionPersistence.loadSession', err);
     return null;

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -80,6 +80,9 @@ async function executeApiRequest<T>(
     throw new SpotifyApiError(response.status, response.statusText);
   }
 
+  // TODO(#1589 / #1584): callers' return-type generic `T` should widen to `T | undefined`
+  // to honestly model 204/empty-body responses. Ripple touches 7+ files (every caller of
+  // `spotifyApiRequest`), so deferred from the services/ sweep.
   if (response.status === 204) {
     return undefined as T;
   }

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -1,4 +1,4 @@
-import type { ProviderId, MediaTrack } from '@/types/domain';
+import type { MediaTrack } from '@/types/domain';
 import type { ArtistInfo, Track, SpotifyArtist, SpotifyTrackItem } from './types';
 import { getLargestImage } from './types';
 import { spotifyApiRequest, fetchAllPaginated } from './api';
@@ -80,8 +80,8 @@ export function backfillProvider(tracks: Track[]): Track[] {
 export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
   return tracks.map((t) => ({
     id: t.id,
-    provider: t.provider as ProviderId,
-    playbackRef: { provider: 'spotify' as ProviderId, ref: t.uri },
+    provider: t.provider,
+    playbackRef: { provider: 'spotify', ref: t.uri },
     name: t.name,
     artists: t.artists,
     artistsData: t.artistsData,

--- a/src/services/spotify/types.ts
+++ b/src/services/spotify/types.ts
@@ -10,7 +10,7 @@ import type { ProviderId } from '@/types/domain';
  */
 export interface Track {
   id: string;
-  provider: string;
+  provider: ProviderId;
   name: string;
   artists: string;
   artistsData?: { name: string; url?: string }[];


### PR DESCRIPTION
Part of #1589, addresses #1584 (services/ sweep).

## Summary

Sweep of `as` casts in `src/services/` per the Phase 2 blueprint. Headline: `lastfm.ts` goes from **21 casts to 1**, well under the ≤ 6 target.

## Changes (per commit)

1. **`lastfm.ts` parser-helper refactor** — introduces module-local `readString` / `readNullableString` / `readNumber` / `readObject` / `readArray` structural narrowers, plus a small `isPlainObject` type guard. `parseSimilarTrack` / `parseSimilarArtist` now take `unknown` and return `T | null`; callers `.filter(isNotNull)` the array. New `parseAlbumTrack` helper used by `getAlbumTracks`. Public surface (`getSimilarTracks`, `getSimilarArtists`, `getArtistTopTracks`, `getAlbumTracks`, `isLastFmConfigured`, `_resetRateLimiter`) is unchanged. All 12 existing tests pass verbatim.

2. **`spotify/types.ts` Track.provider tightening** — was typed `string`, now `ProviderId`. No callers were writing arbitrary strings (only `'spotify'` in `tracksFromCatalog` / `backfillProvider`). Lets `tracksToMediaTracks` drop the smuggled `t.provider as ProviderId` and the noop `'spotify' as ProviderId`.

3. **`sessionPersistence.ts` type predicate** — replaces five `parsed as SessionSnapshot` casts in `loadSession` with one `isSessionSnapshot(value: unknown): value is SessionSnapshot` predicate. Comment notes which fields are structurally asserted (collectionId/collectionName/trackIndex) vs. trusted optional fields.

4. **`libraryCache` FallbackStores widening** — widens to `Record<string, Map<string, unknown>>` (the precise per-store value types weren't actually consumed externally; the only public access is via `getFallbackMap(storeName)`, which has to serve any store). Eliminates the four `as Map<string, unknown>` casts in `getFallbackMap`; `closeCache` now iterates `Object.values(fallbackStores)`.

5. **Misc cleanups + `api.ts` TODO**
   - `libraryDiffEngine` / `librarySyncEngine`: drop two `as CachedPlaylistInfo[]` casts (`CachedPlaylistInfo` extends `PlaylistInfo` with only an optional `snapshot_id`, so `PlaylistInfo[]` is structurally assignable).
   - `spotify/api.ts`: annotate the two `undefined as T` casts in `executeApiRequest` (204 / empty-body) with `// TODO(#1589 / #1584):`. Honestly modeling these means widening `T → T | undefined` across **7 caller files**, which exceeds the sweep's build-green ripple cap. Deferred per the blueprint's escape hatch.

### Behavioural note: `parseAlbumTrack` artist fallback

The new `readString(artistObj, 'name') || fallbackArtist` in `parseAlbumTrack` differs from the prior `(t.artist.name as string) ?? artist`: an API response with `name: ''` now falls through to the `fallbackArtist` instead of returning the empty string. This is intentional — empty artist names from Last.fm are noise, not data. The new `read*` helpers also fix a latent type-laundering bug: the prior `(raw.x as string)` would silently flow numbers, arrays, and objects through as "strings"; the helpers reject anything that isn't actually a string.

## Cast count breakdown (`src/services/`, non-test)

> Rows below count **typed `as` casts only**. The grep entries `spotify/tracks:1`, `libraryDiffEngine:1`, and `librarySyncEngine:1` flagged in raw output are `import { x as y }` aliases, not type assertions — they're false positives and excluded here.

| Area | Before | After |
|---|---|---|
| lastfm.ts | 21 | 1 (env-var boundary) |
| spotify/tracks.ts | 2 | 0 |
| spotify/types.ts | 0 | 0 |
| sessionPersistence.ts | 5 | 1 (`Record<string, unknown>` after typeof guard) |
| cache/libraryCacheLifecycle.ts | 7 | 3 (IDB `event.target` + 2 JSON.parse migration boundaries) |
| cache/libraryDiffEngine.ts | 1 | 0 |
| cache/librarySyncEngine.ts | 1 | 0 |
| spotify/api.ts | 3 | 3 (2 deferred with TODO + 1 `existing as Promise<T>` cache-keyed generic) |
| **Total typed-`as` casts in services/** | **40** | **~28** (all remaining are legitimate boundary casts — IDB, JSON.parse, env, fetch.json, React fiber introspection) |

### Examined and kept

- `cache/librarySearch.ts:52` `as LibrarySearchResult` — examined; kept legitimately. `Object.freeze([])` returns `readonly never[]`, which is structurally incompatible with the mutable array fields on `LibrarySearchResult`. The cast is the standard escape hatch for frozen-empty-value sentinels.

## Out of scope (per blueprint)

- All `__tests__/` files — skipped.
- IDB boundary casts in `settings/*`, `cache/libraryCacheStorage`, `cache/likedCountSnapshot`, `cache/librarySearch` — legitimate.
- `devbug/*` — self-contained dev-only tool; casts are structural narrowing of React-fiber / performance-API unknowns. Left untouched.

## Cross-builder coordination

No symbols or types builder-1's `#1583` (providers/) sweep consumes are removed. `Track.provider` tightening is local to `src/services/spotify/`; the providers tree already treats it as `ProviderId` via `MediaTrack`.

## Verify

- `npx tsc -b --noEmit` — green
- `npm run test:run` — **197 files, 2063 tests, all passing**
- `npm run build` — green