### PR TITLE
refactor(hooks+contexts): tighten src/hooks + src/contexts sweep (#1586)

### DIFF
--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -175,7 +175,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
               onReorderTracks={onReorderQueue}
               showProviderIcons={showProviderIcons}
               radioActive={radioActive}
-              radioSeedDescription={radioState?.seedDescription}
+              radioSeedDescription={radioState?.isActive ? radioState.seedDescription : undefined}
               onSaveQueue={handleOpenSaveQueue}
               canSaveQueue={canSaveQueue}
             />
@@ -192,7 +192,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
               onReorderTracks={onReorderQueue}
               showProviderIcons={showProviderIcons}
               radioActive={radioActive}
-              radioSeedDescription={radioState?.seedDescription}
+              radioSeedDescription={radioState?.isActive ? radioState.seedDescription : undefined}
               onSaveQueue={handleOpenSaveQueue}
               canSaveQueue={canSaveQueue}
             />

--- a/src/components/__tests__/PlayerContent.test.tsx
+++ b/src/components/__tests__/PlayerContent.test.tsx
@@ -278,8 +278,7 @@ describe('PlayerContent', () => {
   it('handles radioState prop when provided', () => {
     // #given
     const radioState = {
-      isActive: false,
-      seedDescription: null,
+      isActive: false as const,
       isGenerating: false,
       error: null,
       lastMatchStats: null,

--- a/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
 
 vi.mock('@/hooks/useRadio', () => ({
   useRadio: vi.fn(() => ({
-    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
     startRadio: vi.fn(),
     stopRadio: vi.fn(),
     isRadioAvailable: true,

--- a/src/hooks/__tests__/usePlayerLogic.currentView.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.currentView.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
 
 vi.mock('@/hooks/useRadio', () => ({
   useRadio: vi.fn(() => ({
-    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
     startRadio: vi.fn(),
     stopRadio: vi.fn(),
     isRadioAvailable: true,

--- a/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
 
 vi.mock('@/hooks/useRadio', () => ({
   useRadio: vi.fn(() => ({
-    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
     startRadio: vi.fn(),
     stopRadio: vi.fn(),
     isRadioAvailable: true,

--- a/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrateFallback.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
 
 vi.mock('@/hooks/useRadio', () => ({
   useRadio: vi.fn(() => ({
-    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
     startRadio: vi.fn(),
     stopRadio: vi.fn(),
     isRadioAvailable: true,

--- a/src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/hooks/useUnifiedLikedTracks', () => ({
 
 vi.mock('@/hooks/useRadio', () => ({
   useRadio: vi.fn(() => ({
-    radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+    radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
     startRadio: vi.fn(),
     stopRadio: vi.fn(),
     isRadioAvailable: true,

--- a/src/hooks/__tests__/usePlayerLogic.radio.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.radio.test.tsx
@@ -124,7 +124,7 @@ function makeMediaTrack(overrides: Partial<MediaTrack> & { name: string; artists
 }
 
 const defaultRadioReturn = {
-  radioState: { isActive: false, seedDescription: null, isGenerating: false, error: null, lastMatchStats: null },
+  radioState: { isActive: false, isGenerating: false, error: null, lastMatchStats: null },
   stopRadio: vi.fn(),
   isRadioAvailable: true,
 };

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -95,7 +95,7 @@ export function useCollectionLoader({
         likedProviderIds.map(async (id) => {
           const catalog = descriptorMap.get(id)?.catalog;
           if (!catalog) return [];
-          return catalog.listTracks({ provider: id, kind: 'liked' }).catch(() => [] as MediaTrack[]);
+          return catalog.listTracks({ provider: id, kind: 'liked' }).catch((): MediaTrack[] => []);
         }),
       );
       const merged = results.flat();

--- a/src/hooks/useImageProcessingWorker.ts
+++ b/src/hooks/useImageProcessingWorker.ts
@@ -2,8 +2,6 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 import type {
   WorkerResponse,
   ImageProcessingRequest,
-  ImageProcessingResponse,
-  ImageProcessingError
 } from '@/workers/imageProcessor.worker';
 
 interface UseImageProcessingWorkerReturn {
@@ -33,8 +31,7 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
         );
 
         workerRef.current.onmessage = (event: MessageEvent<WorkerResponse>) => {
-          const { type } = event.data;
-          const requestId = (event.data as WorkerResponse & { requestId: number }).requestId;
+          const { requestId } = event.data;
           const pendingPromise = pendingPromisesRef.current.get(requestId);
 
           if (!pendingPromise) {
@@ -42,12 +39,10 @@ export const useImageProcessingWorker = (): UseImageProcessingWorkerReturn => {
             return;
           }
 
-          if (type === 'IMAGE_PROCESSED') {
-            const response = event.data as ImageProcessingResponse;
-            pendingPromise.resolve(response.processedImageData);
-          } else if (type === 'IMAGE_PROCESSING_ERROR') {
-            const response = event.data as ImageProcessingError;
-            pendingPromise.reject(new Error(response.error));
+          if (event.data.type === 'IMAGE_PROCESSED') {
+            pendingPromise.resolve(event.data.processedImageData);
+          } else if (event.data.type === 'IMAGE_PROCESSING_ERROR') {
+            pendingPromise.reject(new Error(event.data.error));
           }
 
           pendingPromisesRef.current.delete(requestId);

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -163,7 +163,7 @@ export const useProviderPlayback = ({
       }
     } catch (error) {
       if (error instanceof AuthExpiredError) {
-        onAuthExpired?.(error.providerId as ProviderId);
+        onAuthExpired?.(error.providerId);
         return;
       }
 

--- a/src/hooks/useRadio.ts
+++ b/src/hooks/useRadio.ts
@@ -18,7 +18,6 @@ interface UseRadioReturn {
 export function useRadio(): UseRadioReturn {
   const [radioState, setRadioState] = useState<RadioState>({
     isActive: false,
-    seedDescription: null,
     isGenerating: false,
     error: null,
     lastMatchStats: null,
@@ -34,7 +33,6 @@ export function useRadio(): UseRadioReturn {
 
     setRadioState({
       isActive: false,
-      seedDescription: null,
       isGenerating: true,
       error: null,
       lastMatchStats: null,
@@ -48,7 +46,6 @@ export function useRadio(): UseRadioReturn {
       if (result.queue.length === 0) {
         setRadioState({
           isActive: false,
-          seedDescription: null,
           isGenerating: false,
           error: 'No similar tracks found in your library.',
           lastMatchStats: result.matchStats,
@@ -72,7 +69,6 @@ export function useRadio(): UseRadioReturn {
       const message = err instanceof Error ? err.message : 'Failed to generate radio queue.';
       setRadioState({
         isActive: false,
-        seedDescription: null,
         isGenerating: false,
         error: message,
         lastMatchStats: null,
@@ -85,7 +81,6 @@ export function useRadio(): UseRadioReturn {
     generationRef.current++;
     setRadioState({
       isActive: false,
-      seedDescription: null,
       isGenerating: false,
       error: null,
       lastMatchStats: null,

--- a/src/providers/errors.ts
+++ b/src/providers/errors.ts
@@ -1,6 +1,8 @@
+import type { ProviderId } from '@/types/domain';
+
 export class AuthExpiredError extends Error {
-  readonly providerId: string;
-  constructor(providerId: string) {
+  readonly providerId: ProviderId;
+  constructor(providerId: ProviderId) {
     super(`Auth expired for provider: ${providerId}`);
     this.name = 'AuthExpiredError';
     this.providerId = providerId;

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -94,23 +94,30 @@ export interface RadioResult {
 
 // ── Radio state ──────────────────────────────────────────────────────
 
-// TODO(#1589 / #1586): discriminate by isActive — see .claude/blueprints/issue-1582-foundation.md §3b (revised).
-// Canonical shape:
-//   | { isActive: false; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
-//   | { isActive: true;  seedDescription: string; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
-// Only seedDescription is variant-locked; lastMatchStats and error persist across
-// the active boundary ("last" + post-session semantics). Deferred from #1582
-// because the rewrite ripples through useRadio.ts, 3 UI consumers, and 6 inline
-// test fixtures — hooks/contexts phase:2 sweep (#1586) takes ownership.
-export interface RadioState {
-  /** Whether a radio session is currently active. */
-  isActive: boolean;
-  /** Description of the current radio seed (e.g., "Radio based on Creep by Radiohead"). */
-  seedDescription: string | null;
-  /** Whether radio queue is currently being generated. */
-  isGenerating: boolean;
-  /** Error message from the last radio attempt. */
-  error: string | null;
-  /** Match stats from the last successful radio generation. */
-  lastMatchStats: RadioMatchStats | null;
-}
+/**
+ * Discriminated by `isActive`. `seedDescription` is variant-locked to the
+ * active branch (only meaningful while a session is live); the rest
+ * (`isGenerating`, `error`, `lastMatchStats`) persist across the active
+ * boundary because they carry "last attempt" / post-session semantics.
+ */
+export type RadioState =
+  | {
+      isActive: false;
+      /** Whether radio queue is currently being generated. */
+      isGenerating: boolean;
+      /** Error message from the last radio attempt. */
+      error: string | null;
+      /** Match stats from the last successful radio generation. */
+      lastMatchStats: RadioMatchStats | null;
+    }
+  | {
+      isActive: true;
+      /** Description of the current radio seed (e.g., "Radio based on Creep by Radiohead"). */
+      seedDescription: string;
+      /** Whether radio queue is currently being generated. */
+      isGenerating: boolean;
+      /** Error message from the last radio attempt. */
+      error: string | null;
+      /** Match stats from the last successful radio generation. */
+      lastMatchStats: RadioMatchStats | null;
+    };


### PR DESCRIPTION
Phase:2 sweep for `src/hooks/` + `src/contexts/`. Adopts the deferred `RadioState` discrimination from the foundation TODO, cleans bogus worker-narrowing casts, and tightens `AuthExpiredError.providerId` to `ProviderId`.

## Shipped

### 1. `RadioState` discrimination (deferred from #1582 §3b)

Uses the architect's revised wider shape: only `seedDescription` is variant-locked to `isActive: true`; `isGenerating`, `error`, and `lastMatchStats` persist across the active boundary ("last attempt" / post-session semantics).

```ts
export type RadioState =
  | { isActive: false; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null }
  | { isActive: true;  seedDescription: string; isGenerating: boolean; error: string | null; lastMatchStats: RadioMatchStats | null };
```

- `src/types/radio.ts` — replace interface with disc union; drop the TODO comment.
- `src/hooks/useRadio.ts` — restructure all 5 `setRadioState` calls; inactive variants no longer carry the meaningless `seedDescription: null`.
- `src/components/PlayerContent/DrawerOrchestrator.tsx` — narrow on `isActive` before passing `seedDescription` to `QueueDrawer` / `QueueBottomSheet` (the only call site that read the field without narrowing).
- 7 test fixture files — drop `seedDescription: null` from inline `{ isActive: false, … }` fixtures (`PlayerContent.test.tsx` + 6 `usePlayerLogic.*.test.tsx` files).

No other component consumer needed narrowing. `AudioPlayer` and `PlayerControlsSection` read `radioState?.isGenerating`, which the wider shape keeps on both variants.

### 2. `useImageProcessingWorker` narrowing cleanup

`WorkerResponse = ImageProcessingResponse | ImageProcessingError` is already discriminated by `type`. The `as ImageProcessingResponse` / `as ImageProcessingError` casts inside the `if (type === 'foo')` branches were no-ops; TS narrows automatically. The `event.data as WorkerResponse & { requestId: number }` intersection cast was also bogus — `requestId` exists on both variants. Destructure `requestId` from `event.data` directly.

**Net:** 3 fewer `as` casts in `src/hooks/`.

### 3. `AuthExpiredError.providerId` tightening

`AuthExpiredError` typed `providerId` as `string` even though every construction site (10) passes a literal `'spotify'` or `'dropbox'`. Tightened the field + constructor parameter to `ProviderId`. The downstream cast in `useProviderPlayback.ts:166` (`error.providerId as ProviderId`) is now redundant — deleted.

### 4. `useCollectionLoader` catch-handler cleanup

Replaced `.catch(() => [] as MediaTrack[])` with `.catch((): MediaTrack[] => [])` — explicit return-type annotation removes the cast without changing runtime behavior.

## Cross-area handoffs

- **#1587-b** is unblocked: `RadioState` is live, so PlayerContent / BottomBar sweeps can rely on the narrowed shape. No other UI consumer required narrowing in this PR; if the #1587-b sweep finds a `seedDescription` read it missed, this PR's `DrawerOrchestrator` change is the template.
- **#1583 providers/** already merged; the `AuthExpiredError` constructor tightening touches `src/providers/errors.ts` (1 file outside the hooks+contexts area, within the blueprint's "2 file" budget for cross-area ripples). All 10 construction sites pass valid `ProviderId` literals — no further provider-side changes.
- **#1584 services/** is in-flight; `AuthExpiredError` is constructed in `services/spotify/api.ts` and `services/spotifyPlayer.ts` but always with literal `'spotify'`, so no conflict.

## Casts removed

- `useImageProcessingWorker.ts` × 3 (line 37, 46, 49)
- `useProviderPlayback.ts` × 1 (line 166)
- `useCollectionLoader.ts` × 1 (line 98)

**Net:** 5 fewer `as` casts in `src/hooks/`. Legitimate boundary casts (DOM events, HMR data, JSON.parse in `VisualizerDebugContext`) retained per blueprint.

## Verify

- `npx tsc -b --noEmit` ✅
- `npm run test:run` ✅ (2063/2063)
- `npm run build` ✅

## Acceptance checklist

- [x] `RadioState` is the architect's canonical discriminated union; TODO removed
- [x] `useImageProcessingWorker` no longer casts inside the `type` discriminant check; bogus `& { requestId: number }` removed
- [x] No redundant casts in `useProviderPlayback`
- [x] tsc, test, build all green
- [x] PR targets `feature/typescript-strictness-audit-1589`

Part of #1589.