### PR TITLE
refactor(library): remove dead props, state, and unused returns

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -508,7 +508,6 @@ const AudioPlayerComponent = () => {
             onAddToQueue={handleAddToQueueFromPanel}
             onPlayLikedTracks={handlePlayLikedTracks}
             onQueueLikedTracks={handleQueueLikedTracks}
-            onOpenSettings={handleOpenSettings}
             onResume={handleResume}
             lastSession={null}
             initialSearchQuery={initialSearchQuery}
@@ -646,7 +645,6 @@ const AudioPlayerComponent = () => {
               onAddToQueue={handleAddToQueueFromPanel}
               onPlayLikedTracks={handlePlayLikedTracks}
               onQueueLikedTracks={handleQueueLikedTracks}
-              onOpenSettings={handleOpenSettings}
               onResume={handleResume}
               lastSession={lastSession}
               isPlaying={state.isPlaying}

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.likedClosesOverlay.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.likedClosesOverlay.test.tsx
@@ -97,7 +97,6 @@ vi.mock('../views/HomeView', () => ({
 import LibraryRoute from '../index';
 
 const baseProps = {
-  onOpenSettings: vi.fn(),
   lastSession: null,
   isPlaying: false,
   onMiniPlay: vi.fn(),

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.nav.test.tsx
@@ -74,7 +74,6 @@ vi.mock('../views/HomeView', () => ({
     <div data-testid="home-view">
       <button onClick={() => onNavigate('playlists')}>go-playlists</button>
       <button onClick={() => onNavigate('albums')}>go-albums</button>
-      <button onClick={() => onNavigate('liked')}>go-liked</button>
       <button onClick={() => onSelectCollection('album', 'a1', 'Dark Side', 'spotify')}>select-album</button>
       <button onClick={() => onSelectCollection('playlist', 'p1', 'Chill', 'spotify')}>select-playlist</button>
     </div>
@@ -96,7 +95,6 @@ const mockUsePlayerSizingContext = vi.mocked(usePlayerSizingContext);
 
 const baseProps = {
   onPlaylistSelect: vi.fn(),
-  onOpenSettings: vi.fn(),
   lastSession: null,
 };
 
@@ -136,18 +134,6 @@ describe('LibraryRoute — navigation', () => {
 
     // #then
     expect(screen.getByTestId('see-all-view-albums')).toBeInTheDocument();
-  });
-
-  it('falls back to HomeView when navigating to "liked" (no SeeAll page)', () => {
-    // #given
-    render(<LibraryRoute {...baseProps} />);
-
-    // #when
-    fireEvent.click(screen.getByRole('button', { name: 'go-liked' }));
-
-    // #then — "liked" has no SeeAll; LibraryRoute renders HomeView defensively
-    expect(screen.getByTestId('home-view')).toBeInTheDocument();
-    expect(screen.queryByTestId('see-all-view-liked')).not.toBeInTheDocument();
   });
 
   it('navigates back to HomeView from SeeAllView when onBack fires', () => {

--- a/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
+++ b/src/components/LibraryRoute/__tests__/LibraryRoute.test.tsx
@@ -74,7 +74,6 @@ import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
 
 const baseProps = {
   onPlaylistSelect: vi.fn(),
-  onOpenSettings: vi.fn(),
   lastSession: null,
   isPlaying: false,
   onMiniPlay: vi.fn(),

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.a11y.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.a11y.test.tsx
@@ -55,8 +55,6 @@ vi.mock('../useAlbumSavedStatus', () => ({
     isSaved: null,
     toggleSaved: vi.fn(),
     canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
   }),
 }));
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.edges.test.tsx
@@ -52,8 +52,6 @@ vi.mock('../useAlbumSavedStatus', () => ({
     isSaved: null,
     toggleSaved: vi.fn(),
     canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
   }),
 }));
 

--- a/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
+++ b/src/components/LibraryRoute/contextMenu/__tests__/LibraryContextMenu.test.tsx
@@ -71,8 +71,6 @@ function defaultMocks() {
     isSaved: null,
     toggleSaved: vi.fn(),
     canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
   });
 }
 
@@ -353,8 +351,6 @@ describe('LibraryContextMenu', () => {
         isSaved: true,
         toggleSaved: vi.fn(),
         canToggle: true,
-        saveError: null,
-        clearSaveError: vi.fn(),
       });
 
       // #when

--- a/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
+++ b/src/components/LibraryRoute/contextMenu/__tests__/useMenuItems.test.ts
@@ -80,8 +80,6 @@ function defaultMocks() {
     isSaved: null,
     toggleSaved: vi.fn(),
     canToggle: false,
-    saveError: null,
-    clearSaveError: vi.fn(),
   });
 }
 
@@ -236,8 +234,6 @@ describe('useMenuItems', () => {
       isSaved: true,
       toggleSaved: vi.fn(),
       canToggle: true,
-      saveError: null,
-      clearSaveError: vi.fn(),
     });
 
     // #when

--- a/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
+++ b/src/components/LibraryRoute/contextMenu/useAlbumSavedStatus.ts
@@ -8,8 +8,6 @@ export interface UseAlbumSavedStatusResult {
   isSaved: boolean | null;
   toggleSaved: () => void;
   canToggle: boolean;
-  saveError: string | null;
-  clearSaveError: () => void;
 }
 
 export function useAlbumSavedStatus(
@@ -18,7 +16,6 @@ export function useAlbumSavedStatus(
 ): UseAlbumSavedStatusResult {
   const { activeDescriptor, getDescriptor } = useProviderContext();
   const [isSaved, setIsSaved] = useState<boolean | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
 
   const descriptor = provider ? getDescriptor(provider) : activeDescriptor;
   const canToggle = !!(
@@ -57,7 +54,6 @@ export function useAlbumSavedStatus(
       } catch (err) {
         logLibrary('setAlbumSaved failed', err);
         setIsSaved(!next);
-        setSaveError(next ? 'Failed to add album.' : 'Failed to remove album.');
         return;
       }
 
@@ -80,11 +76,8 @@ export function useAlbumSavedStatus(
     if (!canToggle || !albumId || isSaved === null) return;
     const next = !isSaved;
     setIsSaved(next);
-    setSaveError(null);
     commitToggle(next).catch((err) => logLibrary('toggleSaved unexpected error', err));
   }, [canToggle, albumId, isSaved, commitToggle]);
 
-  const clearSaveError = useCallback(() => setSaveError(null), []);
-
-  return { isSaved, toggleSaved, canToggle, saveError, clearSaveError };
+  return { isSaved, toggleSaved, canToggle };
 }

--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -14,11 +14,6 @@ import { useLibrarySearch } from './search/useLibrarySearch';
 import LibraryContextMenu from './contextMenu/LibraryContextMenu';
 import { LibraryContextMenuOpenContext } from './contextMenu/LibraryContextMenuOpenContext';
 
-// LibraryRoute assumes upstream guards have already filtered out cold-start cases:
-// - AudioPlayer.tsx routes to ProviderSetupScreen when needsSetup === true
-// - PlayerStateRenderer.tsx routes to WelcomeScreen when !welcomeSeen
-// If this component renders, at least one provider is connected AND welcome has been dismissed.
-
 export interface LibraryRouteProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
@@ -29,7 +24,6 @@ export interface LibraryRouteProps {
     provider?: ProviderId,
   ) => Promise<void>) | undefined;
   onQueueLikedTracks?: ((tracks: MediaTrack[], collectionName?: string) => void) | undefined;
-  onOpenSettings: () => void;
   onResume?: (() => void) | undefined;
   lastSession?: SessionSnapshot | null | undefined;
   onPlayNext?: ((
@@ -132,13 +126,6 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
     triggerRef.current?.focus();
   }, []);
 
-  const handlePlayCollection = useCallback(
-    (kind: 'playlist' | 'album', id: string, name: string, provider?: ProviderId) => {
-      handleSelectCollection(kind, id, name, provider);
-    },
-    [handleSelectCollection],
-  );
-
   const handleAddToQueueAction = useCallback(
     (id: string, name: string, provider?: ProviderId) => {
       void onAddToQueue(id, name, provider);
@@ -174,7 +161,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         onContextMenuRequest={handleContextMenuRequest}
       />
     );
-  } else if (effectiveView === 'home' || effectiveView === 'liked') {
+  } else if (effectiveView === 'home') {
     body = (
       <HomeView
         layout={layout}
@@ -212,7 +199,7 @@ const LibraryRoute: React.FC<LibraryRouteProps> = ({
         request={contextRequest}
         onClose={handleCloseContextMenu}
         onReturnFocusClose={handleReturnFocusClose}
-        onPlayCollection={handlePlayCollection}
+        onPlayCollection={handleSelectCollection}
         onAddToQueue={handleAddToQueueAction}
         onPlayNext={onPlayNext}
         onStartRadioForCollection={onStartRadioForCollection}

--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -28,7 +28,6 @@ export type LibraryRouteView =
   | 'pinned'
   | 'playlists'
   | 'albums'
-  | 'liked'
   | 'search';
 
 /** Kinds a library card represents directly (no meta-wrappers). */

--- a/src/components/LibraryRoute/views/SeeAllView.tsx
+++ b/src/components/LibraryRoute/views/SeeAllView.tsx
@@ -11,7 +11,7 @@ import { BackToLibraryIcon } from '@/components/icons/QuickActionIcons';
 import type { ContextMenuRequest, LibraryItemKind, LibraryRouteView } from '../types';
 import { SeeAllRoot, BackBar, BackButton, BackTitle } from './views.styled';
 
-const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>, string> = {
+const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'search'>, string> = {
   'recently-played': 'Recently Played',
   pinned: 'Pinned',
   playlists: 'Playlists',
@@ -19,7 +19,7 @@ const TITLES: Record<Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>, str
 };
 
 export interface SeeAllViewProps {
-  view: Exclude<LibraryRouteView, 'home' | 'liked' | 'search'>;
+  view: Exclude<LibraryRouteView, 'home' | 'search'>;
   onBack: () => void;
   onSelectCollection: (
     kind: LibraryItemKind,

--- a/src/components/PlayerStateRenderer.tsx
+++ b/src/components/PlayerStateRenderer.tsx
@@ -340,7 +340,6 @@ const PlayerStateRenderer: React.FC<PlayerStateRendererProps> = ({
             onAddToQueue={onAddToQueue}
             onPlayLikedTracks={onPlayLikedTracks}
             onQueueLikedTracks={onQueueLikedTracks}
-            onOpenSettings={onOpenSettings}
             onResume={onResume}
             lastSession={lastSession}
             isPlaying={false}

--- a/src/components/__tests__/AudioPlayer.pendingQuery.test.tsx
+++ b/src/components/__tests__/AudioPlayer.pendingQuery.test.tsx
@@ -79,7 +79,6 @@ import LibraryRoute from '../LibraryRoute';
 
 const baseProps = {
   onPlaylistSelect: vi.fn(),
-  onOpenSettings: vi.fn(),
   lastSession: null,
   isPlaying: false,
   onMiniPlay: vi.fn(),


### PR DESCRIPTION
Closes #1604

Removes five dead-code findings surfaced by the tighten-to-spec audit of `src/components/LibraryRoute/` against `openspec/specs/library/spec.md`:

- **O-1**: drop `onOpenSettings` required prop (never used in component body)
- **O-2**: drop `'liked'` from `LibraryRouteView` (dead enum arm; nothing ever called `setView('liked')`)
- **R-1**: delete `handlePlayCollection` wrapper (no-op delegation to `handleSelectCollection`)
- **B-1**: delete cross-file comment in `index.tsx` (described sibling file routing, not a module invariant)
- **B-2**: remove `saveError`/`clearSaveError` from `useAlbumSavedStatus` (unconsumed channel; errors already surface via `closeAfter` toast)

Also fixed a missed call site in `PlayerStateRenderer.tsx` that still passed `onOpenSettings` to `LibraryRoute` (caught by tsc), and removed the nav test for the now-deleted `'liked'`-view fallback behavior.