### PR TITLE
refactor(components): #1587 slice a (ui/controls/LibraryRoute/SettingsV2/styled)

### DIFF
--- a/src/components/LibraryRoute/card/LibraryCard.tsx
+++ b/src/components/LibraryRoute/card/LibraryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import type { ContextMenuRequest, LibraryItemKind } from '../types';
+import type { ContextMenuRequest, LibraryItemKind, LibraryCollectionKind } from '../types';
 import type { ProviderId } from '@/types/domain';
 import { useLongPress } from './useLongPress';
 import ProviderIcon from '@/components/ProviderIcon';
@@ -15,7 +15,7 @@ import {
 } from './LibraryCard.styled';
 
 export interface LibraryCardProps {
-  kind: LibraryItemKind;
+  kind: LibraryCollectionKind;
   id: string;
   provider?: ProviderId;
   name: string;

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -127,9 +127,8 @@ export function buildMenuItems(request: ContextMenuRequest, actions: MenuActions
 
   if (request.kind === 'recently-played') {
     isRecentlyPlayed = true;
-    const original = request.originalKind ?? 'playlist';
-    if (original === 'album') items = buildAlbumItems(actions);
-    else if (original === 'liked') items = buildLikedItems(actions);
+    if (request.originalKind === 'album') items = buildAlbumItems(actions);
+    else if (request.originalKind === 'liked') items = buildLikedItems(actions);
     else items = buildPlaylistItems(actions);
   } else if (request.kind === 'album') {
     items = buildAlbumItems(actions);

--- a/src/components/LibraryRoute/contextMenu/useMenuItems.ts
+++ b/src/components/LibraryRoute/contextMenu/useMenuItems.ts
@@ -91,9 +91,7 @@ export function useMenuItems(
     if (!request) return [];
 
     const effectiveKind: 'playlist' | 'album' | 'liked' =
-      request.kind === 'recently-played'
-        ? request.originalKind ?? 'playlist'
-        : (request.kind as 'playlist' | 'album' | 'liked');
+      request.kind === 'recently-played' ? request.originalKind : request.kind;
 
     const isPlaylistKind = effectiveKind === 'playlist';
     const isAlbumKind = effectiveKind === 'album';

--- a/src/components/LibraryRoute/hooks/useAlbumsSection.ts
+++ b/src/components/LibraryRoute/hooks/useAlbumsSection.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { useLibrarySync } from '@/hooks/useLibrarySync';
 import { usePinnedItems } from '@/hooks/usePinnedItems';
 import type { AlbumInfo } from '@/services/spotify';
-import type { ProviderId } from '@/types/domain';
 import type { SectionState, UseCollectionSectionParams } from '../types';
 
 export type UseAlbumsSectionParams = UseCollectionSectionParams;
@@ -17,7 +16,7 @@ export function useAlbumsSection(
     let result = albums;
     if (providerFilter && providerFilter.length > 0) {
       const allowed = new Set(providerFilter);
-      result = result.filter((a) => allowed.has((a.provider ?? 'spotify') as ProviderId));
+      result = result.filter((a) => allowed.has(a.provider ?? 'spotify'));
     }
     if (excludePinned) {
       const pinnedSet = new Set(pinnedAlbumIds);

--- a/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
+++ b/src/components/LibraryRoute/hooks/usePlaylistsSection.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { useLibrarySync } from '@/hooks/useLibrarySync';
 import { usePinnedItems } from '@/hooks/usePinnedItems';
 import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
-import type { ProviderId } from '@/types/domain';
 import type { SectionState, UseCollectionSectionParams } from '../types';
 
 export type UsePlaylistsSectionParams = UseCollectionSectionParams;
@@ -17,7 +16,7 @@ export function usePlaylistsSection(
     let result = playlists;
     if (providerFilter && providerFilter.length > 0) {
       const allowed = new Set(providerFilter);
-      result = result.filter((p) => allowed.has((p.provider ?? 'spotify') as ProviderId));
+      result = result.filter((p) => allowed.has(p.provider ?? 'spotify'));
     }
     if (excludePinned) {
       const pinnedSet = new Set(pinnedPlaylistIds);

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -188,7 +188,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
   } else {
     body = (
       <SeeAllView
-        view={effectiveView as Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>}
+        view={effectiveView}
         onBack={() => setView('home')}
         onSelectCollection={handleSelectCollection}
         onContextMenuRequest={handleContextMenuRequest}

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -31,21 +31,33 @@ export type LibraryRouteView =
   | 'liked'
   | 'search';
 
-export type LibraryItemKind = 'playlist' | 'album' | 'liked' | 'recently-played';
+/** Kinds a library card represents directly (no meta-wrappers). */
+export type LibraryCollectionKind = 'playlist' | 'album' | 'liked';
 
-export interface ContextMenuRequest {
-  kind: LibraryItemKind;
+export type LibraryItemKind = LibraryCollectionKind | 'recently-played';
+
+interface ContextMenuRequestBase {
   id: string;
   provider?: ProviderId;
   name: string;
   anchorRect: DOMRect;
   /** The CardButton element that triggered the menu; used to return focus on keyboard dismiss. */
   triggerElement?: HTMLElement;
-  /** When kind === 'recently-played', the underlying collection kind so the menu can dispatch the right schema. */
-  originalKind?: 'playlist' | 'album' | 'liked';
-  /** When kind === 'recently-played', back-pointer used by the "Remove from history" action. */
-  recentRef?: CollectionRef;
 }
+
+export type ContextMenuRequest = ContextMenuRequestBase &
+  (
+    | { kind: 'playlist' }
+    | { kind: 'album' }
+    | { kind: 'liked' }
+    | {
+        kind: 'recently-played';
+        /** Underlying collection kind so the menu can dispatch the right schema. */
+        originalKind: 'playlist' | 'album' | 'liked';
+        /** Back-pointer used by the "Remove from history" action. */
+        recentRef: CollectionRef;
+      }
+  );
 
 export type {
   CachedPlaylistInfo,

--- a/src/components/SettingsV2/sections.ts
+++ b/src/components/SettingsV2/sections.ts
@@ -43,5 +43,5 @@ export const SETTINGS_V2_SECTIONS: readonly SettingsV2SectionDescriptor[] = [
 export const DEFAULT_SETTINGS_V2_SECTION: SettingsV2SectionId = 'sources';
 
 export function isSettingsV2SectionId(value: string | null | undefined): value is SettingsV2SectionId {
-  return typeof value === 'string' && (SETTINGS_V2_SECTION_IDS as readonly string[]).includes(value);
+  return typeof value === 'string' && SETTINGS_V2_SECTION_IDS.some((id) => id === value);
 }

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -1,6 +1,7 @@
 import { memo, Fragment, useState, useCallback, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import type { ArtistInfo } from '../../services/spotify';
+import type { ProviderId } from '@/types/domain';
 import { useProviderContext } from '../../contexts/ProviderContext';
 import { spotifyLibrarySyncEngine } from '../../services/cache/librarySyncEngine';
 import { PlayerTrackName, PlayerTrackAlbum, AlbumLink, PlayerTrackArtist, TrackInfoOnlyRow, ArtistLink } from './styled';
@@ -10,7 +11,7 @@ import TrackRadioPopover from './TrackRadioPopover';
 interface TrackInfoProps {
     track: {
         name?: string;
-        provider?: string;
+        provider?: ProviderId;
         artists?: string;
         artistsData?: ArtistInfo[];
         album?: string;
@@ -45,7 +46,7 @@ const areTrackInfoPropsEqual = (
 
 type PopoverState =
     | { type: 'artist'; artistName: string; artistUrl: string; rect: DOMRect }
-    | { type: 'album'; albumId: string; albumName: string; rect: DOMRect }
+    | { type: 'album'; albumId: string; albumName: string; artistName: string; trackImage: string; rect: DOMRect }
     | { type: 'radio'; trackName: string; rect: DOMRect }
     | null;
 
@@ -55,7 +56,7 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
     const artistRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
     const albumRef = useRef<HTMLButtonElement>(null);
     const { activeDescriptor, getDescriptor } = useProviderContext();
-    const trackDescriptor = track?.provider ? getDescriptor(track.provider as import('@/types/domain').ProviderId) : activeDescriptor;
+    const trackDescriptor = track?.provider ? getDescriptor(track.provider) : activeDescriptor;
     const capabilities = trackDescriptor?.capabilities;
     const catalog = trackDescriptor?.catalog;
 
@@ -90,8 +91,19 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
         if (!track?.albumId || !track?.album) return;
         const target = e.currentTarget as HTMLElement;
         const rect = target.getBoundingClientRect();
-        setPopover({ type: 'album', albumId: track.albumId, albumName: track.album, rect });
-    }, [track?.albumId, track?.album]);
+        // Capture artistName + image at click time. The popover may outlive the
+        // current `track` value (e.g. next song starts mid-popover), so reading
+        // `track.artists` during render in buildAlbumOptions/optimisticAddAlbum
+        // could surface the wrong artist. Snapshot what the user clicked.
+        setPopover({
+            type: 'album',
+            albumId: track.albumId,
+            albumName: track.album,
+            artistName: track.artists ?? '',
+            trackImage: track.image ?? '',
+            rect,
+        });
+    }, [track?.albumId, track?.album, track?.artists, track?.image]);
 
     const handleTrackNameClick = useCallback((e: React.MouseEvent) => {
         e.preventDefault();
@@ -114,13 +126,13 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
         ? DiscogsIcon
         : SpotifyIcon;
 
-    const getAlbumExternalUrl = (albumId: string, albumName: string): string | undefined => {
+    const getAlbumExternalUrl = (albumId: string, albumName: string, artistName: string): string | undefined => {
         if (trackDescriptor?.getExternalUrls) {
-            const urls = trackDescriptor.getExternalUrls({ type: 'album', name: albumName, artistName: track?.artists ?? '' });
+            const urls = trackDescriptor.getExternalUrls({ type: 'album', name: albumName, artistName });
             return urls?.[0]?.url;
         }
         if (trackDescriptor?.getExternalUrl) {
-            return trackDescriptor.getExternalUrl({ type: 'album', name: albumName, artistName: track?.artists ?? '' });
+            return trackDescriptor.getExternalUrl({ type: 'album', name: albumName, artistName });
         }
         if (trackDescriptor?.id === 'spotify' && albumId) {
             return `https://open.spotify.com/album/${albumId}`;
@@ -224,8 +236,8 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
                             spotifyLibrarySyncEngine.optimisticAddAlbum({
                                 id: popover.albumId,
                                 name: popover.albumName,
-                                artists: track?.artists ?? '',
-                                images: track?.image ? [{ url: track.image, height: null, width: null }] : [],
+                                artists: popover.artistName,
+                                images: popover.trackImage ? [{ url: popover.trackImage, height: null, width: null }] : [],
                                 release_date: '',
                                 total_tracks: 0,
                                 uri: `spotify:album:${popover.albumId}`,
@@ -237,7 +249,7 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
             });
         }
         if (hasExternalLink) {
-            const externalUrls = trackDescriptor?.getExternalUrls?.({ type: 'album', name: popover.albumName, artistName: track?.artists ?? '' });
+            const externalUrls = trackDescriptor?.getExternalUrls?.({ type: 'album', name: popover.albumName, artistName: popover.artistName });
             if (externalUrls) {
                 for (const entry of externalUrls) {
                     const IconComponent = ICON_MAP[entry.icon] ?? DiscogsIcon;
@@ -248,7 +260,7 @@ const TrackInfo = memo<TrackInfoProps>(({ track, isMobile, isTablet, onArtistBro
                     });
                 }
             } else {
-                const albumUrl = getAlbumExternalUrl(popover.albumId, popover.albumName);
+                const albumUrl = getAlbumExternalUrl(popover.albumId, popover.albumName, popover.artistName);
                 if (albumUrl) {
                     options.push({
                         label: `View album on ${providerName}`,


### PR DESCRIPTION
Part of #1589, addresses #1587 slice **a** per the Phase 2 components-sweep blueprint (architect split #1587 three ways; this is slice a).

## Scope

Slice a covers: `src/components/ui/`, `src/components/controls/`, `src/components/LibraryRoute/`, `src/components/SettingsV2/`, `src/components/styled/`. Slices b (PlayerContent/BottomBar/queue/...) and c (visualizers/AppSettingsMenu/DevBug/...) are out of scope and untouched.

## Commits (3, logical chunks)

### 1. `refactor(LibraryRoute): discriminate ContextMenuRequest by kind`
Adopts the blueprint's discriminated-union shape verbatim:
```ts
type ContextMenuRequest = ContextMenuRequestBase & (
  | { kind: 'playlist' }
  | { kind: 'album' }
  | { kind: 'liked' }
  | { kind: 'recently-played'; originalKind: 'playlist' | 'album' | 'liked'; recentRef: CollectionRef }
);
```
- Introduces `LibraryCollectionKind = 'playlist' | 'album' | 'liked'` for the three-member subset; reuses it on `LibraryCardProps.kind` (which never produces a `'recently-played'` request directly — `RecentlyPlayedSection` wraps the callback to inject the meta fields).
- `useMenuItems.ts:96` cast `request.kind as 'playlist' | 'album' | 'liked'` deleted — TS narrows naturally via the `request.kind === 'recently-played'` branch.
- `menuItemsForKind.ts:130` `request.originalKind ?? 'playlist'` fallback deleted — `originalKind` is required by the type.

Producer (`RecentlyPlayedSection.tsx:60-68`) already set `kind`, `originalKind`, `recentRef` together; no change needed there.

### 2. `refactor(components): drop redundant casts in LibraryRoute + SettingsV2`
- `LibraryRoute/index.tsx:191` — drop `effectiveView as Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>`. The surrounding `if/else` already narrows `effectiveView` after the prior `'search' | 'home' | 'liked'` branches.
- `usePlaylistsSection.ts:20` / `useAlbumsSection.ts:20` — drop `as ProviderId` on `(p.provider ?? 'spotify') as ProviderId`. The expression already evaluates to `ProviderId` since `'spotify'` is a literal member. The `?? 'spotify'` fallback is **retained** — `PlaylistInfo.provider` / `AlbumInfo.provider` are legitimately optional.
- `SettingsV2/sections.ts:46` — replace `(SETTINGS_V2_SECTION_IDS as readonly string[]).includes(value)` workaround with `.some((id) => id === value)`. The predicate compiles cast-free.

### 3. `fix(TrackInfo): snapshot album popover context at click time`
**Behaviour change** — resolves a latent stale-popover race surfaced by foundation #1582's discriminated `ExternalLinkRequest` (which made `album.artistName` required). Reviewer flagged the wave-1 `track?.artists ?? ''` fallbacks; the lead approved option D1 (component-side fix) over D2 (type-only).

**The bug:** the album popover's `buildAlbumOptions` / `optimisticAddAlbum` / `getAlbumExternalUrl` read `track?.artists` and `track?.image` during render, with `?? ''` as defensive fallback. But the popover lifecycle is decoupled from the `track` prop — a new song can start while the popover is still open. The menu would then surface the *new* song's artist (and write the wrong artist into the optimistic library cache on Add-to-Library).

**The fix:** capture `artistName` + `trackImage` into `PopoverState` alongside `albumId` / `albumName` at `handleAlbumClick`. `buildAlbumOptions` now reads from the snapshot, not the current `track`. The four render-time `?? ''` fallbacks at lines 119, 123, 227, 240 collapse to one click-time `?? ''` at the snapshot constructor — the latter handles `TrackInfoProps.track.artists?: string`'s structurally-permitted undefined. A follow-up could tighten `TrackInfoProps.track.artists` to required `string`, eliminating the snapshot-site fallback too; out of scope here.

Also tightens `TrackInfoProps.track.provider` from `string` to `ProviderId`, which removes the line-58 `track.provider as ProviderId` cast.

Diff size: 24 insertions / 12 deletions in `TrackInfo.tsx` (within the blueprint's ≤25 LOC cap for D1). Caller (`SpotifyPlayerControls.tsx`, slice b) is unaffected — it passes `currentTrack: MediaTrack | null` which already meets the tighter shape.

## Cast inventory (slice a, typed-`as` casts only, non-test)

| File | Before | After |
|---|---|---|
| `LibraryRoute/index.tsx` | 2 | 1 (composedPath HTMLElement boundary) |
| `LibraryRoute/contextMenu/useMenuItems.ts` | 1 | 0 |
| `LibraryRoute/hooks/usePlaylistsSection.ts` | 1 | 0 |
| `LibraryRoute/hooks/useAlbumsSection.ts` | 1 | 0 |
| `SettingsV2/sections.ts` | 1 | 0 |
| `controls/TrackInfo.tsx` | 4 (3 DOM event + 1 ProviderId) | 3 (DOM event only) |
| **All remaining** | | DOM event boundary (`HTMLElement`, `Node`, `TouchEvent`, `MouseEvent`), CSS-custom-property (`React.CSSProperties`), `err as Record<string, unknown>` in `isMenuActionError`, form-input value (`LibrarySort`), `styled-components` declaration-merging shim (`Alert`, `Card`) — all per blueprint's "legitimate" bucket |

## Cross-slice / cross-PR

- **No slice b/c files touched.** TrackInfo's sole external caller (`SpotifyPlayerControls`, slice b) needs no edits — narrower `provider: ProviderId` is satisfied by callers passing `MediaTrack | null`.
- **No conflict with #1586 (hooks+contexts).** This slice has no `RadioState` consumers (those live in slice b's PlayerContent/BottomBar).

## Verify

- `npx tsc -b --noEmit` — green
- `npm run test:run` — **197 files, 2063 tests, all passing**
- `npm run build` — green
- `git status --porcelain` — clean
