### PR TITLE
refactor(components): slice b — PlayerContent / AudioPlayer / SaveQueueDialog cleanup (#1587-b)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -84,7 +84,7 @@ const AudioPlayerComponent = () => {
   const { currentTrack, currentTrackIndex, setCurrentTrackIndex, showQueue, setShowQueue } = useCurrentTrackContext();
 
   const resolveDisplayProvider = useCallback((): import('@/types/domain').ProviderId | undefined => (
-    (currentTrack?.provider as import('@/types/domain').ProviderId | undefined)
+    currentTrack?.provider
     ?? playbackProviderRef.current
     ?? undefined
   ), [currentTrack, playbackProviderRef]);
@@ -125,7 +125,7 @@ const AudioPlayerComponent = () => {
   );
 
   const handleAlbumPlay = useCallback((albumId: string) => {
-    collectionProviderRef.current = currentTrack?.provider as import('@/types/domain').ProviderId | undefined;
+    collectionProviderRef.current = currentTrack?.provider;
     handlers.loadCollection(
       toAlbumPlaylistId(albumId),
       currentTrack?.provider,
@@ -230,6 +230,7 @@ const AudioPlayerComponent = () => {
     toast(`Couldn't resume your last session.`, { id: RESUME_TOAST_ID, duration: Infinity });
   }, [resetLastSession]);
   const withResumeDismiss = useCallback(
+    // Generic-recovery cast: TS can't re-derive T from the wrapper's parameter list.
     <T extends (...args: never[]) => unknown>(fn: T): T => ((...args) => {
       toast.dismiss(RESUME_TOAST_ID);
       return fn(...args);

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -103,7 +103,7 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
     [connectedProviderIds],
   );
   const canSaveQueue = saveProviders.length > 0 && tracks.length > 0;
-  const trackProviders = useMemo(() => new Set(tracks.map(t => t.provider).filter(Boolean)), [tracks]);
+  const trackProviders = useMemo(() => new Set(tracks.map(t => t.provider)), [tracks]);
 
   const handleOpenSaveQueue = useCallback(() => setShowSaveQueueDialog(true), []);
   const handleCloseSaveQueue = useCallback(() => setShowSaveQueueDialog(false), []);

--- a/src/components/QuickAccessPanel/PinRing.tsx
+++ b/src/components/QuickAccessPanel/PinRing.tsx
@@ -16,6 +16,7 @@ function getLikedSongsGradient(providerId?: string | 'unified'): string {
     const fallback = colors[0] ?? theme.colors.accent;
     return `linear-gradient(135deg, ${fallback} 0%, ${fallback} 100%)`;
   }
+  // providerId comes from snapshot/storage strings; registry.get returns undefined for unknown ids.
   const descriptor = providerId ? providerRegistry.get(providerId as ProviderId) : undefined;
   const color = descriptor?.color ?? theme.colors.accent;
   return `linear-gradient(135deg, ${color} 0%, ${color}cc 100%)`;

--- a/src/components/SaveQueueDialog.tsx
+++ b/src/components/SaveQueueDialog.tsx
@@ -80,7 +80,7 @@ interface SaveQueueDialogProps {
   onSave: (name: string, provider: ProviderId) => Promise<boolean>;
   onClose: () => void;
   availableProviders: ProviderId[];
-  trackProviders: Set<string | undefined>;
+  trackProviders: Set<ProviderId>;
   defaultName?: string;
 }
 
@@ -124,7 +124,7 @@ export default function SaveQueueDialog({ onSave, onClose, availableProviders, t
 
   const showProviderSelector = availableProviders.length > 1;
   const targetDescriptor = providerRegistry.get(provider);
-  const hasOtherProviderTracks = Array.from(trackProviders).some(p => p && p !== provider);
+  const hasOtherProviderTracks = Array.from(trackProviders).some(p => p !== provider);
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open && !saving) onClose(); }}>

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -48,7 +48,7 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({
   const { isMobile, isTablet, isDesktop } = usePlayerSizingContext();
   const { hasMultipleProviders, enabledProviderIds } = useProviderContext();
   const showProviderBadge = hasMultipleProviders && enabledProviderIds.length > 1;
-  const trackProvider = currentTrack?.provider as ProviderId | undefined;
+  const trackProvider = currentTrack?.provider;
 
   // Use Spotify controls hook — like state is always provided via props from usePlayerLogic
   const {


### PR DESCRIPTION
Sub-PR **b** of the `src/components/` sweep (#1587). Scope is the slice-b file set: `PlayerContent/`, `BottomBar/`, `QuickAccessPanel/`, `SaveQueueDialog`, `SpotifyPlayerControls`, `AudioPlayer.tsx`, `PlayerStateRenderer.tsx`, `QueueDrawer.tsx`, `QueueBottomSheet.tsx`, `AlbumArt*`. (`PlaylistSelection/` no longer exists in the tree.)

## Shipped

### 1. Redundant `ProviderId` casts dropped (3 sites)

`MediaTrack.provider: ProviderId` is required post-foundation, so `currentTrack?.provider` is already `ProviderId | undefined` and the trailing `as ProviderId | undefined` assertions were no-ops:

- `AudioPlayer.tsx:87` — `resolveDisplayProvider` body
- `AudioPlayer.tsx:128` — `collectionProviderRef.current` assignment
- `SpotifyPlayerControls.tsx:51` — `trackProvider` memoization

### 2. `SaveQueueDialog.trackProviders` tightened to `Set<ProviderId>`

Was `Set<string | undefined>` — a defensive shape that pre-dates `MediaTrack.provider` becoming required. The construction site in `DrawerOrchestrator.tsx:106` was running a `.filter(Boolean)` on `tracks.map(t => t.provider)` that filtered nothing because every element is already a `ProviderId`. Drop the filter; tighten the prop; simplify the consumer check `p && p !== provider` → `p !== provider`.

### 3. Generic-recovery cast at `AudioPlayer.tsx:236` annotated

`((...args) => ...) as T` for a function wrapper — TS can't re-derive `T` from the wrapper's parameter list. Legitimate TS limitation; left in place with a one-line comment per blueprint guidance.

### 4. `QuickAccessPanel/PinRing.tsx:19` cast commented

`providerId as ProviderId` at a `providerRegistry.get` call. `providerId` arrives from snapshot/storage as plain `string`, and `registry.get` returns `undefined` for unknown ids. Safe at the boundary; added a one-line comment.

## seedDescription narrowing (per dispatch brief)

Surveyed slice-b files for `seedDescription` reads after #1586 landed the discriminated `RadioState`. **Zero new narrowing needed.** The only consumers in slice b are in `DrawerOrchestrator.tsx` and they were already narrowed by #1586 (lines 178, 195, 209 all read `radioState?.isActive ? radioState.seedDescription : ...`). No other component in slice b reads `seedDescription` directly.

## Casts retained (legitimate DOM/ref boundaries)

`PlayerContent/index.tsx:175` (`e.target as Node`), `PlayerContent/AlbumArtSection.tsx:221` (`e.target as Element`), `PlayerContent/GestureLayer.tsx:67` (React ref boundary), `AlbumArtQuickSwapBack.tsx:175` (`e.target as Node`), `AlbumArt.tsx:280` (`e.target as HTMLImageElement`). All standard DOM-event narrowing patterns — kept per blueprint.

## Cross-area handoffs

None outside slice b. The `SaveQueueDialog` tightening propagated to `DrawerOrchestrator.tsx` (slice b owns this file). No spill into slice a (`controls/`, `LibraryRoute/`, `SettingsV2/`, `ui/`, `styled/`) or slice c (`visualizers/`, `AppSettingsMenu/`, `DevBug/`, `CmdKPalette/`).

## Verify

- `npx tsc -b --noEmit` ✅
- `npm run test:run` ✅ (2063/2063)
- `npm run build` ✅

## Acceptance checklist

- [x] No redundant `as ProviderId` / `as MediaTrack` casts in slice-b files
- [x] DOM event casts retained (legitimate)
- [x] `SaveQueueDialog.trackProviders: Set<ProviderId>` per blueprint structural cleanup
- [x] `seedDescription` narrowing audited (no new sites)
- [x] tsc, test, build all green
- [x] PR targets `feature/typescript-strictness-audit-1589`

Part of #1589.