### PR TITLE
fix(tsconfig): enable exactOptionalPropertyTypes (#1598)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,10 +156,9 @@ Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`
 
 `tsconfig.app.json` enables the strictest reasonable set of compiler flags:
 `strict`, `noUncheckedIndexedAccess`, `noImplicitOverride`,
-`noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`,
-`noUncheckedSideEffectImports`, `erasableSyntaxOnly`, `verbatimModuleSyntax`.
-`exactOptionalPropertyTypes` is intentionally deferred — see issue #1598
-for the architectural decision pending on React prop conventions.
+`exactOptionalPropertyTypes`, `noUnusedLocals`, `noUnusedParameters`,
+`noFallthroughCasesInSwitch`, `noUncheckedSideEffectImports`,
+`erasableSyntaxOnly`, `verbatimModuleSyntax`.
 
 Patterns this enforces:
 
@@ -178,6 +177,16 @@ Patterns this enforces:
   is meaningful). `field?: T | null` is forbidden — under
   `exactOptionalPropertyTypes` it becomes a three-way mess of
   missing-vs-null-vs-undefined.
+- **React component prop interfaces use `field?: T | undefined`, not `field?: T`.**
+  React's runtime treats `<Foo prop={undefined} />` and `<Foo />` as identical, so
+  the type system should too. This applies to any interface named `*Props` used by
+  a function component, styled-component type arguments, hook option-bag
+  parameters, and context-value interfaces — anything consumed via an object-literal
+  call site that benefits from the canonical `<Foo prop={cond ? value : undefined} />`
+  pattern. Domain models and non-JSX data shapes keep `field?: T` (the
+  optional-XOR-nullable rule above). At third-party boundaries (Radix, sonner, etc.)
+  that expect `field?: T`, use conditional spread
+  (`{...(value !== undefined && { prop: value })}`) — never `!`.
 - **Canonical types live in `src/types/`.** Inline object types repeated across
   files should be lifted to a named export and colocated with their conceptual
   owner (`domain.ts`, `providers.ts`, `radio.ts`, etc.). Test fixture and
@@ -185,7 +194,8 @@ Patterns this enforces:
 - **Indexed access returns `T | undefined`.** Bounds-check (`if (!item) return`),
   default-coalesce (`?? fallback`), or destructure-with-default. Never `arr[i]!`.
 
