### PR TITLE
build(tsconfig): enable noImplicitOverride + noUncheckedIndexedAccess; defer EOPT (#1585)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,41 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 - Strict TypeScript; `import type` when possible; types in `src/types/`
 - Empty `catch` blocks are permitted only when paired with `logCaughtError('<context>', err)` from `src/utils/logCaughtError.ts` so swallowed failures still surface in dev. Existing rationale comments inside the catch should stay; the helper call is additive.
 
+### Type strictness baseline
+
+`tsconfig.app.json` enables the strictest reasonable set of compiler flags:
+`strict`, `noUncheckedIndexedAccess`, `noImplicitOverride`,
+`noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`,
+`noUncheckedSideEffectImports`, `erasableSyntaxOnly`, `verbatimModuleSyntax`.
+`exactOptionalPropertyTypes` is intentionally deferred — see issue #1598
+for the architectural decision pending on React prop conventions.
+
+Patterns this enforces:
+
+- **No unjustified `as` casts.** Casts are only acceptable at deserialization
+  boundaries (`JSON.parse`, IndexedDB `req.result`, `MessageEvent.data`,
+  `CustomEvent.detail`, `event.target as HTMLElement`, `import.meta.env.*`).
+  Anywhere else, fix the underlying type instead. Forbidden: `as any`, `@ts-ignore`,
+  `@ts-expect-error`, non-null `!` to silence a strictness error.
+- **Discriminated unions for variant shapes.** When a shape has variants that
+  carry different required fields, use a discriminated union with a literal
+  `kind` / `type` / `phase` / `isActive` field — not optional fields on a flat
+  interface. See `CollectionRef`, `ExternalLinkRequest`, `RadioProgress`,
+  `RadioState`, `ContextMenuRequest` for examples.
+- **Optional XOR nullable, never both.** A field is either `field?: T`
+  (absence means "not provided") or `field: T | null` (always present, `null`
+  is meaningful). `field?: T | null` is forbidden — under
+  `exactOptionalPropertyTypes` it becomes a three-way mess of
+  missing-vs-null-vs-undefined.
+- **Canonical types live in `src/types/`.** Inline object types repeated across
+  files should be lifted to a named export and colocated with their conceptual
+  owner (`domain.ts`, `providers.ts`, `radio.ts`, etc.). Test fixture and
+  component-local shapes can stay local.
+- **Indexed access returns `T | undefined`.** Bounds-check (`if (!item) return`),
+  default-coalesce (`?? fallback`), or destructure-with-default. Never `arr[i]!`.
+
+These conventions were established by the TypeScript strictness audit epic (#1589).
+
 ## Testing
 
 ### Unit / integration (Vitest)

--- a/src/components/DevBug/AnnotationOverlay.tsx
+++ b/src/components/DevBug/AnnotationOverlay.tsx
@@ -141,10 +141,15 @@ function renderAnnotation(ctx: CanvasRenderingContext2D, annotation: Annotation,
       ctx.restore();
       return;
     }
+    const [first, ...rest] = annotation.points;
+    if (!first) {
+      ctx.restore();
+      return;
+    }
     ctx.beginPath();
-    ctx.moveTo(annotation.points[0].x * dpr, annotation.points[0].y * dpr);
-    for (let i = 1; i < annotation.points.length; i++) {
-      ctx.lineTo(annotation.points[i].x * dpr, annotation.points[i].y * dpr);
+    ctx.moveTo(first.x * dpr, first.y * dpr);
+    for (const point of rest) {
+      ctx.lineTo(point.x * dpr, point.y * dpr);
     }
     ctx.stroke();
   }

--- a/src/components/DevBug/DevBugFAB.tsx
+++ b/src/components/DevBug/DevBugFAB.tsx
@@ -221,8 +221,9 @@ export function DevBugFAB() {
 
   const handleAreaSelected = useCallback(
     (_elements: Element[], infos: SelectedElement[]) => {
-      if (infos.length > 0) {
-        panel.open(infos[0]);
+      const first = infos[0];
+      if (first) {
+        panel.open(first);
       }
     },
     [panel],

--- a/src/components/EyedropperOverlay.tsx
+++ b/src/components/EyedropperOverlay.tsx
@@ -35,7 +35,7 @@ const EyedropperOverlay: React.FC<EyedropperOverlayProps> = ({ image, onPick, on
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const pixel = ctx.getImageData(x, y, 1, 1).data;
-    const color = `#${[pixel[0], pixel[1], pixel[2]].map(v => v.toString(16).padStart(2, '0')).join('')}`;
+    const color = `#${[pixel[0] ?? 0, pixel[1] ?? 0, pixel[2] ?? 0].map(v => v.toString(16).padStart(2, '0')).join('')}`;
     onPick(color);
     onClose();
   };
@@ -49,7 +49,7 @@ const EyedropperOverlay: React.FC<EyedropperOverlayProps> = ({ image, onPick, on
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const pixel = ctx.getImageData(x, y, 1, 1).data;
-    const color = `#${[pixel[0], pixel[1], pixel[2]].map(v => v.toString(16).padStart(2, '0')).join('')}`;
+    const color = `#${[pixel[0] ?? 0, pixel[1] ?? 0, pixel[2] ?? 0].map(v => v.toString(16).padStart(2, '0')).join('')}`;
     setHoverColor(color);
   };
 

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -82,16 +82,16 @@ const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      items[(idx + 1) % items.length].focus();
+      items[(idx + 1) % items.length]?.focus();
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      items[(idx - 1 + items.length) % items.length].focus();
+      items[(idx - 1 + items.length) % items.length]?.focus();
     } else if (e.key === 'Home') {
       e.preventDefault();
-      items[0].focus();
+      items[0]?.focus();
     } else if (e.key === 'End') {
       e.preventDefault();
-      items[items.length - 1].focus();
+      items[items.length - 1]?.focus();
     }
   }, []);
 

--- a/src/components/MosaicThumbnail.tsx
+++ b/src/components/MosaicThumbnail.tsx
@@ -69,7 +69,7 @@ export const MosaicThumbnail: React.FC<MosaicThumbnailProps> = React.memo(
     // Build the 4 quadrants
     let quadrants: (string | null)[];
     if (resolved.length >= 4) {
-      quadrants = [resolved[0], resolved[1], resolved[2], resolved[3]];
+      quadrants = [resolved[0] ?? null, resolved[1] ?? null, resolved[2] ?? null, resolved[3] ?? null];
     } else {
       // 2-3 paths → diagonal duplication: A in Q1+Q4, B in Q2+Q3
       const a = resolved[0] ?? null;

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -203,7 +203,8 @@ export const PlayerControlsSection: React.FC<PlayerControlsSectionProps> = React
   const handleCycleVisualizerStyle = useCallback(() => {
     const currentIndex = VISUALIZER_CYCLE.indexOf(backgroundVisualizerStyle);
     const nextIndex = (currentIndex + 1) % VISUALIZER_CYCLE.length;
-    setBackgroundVisualizerStyle(VISUALIZER_CYCLE[nextIndex]);
+    const next = VISUALIZER_CYCLE[nextIndex];
+    if (next) setBackgroundVisualizerStyle(next);
   }, [backgroundVisualizerStyle, setBackgroundVisualizerStyle]);
 
   const handleTranslucenceToggle = useCallback(() => {

--- a/src/components/QuickAccessPanel/index.tsx
+++ b/src/components/QuickAccessPanel/index.tsx
@@ -82,7 +82,7 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = ({
     const perProvider = likedSongsPerProvider.filter(e =>
       providerIds.length === 0 || providerIds.includes(e.provider),
     );
-    const resolvedProvider = perProvider.length === 1 ? perProvider[0].provider : undefined;
+    const resolvedProvider = perProvider.length === 1 ? perProvider[0]?.provider : undefined;
     onPlaylistSelect(LIKED_SONGS_ID, LIKED_SONGS_NAME, resolvedProvider);
   };
 

--- a/src/components/SaveQueueDialog.tsx
+++ b/src/components/SaveQueueDialog.tsx
@@ -94,7 +94,7 @@ export default function SaveQueueDialog({ onSave, onClose, availableProviders, t
     });
     return `Queue — ${date}`;
   });
-  const [provider, setProvider] = useState<ProviderId>(availableProviders[0]);
+  const [provider, setProvider] = useState<ProviderId>(availableProviders[0] ?? 'spotify');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/SettingsV2/sections.ts
+++ b/src/components/SettingsV2/sections.ts
@@ -17,7 +17,7 @@ export interface SettingsV2SectionDescriptor {
   description: string;
 }
 
-export const SETTINGS_V2_SECTIONS: readonly SettingsV2SectionDescriptor[] = [
+export const SETTINGS_V2_SECTIONS: readonly [SettingsV2SectionDescriptor, ...SettingsV2SectionDescriptor[]] = [
   {
     id: 'sources',
     label: 'Sources',

--- a/src/components/controls/VolumeControl/index.tsx
+++ b/src/components/controls/VolumeControl/index.tsx
@@ -108,6 +108,7 @@ const VolumeControl = memo<VolumeControlProps>(({
     const sliderValue = useMemo(() => [displayVolume], [displayVolume]);
 
     const handleSliderChange = useCallback(([next]: number[]) => {
+        if (next === undefined) return;
         onVolumeChange(next);
     }, [onVolumeChange]);
 

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -71,7 +71,7 @@ export function useCollectionLoader({
     const shouldShuffle = shuffleEnabled || options?.forceShuffle === true;
     if (shouldShuffle) {
       const indices = shuffleArray(tracks.map((_, i) => i));
-      const shuffled = indices.map(i => tracks[i]);
+      const shuffled = indices.map(i => tracks[i]).filter((t): t is MediaTrack => t !== undefined);
       mediaTracksRef.current = shuffled;
       setTracks(shuffled);
     } else {
@@ -106,19 +106,21 @@ export function useCollectionLoader({
       applyTracks(merged);
 
       const firstTrack = mediaTracksRef.current[0];
-      const firstProvider = getDescriptor(firstTrack.provider);
-      if (firstProvider) {
-        drivingProviderRef.current = firstTrack.provider;
-        if (firstTrack.provider !== activeDescriptor?.id) {
-          setActiveProviderId(firstTrack.provider);
+      if (firstTrack) {
+        const firstProvider = getDescriptor(firstTrack.provider);
+        if (firstProvider) {
+          drivingProviderRef.current = firstTrack.provider;
+          if (firstTrack.provider !== activeDescriptor?.id) {
+            setActiveProviderId(firstTrack.provider);
+          }
+          queueSnapshot('Unified Liked loaded', merged, mediaTracksRef.current.length, 0);
+          await playTrack(0);
+          record(
+            { provider: firstTrack.provider, kind: 'liked' },
+            name ?? LIKED_SONGS_NAME,
+            firstTrack.image ?? null,
+          );
         }
-        queueSnapshot('Unified Liked loaded', merged, mediaTracksRef.current.length, 0);
-        await playTrack(0);
-        record(
-          { provider: firstTrack.provider, kind: 'liked' },
-          name ?? LIKED_SONGS_NAME,
-          firstTrack.image ?? null,
-        );
       }
       return merged.length;
     } catch (err) {

--- a/src/hooks/useHorizontalSwipeToRemove.ts
+++ b/src/hooks/useHorizontalSwipeToRemove.ts
@@ -55,6 +55,7 @@ export function useHorizontalSwipeToRemove(
 
     const handleTouchStart = (e: TouchEvent) => {
       const touch = e.touches[0];
+      if (!touch) return;
       startXRef.current = touch.clientX;
       startYRef.current = touch.clientY;
       currentDeltaXRef.current = 0;
@@ -70,6 +71,7 @@ export function useHorizontalSwipeToRemove(
       if (directionLockedRef.current === 'vertical') return;
 
       const touch = e.touches[0];
+      if (!touch) return;
       const deltaX = touch.clientX - startXRef.current;
       const deltaY = touch.clientY - startYRef.current;
 

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -160,6 +160,7 @@ export function useQueueManagement({
       if (index === currentTrackIndex) return;
 
       const removedTrack = tracks[index];
+      if (!removedTrack) return;
       logQueue('handleRemoveFromQueue — removing index=%d, track=%s, queueLen=%d', index, trkSummary(removedTrack), tracks.length);
 
       if (tracks.length <= 1) {

--- a/src/hooks/useSwipeGesture.ts
+++ b/src/hooks/useSwipeGesture.ts
@@ -93,6 +93,7 @@ export function useSwipeGesture(
     if (isAnimating) return;
 
     const touch = e.touches[0];
+    if (!touch) return;
     startXRef.current = touch.clientX;
     startYRef.current = touch.clientY;
     startTimeRef.current = Date.now();
@@ -104,6 +105,7 @@ export function useSwipeGesture(
     if (directionLockedRef.current === 'vertical') return;
 
     const touch = e.touches[0];
+    if (!touch) return;
     const deltaX = touch.clientX - startXRef.current;
     const deltaY = touch.clientY - startYRef.current;
 

--- a/src/hooks/useVerticalSwipeGesture.ts
+++ b/src/hooks/useVerticalSwipeGesture.ts
@@ -60,6 +60,7 @@ export function useVerticalSwipeGesture(
 
     const handleTouchStart = (e: TouchEvent) => {
       const touch = e.touches[0];
+      if (!touch) return;
       startYRef.current = touch.clientY;
       startXRef.current = touch.clientX;
       startTimeRef.current = Date.now();
@@ -71,6 +72,7 @@ export function useVerticalSwipeGesture(
       if (directionLockedRef.current === 'horizontal') return;
 
       const touch = e.touches[0];
+      if (!touch) return;
       const deltaY = touch.clientY - startYRef.current;
       const deltaX = touch.clientX - startXRef.current;
 

--- a/src/providers/dropbox/dropboxCatalogHelpers.ts
+++ b/src/providers/dropbox/dropboxCatalogHelpers.ts
@@ -48,8 +48,9 @@ function findArtByNames(entries: DropboxFileEntry[], names: string[]): string | 
 }
 
 export function pickAlbumArtPath(entries: DropboxFileEntry[]): string | null {
-  if (entries.length === 0) return null;
-  return findArtByNames(entries, ALBUM_ART_NAMES) ?? entries[0].path_lower;
+  const first = entries[0];
+  if (!first) return null;
+  return findArtByNames(entries, ALBUM_ART_NAMES) ?? first.path_lower;
 }
 
 export function parentDir(path: string): string {
@@ -59,7 +60,7 @@ export function parentDir(path: string): string {
 function parseFilename(filename: string): { name: string; trackNumber?: number } {
   const base = filename.replace(/\.[^/.]+$/, '');
   const match = base.match(/^(\d{1,3})\s*[-.\s]\s*(.+)$/);
-  if (match) {
+  if (match && match[1] && match[2]) {
     return { name: match[2].trim(), trackNumber: parseInt(match[1], 10) };
   }
   return { name: base };
@@ -75,7 +76,7 @@ export function entryToMediaTrack(entry: DropboxFileEntry, imageUrl?: string): M
   const { name, trackNumber } = parseFilename(entry.name);
 
   const displayParts = entry.path_display.split('/').filter(Boolean);
-  const albumName = displayParts.length >= 2 ? displayParts[displayParts.length - 2] : 'Unknown Album';
+  const albumName = (displayParts.length >= 2 ? displayParts[displayParts.length - 2] : undefined) ?? 'Unknown Album';
   const artistName = displayParts.length >= 3 ? displayParts[displayParts.length - 3] : undefined;
 
   const albumId = parentDir(entry.path_lower);

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -273,9 +273,11 @@ export async function listSavedPlaylists(
   await Promise.all(
     collections.map(async (collection, i) => {
       try {
-        const data = await loadPlaylistFile(auth, filePaths[i]);
+        const path = filePaths[i];
+        if (!path) return;
+        const data = await loadPlaylistFile(auth, path);
         logLibrary('listSavedPlaylists: "%s" file=%s data=%s tracks=%d',
-          collection.name, filePaths[i], data ? 'loaded' : 'null', data?.tracks?.length ?? -1);
+          collection.name, path, data ? 'loaded' : 'null', data?.tracks?.length ?? -1);
         if (data) {
           collection.trackCount = data.tracks.length;
           const albumMap = buildAlbumCoverMap(data.tracks);

--- a/src/providers/spotify/spotifyPlaybackAdapter.ts
+++ b/src/providers/spotify/spotifyPlaybackAdapter.ts
@@ -157,7 +157,7 @@ export class SpotifyPlaybackAdapter implements PlaybackProvider {
 
       if (is429) {
         const retryAfterMatch = message.match(/retry.?after[:\s]+(\d+)/i);
-        const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1], 10) : 0;
+        const retryAfterSec = retryAfterMatch ? parseInt(retryAfterMatch[1] ?? '0', 10) : 0;
         const backoffMs = retryAfterSec > 0
           ? retryAfterSec * 1000
           : SPOTIFY_BASE_BACKOFF_MS * Math.pow(2, retryCount);

--- a/src/services/cache/libraryDiffEngine.ts
+++ b/src/services/cache/libraryDiffEngine.ts
@@ -89,6 +89,7 @@ async function syncPlaylists(newTotal: number, signal: AbortSignal): Promise<Cac
 
   for (let i = 0; i < allFetched.length; i++) {
     const p = allFetched[i];
+    if (!p) continue;
     const cached = cachedMap.get(p.id);
     p.added_at =
       cached?.added_at ||

--- a/src/services/catalogMatcher.ts
+++ b/src/services/catalogMatcher.ts
@@ -73,9 +73,10 @@ export function matchTrack(
 
   const key = makeNormalizedKey(candidate.artist, candidate.name);
   const nameMatches = indexes.byNormalizedKey.get(key);
-  if (nameMatches && nameMatches.length > 0) {
+  const firstMatch = nameMatches?.[0];
+  if (firstMatch) {
     return {
-      track: nameMatches[0],
+      track: firstMatch,
       confidence: 'name-exact',
       lastfmMatchScore: candidate.matchScore,
     };

--- a/src/services/devbug/issueFormatter.ts
+++ b/src/services/devbug/issueFormatter.ts
@@ -13,8 +13,8 @@ function resolveComponentLabel(element: SelectedElement): string {
 
 export function formatIssueTitle(report: BugReport): string {
   const categories = report.categories.length > 0 ? report.categories.join(', ') : 'general';
-  const component =
-    report.elements.length > 0 ? resolveComponentLabel(report.elements[0]) : 'unknown';
+  const firstElement = report.elements[0];
+  const component = firstElement ? resolveComponentLabel(firstElement) : 'unknown';
   return `[DevBug] ${categories} — ${component}`;
 }
 

--- a/src/services/devbug/perfCapture.ts
+++ b/src/services/devbug/perfCapture.ts
@@ -59,8 +59,9 @@ export function startPerfCapture(): void {
   try {
     lcpObserver = new PerformanceObserver((list) => {
       const entries = list.getEntries();
-      if (entries.length > 0) {
-        latestLcp = entries[entries.length - 1].startTime;
+      const last = entries[entries.length - 1];
+      if (last) {
+        latestLcp = last.startTime;
       }
     });
     lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });

--- a/src/services/devbug/reportBuilder.ts
+++ b/src/services/devbug/reportBuilder.ts
@@ -91,7 +91,7 @@ function isGenericName(name: string): boolean {
 
 function unwrapDisplayName(displayName: string): string {
   const match = displayName.match(/^(?:Styled|ForwardRef|Memo)\((.+)\)$/);
-  return match ? match[1] : displayName;
+  return match?.[1] ?? displayName;
 }
 
 export function getReactComponentName(element: Element): string | null {

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -29,7 +29,7 @@ async function waitForRateLimit(): Promise<void> {
   const now = Date.now();
   requestTimestamps = requestTimestamps.filter((t) => now - t < WINDOW_MS);
   if (requestTimestamps.length >= RATE_LIMIT) {
-    const oldest = requestTimestamps[0];
+    const oldest = requestTimestamps[0] ?? now;
     const waitMs = WINDOW_MS - (now - oldest) + RATE_LIMIT_PADDING_MS;
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }

--- a/src/services/settings/settingsDb.ts
+++ b/src/services/settings/settingsDb.ts
@@ -76,7 +76,7 @@ export async function settingsPut<T extends { key: string }>(store: string, valu
   await initSettingsDb();
   if (fallbackMode) {
     ensureFallbackStore(store);
-    fallbackStores[store].set(value.key, value);
+    fallbackStores[store]?.set(value.key, value);
     return;
   }
   try {
@@ -84,7 +84,7 @@ export async function settingsPut<T extends { key: string }>(store: string, valu
   } catch (err) {
     logCaughtError('settingsDb.settingsPut', err);
     ensureFallbackStore(store);
-    fallbackStores[store].set(value.key, value);
+    fallbackStores[store]?.set(value.key, value);
   }
 }
 

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -144,7 +144,7 @@ function isCollectionKind(x: string): x is ParseableCollectionKind {
 export function keyToCollectionRef(key: string): CollectionRef | null {
   const parts = key.split(':');
   if (parts.length < 3) return null;
-  const [provider, kind, ...idParts] = parts;
+  const [provider = '', kind = '', ...idParts] = parts;
   if (!isProviderId(provider) || !isCollectionKind(kind)) return null;
   if (kind === 'liked') return { provider, kind };
   const id = idParts.join(':');

--- a/src/utils/colorExtractor.ts
+++ b/src/utils/colorExtractor.ts
@@ -111,10 +111,10 @@ export async function extractDominantColor(imageUrl: string): Promise<ExtractedC
           const colorMap = new Map<string, ColorData>();
 
           for (let i = 0; i < data.length; i += PIXEL_SAMPLE_STRIDE) {
-            const r = data[i];
-            const g = data[i + 1];
-            const b = data[i + 2];
-            const a = data[i + 3];
+            const r = data[i] ?? 0;
+            const g = data[i + 1] ?? 0;
+            const b = data[i + 2] ?? 0;
+            const a = data[i + 3] ?? 0;
 
             if (a < ALPHA_THRESHOLD) continue;
 
@@ -195,7 +195,7 @@ export function getTransparentVariant(color: string, opacity = 0.2): string {
   } else if (color.startsWith('rgb')) {
     const matches = color.match(/\d+/g);
     if (!matches) return color;
-    [r, g, b] = matches.map(Number);
+    [r = 0, g = 0, b = 0] = matches.map(Number);
   } else {
     return color;
   }
@@ -231,10 +231,10 @@ export async function extractTopVibrantColors(imageUrl: string, count = 3): Prom
           const colorMap = new Map<string, ColorData>();
 
           for (let i = 0; i < data.length; i += PIXEL_SAMPLE_STRIDE) {
-            const r = data[i];
-            const g = data[i + 1];
-            const b = data[i + 2];
-            const a = data[i + 3];
+            const r = data[i] ?? 0;
+            const g = data[i + 1] ?? 0;
+            const b = data[i + 2] ?? 0;
+            const a = data[i + 3] ?? 0;
             if (a < ALPHA_THRESHOLD) continue;
             const rBucket = Math.floor(r / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;
             const gBucket = Math.floor(g / COLOR_BUCKET_SIZE) * COLOR_BUCKET_SIZE;

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -15,11 +15,14 @@ export const getRelativeLuminance = (hex: string): number => {
   const [r, g, b] = hexToRgb(hex);
   
   // Convert to 0-1 range
-  const [rs, gs, bs] = [r, g, b].map(c => {
+  const linearize = (c: number): number => {
     const val = c / 255;
     return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
-  });
-  
+  };
+  const rs = linearize(r);
+  const gs = linearize(g);
+  const bs = linearize(b);
+
   return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
 };
 

--- a/src/utils/featureDetection.ts
+++ b/src/utils/featureDetection.ts
@@ -160,7 +160,7 @@ const getFallbackValues = (features: BrowserFeatures) => {
         return `aspect-ratio: ${ratio}`;
       }
       // Use padding-bottom trick for aspect ratio
-      const [width, height] = ratio.split('/').map(Number);
+      const [width = 1, height = 1] = ratio.split('/').map(Number);
       const percentage = (height / width) * 100;
       return `padding-bottom: ${percentage}%`;
     },

--- a/src/utils/id3Parser.ts
+++ b/src/utils/id3Parser.ts
@@ -21,31 +21,35 @@ interface AudioMetadata {
   releaseYear?: number;
 }
 
+// Byte reads use `?? 0` to satisfy noUncheckedIndexedAccess. Callers gate the
+// read with explicit length checks (`offset + N <= bytes.length`), so the
+// fallback is unreachable; treating a missing byte as zero matches the
+// pre-flag runtime behavior of bitwise ops on `undefined`.
 function readSynchsafeInt(bytes: Uint8Array, offset: number): number {
   return (
-    ((bytes[offset] & 0x7f) << 21) |
-    ((bytes[offset + 1] & 0x7f) << 14) |
-    ((bytes[offset + 2] & 0x7f) << 7) |
-    (bytes[offset + 3] & 0x7f)
+    (((bytes[offset] ?? 0) & 0x7f) << 21) |
+    (((bytes[offset + 1] ?? 0) & 0x7f) << 14) |
+    (((bytes[offset + 2] ?? 0) & 0x7f) << 7) |
+    ((bytes[offset + 3] ?? 0) & 0x7f)
   );
 }
 
 function readUint32BE(bytes: Uint8Array, offset: number): number {
   return (
-    (bytes[offset] << 24) |
-    (bytes[offset + 1] << 16) |
-    (bytes[offset + 2] << 8) |
-    bytes[offset + 3]
+    ((bytes[offset] ?? 0) << 24) |
+    ((bytes[offset + 1] ?? 0) << 16) |
+    ((bytes[offset + 2] ?? 0) << 8) |
+    (bytes[offset + 3] ?? 0)
   );
 }
 
 function readUint24BE(bytes: Uint8Array, offset: number): number {
-  return (bytes[offset] << 16) | (bytes[offset + 1] << 8) | bytes[offset + 2];
+  return ((bytes[offset] ?? 0) << 16) | ((bytes[offset + 1] ?? 0) << 8) | (bytes[offset + 2] ?? 0);
 }
 
 function decodeTextFrame(data: Uint8Array): string {
   if (data.length === 0) return '';
-  const encoding = data[0];
+  const encoding = data[0] ?? 0;
   const raw = data.slice(1);
 
   let decoded: string;
@@ -74,7 +78,7 @@ function skipNullTerminatedString(data: Uint8Array, pos: number, encoding: numbe
 
 function decodeAPIC(data: Uint8Array): { data: Uint8Array; mimeType: string } | null {
   if (data.length < 4) return null;
-  const encoding = data[0];
+  const encoding = data[0] ?? 0;
 
   let mimeEnd = 1;
   while (mimeEnd < data.length && data[mimeEnd] !== 0) mimeEnd++;
@@ -88,7 +92,7 @@ function decodeAPIC(data: Uint8Array): { data: Uint8Array; mimeType: string } | 
 
 function decodePIC(data: Uint8Array): { data: Uint8Array; mimeType: string } | null {
   if (data.length < 6) return null;
-  const encoding = data[0];
+  const encoding = data[0] ?? 0;
   const format = new TextDecoder('latin1').decode(data.slice(1, 4));
 
   // Skip past: format (3 bytes) + picture type (1 byte) = offset 5, then description
@@ -105,7 +109,7 @@ function decodePIC(data: Uint8Array): { data: Uint8Array; mimeType: string } | n
  */
 function decodeTXXX(data: Uint8Array): { description: string; value: string } | null {
   if (data.length < 2) return null;
-  const encoding = data[0];
+  const encoding = data[0] ?? 0;
 
   // Find end of description (null-terminated)
   const descEnd = skipNullTerminatedString(data, 1, encoding);
@@ -135,12 +139,12 @@ function decodeTXXX(data: Uint8Array): { description: string; value: string } | 
 function extractYearFromDateString(value: string): number | null {
   const match = value.match(/^(\d{4})/);
   if (!match) return null;
-  const year = parseInt(match[1], 10);
+  const year = parseInt(match[1] ?? '', 10);
   return year > 0 && year < 3000 ? year : null;
 }
 
 function readUint32LE(bytes: Uint8Array, offset: number): number {
-  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24);
+  return (bytes[offset] ?? 0) | ((bytes[offset + 1] ?? 0) << 8) | ((bytes[offset + 2] ?? 0) << 16) | ((bytes[offset + 3] ?? 0) << 24);
 }
 
 function parseFlac(bytes: Uint8Array): AudioMetadata {
@@ -148,7 +152,7 @@ function parseFlac(bytes: Uint8Array): AudioMetadata {
   let offset = 4; // skip "fLaC"
 
   while (offset + 4 <= bytes.length) {
-    const header = bytes[offset];
+    const header = bytes[offset] ?? 0;
     const isLast = (header & 0x80) !== 0;
     const blockType = header & 0x7f;
     const blockLength = readUint24BE(bytes, offset + 1);
@@ -196,13 +200,13 @@ function parseFlac(bytes: Uint8Array): AudioMetadata {
             const picBytes = Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
             let p = 0;
             p += 4; // picture type
-            const mimeLen = (picBytes[p] << 24) | (picBytes[p+1] << 16) | (picBytes[p+2] << 8) | picBytes[p+3];
+            const mimeLen = ((picBytes[p] ?? 0) << 24) | ((picBytes[p+1] ?? 0) << 16) | ((picBytes[p+2] ?? 0) << 8) | (picBytes[p+3] ?? 0);
             p += 4;
             const mimeType = new TextDecoder('latin1').decode(picBytes.slice(p, p + mimeLen)) || 'image/jpeg';
             p += mimeLen;
-            const descLen = (picBytes[p] << 24) | (picBytes[p+1] << 16) | (picBytes[p+2] << 8) | picBytes[p+3];
+            const descLen = ((picBytes[p] ?? 0) << 24) | ((picBytes[p+1] ?? 0) << 16) | ((picBytes[p+2] ?? 0) << 8) | (picBytes[p+3] ?? 0);
             p += 4 + descLen + 16; // skip desc + width/height/depth/colors
-            const dataLen = (picBytes[p] << 24) | (picBytes[p+1] << 16) | (picBytes[p+2] << 8) | picBytes[p+3];
+            const dataLen = ((picBytes[p] ?? 0) << 24) | ((picBytes[p+1] ?? 0) << 16) | ((picBytes[p+2] ?? 0) << 8) | (picBytes[p+3] ?? 0);
             p += 4;
             result.coverArt = { data: picBytes.slice(p, p + dataLen), mimeType };
           } catch (err) {
@@ -242,8 +246,8 @@ export function parseID3(buffer: ArrayBuffer): AudioMetadata {
     return {};
   }
 
-  const majorVersion = bytes[3];
-  const flags = bytes[5];
+  const majorVersion = bytes[3] ?? 0;
+  const flags = bytes[5] ?? 0;
   const tagSize = readSynchsafeInt(bytes, 6);
 
   let offset = 10;
@@ -265,8 +269,8 @@ export function parseID3(buffer: ArrayBuffer): AudioMetadata {
   if (majorVersion === 2) {
     // ID3v2.2: 3-char IDs, 3-byte sizes, no frame flags
     while (offset + 6 <= end) {
-      if (bytes[offset] === 0) break;
-      const frameId = String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2]);
+      if ((bytes[offset] ?? 0) === 0) break;
+      const frameId = String.fromCharCode(bytes[offset] ?? 0, bytes[offset + 1] ?? 0, bytes[offset + 2] ?? 0);
       const frameSize = readUint24BE(bytes, offset + 3);
       offset += 6;
 
@@ -288,12 +292,12 @@ export function parseID3(buffer: ArrayBuffer): AudioMetadata {
   } else {
     // ID3v2.3 and v2.4: 4-char IDs, 4-byte sizes, 2-byte frame flags
     while (offset + 10 <= end) {
-      if (bytes[offset] === 0) break;
+      if ((bytes[offset] ?? 0) === 0) break;
       const frameId = String.fromCharCode(
-        bytes[offset],
-        bytes[offset + 1],
-        bytes[offset + 2],
-        bytes[offset + 3],
+        bytes[offset] ?? 0,
+        bytes[offset + 1] ?? 0,
+        bytes[offset + 2] ?? 0,
+        bytes[offset + 3] ?? 0,
       );
       const frameSize =
         majorVersion === 4

--- a/src/utils/mosaicSelection.ts
+++ b/src/utils/mosaicSelection.ts
@@ -22,14 +22,14 @@ function weightedPick(
 ): number {
   let totalWeight = 0;
   for (let i = 0; i < albums.length; i++) {
-    if (!exclude.has(i)) totalWeight += albums[i].trackCount;
+    if (!exclude.has(i)) totalWeight += albums[i]?.trackCount ?? 0;
   }
   if (totalWeight === 0) return -1;
 
   let target = rng() * totalWeight;
   for (let i = 0; i < albums.length; i++) {
     if (exclude.has(i)) continue;
-    target -= albums[i].trackCount;
+    target -= albums[i]?.trackCount ?? 0;
     if (target <= 0) return i;
   }
   return albums.length - 1;
@@ -50,11 +50,13 @@ export function selectMosaicCovers(
   }
 
   if (albums.length === 0) return [];
-  if (albums.length === 1) return [albums[0].key];
+  const [first, second] = albums;
+  if (albums.length === 1 || !second) return first ? [first.key] : [];
 
   if (albums.length <= 3) {
     const sorted = [...albums].sort((a, b) => b.trackCount - a.trackCount);
-    return [sorted[0].key, sorted[1].key];
+    const [s0, s1] = sorted;
+    return s0 && s1 ? [s0.key, s1.key] : [];
   }
 
   const seed = hashString(playlistId);
@@ -65,7 +67,9 @@ export function selectMosaicCovers(
   for (let i = 0; i < 4 && excluded.size < albums.length; i++) {
     const idx = weightedPick(albums, rng, excluded);
     if (idx === -1) break;
-    picked.push(albums[idx].key);
+    const album = albums[idx];
+    if (!album) break;
+    picked.push(album.key);
     excluded.add(idx);
   }
 

--- a/src/utils/queueTrackMirror.ts
+++ b/src/utils/queueTrackMirror.ts
@@ -51,6 +51,7 @@ export function insertMediaTracksAt(
 export function moveItemInArray<T>(arr: readonly T[], fromIndex: number, toIndex: number): T[] {
   const result = [...arr];
   const [item] = result.splice(fromIndex, 1);
+  if (item === undefined) return result;
   result.splice(toIndex, 0, item);
   return result;
 }

--- a/src/utils/shuffleArray.ts
+++ b/src/utils/shuffleArray.ts
@@ -3,8 +3,9 @@ export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    const a = shuffled[i] as T;
-    const b = shuffled[j] as T;
+    const a = shuffled[i];
+    const b = shuffled[j];
+    if (a === undefined || b === undefined) continue;
     shuffled[i] = b;
     shuffled[j] = a;
   }

--- a/src/utils/shuffleArray.ts
+++ b/src/utils/shuffleArray.ts
@@ -3,7 +3,10 @@ export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    const a = shuffled[i] as T;
+    const b = shuffled[j] as T;
+    shuffled[i] = b;
+    shuffled[j] = a;
   }
   return shuffled;
 }

--- a/src/utils/visualizerUtils.ts
+++ b/src/utils/visualizerUtils.ts
@@ -15,9 +15,9 @@
 function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result ? {
-    r: parseInt(result[1], 16),
-    g: parseInt(result[2], 16),
-    b: parseInt(result[3], 16)
+    r: parseInt(result[1] ?? '0', 16),
+    g: parseInt(result[2] ?? '0', 16),
+    b: parseInt(result[3] ?? '0', 16)
   } : null;
 }
 

--- a/src/workers/imageProcessor.worker.ts
+++ b/src/workers/imageProcessor.worker.ts
@@ -50,13 +50,13 @@ const processImageData = (
   
   // Process each pixel
   for (let i = 0; i < data.length; i += 4) {
-    const r = data[i];
-    const g = data[i + 1];
-    const b = data[i + 2];
-    const a = data[i + 3];
-    
+    const r = data[i] ?? 0;
+    const g = data[i + 1] ?? 0;
+    const b = data[i + 2] ?? 0;
+    const a = data[i + 3] ?? 0;
+
     const dist = colorDistance([r, g, b], accentColorRgb);
-    
+
     if (dist < maxDistance) {
       // factor: 0 (exact match) -> 1 (at threshold)
       const factor = dist / maxDistance;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "noImplicitOverride": true
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**/*", "src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,6 +27,8 @@
     "noUncheckedSideEffectImports": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true
+    // TS-strict: exactOptionalPropertyTypes deferred — see issue #1598.
+    // "exactOptionalPropertyTypes": true
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**/*", "src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,8 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**/*", "src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*"]


### PR DESCRIPTION
Phase:3 — final issue in the typescript-strictness-audit epic. Flips two of the three strict tsconfig flags, fixes the resulting fallout, defers the third with an architect-reviewed follow-up issue, and updates `CLAUDE.md` with the strictness baseline.

## Per-flag impact at first enable

| Flag | Errors at flip | Files affected | Outcome |
|---|---|---|---|
| `noImplicitOverride` | 0 | 0 | **Enabled.** Four `extends Error` subclasses (`AuthExpiredError`, `UnavailableTrackError`, `InvalidProviderDescriptorError`, `SpotifyApiError`) set `this.name` in their constructors — that's a property assign, not a method override, so the flag has nothing to fire on. Architect's blueprint prediction held. |
| `exactOptionalPropertyTypes` | 124 | 59 | **Deferred** to follow-up #1598. ~70% of fallout is JSX prop sites where `T \| undefined` is passed to a `T?`-typed prop; React's runtime treats `prop={undefined}` and an omitted prop as identical, so the strictness adds friction without adding safety at framework boundaries. Architect ruled this is the right defer (vs. blueprint's original lean toward NUIA) — the question deserves a design decision separate from this epic. |
| `noUncheckedIndexedAccess` | 134 | 36 | **Enabled.** All 134 errors fixed mechanically. |

## Fix categories applied for NUIA

| Idiom | Used at | Count |
|---|---|---|
| `(arr[i] ?? 0)` for byte/pixel loops | `id3Parser`, `colorExtractor`, `workers/imageProcessor`, `spotifyPlaybackAdapter`, `EyedropperOverlay`, `MosaicThumbnail` | ~60 |
| Bind narrowed `const` + early guard (`if (!x) return`) | `useSwipeGesture`, `useVerticalSwipeGesture`, `useHorizontalSwipeToRemove`, `useQueueManagement`, `useCollectionLoader`, `dropboxCatalogHelpers`, `DevBugFAB`, `AnnotationOverlay`, `SaveQueueDialog`, `QuickAccessPanel`, `PlayerControlsSection`, `VolumeControl`, `lastfm`, `dropboxPlaylistStorage`, `libraryDiffEngine`, `catalogMatcher`, `issueFormatter`, `perfCapture`, `reportBuilder` | ~50 |
| Destructure-with-default | `featureDetection`, `colorUtils`, `types/domain` (`keyToCollectionRef`) | ~10 |
| Optional chain on indexed `.method()` calls | `LibraryContextMenu` (focus), `settingsDb` (set), `QuickAccessPanel` | ~6 |
| Non-empty readonly tuple typing | `SETTINGS_V2_SECTIONS` (fixes 6 downstream errors) | 1 |
| Filter-undefined on derived arrays | `useCollectionLoader` (shuffled tracks) | 1 |

Final cast inventory after fixes: zero `arr[i]!` non-null assertions introduced (epic blueprint forbids them). All remaining `as <Type>` casts in `src/` (excluding tests/imports) fall in the blueprint-acknowledged legitimate boundary categories (DOM events, IDB, JSON.parse, CustomEvent, HMR, ArrayBuffer for WebAudio, generic-recovery in cache-keyed dedup).

## Deferred — EOPT follow-up

Issue **#1598** filed against `develop` with the architect's framing:
1. Widen all React component prop interfaces to `T | undefined`, aligning types with React's runtime equivalence.
2. Restructure callers to omit the prop when undefined.
3. Hybrid: hold prop interfaces strict, introduce an `omitUndefined` JSX helper for high-friction sites.

Plus ~12 non-JSX explicit-undefined sites that should land regardless (catalogued in the issue body).

`tsconfig.app.json` carries an inline `// TS-strict: exactOptionalPropertyTypes deferred — see issue #1598` comment above the (commented-out) flag so future readers find the rationale without grepping PR history.

## Documentation

`CLAUDE.md` Coding Conventions section gained a new "Type strictness baseline" subsection listing:
- The enabled strict flags
- The deferred EOPT with #1598 reference
- The five patterns the audit epic enforces (no unjustified casts; disc unions for variants; optional XOR nullable; canonical types in `src/types/`; indexed access returns `T | undefined`)

## Verify

- `npx tsc -b --noEmit` ✅
- `npm run test:run` ✅ (2063/2063)
- `npm run build` ✅
- Post-merge cast regression sweep ✅ (all survivors are blueprint-acknowledged boundary casts; one borderline `as T` I introduced in `shuffleArray` was replaced with an explicit guard before commit)

## Commits in this PR

1. `build(tsconfig): enable noImplicitOverride` — 0-fallout flag flip
2. `build(tsconfig): enable noUncheckedIndexedAccess + fix utils/workers bounds` — flag + binary-parser fixes (id3Parser 37, colorExtractor 11, others)
3. `fix(hooks/types): guard indexed reads for noUncheckedIndexedAccess` — hooks + `keyToCollectionRef`
4. `fix(components/providers/services): guard indexed reads for noUncheckedIndexedAccess` — broad sweep of remaining 21 errors
5. `build(tsconfig): mark exactOptionalPropertyTypes deferral with issue ref` — `#1598` cross-ref comment
6. `refactor(utils/shuffle): replace borderline 'as T' with explicit guard` — clean up self-introduced cast
7. `docs(claude): document type strictness baseline` — Coding Conventions update

## Acceptance checklist

- [x] `tsconfig.app.json` has `noImplicitOverride`, `noUncheckedIndexedAccess` enabled; EOPT deferred with inline cross-ref
- [x] tsc, build, test all green
- [x] No new `as <Type>` casts outside legitimate boundary categories
- [x] `CLAUDE.md` strictness-baseline subsection
- [x] EOPT follow-up filed (#1598) and referenced in tsconfig + PR body
- [x] PR targets `feature/typescript-strictness-audit-1589`

Closes #1585. Part of #1589.