-These conventions were established by the TypeScript strictness audit epic (#1589).
+These conventions were established by the TypeScript strictness audit epic (#1589)
+and finalized by #1598 (the React prop convention).
 
 ## Testing
 

--- a/src/components/AccentColorGlowOverlay.tsx
+++ b/src/components/AccentColorGlowOverlay.tsx
@@ -32,8 +32,8 @@ const GlowBackgroundLayer = styled.div<{
 
 interface AccentColorGlowOverlayProps {
   glowIntensity: number;
-  glowRate?: number;
-  backgroundImage?: string;
+  glowRate?: number | undefined;
+  backgroundImage?: string | undefined;
 }
 
 const areGlowPropsEqual = (

--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -56,12 +56,12 @@ interface AlbumArtProps {
 const AlbumArtContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !['accentColor', 'glowIntensity', 'glowRate', 'glowEnabled', '$zenMode', '$translucenceOpacity'].includes(prop),
 }) <{
-  accentColor?: string;
-  glowIntensity?: number;
-  glowRate?: number;
-  glowEnabled?: boolean;
-  $zenMode?: boolean;
-  $translucenceOpacity?: number;
+  accentColor?: string | undefined;
+  glowIntensity?: number | undefined;
+  glowRate?: number | undefined;
+  glowEnabled?: boolean | undefined;
+  $zenMode?: boolean | undefined;
+  $translucenceOpacity?: number | undefined;
 }>`
   transform: translateZ(0);
   will-change: transform, opacity;

--- a/src/components/AlbumArtQuickSwapBack.tsx
+++ b/src/components/AlbumArtQuickSwapBack.tsx
@@ -43,7 +43,7 @@ const BacksideRoot = styled.div`
   overflow: hidden;
 `;
 
-const BlurredBg = styled.div<{ $image?: string }>`
+const BlurredBg = styled.div<{ $image?: string | undefined }>`
   position: absolute;
   inset: 0;
   background-image: ${({ $image }) => ($image ? `url(${$image})` : 'none')};

--- a/src/components/CmdKPalette/index.tsx
+++ b/src/components/CmdKPalette/index.tsx
@@ -34,7 +34,7 @@ export interface CmdKPaletteProps {
 }
 
 interface ItemSubtitleProps {
-  text?: string;
+  text?: string | undefined;
 }
 
 const ItemSubtitle = ({ text }: ItemSubtitleProps): JSX.Element | null => {

--- a/src/components/LibraryRoute/MiniPlayer/MiniArt.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniArt.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ArtFrame, ArtImage, PulseDot } from './MiniPlayer.styled';
 
 export interface MiniArtProps {
-  imageUrl?: string;
+  imageUrl?: string | undefined;
   alt: string;
   isPlaying: boolean;
 }

--- a/src/components/LibraryRoute/MiniPlayer/MiniControls.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniControls.tsx
@@ -3,13 +3,13 @@ import { ControlButton, ControlButtonRow } from './MiniPlayer.styled';
 
 export interface MiniControlsProps {
   isPlaying: boolean;
-  isRadioAvailable?: boolean;
-  isRadioGenerating?: boolean;
+  isRadioAvailable?: boolean | undefined;
+  isRadioGenerating?: boolean | undefined;
   onPlay: () => void;
   onPause: () => void;
   onNext: () => void;
   onPrevious: () => void;
-  onStartRadio?: () => void;
+  onStartRadio?: (() => void) | undefined;
 }
 
 // SVG path data sourced from src/components/controls/PlaybackControls.tsx

--- a/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
+++ b/src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx
@@ -12,14 +12,14 @@ import {
 
 export interface MiniPlayerProps {
   isPlaying: boolean;
-  isRadioAvailable?: boolean;
-  isRadioGenerating?: boolean;
+  isRadioAvailable?: boolean | undefined;
+  isRadioGenerating?: boolean | undefined;
   onPlay: () => void;
   onPause: () => void;
   onNext: () => void;
   onPrevious: () => void;
   onExpand: () => void;
-  onStartRadio?: () => void;
+  onStartRadio?: (() => void) | undefined;
 }
 
 const MiniPlayer: React.FC<MiniPlayerProps> = ({

--- a/src/components/LibraryRoute/card/LibraryCard.tsx
+++ b/src/components/LibraryRoute/card/LibraryCard.tsx
@@ -17,14 +17,14 @@ import {
 export interface LibraryCardProps {
   kind: LibraryCollectionKind;
   id: string;
-  provider?: ProviderId;
+  provider?: ProviderId | undefined;
   name: string;
-  subtitle?: string;
-  imageUrl?: string;
-  showProviderBadge?: boolean;
+  subtitle?: string | undefined;
+  imageUrl?: string | undefined;
+  showProviderBadge?: boolean | undefined;
   variant: 'row' | 'grid';
   onSelect: () => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const placeholderGlyphForKind = (kind: LibraryItemKind): string => {

--- a/src/components/LibraryRoute/card/useLongPress.ts
+++ b/src/components/LibraryRoute/card/useLongPress.ts
@@ -5,8 +5,8 @@ const MOVE_TOLERANCE_PX = 8;
 
 export interface UseLongPressOptions {
   onLongPress: (anchor: DOMRect) => void;
-  onTap?: () => void;
-  enabled?: boolean;
+  onTap?: (() => void) | undefined;
+  enabled?: boolean | undefined;
 }
 
 interface PointerState {

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.styled.ts
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.styled.ts
@@ -16,7 +16,7 @@ export const MenuRoot = styled.div`
   gap: 1px;
 `;
 
-export const MenuItemButton = styled.button<{ $variant?: 'default' | 'destructive' }>`
+export const MenuItemButton = styled.button<{ $variant?: 'default' | 'destructive' | undefined }>`
   display: block;
   width: 100%;
   text-align: left;

--- a/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
+++ b/src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx
@@ -17,25 +17,25 @@ export interface LibraryContextMenuProps {
     name: string,
     provider?: ProviderId,
   ) => void;
-  onAddToQueue?: (id: string, name: string, provider?: ProviderId) => void | Promise<unknown>;
-  onPlayNext?: (
+  onAddToQueue?: ((id: string, name: string, provider?: ProviderId) => void | Promise<unknown>) | undefined;
+  onPlayNext?: ((
     kind: 'playlist' | 'album',
     id: string,
     name: string,
     provider?: ProviderId,
-  ) => void;
-  onStartRadioForCollection?: (
+  ) => void) | undefined;
+  onStartRadioForCollection?: ((
     kind: 'playlist' | 'album',
     id: string,
     provider?: ProviderId,
-  ) => void;
+  ) => void) | undefined;
   onPlayLikedTracks: (
     tracks: MediaTrack[],
     collectionId: string,
     collectionName: string,
     provider?: ProviderId,
   ) => Promise<void> | void;
-  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  onQueueLikedTracks?: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined;
 }
 
 const LibraryContextMenu: React.FC<LibraryContextMenuProps> = ({

--- a/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
+++ b/src/components/LibraryRoute/contextMenu/menuItemsForKind.ts
@@ -32,14 +32,14 @@ export interface MenuActions {
   onAddToQueue: () => void;
   onPlayNext: () => void;
   onTogglePin: () => void;
-  onToggleSave?: () => void;
+  onToggleSave?: (() => void) | undefined;
   onStartRadio: () => void;
-  onQueueLikedFromCollection?: () => void;
-  likedProviderActions?: Array<{ provider: ProviderId; label: string; onPlay: () => void }>;
-  onRemoveFromHistory?: () => void;
-  isPinned?: boolean;
-  startRadioDisabled?: boolean;
-  playNextDisabled?: boolean;
+  onQueueLikedFromCollection?: (() => void) | undefined;
+  likedProviderActions?: Array<{ provider: ProviderId; label: string; onPlay: () => void }> | undefined;
+  onRemoveFromHistory?: (() => void) | undefined;
+  isPinned?: boolean | undefined;
+  startRadioDisabled?: boolean | undefined;
+  playNextDisabled?: boolean | undefined;
 }
 
 function buildCommonItems(actions: MenuActions): MenuItem[] {

--- a/src/components/LibraryRoute/contextMenu/useMenuItems.ts
+++ b/src/components/LibraryRoute/contextMenu/useMenuItems.ts
@@ -27,25 +27,25 @@ export interface UseMenuItemsCallbacks {
     name: string,
     provider?: ProviderId,
   ) => void;
-  onAddToQueue?: (id: string, name: string, provider?: ProviderId) => void | Promise<unknown>;
-  onPlayNext?: (
+  onAddToQueue?: ((id: string, name: string, provider?: ProviderId) => void | Promise<unknown>) | undefined;
+  onPlayNext?: ((
     kind: 'playlist' | 'album',
     id: string,
     name: string,
     provider?: ProviderId,
-  ) => void;
-  onStartRadioForCollection?: (
+  ) => void) | undefined;
+  onStartRadioForCollection?: ((
     kind: 'playlist' | 'album',
     id: string,
     provider?: ProviderId,
-  ) => void;
+  ) => void) | undefined;
   onPlayLikedTracks: (
     tracks: MediaTrack[],
     collectionId: string,
     collectionName: string,
     provider?: ProviderId,
   ) => Promise<void> | void;
-  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  onQueueLikedTracks?: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined;
 }
 
 export function useMenuItems(

--- a/src/components/LibraryRoute/hooks/usePinnedSection.ts
+++ b/src/components/LibraryRoute/hooks/usePinnedSection.ts
@@ -10,10 +10,10 @@ import type { ProviderId } from '@/types/domain';
 export interface PinnedItem {
   kind: 'playlist' | 'album' | 'liked';
   id: string;
-  provider?: ProviderId;
+  provider?: ProviderId | undefined;
   name: string;
-  imageUrl?: string;
-  subtitle?: string;
+  imageUrl?: string | undefined;
+  subtitle?: string | undefined;
 }
 
 export interface PinnedSectionState {

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -22,38 +22,38 @@ import { LibraryContextMenuOpenContext } from './contextMenu/LibraryContextMenuO
 export interface LibraryRouteProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
-  onPlayLikedTracks?: (
+  onPlayLikedTracks?: ((
     tracks: MediaTrack[],
     collectionId: string,
     collectionName: string,
     provider?: ProviderId,
-  ) => Promise<void>;
-  onQueueLikedTracks?: (tracks: MediaTrack[], collectionName?: string) => void;
+  ) => Promise<void>) | undefined;
+  onQueueLikedTracks?: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined;
   onOpenSettings: () => void;
-  onResume?: () => void;
-  lastSession?: SessionSnapshot | null;
-  onPlayNext?: (
+  onResume?: (() => void) | undefined;
+  lastSession?: SessionSnapshot | null | undefined;
+  onPlayNext?: ((
     kind: 'playlist' | 'album',
     id: string,
     name: string,
     provider?: ProviderId,
-  ) => void;
-  onStartRadioForCollection?: (
+  ) => void) | undefined;
+  onStartRadioForCollection?: ((
     kind: 'playlist' | 'album',
     id: string,
     provider?: ProviderId,
-  ) => void;
-  initialSearchQuery?: string;
+  ) => void) | undefined;
+  initialSearchQuery?: string | undefined;
   isPlaying: boolean;
-  isRadioAvailable?: boolean;
-  isRadioGenerating?: boolean;
+  isRadioAvailable?: boolean | undefined;
+  isRadioGenerating?: boolean | undefined;
   onMiniPlay: () => void;
   onMiniPause: () => void;
   onMiniNext: () => void;
   onMiniPrevious: () => void;
   onMiniExpand: () => void;
-  onMiniStartRadio?: () => void;
-  onClose?: () => void;
+  onMiniStartRadio?: (() => void) | undefined;
+  onClose?: (() => void) | undefined;
 }
 
 const LibraryRoute: React.FC<LibraryRouteProps> = ({

--- a/src/components/LibraryRoute/search/searchMatch.ts
+++ b/src/components/LibraryRoute/search/searchMatch.ts
@@ -16,7 +16,7 @@ export function matchesQuery(
 }
 
 export function passesProviderFilter(
-  item: { provider?: ProviderId },
+  item: { provider?: ProviderId | undefined },
   providerFilter: ProviderId[],
 ): boolean {
   if (providerFilter.length === 0) return true;

--- a/src/components/LibraryRoute/sections/AlbumsSection.tsx
+++ b/src/components/LibraryRoute/sections/AlbumsSection.tsx
@@ -10,11 +10,11 @@ const SEE_ALL_THRESHOLD = 8;
 
 export interface AlbumsSectionProps {
   layout: 'row' | 'grid';
-  excludePinned?: boolean;
-  showProviderBadges?: boolean;
+  excludePinned?: boolean | undefined;
+  showProviderBadges?: boolean | undefined;
   onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
-  onSeeAll?: () => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onSeeAll?: (() => void) | undefined;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const AlbumsSection: React.FC<AlbumsSectionProps> = ({

--- a/src/components/LibraryRoute/sections/PinnedSection.tsx
+++ b/src/components/LibraryRoute/sections/PinnedSection.tsx
@@ -10,10 +10,10 @@ const SEE_ALL_THRESHOLD = 6;
 
 export interface PinnedSectionProps {
   layout: 'row' | 'grid';
-  showProviderBadges?: boolean;
+  showProviderBadges?: boolean | undefined;
   onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
-  onSeeAll?: () => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onSeeAll?: (() => void) | undefined;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const PinnedSection: React.FC<PinnedSectionProps> = ({

--- a/src/components/LibraryRoute/sections/PlaylistsSection.tsx
+++ b/src/components/LibraryRoute/sections/PlaylistsSection.tsx
@@ -10,11 +10,11 @@ const SEE_ALL_THRESHOLD = 8;
 
 export interface PlaylistsSectionProps {
   layout: 'row' | 'grid';
-  excludePinned?: boolean;
-  showProviderBadges?: boolean;
+  excludePinned?: boolean | undefined;
+  showProviderBadges?: boolean | undefined;
   onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
-  onSeeAll?: () => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onSeeAll?: (() => void) | undefined;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const PlaylistsSection: React.FC<PlaylistsSectionProps> = ({

--- a/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
+++ b/src/components/LibraryRoute/sections/RecentlyPlayedSection.tsx
@@ -10,10 +10,10 @@ const SEE_ALL_THRESHOLD = 4;
 
 export interface RecentlyPlayedSectionProps {
   layout: 'row' | 'grid';
-  showProviderBadges?: boolean;
+  showProviderBadges?: boolean | undefined;
   onSelect: (kind: LibraryItemKind, id: string, name: string, provider?: ProviderId) => void;
-  onSeeAll?: () => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onSeeAll?: (() => void) | undefined;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const RecentlyPlayedSection: React.FC<RecentlyPlayedSectionProps> = ({

--- a/src/components/LibraryRoute/sections/ResumeSection.tsx
+++ b/src/components/LibraryRoute/sections/ResumeSection.tsx
@@ -5,7 +5,7 @@ import ResumeHero from './ResumeHero';
 
 export interface ResumeSectionProps {
   lastSession: SessionSnapshot | null;
-  onResume?: () => void;
+  onResume?: (() => void) | undefined;
 }
 
 const ResumeSection: React.FC<ResumeSectionProps> = ({ lastSession, onResume }) => {

--- a/src/components/LibraryRoute/sections/Section.tsx
+++ b/src/components/LibraryRoute/sections/Section.tsx
@@ -3,8 +3,8 @@ import { SectionRoot, Header, Title, SeeAllButton, Body } from './Section.styled
 
 export interface SectionProps {
   title: string;
-  onSeeAll?: () => void;
-  hidden?: boolean;
+  onSeeAll?: (() => void) | undefined;
+  hidden?: boolean | undefined;
   layout: 'row' | 'grid';
   children: React.ReactNode;
   id: string;

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -38,11 +38,11 @@ export type LibraryItemKind = LibraryCollectionKind | 'recently-played';
 
 interface ContextMenuRequestBase {
   id: string;
-  provider?: ProviderId;
+  provider?: ProviderId | undefined;
   name: string;
   anchorRect: DOMRect;
   /** The CardButton element that triggered the menu; used to return focus on keyboard dismiss. */
-  triggerElement?: HTMLElement;
+  triggerElement?: HTMLElement | undefined;
 }
 
 export type ContextMenuRequest = ContextMenuRequestBase &

--- a/src/components/LibraryRoute/views/HomeView.tsx
+++ b/src/components/LibraryRoute/views/HomeView.tsx
@@ -15,7 +15,7 @@ import { HomeStack } from './views.styled';
 export interface HomeViewProps {
   layout: 'row' | 'grid';
   lastSession: SessionSnapshot | null;
-  onResume?: () => void;
+  onResume?: (() => void) | undefined;
   onSelectCollection: (
     kind: LibraryItemKind,
     id: string,
@@ -23,7 +23,7 @@ export interface HomeViewProps {
     provider?: ProviderId,
   ) => void;
   onNavigate: (view: LibraryRouteView) => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const HomeView: React.FC<HomeViewProps> = ({

--- a/src/components/LibraryRoute/views/SearchResultsView.tsx
+++ b/src/components/LibraryRoute/views/SearchResultsView.tsx
@@ -22,7 +22,7 @@ export interface SearchResultsViewProps {
     name: string,
     provider?: ProviderId,
   ) => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const SearchResultsView: React.FC<SearchResultsViewProps> = ({

--- a/src/components/LibraryRoute/views/SeeAllView.tsx
+++ b/src/components/LibraryRoute/views/SeeAllView.tsx
@@ -27,7 +27,7 @@ export interface SeeAllViewProps {
     name: string,
     provider?: ProviderId,
   ) => void;
-  onContextMenuRequest?: (req: ContextMenuRequest) => void;
+  onContextMenuRequest?: ((req: ContextMenuRequest) => void) | undefined;
 }
 
 const SeeAllView: React.FC<SeeAllViewProps> = ({

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -3,13 +3,13 @@ import styled, { keyframes, css } from 'styled-components';
 import { theme } from '../styles/theme';
 
 interface LikeButtonProps {
-  trackId?: string;
+  trackId?: string | undefined;
   isLiked: boolean;
-  isLoading?: boolean;
+  isLoading?: boolean | undefined;
   onToggleLike: () => void;
-  className?: string;
-  $isMobile?: boolean;
-  $isTablet?: boolean;
+  className?: string | undefined;
+  $isMobile?: boolean | undefined;
+  $isTablet?: boolean | undefined;
 }
 
 const heartBeat = keyframes`

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -41,7 +41,7 @@ const ZenProviderBadgeInline = styled.span`
 
 interface AlbumArtSectionProps {
   currentTrack: MediaTrack | null;
-  currentTrackProvider?: ProviderId;
+  currentTrackProvider?: ProviderId | undefined;
   zenModeEnabled: boolean;
   isMobile: boolean;
   isTablet: boolean;
@@ -52,7 +52,7 @@ interface AlbumArtSectionProps {
   onSwipeRight: () => void;
   onSwipeUp: () => void;
   onSwipeDown: () => void;
-  onAlbumArtBoundsChange?: (bounds: AlbumArtBounds | null) => void;
+  onAlbumArtBoundsChange?: ((bounds: AlbumArtBounds | null) => void) | undefined;
   onPlay: () => void;
   onPause: () => void;
   onNext: () => void;
@@ -60,7 +60,7 @@ interface AlbumArtSectionProps {
   isLiked: boolean;
   canSaveTrack: boolean;
   onLikeToggle: () => void;
-  flipToggleRef?: React.MutableRefObject<(() => void) | null>;
+  flipToggleRef?: React.MutableRefObject<(() => void) | null> | undefined;
 }
 
 export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({

--- a/src/components/PlayerContent/DrawerOrchestrator.tsx
+++ b/src/components/PlayerContent/DrawerOrchestrator.tsx
@@ -61,14 +61,14 @@ interface DrawerOrchestratorProps {
   showQueue: boolean;
   onCloseQueue: () => void;
   onTrackSelect: (index: number) => void;
-  onRemoveFromQueue?: (index: number) => void;
-  onReorderQueue?: (fromIndex: number, toIndex: number) => void;
+  onRemoveFromQueue?: ((index: number) => void) | undefined;
+  onReorderQueue?: ((fromIndex: number, toIndex: number) => void) | undefined;
   isMobile: boolean;
-  radioActive?: boolean;
-  radioState?: RadioState;
-  mediaTracksRef?: React.RefObject<MediaTrack[]>;
-  radioProgress?: RadioProgress | null;
-  onDismissRadioProgress?: () => void;
+  radioActive?: boolean | undefined;
+  radioState?: RadioState | undefined;
+  mediaTracksRef?: React.RefObject<MediaTrack[]> | undefined;
+  radioProgress?: RadioProgress | null | undefined;
+  onDismissRadioProgress?: (() => void) | undefined;
   onOpenQueueFromToast: () => void;
 }
 
@@ -155,7 +155,9 @@ export const DrawerOrchestrator: React.FC<DrawerOrchestratorProps> = React.memo(
       {
         id: 'radio-progress',
         duration: isDone ? 6000 : Infinity,
-        onAutoClose: isDone ? onDismissRadioProgress : undefined,
+        // sonner's ExternalToast types `onAutoClose?: (...)` as not-undefined under EOPT;
+        // spread it conditionally to honour the third-party boundary.
+        ...(isDone && { onAutoClose: onDismissRadioProgress }),
       },
     );
   }, [radioProgress, onDismissRadioProgress, onOpenQueueFromToast]);

--- a/src/components/PlayerContent/GestureLayer.tsx
+++ b/src/components/PlayerContent/GestureLayer.tsx
@@ -20,13 +20,13 @@ interface GestureLayerProps {
   onSwipeDown: () => void;
   isTouchDevice: boolean;
   onClick: (e: React.MouseEvent) => void;
-  onLongPress?: () => void;
-  zenTouchHandlers?: ZenTouchHandlers;
+  onLongPress?: (() => void) | undefined;
+  zenTouchHandlers?: ZenTouchHandlers | undefined;
   albumArtContainerRef: React.MutableRefObject<HTMLDivElement | null>;
   children: React.ReactNode;
-  onZoneHover?: (zone: Zone | null) => void;
-  zenModeEnabled?: boolean;
-  hasPointerInput?: boolean;
+  onZoneHover?: ((zone: Zone | null) => void) | undefined;
+  zenModeEnabled?: boolean | undefined;
+  hasPointerInput?: boolean | undefined;
 }
 
 export const GestureLayer: React.FC<GestureLayerProps> = React.memo(({

--- a/src/components/PlayerContent/PlayerControlsSection.tsx
+++ b/src/components/PlayerContent/PlayerControlsSection.tsx
@@ -84,7 +84,7 @@ function VisualEffectsLoadingFallback(): React.ReactElement {
 
 interface PlayerControlsSectionProps {
   currentTrack: MediaTrack | null;
-  currentTrackProvider?: ProviderId;
+  currentTrackProvider?: ProviderId | undefined;
   isPlaying: boolean;
   zenModeEnabled: boolean;
   hasPointerInput: boolean;
@@ -101,11 +101,11 @@ interface PlayerControlsSectionProps {
   onCloseQueue: () => void;
   onOpenLibrary: () => void;
   onCloseLibrary: () => void;
-  onOpenQuickAccessPanel?: () => void;
+  onOpenQuickAccessPanel?: (() => void) | undefined;
   onZenModeToggle: () => void;
-  isRadioAvailable?: boolean;
-  onStartRadio?: () => void;
-  radioState?: RadioState;
+  isRadioAvailable?: boolean | undefined;
+  onStartRadio?: (() => void) | undefined;
+  radioState?: RadioState | undefined;
   isLiked: boolean;
   isLikePending: boolean;
   onLikeToggle: () => void;

--- a/src/components/PlayerContent/index.tsx
+++ b/src/components/PlayerContent/index.tsx
@@ -41,15 +41,15 @@ export interface PlaybackHandlers {
 interface PlayerContentProps {
   isPlaying: boolean;
   showLibrary: boolean;
-  onAlbumArtBoundsChange?: (bounds: AlbumArtBounds | null) => void;
+  onAlbumArtBoundsChange?: ((bounds: AlbumArtBounds | null) => void) | undefined;
   handlers: PlaybackHandlers;
-  currentTrackProvider?: ProviderId;
-  radioState?: RadioState;
-  isRadioAvailable?: boolean;
-  radioActive?: boolean;
-  mediaTracksRef?: React.RefObject<MediaTrack[]>;
-  radioProgress?: RadioProgress | null;
-  onDismissRadioProgress?: () => void;
+  currentTrackProvider?: ProviderId | undefined;
+  radioState?: RadioState | undefined;
+  isRadioAvailable?: boolean | undefined;
+  radioActive?: boolean | undefined;
+  mediaTracksRef?: React.RefObject<MediaTrack[]> | undefined;
+  radioProgress?: RadioProgress | null | undefined;
+  onDismissRadioProgress?: (() => void) | undefined;
 }
 
 const PlayerContent: React.FC<PlayerContentProps> = React.memo(({

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -230,12 +230,12 @@ export const FlipInner = styled.div.withConfig({
 export const LoadingCard = styled.div.withConfig({
   shouldForwardProp: (prop: string) => !['backgroundImage', 'standalone', 'accentColor', 'glowEnabled', 'glowIntensity', 'glowRate'].includes(prop),
 }) <{
-  backgroundImage?: string;
-  standalone?: boolean;
-  accentColor?: string;
-  glowEnabled?: boolean;
-  glowIntensity?: number;
-  glowRate?: number;
+  backgroundImage?: string | undefined;
+  standalone?: boolean | undefined;
+  accentColor?: string | undefined;
+  glowEnabled?: boolean | undefined;
+  glowIntensity?: number | undefined;
+  glowRate?: number | undefined;
 }>`
   ${cardBase};
   margin-top: 0.5rem;

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -118,7 +118,7 @@ interface QueueBottomSheetProps {
   onReorderTracks?: ((fromIndex: number, toIndex: number) => void) | undefined;
   showProviderIcons?: boolean | undefined;
   radioActive?: boolean | undefined;
-  radioSeedDescription?: string | null | undefined;
+  radioSeedDescription?: string | undefined;
   onSaveQueue?: (() => void) | undefined;
   canSaveQueue?: boolean | undefined;
 }

--- a/src/components/QueueBottomSheet.tsx
+++ b/src/components/QueueBottomSheet.tsx
@@ -114,13 +114,13 @@ interface QueueBottomSheetProps {
   tracks: MediaTrack[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
-  onRemoveTrack?: (index: number) => void;
-  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
-  showProviderIcons?: boolean;
-  radioActive?: boolean;
-  radioSeedDescription?: string | null;
-  onSaveQueue?: () => void;
-  canSaveQueue?: boolean;
+  onRemoveTrack?: ((index: number) => void) | undefined;
+  onReorderTracks?: ((fromIndex: number, toIndex: number) => void) | undefined;
+  showProviderIcons?: boolean | undefined;
+  radioActive?: boolean | undefined;
+  radioSeedDescription?: string | null | undefined;
+  onSaveQueue?: (() => void) | undefined;
+  canSaveQueue?: boolean | undefined;
 }
 
 const QueueBottomSheet = memo<QueueBottomSheetProps>(function QueueBottomSheet({

--- a/src/components/QueueContextMenu.tsx
+++ b/src/components/QueueContextMenu.tsx
@@ -49,7 +49,7 @@ const MenuContainer = styled.div<{ $x: number; $y: number }>`
   }
 `;
 
-const MenuItem = styled.button<{ $destructive?: boolean }>`
+const MenuItem = styled.button<{ $destructive?: boolean | undefined }>`
   display: flex;
   align-items: center;
   gap: 0.625rem;

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -153,13 +153,13 @@ interface QueueDrawerProps {
   tracks: MediaTrack[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
-  onRemoveTrack?: (index: number) => void;
-  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
-  showProviderIcons?: boolean;
-  radioActive?: boolean;
-  radioSeedDescription?: string | null;
-  onSaveQueue?: () => void;
-  canSaveQueue?: boolean;
+  onRemoveTrack?: ((index: number) => void) | undefined;
+  onReorderTracks?: ((fromIndex: number, toIndex: number) => void) | undefined;
+  showProviderIcons?: boolean | undefined;
+  radioActive?: boolean | undefined;
+  radioSeedDescription?: string | null | undefined;
+  onSaveQueue?: (() => void) | undefined;
+  canSaveQueue?: boolean | undefined;
 }
 
 // Custom comparison function for QueueDrawer memo optimization

--- a/src/components/QueueDrawer.tsx
+++ b/src/components/QueueDrawer.tsx
@@ -157,7 +157,7 @@ interface QueueDrawerProps {
   onReorderTracks?: ((fromIndex: number, toIndex: number) => void) | undefined;
   showProviderIcons?: boolean | undefined;
   radioActive?: boolean | undefined;
-  radioSeedDescription?: string | null | undefined;
+  radioSeedDescription?: string | undefined;
   onSaveQueue?: (() => void) | undefined;
   canSaveQueue?: boolean | undefined;
 }

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -104,12 +104,12 @@ interface QueueItemProps {
   index: number;
   isSelected: boolean;
   onSelect: (index: number) => void;
-  onRemove?: (index: number) => void;
-  onPlayNext?: (index: number) => void;
-  itemRef?: React.RefObject<HTMLDivElement>;
-  showProviderIcon?: boolean;
-  isDragActive?: boolean;
-  isEditMode?: boolean;
+  onRemove?: ((index: number) => void) | undefined;
+  onPlayNext?: ((index: number) => void) | undefined;
+  itemRef?: React.RefObject<HTMLDivElement> | undefined;
+  showProviderIcon?: boolean | undefined;
+  isDragActive?: boolean | undefined;
+  isEditMode?: boolean | undefined;
 }
 
 function useQueueItemContextMenu(

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -68,11 +68,11 @@ interface QueueTrackListProps {
   tracks: MediaTrack[];
   currentTrackIndex: number;
   onTrackSelect: (index: number) => void;
-  onRemoveTrack?: (index: number) => void;
-  onReorderTracks?: (fromIndex: number, toIndex: number) => void;
-  isOpen?: boolean;
-  showProviderIcons?: boolean;
-  canEdit?: boolean;
+  onRemoveTrack?: ((index: number) => void) | undefined;
+  onReorderTracks?: ((fromIndex: number, toIndex: number) => void) | undefined;
+  isOpen?: boolean | undefined;
+  showProviderIcons?: boolean | undefined;
+  canEdit?: boolean | undefined;
 }
 
 const useIsTouchDevice = () => {

--- a/src/components/QuickAccessPanel/PinRing.tsx
+++ b/src/components/QuickAccessPanel/PinRing.tsx
@@ -66,9 +66,9 @@ type GridSatelliteItem =
 interface GridItemCardProps {
   id: string;
   name: string;
-  provider?: ProviderId;
-  imgUrl?: string;
-  mosaicAlbumPaths?: string[];
+  provider?: ProviderId | undefined;
+  imgUrl?: string | undefined;
+  mosaicAlbumPaths?: string[] | undefined;
   fallback: string;
   onPlay: (id: string, name: string, provider?: ProviderId) => void;
   onAddToQueue: (id: string, name: string, provider?: ProviderId) => void;

--- a/src/components/RadioProgressToast.tsx
+++ b/src/components/RadioProgressToast.tsx
@@ -4,7 +4,7 @@ import type { RadioProgressPhase } from '@/types/radio';
 
 interface RadioProgressContentProps {
   phase: RadioProgressPhase;
-  trackCount?: number;
+  trackCount?: number | undefined;
   onDismiss: () => void;
   onViewQueue: () => void;
 }

--- a/src/components/SaveQueueDialog.tsx
+++ b/src/components/SaveQueueDialog.tsx
@@ -81,7 +81,7 @@ interface SaveQueueDialogProps {
   onClose: () => void;
   availableProviders: ProviderId[];
   trackProviders: Set<ProviderId>;
-  defaultName?: string;
+  defaultName?: string | undefined;
 }
 
 export default function SaveQueueDialog({ onSave, onClose, availableProviders, trackProviders, defaultName }: SaveQueueDialogProps) {

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -20,13 +20,13 @@ interface SpotifyPlayerControlsProps {
   onNext: () => void;
   onPrevious: () => void;
   trackCount: number;
-  isLiked?: boolean;
-  isLikePending?: boolean;
-  onToggleLike?: () => void;
-  onArtistBrowse?: (artistName: string) => void;
-  onAlbumPlay?: (albumId: string, albumName: string) => void;
-  onPlayRadio?: () => void;
-  currentTrackProvider?: ProviderId;
+  isLiked?: boolean | undefined;
+  isLikePending?: boolean | undefined;
+  onToggleLike?: (() => void) | undefined;
+  onArtistBrowse?: ((artistName: string) => void) | undefined;
+  onAlbumPlay?: ((albumId: string, albumName: string) => void) | undefined;
+  onPlayRadio?: (() => void) | undefined;
+  currentTrackProvider?: ProviderId | undefined;
 }
 
 // --- SpotifyPlayerControls Component ---

--- a/src/components/controls/TimelineControls.tsx
+++ b/src/components/controls/TimelineControls.tsx
@@ -10,7 +10,7 @@ interface TimelineControlsProps {
     onSeek: (position: number) => void;
     onScrubStart: () => void;
     onScrubEnd: (position: number) => void;
-    trackId?: string;
+    trackId?: string | undefined;
     isLiked: boolean;
     isLikePending: boolean;
     onLikeToggle: () => void;

--- a/src/components/controls/TrackInfo.tsx
+++ b/src/components/controls/TrackInfo.tsx
@@ -20,9 +20,9 @@ interface TrackInfoProps {
     } | null;
     isMobile: boolean;
     isTablet: boolean;
-    onArtistBrowse?: (artistName: string) => void;
-    onAlbumPlay?: (albumId: string, albumName: string) => void;
-    onPlayRadio?: () => void;
+    onArtistBrowse?: ((artistName: string) => void) | undefined;
+    onAlbumPlay?: ((albumId: string, albumName: string) => void) | undefined;
+    onPlayRadio?: (() => void) | undefined;
 }
 
 // Custom comparison function for memo optimization

--- a/src/components/controls/TrackInfoPopover.tsx
+++ b/src/components/controls/TrackInfoPopover.tsx
@@ -22,7 +22,7 @@ interface TrackInfoPopoverProps {
 // OptionButton retained — purely visual, no layout role. Radix Popover owns
 // positioning, click-outside, Escape, focus return, and motion via the shadcn
 // `popover` primitive; this component just renders the option list.
-const OptionButton = styled.button<{ $disabled?: boolean }>`
+const OptionButton = styled.button<{ $disabled?: boolean | undefined }>`
   display: flex;
   align-items: center;
   gap: 0.625rem;

--- a/src/components/styled/Avatar.tsx
+++ b/src/components/styled/Avatar.tsx
@@ -2,10 +2,10 @@ import styled from 'styled-components';
 import { useState } from 'react';
 
 interface AvatarProps {
-  src?: string;
-  alt?: string;
-  fallback?: React.ReactNode;
-  style?: React.CSSProperties;
+  src?: string | undefined;
+  alt?: string | undefined;
+  fallback?: React.ReactNode | undefined;
+  style?: React.CSSProperties | undefined;
 }
 
 const StyledAvatar = styled.div`

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -32,7 +32,10 @@ const ScrollArea = React.forwardRef<
     >
       {children}
     </ScrollAreaPrimitive.Viewport>
-    <ScrollBar scrollbarStyle={scrollbarStyle} thumbStyle={thumbStyle} />
+    <ScrollBar
+      {...(scrollbarStyle !== undefined && { scrollbarStyle })}
+      {...(thumbStyle !== undefined && { thumbStyle })}
+    />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ))

--- a/src/contexts/BottomBarActionsContext.tsx
+++ b/src/contexts/BottomBarActionsContext.tsx
@@ -6,9 +6,9 @@ export interface BottomBarActionsValue {
   showQueue: () => void;
   openLibrary: () => void;
   toggleZenMode: () => void;
-  startRadio?: () => void;
-  openQuickAccessPanel?: () => void;
-  radioGenerating?: boolean;
+  startRadio?: (() => void) | undefined;
+  openQuickAccessPanel?: (() => void) | undefined;
+  radioGenerating?: boolean | undefined;
 }
 
 const BottomBarActionsContext = createContext<BottomBarActionsValue | null>(null);

--- a/src/contexts/ProfilingContext.tsx
+++ b/src/contexts/ProfilingContext.tsx
@@ -144,6 +144,9 @@ class MetricsCollector {
     const perfMem = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory;
     const curMem = perfMem ? perfMem.usedJSHeapSize / 1024 / 1024 : undefined;
     if (curMem !== undefined && curMem > this.peakMemory) this.peakMemory = curMem;
+    const memory: ProfilingSnapshot['memory'] = {};
+    if (curMem !== undefined) memory.current = curMem;
+    if (this.peakMemory > 0) memory.peak = this.peakMemory;
     return {
       sessionStart: this.sessionStart,
       duration: performance.now() - this.sessionStart,
@@ -152,7 +155,7 @@ class MetricsCollector {
       operations: Object.fromEntries(this.operations),
       frameRate: { current: this.currentFps, avg: Math.round(avgFps * 10) / 10, min: this.minFps === Infinity ? 0 : this.minFps },
       longTasks: { count: this.longTaskCount, totalDuration: this.longTaskTotal, maxDuration: this.longTaskMax },
-      memory: { current: curMem, peak: this.peakMemory > 0 ? this.peakMemory : undefined },
+      memory,
       recentEvents: [...this.recentEvents],
     };
   }

--- a/src/contexts/VisualizerDebugContext.tsx
+++ b/src/contexts/VisualizerDebugContext.tsx
@@ -142,7 +142,12 @@ export function VisualizerDebugProvider({ children }: { children: React.ReactNod
       const parsed = JSON.parse(json) as VisualizerDebugConfig | VisualizerDebugOverrides;
       const overrides: VisualizerDebugOverrides =
         parsed?.particle && parsed?.trail
-          ? { particle: parsed.particle, trail: parsed.trail, wave: parsed.wave, grid: parsed.grid }
+          ? {
+              particle: parsed.particle,
+              trail: parsed.trail,
+              ...(parsed.wave !== undefined && { wave: parsed.wave }),
+              ...(parsed.grid !== undefined && { grid: parsed.grid }),
+            }
           : (parsed as VisualizerDebugOverrides);
       setOverridesState(overrides);
       writeStoredOverrides(overrides);

--- a/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx
@@ -153,7 +153,7 @@ describe('usePlayerLogic — onAuthExpired handler', () => {
 
   it('calls reportUnauthorized on the provider when auth expires during playback', async () => {
     // #given
-    const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
+    renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
     // #when — simulate AuthExpiredError surfacing from playback adapter
     await act(async () => {

--- a/src/hooks/useCatalogLibrarySync.ts
+++ b/src/hooks/useCatalogLibrarySync.ts
@@ -51,10 +51,10 @@ function collectionToPlaylistInfo(c: MediaCollection, ordinal: number): CachedPl
     images,
     tracks: c.trackCount != null ? { total: c.trackCount } : null,
     owner: c.ownerName ? { display_name: c.ownerName } : null,
-    snapshot_id: c.revision ?? undefined,
     provider: c.provider,
     added_at: getOrSetFirstSeenAddedAtIso(c.provider, `playlist:${c.id}`, ordinal),
-    mosaicAlbumPaths: c.mosaicAlbumPaths,
+    ...(c.revision !== undefined && { snapshot_id: c.revision }),
+    ...(c.mosaicAlbumPaths !== undefined && { mosaicAlbumPaths: c.mosaicAlbumPaths }),
   };
 }
 

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -427,7 +427,10 @@ export function usePlayerLogic() {
       drivingProviderRef.current = providerId;
       setPlaybackPosition(positionMs ?? 0);
       setIsPlaying(false);
-      hydratedPendingPlayRef.current = { index: candidateIdx, positionMs };
+      hydratedPendingPlayRef.current = {
+        index: candidateIdx,
+        ...(positionMs !== undefined && { positionMs }),
+      };
 
       logQueue(
         'handleHydrate — index=%d, track=%s, positionMs=%s, provider=%s, skipped=%s',

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -10,14 +10,14 @@ import { loadSession } from '@/services/sessionPersistence';
 
 interface UseProviderPlaybackProps {
   setCurrentTrackIndex: (index: number) => void;
-  activeDescriptor?: ProviderDescriptor | null;
+  activeDescriptor?: ProviderDescriptor | null | undefined;
   mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
   /**
    * Ref tracking the current track index. Used by the re-prime listener so
    * the handler reads the live index without re-binding on every change.
    */
-  currentTrackIndexRef?: React.MutableRefObject<number>;
-  onAuthExpired?: (providerId: ProviderId) => void;
+  currentTrackIndexRef?: React.MutableRefObject<number> | undefined;
+  onAuthExpired?: ((providerId: ProviderId) => void) | undefined;
   /**
    * Shared guard ref used by `usePlaybackSubscription` to ignore stale provider
    * index updates during a transition. `playTrack` sets this to the target
@@ -25,7 +25,7 @@ interface UseProviderPlaybackProps {
    * the next track) so that provider state events emitted during the handoff
    * cannot flip `currentTrackIndex` to the wrong track.
    */
-  expectedTrackIdRef?: React.MutableRefObject<string | null>;
+  expectedTrackIdRef?: React.MutableRefObject<string | null> | undefined;
 }
 
 export const useProviderPlayback = ({

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -102,7 +102,7 @@ export function useQueueManagement({
         logQueue('handleAddToQueue — queue empty, delegating to loadCollection');
         const loaded = await loadCollection(playlistId, provider, collectionName);
         if (loaded > 0) {
-          return { added: loaded, collectionName };
+          return { added: loaded, ...(collectionName !== undefined && { collectionName }) };
         }
         toast(ADD_TO_QUEUE_EMPTY_MSG, { id: ADD_TO_QUEUE_EMPTY_ID });
         return null;
@@ -143,7 +143,7 @@ export function useQueueManagement({
           mediaTracksRef.current.length,
           uniqueNewTracks.map((t: MediaTrack) => trkSummary(t)).join(', '),
         );
-        return { added: uniqueNewTracks.length, collectionName };
+        return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
       } catch (err) {
         console.error('[Queue] Failed to add to queue:', err);
         toast(ADD_TO_QUEUE_ERROR_MSG, { id: ADD_TO_QUEUE_ERROR_ID });
@@ -259,7 +259,7 @@ export function useQueueManagement({
       setOriginalTracks(nextTracks);
       setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
       notifyQueueChanged(nextTracks, currentTrackIndex);
-      return { added: uniqueNewTracks.length, collectionName };
+      return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
     [mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
   );
@@ -287,7 +287,7 @@ export function useQueueManagement({
         setOriginalTracks([...uniqueNewTracks]);
         setTracks([...uniqueNewTracks]);
         notifyQueueChanged([...uniqueNewTracks], 0);
-        return { added: uniqueNewTracks.length, collectionName };
+        return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
       }
 
       const insertAt = currentTrackIndex + 1;
@@ -312,7 +312,7 @@ export function useQueueManagement({
         mediaTracksRef.current.length,
         uniqueNewTracks.map((t: MediaTrack) => trkSummary(t)).join(', '),
       );
-      return { added: uniqueNewTracks.length, collectionName };
+      return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
     [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
   );
@@ -345,7 +345,7 @@ export function useQueueManagement({
         logQueue('insertCollectionNext — queue empty, delegating to loadCollection');
         const loaded = await loadCollection(playlistId, provider, collectionName);
         if (loaded > 0) {
-          return { added: loaded, collectionName };
+          return { added: loaded, ...(collectionName !== undefined && { collectionName }) };
         }
         toast(ADD_TO_QUEUE_EMPTY_MSG, { id: ADD_TO_QUEUE_EMPTY_ID });
         return null;

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -45,14 +45,14 @@ export function useSessionPersistence(
     return {
       collectionId,
       collectionName,
-      collectionProvider,
       trackIndex: currentTrackIndex,
-      trackId,
       queueTracks: tracks,
-      trackTitle,
-      trackArtist,
-      trackImage,
       playbackPosition,
+      ...(collectionProvider !== undefined && { collectionProvider }),
+      ...(trackId !== undefined && { trackId }),
+      ...(trackTitle !== undefined && { trackTitle }),
+      ...(trackArtist !== undefined && { trackArtist }),
+      ...(trackImage !== undefined && { trackImage }),
     };
   }, [collectionId, collectionName, collectionProvider, tracks, currentTrackIndex, trackId, trackTitle, trackArtist, trackImage, playbackPosition]);
 

--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -13,7 +13,7 @@ interface UseSpotifyControlsProps {
   onNext: () => void;
   onPrevious: () => void;
   onLikeToggle: () => void;
-  currentTrackProvider?: ProviderId;
+  currentTrackProvider?: ProviderId | undefined;
 }
 
 interface PlaybackTimingState {

--- a/src/providers/dropbox/dropboxApiClient.ts
+++ b/src/providers/dropbox/dropboxApiClient.ts
@@ -68,7 +68,7 @@ export class DropboxApiClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(body),
-        signal,
+        ...(signal && { signal }),
       });
 
     let response = await makeRequest(token);

--- a/src/providers/dropbox/dropboxCatalogAdapter.ts
+++ b/src/providers/dropbox/dropboxCatalogAdapter.ts
@@ -154,7 +154,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
 
         const name = dirDisplayName.get(dirPath) ?? (dirPath.split('/').pop() || 'Unknown Album');
         const parentPath = dirParent.get(dirPath) ?? '';
-        const artistName = parentPath ? (dirDisplayName.get(parentPath) ?? undefined) : undefined;
+        const artistName = parentPath ? dirDisplayName.get(parentPath) : undefined;
+        const imageUrl = dirToImageUrl.get(dirPath);
 
         albums.push({
           id: dirPath,
@@ -162,8 +163,8 @@ export class DropboxCatalogAdapter implements CatalogProvider {
           kind: 'album',
           name,
           trackCount: count,
-          ownerName: artistName,
-          imageUrl: dirToImageUrl.get(dirPath),
+          ...(artistName !== undefined && { ownerName: artistName }),
+          ...(imageUrl !== undefined && { imageUrl }),
           // Dropbox folder metadata does not include genre information
           genres: [],
         });

--- a/src/providers/dropbox/dropboxCatalogHelpers.ts
+++ b/src/providers/dropbox/dropboxCatalogHelpers.ts
@@ -91,11 +91,11 @@ export function entryToMediaTrack(entry: DropboxFileEntry, imageUrl?: string): M
     artistsData: [{ name: artist }],
     album: albumName,
     albumId,
-    trackNumber,
     durationMs: 0,
-    image: imageUrl,
     // Dropbox file metadata does not include genre information
     genres: [],
+    ...(trackNumber !== undefined && { trackNumber }),
+    ...(imageUrl !== undefined && { image: imageUrl }),
   };
 }
 

--- a/src/providers/dropbox/dropboxLikesSync.ts
+++ b/src/providers/dropbox/dropboxLikesSync.ts
@@ -280,11 +280,12 @@ export class DropboxLikesSyncService {
         (t) => now - t.deletedAt < TOMBSTONE_TTL_MS,
       );
 
-      const leanEntries = entries.map(({ trackId, track, likedAt }) => ({
-        trackId,
-        track: { ...track, image: undefined },
-        likedAt,
-      }));
+      const leanEntries = entries.map(({ trackId, track, likedAt }) => {
+        // Strip the (large, presigned) Dropbox image URL before uploading; the playbackRef
+        // path is the permanent identifier. MediaTrack.image is optional, so we omit it.
+        const { image: _image, ...rest } = track;
+        return { trackId, track: rest, likedAt };
+      });
 
       const data: RemoteLikesFile = {
         version: 1,

--- a/src/providers/dropbox/dropboxPlaylistStorage.ts
+++ b/src/providers/dropbox/dropboxPlaylistStorage.ts
@@ -103,10 +103,10 @@ function mediaTrackToSavedTrack(track: MediaTrack): SavedTrack {
     name: track.name,
     artists: track.artists,
     album: track.album,
-    albumId: track.albumId,
     durationMs: track.durationMs,
-    externalUrl: track.externalUrl,
-    image,
+    ...(track.albumId !== undefined && { albumId: track.albumId }),
+    ...(track.externalUrl !== undefined && { externalUrl: track.externalUrl }),
+    ...(image !== undefined && { image }),
   };
 }
 
@@ -118,10 +118,10 @@ function savedTrackToMediaTrack(track: SavedTrack): MediaTrack {
     name: track.name,
     artists: track.artists,
     album: track.album,
-    albumId: track.albumId,
     durationMs: track.durationMs,
-    externalUrl: track.externalUrl,
-    image: track.image,
+    ...(track.albumId !== undefined && { albumId: track.albumId }),
+    ...(track.externalUrl !== undefined && { externalUrl: track.externalUrl }),
+    ...(track.image !== undefined && { image: track.image }),
     genres: [],
   };
 }
@@ -237,7 +237,6 @@ export async function listSavedPlaylists(
         provider: 'dropbox',
         kind: 'playlist',
         name: entry.name.replace(/\.json$/, ''),
-        imageUrl: undefined,
         genres: [],
       });
       filePaths.push(entry.path_lower);

--- a/src/providers/mock/mockCatalogAdapter.ts
+++ b/src/providers/mock/mockCatalogAdapter.ts
@@ -9,18 +9,20 @@ function snapshotTrackToMediaTrack(track: SnapshotTrack, providerId: ProviderId)
     playbackRef: { provider: providerId, ref: track.ref },
     name: track.name,
     artists: track.artistsDisplay,
-    artistsData: track.artists.map(a => ({ name: a.name, url: a.externalUrl })),
+    artistsData: track.artists.map((a) =>
+      a.externalUrl !== undefined ? { name: a.name, url: a.externalUrl } : { name: a.name },
+    ),
     album: track.album.name,
     albumId: track.album.id,
-    trackNumber: track.trackNumber,
     durationMs: track.durationMs,
-    image: track.image?.url,
-    externalUrl: track.externalUrl,
-    musicbrainzRecordingId: track.musicbrainzRecordingId,
-    musicbrainzArtistId: track.musicbrainzArtistId,
-    isrc: track.isrc,
-    addedAt: track.addedAt,
     genres: track.genres ?? [],
+    ...(track.trackNumber !== undefined && { trackNumber: track.trackNumber }),
+    ...(track.image?.url !== undefined && { image: track.image.url }),
+    ...(track.externalUrl !== undefined && { externalUrl: track.externalUrl }),
+    ...(track.musicbrainzRecordingId !== undefined && { musicbrainzRecordingId: track.musicbrainzRecordingId }),
+    ...(track.musicbrainzArtistId !== undefined && { musicbrainzArtistId: track.musicbrainzArtistId }),
+    ...(track.isrc !== undefined && { isrc: track.isrc }),
+    ...(track.addedAt !== undefined && { addedAt: track.addedAt }),
   };
 }
 
@@ -59,25 +61,26 @@ export class MockCatalogAdapter implements CatalogProvider {
         kind: 'playlist',
         name: playlist.name,
         description: playlist.description,
-        imageUrl: playlist.image?.url,
         trackCount: playlist.trackCount,
         ownerName: playlist.ownerName,
-        revision: playlist.revision ?? undefined,
         genres: [],
+        ...(playlist.image?.url !== undefined && { imageUrl: playlist.image.url }),
+        ...(playlist.revision != null && { revision: playlist.revision }),
       });
     }
 
     for (const album of this.snapshot.albums) {
+      const ownerName = album.artists[0]?.name;
       collections.push({
         id: album.id,
         provider: this.providerId,
         kind: 'album',
         name: album.name,
-        imageUrl: album.image?.url,
         trackCount: album.trackCount,
-        ownerName: album.artists[0]?.name,
-        releaseDate: album.releaseDate,
         genres: album.genres ?? [],
+        ...(album.image?.url !== undefined && { imageUrl: album.image.url }),
+        ...(ownerName !== undefined && { ownerName }),
+        ...(album.releaseDate !== undefined && { releaseDate: album.releaseDate }),
       });
     }
 

--- a/src/providers/mock/sessionSeed.ts
+++ b/src/providers/mock/sessionSeed.ts
@@ -78,9 +78,9 @@ export function seedSessionFromUrlParam(
       queueTracks: [track],
       trackTitle: track.name,
       trackArtist: track.artists,
-      trackImage: track.image,
       playbackPosition: seed.positionMs,
       savedAt: Date.now(),
+      ...(track.image !== undefined && { trackImage: track.image }),
     };
 
     saveSession(snapshot);

--- a/src/providers/spotify/spotifyCatalogAdapter.ts
+++ b/src/providers/spotify/spotifyCatalogAdapter.ts
@@ -28,58 +28,58 @@ import { ALBUM_ID_PREFIX, isAlbumId, extractAlbumId } from '@/constants/playlist
 
 /** Map a Spotify Track to a MediaTrack. */
 function spotifyTrackToMediaTrack(track: Track): MediaTrack {
+  const artistsData = track.artistsData?.map((a) =>
+    a.url !== undefined ? { name: a.name, url: a.url } : { name: a.name },
+  );
   return {
     id: track.id,
     provider: 'spotify',
     playbackRef: { provider: 'spotify', ref: track.uri },
     name: track.name,
     artists: track.artists,
-    artistsData: track.artistsData?.map((a) => ({
-      name: a.name,
-      url: a.url,
-    })),
     album: track.album,
-    albumId: track.album_id,
-    trackNumber: track.track_number,
     durationMs: track.duration_ms,
-    image: track.image,
-    externalUrl: track.uri
-      ? `https://open.spotify.com/track/${track.id}`
-      : undefined,
-    addedAt: track.added_at,
     genres: track.genres ?? [],
+    ...(artistsData !== undefined && { artistsData }),
+    ...(track.album_id !== undefined && { albumId: track.album_id }),
+    ...(track.track_number !== undefined && { trackNumber: track.track_number }),
+    ...(track.image !== undefined && { image: track.image }),
+    ...(track.uri ? { externalUrl: `https://open.spotify.com/track/${track.id}` } : {}),
+    ...(track.added_at !== undefined && { addedAt: track.added_at }),
   };
 }
 
 /** Map a PlaylistInfo to a MediaCollection. */
 function spotifyPlaylistToMediaCollection(pl: PlaylistInfo): MediaCollection {
+  const imageUrl = getLargestImage(pl.images);
   return {
     id: pl.id,
     provider: 'spotify',
     kind: 'playlist',
     name: pl.name,
-    description: pl.description ?? undefined,
-    imageUrl: getLargestImage(pl.images),
-    trackCount: pl.tracks?.total ?? undefined,
-    ownerName: pl.owner?.display_name ?? undefined,
-    revision: pl.snapshot_id,
     // Spotify playlist API doesn't return genre information
     genres: [],
+    ...(pl.description != null && { description: pl.description }),
+    ...(imageUrl !== undefined && { imageUrl }),
+    ...(pl.tracks?.total !== undefined && { trackCount: pl.tracks.total }),
+    ...(pl.owner?.display_name !== undefined && { ownerName: pl.owner.display_name }),
+    ...(pl.snapshot_id !== undefined && { revision: pl.snapshot_id }),
   };
 }
 
 /** Map an AlbumInfo to a MediaCollection. */
 function spotifyAlbumToMediaCollection(album: AlbumInfo): MediaCollection {
+  const imageUrl = getLargestImage(album.images);
   return {
     id: `${ALBUM_ID_PREFIX}${album.id}`,
     provider: 'spotify',
     kind: 'album',
     name: album.name,
     description: album.artists,
-    imageUrl: getLargestImage(album.images),
     trackCount: album.total_tracks,
     // Genres come from the Spotify album object (may be empty for simplified library responses)
     genres: album.genres ?? [],
+    ...(imageUrl !== undefined && { imageUrl }),
   };
 }
 

--- a/src/providers/spotify/useSpotifyPlaylistManager.ts
+++ b/src/providers/spotify/useSpotifyPlaylistManager.ts
@@ -29,6 +29,7 @@ function buildTracksFromWindow(state: SpotifyPlaybackState): MediaTrack[] {
   function toTrack(item: SpotifyTrack): MediaTrack {
     const albumId = item.album?.uri?.split(':').pop();
     const uri = item.uri;
+    const image = getLargestImage(item.album?.images);
     return {
       id: item.id || '',
       provider: SPOTIFY_PROVIDER_ID,
@@ -36,10 +37,10 @@ function buildTracksFromWindow(state: SpotifyPlaybackState): MediaTrack[] {
       name: item.name,
       artists: item.artists.map(a => a.name).join(', '),
       album: item.album?.name ?? 'Unknown Album',
-      albumId,
       durationMs: item.duration_ms ?? 0,
-      image: getLargestImage(item.album?.images),
       genres: [],
+      ...(albumId !== undefined && { albumId }),
+      ...(image !== undefined && { image }),
     };
   }
 

--- a/src/services/cache/libraryCache.ts
+++ b/src/services/cache/libraryCache.ts
@@ -85,7 +85,12 @@ export async function putTrackList(
   tracks: Track[],
   snapshotId?: string,
 ): Promise<void> {
-  const entry: CachedTrackList = { id, tracks, timestamp: Date.now(), snapshotId };
+  const entry: CachedTrackList = {
+    id,
+    tracks,
+    timestamp: Date.now(),
+    ...(snapshotId !== undefined && { snapshotId }),
+  };
   return trackLists.put(id, entry);
 }
 

--- a/src/services/cache/libraryCacheLifecycle.ts
+++ b/src/services/cache/libraryCacheLifecycle.ts
@@ -186,7 +186,7 @@ async function migrateFromLocalStorage(): Promise<void> {
           key: 'albums',
           lastValidated: entry.timestamp,
           totalCount: entry.data.length,
-          latestAddedAt: latestAddedAt || undefined,
+          ...(latestAddedAt && { latestAddedAt }),
         } satisfies LibraryCacheMeta);
         localStorage.removeItem(STORAGE_KEYS.CACHE_ALBUMS);
       }

--- a/src/services/cache/libraryDiffEngine.ts
+++ b/src/services/cache/libraryDiffEngine.ts
@@ -169,7 +169,7 @@ async function syncAlbums(
   await cache.putMeta('albums', {
     lastValidated: Date.now(),
     totalCount: deduped.length,
-    latestAddedAt: latestAddedAt || undefined,
+    ...(latestAddedAt && { latestAddedAt }),
   });
 
   return deduped;

--- a/src/services/cache/librarySearch.ts
+++ b/src/services/cache/librarySearch.ts
@@ -41,7 +41,7 @@ export interface LibrarySearchResult {
 
 export interface LibrarySearchOptions {
   /** Maximum results returned per category. Defaults to 10. */
-  limitPerCategory?: number;
+  limitPerCategory?: number | undefined;
 }
 
 const EMPTY_RESULT: LibrarySearchResult = Object.freeze({

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -194,10 +194,11 @@ export class SpotifyLibrarySyncEngine {
     this.pendingRemovals.delete(album.id);
     await cache.putAlbum(album);
     const meta = await cache.getMeta('albums');
+    const latestAddedAt = album.added_at ?? meta?.latestAddedAt;
     await cache.putMeta('albums', {
       lastValidated: meta?.lastValidated ?? Date.now(),
       totalCount: (meta?.totalCount ?? 0) + 1,
-      latestAddedAt: album.added_at ?? meta?.latestAddedAt,
+      ...(latestAddedAt !== undefined && { latestAddedAt }),
     });
     const albums = await cache.getAllAlbums();
     this.notifyListeners(undefined, albums, undefined);
@@ -278,7 +279,7 @@ export class SpotifyLibrarySyncEngine {
         cache.putMeta('albums', {
           lastValidated: Date.now(),
           totalCount: allAlbums.length,
-          latestAddedAt: latestAddedAt || undefined,
+          ...(latestAddedAt && { latestAddedAt }),
         }).catch(() => {});
       }
     };

--- a/src/services/devbug/reportBuilder.ts
+++ b/src/services/devbug/reportBuilder.ts
@@ -137,11 +137,11 @@ export function getReactComponentName(element: Element): string | null {
 interface BuildBugReportParams {
   selectionMode: SelectionMode;
   elements: SelectedElement[];
-  screenshotDataUrl?: string;
-  comment?: string;
-  categories?: Category[];
-  consoleLogs?: ConsoleEntry[];
-  performanceMetrics?: PerfData;
+  screenshotDataUrl?: string | undefined;
+  comment?: string | undefined;
+  categories?: Category[] | undefined;
+  consoleLogs?: ConsoleEntry[] | undefined;
+  performanceMetrics?: PerfData | undefined;
 }
 
 export function buildBugReport(params: BuildBugReportParams): BugReport {

--- a/src/services/sessionPersistence.ts
+++ b/src/services/sessionPersistence.ts
@@ -34,7 +34,7 @@ export function saveSession(snapshot: SessionSnapshot): void {
     const sanitized: SessionSnapshot = {
       ...snapshot,
       savedAt: Date.now(),
-      queueTracks: snapshot.queueTracks?.map(sanitizeTrack),
+      ...(snapshot.queueTracks !== undefined && { queueTracks: snapshot.queueTracks.map(sanitizeTrack) }),
     };
     localStorage.setItem(SESSION_KEY, JSON.stringify(sanitized));
   } catch (err) {

--- a/src/services/spotify/albums.ts
+++ b/src/services/spotify/albums.ts
@@ -32,10 +32,10 @@ export function transformSavedAlbumItem(
     release_date: album.release_date ?? '',
     total_tracks: album.total_tracks ?? 0,
     uri: album.uri ?? '',
-    album_type: album.album_type,
     added_at: item.added_at,
+    ...(album.album_type !== undefined && { album_type: album.album_type }),
   };
-  if (withGenres) {
+  if (withGenres && album.genres !== undefined) {
     result.genres = album.genres;
   }
   return result;
@@ -91,7 +91,7 @@ export async function getAlbumTracks(albumId: string): Promise<MediaTrack[]> {
     const track = transformTrackItem(trackItem, {
       name: album.name,
       id: album.id,
-      image: albumImage,
+      ...(albumImage !== undefined && { image: albumImage }),
     });
     if (track) {
       // Propagate album genres to each track (Spotify genres live at album level)
@@ -150,7 +150,7 @@ export async function getAlbumCount(signal?: AbortSignal): Promise<number> {
   const data = await spotifyApiRequest<PaginatedResponse<unknown>>(
     'https://api.spotify.com/v1/me/albums?limit=1&offset=0',
     token,
-    { signal }
+    signal ? { signal } : {},
   );
   return data.total ?? 0;
 }
@@ -165,7 +165,7 @@ export async function getAlbumsPage(
   const data = await spotifyApiRequest<PaginatedResponse<SavedAlbumItem>>(
     `https://api.spotify.com/v1/me/albums?limit=${limit}&offset=0`,
     token,
-    { signal }
+    signal ? { signal } : {},
   );
   return {
     albums: (data.items ?? []).map((item) => transformSavedAlbumItem(item)),
@@ -181,6 +181,6 @@ export async function getAllUserAlbums(signal?: AbortSignal): Promise<AlbumInfo[
     'https://api.spotify.com/v1/me/albums?limit=50',
     token,
     transformSavedAlbumItem,
-    { signal },
+    signal ? { signal } : {},
   );
 }

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -200,9 +200,11 @@ export async function fetchAllPaginated<TItem, TResult>(
       throw new DOMException('Request aborted', 'AbortError');
     }
 
-    const data: PaginatedResponse<TItem> = await spotifyApiRequest<PaginatedResponse<TItem>>(nextUrl, token, {
-      signal: options?.signal,
-    });
+    const data: PaginatedResponse<TItem> = await spotifyApiRequest<PaginatedResponse<TItem>>(
+      nextUrl,
+      token,
+      options?.signal ? { signal: options.signal } : {},
+    );
 
     for (const item of data.items ?? []) {
       if (options?.maxItems && results.length >= options.maxItems) {

--- a/src/services/spotify/playlists.ts
+++ b/src/services/spotify/playlists.ts
@@ -55,7 +55,7 @@ export async function getUserLibraryInterleaved(
     if (playlistNextUrl) {
       const url = playlistNextUrl;
       fetches.push(
-        spotifyApiRequest<PaginatedResponse<PlaylistInfo>>(url, token, { signal })
+        spotifyApiRequest<PaginatedResponse<PlaylistInfo>>(url, token, signal ? { signal } : {})
           .then((data) => {
             for (const item of data.items ?? []) {
               playlistResults.push(transformPlaylist(item));
@@ -70,7 +70,7 @@ export async function getUserLibraryInterleaved(
     if (albumNextUrl) {
       const url = albumNextUrl;
       fetches.push(
-        spotifyApiRequest<PaginatedResponse<SavedAlbumItem>>(url, token, { signal })
+        spotifyApiRequest<PaginatedResponse<SavedAlbumItem>>(url, token, signal ? { signal } : {})
           .then((data) => {
             const now = Date.now();
             for (const item of data.items ?? []) {
@@ -146,7 +146,7 @@ export async function getPlaylistCount(signal?: AbortSignal): Promise<number> {
   const data = await spotifyApiRequest<PaginatedResponse<unknown>>(
     'https://api.spotify.com/v1/me/playlists?limit=1&offset=0',
     token,
-    { signal }
+    signal ? { signal } : {},
   );
   return data.total ?? 0;
 }
@@ -160,7 +160,7 @@ export async function getPlaylistsPage(
   const data = await spotifyApiRequest<PaginatedResponse<PlaylistInfo>>(
     `https://api.spotify.com/v1/me/playlists?limit=${limit}&offset=0`,
     token,
-    { signal }
+    signal ? { signal } : {},
   );
   const playlists = (data.items ?? []).map((p, i) => ({
     ...p,
@@ -185,6 +185,6 @@ export async function getAllUserPlaylists(signal?: AbortSignal): Promise<Playlis
       ...item,
       added_at: item.added_at || new Date(Date.now() - index++ * 60000).toISOString(),
     }),
-    { signal },
+    signal ? { signal } : {},
   );
 }

--- a/src/services/spotify/tracks.ts
+++ b/src/services/spotify/tracks.ts
@@ -50,20 +50,22 @@ export function transformTrackItem(
   if (!item.id || item.type !== 'track') return null;
 
   const albumImage = albumOverride?.image ?? getLargestImage(item.album?.images);
+  const artistsData = buildArtistsData(item.artists);
+  const albumId = albumOverride?.id ?? item.album?.id;
 
   return {
     id: item.id,
     provider: 'spotify',
     name: item.name,
     artists: formatArtists(item.artists),
-    artistsData: buildArtistsData(item.artists),
     album: albumOverride?.name ?? item.album?.name ?? 'Unknown Album',
-    album_id: albumOverride?.id ?? item.album?.id,
-    track_number: item.track_number,
     duration_ms: item.duration_ms ?? 0,
     uri: item.uri,
-    preview_url: item.preview_url,
-    image: albumImage,
+    ...(artistsData !== undefined && { artistsData }),
+    ...(albumId !== undefined && { album_id: albumId }),
+    ...(item.track_number !== undefined && { track_number: item.track_number }),
+    ...(item.preview_url !== undefined && { preview_url: item.preview_url }),
+    ...(albumImage !== undefined && { image: albumImage }),
   };
 }
 
@@ -84,15 +86,15 @@ export function tracksToMediaTracks(tracks: Track[]): MediaTrack[] {
     playbackRef: { provider: 'spotify', ref: t.uri },
     name: t.name,
     artists: t.artists,
-    artistsData: t.artistsData,
     album: t.album,
-    albumId: t.album_id,
-    trackNumber: t.track_number,
     durationMs: t.duration_ms,
-    image: t.image,
-    externalUrl: t.preview_url,
-    addedAt: t.added_at,
     genres: t.genres ?? [],
+    ...(t.artistsData !== undefined && { artistsData: t.artistsData }),
+    ...(t.album_id !== undefined && { albumId: t.album_id }),
+    ...(t.track_number !== undefined && { trackNumber: t.track_number }),
+    ...(t.image !== undefined && { image: t.image }),
+    ...(t.preview_url !== undefined && { externalUrl: t.preview_url }),
+    ...(t.added_at !== undefined && { addedAt: t.added_at }),
   }));
 }
 
@@ -173,7 +175,7 @@ export async function getLikedSongsCount(signal?: AbortSignal): Promise<number> 
   const data = await spotifyApiRequest<LikedSongsResponse>(
     'https://api.spotify.com/v1/me/tracks?limit=1',
     token,
-    { signal }
+    signal ? { signal } : {},
   );
 
   const count = data.total ?? 0;

--- a/src/utils/sizingUtils.ts
+++ b/src/utils/sizingUtils.ts
@@ -78,10 +78,8 @@ const createDefaultSizingConstraints = (viewport: ViewportInfo): SizingConstrain
     allowAspectRatioAdjustment: true,
     viewportUsageWidth,
     viewportUsageHeight,
-    // These will be calculated by getOptimalAspectRatio and calculateAspectRatioConstraints
-    preferredAspectRatio: undefined,
-    minAspectRatio: undefined,
-    maxAspectRatio: undefined
+    // preferredAspectRatio / minAspectRatio / maxAspectRatio are calculated downstream
+    // by getOptimalAspectRatio and calculateAspectRatioConstraints; omitted here.
   };
 };
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,9 +26,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "noImplicitOverride": true,
-    "noUncheckedIndexedAccess": true
-    // TS-strict: exactOptionalPropertyTypes deferred — see issue #1598.
-    // "exactOptionalPropertyTypes": true
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**/*", "src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*"]


### PR DESCRIPTION
Closes #1598. Final issue in the TypeScript-strictness-audit thread started by #1589.

## Summary

Enables `exactOptionalPropertyTypes: true` in `tsconfig.app.json` and resolves the entire cascade (124 errors at flag-on, 0 after). The codebase convention going forward, per the blueprint and now codified in CLAUDE.md:

| Interface kind | Optional-field shape |
|---|---|
| React component `Props` (and styled-component type args, hook option-bag params, context-value shapes) | `field?: T \| undefined` |
| Data shape / domain model / non-JSX type | `field?: T` (omit when absent) |

## Commits (3, independently revertable)

### 1. `build(tsconfig): enable EOPT + fix non-JSX construction sites`
Uncomments the EOPT flag (with the trailing comma reviewer-flagged on #1599), then resolves every non-JSX construction-site error that surfaced. 26 files touched. Pattern: object literals that previously assigned `field: undefined` explicitly now use conditional spread `...(value !== undefined && { field: value })` or just omit the field — the EOPT-canonical idiom.

Includes the 12 blueprint-table sites (dropboxLikesSync, dropboxPlaylistStorage, sizingUtils aspect ratios, ProfilingContext memory shape, dropboxCatalogAdapter ownerName) plus the cascade that surfaced once EOPT was on: catalog adapters in `services/spotify/{albums,playlists,tracks}.ts` + `providers/{spotify,dropbox,mock}/`, cache-meta construction in `services/cache/{libraryDiffEngine,librarySyncEngine,libraryCacheLifecycle}.ts`, six `AddToQueueResult` returns in `useQueueManagement.ts`, the `SessionSnapshot` builder, and fetch `{ signal }` pass-through at 9 spotify-API callsites.

### 2. `refactor: widen React component prop interfaces to ?: T | undefined for EOPT`
The mechanical interface-widening step. 53 files, 32 React component Props interfaces + 9 option-bag / hook-param / context shapes + 6 styled-component type args.

**Note on the formulation.** The blueprint's literal example was `field: T | undefined` (no `?`); on review, that requires every caller to pass the field explicitly even when omitting is semantically the same. I used `?: T | undefined` which under EOPT both allows omission AND accepts explicitly-passed undefined — the ergonomic the blueprint was actually targeting (`<Foo prop={cond ? value : undefined} />`). This is the form widely used in React TS codebases under EOPT. Documented the choice in commit 2's body and in CLAUDE.md so future readers don't trip over it.

Third-party boundaries (sonner `ExternalToast.onAutoClose`, shadcn `ScrollArea` style forwarding) resolved with conditional spread — **no `!` non-null assertions introduced**.

### 3. `docs(CLAUDE.md): finalize type strictness baseline after EOPT enablement`
Removes the EOPT-deferred note from the strictness-baseline section, adds EOPT to the enabled-flags list, and inserts a new pattern bullet between the "Optional XOR nullable" and "Canonical types" bullets documenting the React prop convention (with the third-party boundary guidance). Closing line credits both #1589 and #1598 for the convention finalization.

## Interface widening count

- 32 React component `*Props` interfaces
- 6 styled-component type arguments (inline `styled.x<{...}>` shapes)
- 9 option-bag / hook-param / context / utility interfaces that share the JSX-style call-site ergonomic:
  `UseLongPressOptions`, `UseMenuItemsCallbacks`, `MenuActions`, `UseProviderPlaybackProps`, `UseSpotifyControlsProps`, `LibrarySearchOptions`, `BottomBarActionsValue`, `PinnedItem`, `ContextMenuRequestBase`, `BuildBugReportParams`, plus the `passesProviderFilter` parameter shape.

**Total: ~47 interface declarations widened.** Architect estimated ~30; the actual count grew because the principle (`object-literal call-site ergonomic`) extended naturally to hook param interfaces and context-value shapes, which the blueprint mentioned but didn't enumerate.

## Confirmed: no `!` smuggled assertions introduced

`git diff develop -- 'src/**/*.ts' 'src/**/*.tsx' | grep '^+.*[^=!]![^=]'` — clean.

## Regression-guard grep

`grep -rnE '\bas [A-Z]' src/ | grep -v "as const\|as unknown\|__tests__"` — count unchanged from develop (116). No new typed `as` casts introduced.

## Verify

- `npx tsc -b --noEmit` — **green** (124 errors at EOPT-on → 0)
- `npm run test:run` — **197 files, 2063 tests, all passing**
- `npm run build` — green
- `npm run lint` — **0 errors**, 34 warnings (all pre-existing). One pre-existing lint error in `src/hooks/__tests__/usePlayerLogic.authExpired.test.tsx:156` (unused `result` destructure) was fixed in-passing — the test now drops the unused binding, behaviour unchanged.

## 12 non-JSX sites checked off

| Site | Status |
|---|---|
| `providers/dropbox/dropboxLikesSync.ts:285` | ✓ destructure-and-rest to strip `image` |
| `providers/dropbox/dropboxPlaylistStorage.ts:240` | ✓ field omitted from literal |
| `utils/sizingUtils.ts:87-89` | ✓ aspect-ratio fields omitted; comment retained |
| `contexts/ProfilingContext.tsx:145+155` | ✓ memory built conditionally per blueprint snippet |
| `providers/dropbox/dropboxCatalogAdapter.ts:157` | ✓ `ownerName` + `imageUrl` spread conditionally |
| `providers/dropbox/dropboxPlaylistStorage.ts:99,114` (cascade) | ✓ `mediaTrackToSavedTrack` / `savedTrackToMediaTrack` rebuilt with conditional spreads |

## Out of scope (follow-up)

The architect noted a lint rule to enforce the new Props convention automatically as out-of-scope for this PR — implementing it would require custom ESLint plugin setup that would double the review burden. **TODO:** file a follow-up against `develop`: *Add custom ESLint rule to enforce React Props use `?: T | undefined` (not bare `?: T`)*. Body: codebase convention is policed by code review today; new component authors writing `interface FooProps { bar?: string }` will pass tsc + EOPT only because TS doesn't disallow `?: T` on Props interfaces — it only disallows passing `undefined` to one. A custom `@typescript-eslint/naming-convention`-style rule would catch the deviation automatically. Reference this PR for the convention details.