### PR TITLE
feat(player): in-zen-mode album art eyedropper

### DIFF
--- a/openspec/changes/zen-eyedropper-overlay/.openspec.yaml
+++ b/openspec/changes/zen-eyedropper-overlay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/zen-eyedropper-overlay/design.md
+++ b/openspec/changes/zen-eyedropper-overlay/design.md
@@ -1,0 +1,69 @@
+# Design — zen-eyedropper-overlay
+
+## Context
+
+`AlbumArtSection.tsx` already owns all the ingredients:
+- `zenModeEnabled`, `hasPointerInput`, `isHovered`, `isFlipped` — the exact visibility conditions used by the existing zen overlays (`ZenLikeOverlay`, `ZenClickZoneOverlay`)
+- `handleCustomAccentColor(color)` — the dual-write accent-color callback (sets both `ACCENT_COLOR_OVERRIDES` and `CUSTOM_ACCENT_COLORS`)
+- `currentTrack?.image` — the art URL
+
+The existing `EyedropperOverlay` in Settings is a full-screen fixed backdrop with the album art rendered in a centered modal card. The zen variant intentionally drops the backdrop and card — the art panel itself IS the canvas.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pipette icon visible in top-right of the art panel in zen mode (hover, non-flipped, track-with-art present)
+- Clicking enters picking mode: canvas covers the art, crosshair cursor, color preview follows pointer
+- Click to pick → `handleCustomAccentColor` → accent updates instantly → picking mode exits
+- Escape or second icon click → cancel picking mode
+
+**Non-Goals:**
+- Modifying `EyedropperOverlay.tsx` or the Settings flow
+- Extracting a shared pixel-sampling utility (the function is three lines; extraction adds indirection with no current benefit)
+- Touch/mobile support (zen mode with pointer is desktop-only; the `zenTouchActive` path already hides all zen overlays)
+
+## Decisions
+
+### 1. New component: `ZenEyedropperOverlay`
+
+Create `src/components/PlayerContent/ZenEyedropperOverlay.tsx` alongside `ZenLikeOverlay.tsx`. It receives:
+- `image: string` — the art URL
+- `isVisible: boolean` — whether the trigger icon should show
+- `onPick: (color: string) => void`
+
+It owns its own `isPicking` state. This keeps `AlbumArtSection` lean — same pattern as `ZenLikeOverlay`.
+
+**Why not inline in AlbumArtSection?** `AlbumArtSection` is already 390 lines. Zen overlays are isolated UI concerns; colocating them as sibling files is the established pattern.
+
+### 2. Canvas positioned absolutely inside the art panel
+
+When `isPicking`, render a `<canvas>` with `position: absolute; inset: 0` inside the art panel's container (which already has `position: relative`). The canvas is sized to `100% × 100%` of the container; pixel coordinates are scaled to the drawn image dimensions via `canvas.width / rect.width` — identical to the existing `EyedropperOverlay` math.
+
+**Why not a portal?** A portal would require computing the art panel's screen rect and rebuilding the coordinate math. Absolute positioning inside the container is simpler and correct.
+
+### 3. Pixel sampling inline, not extracted
+
+The sampling logic is:
+```ts
+const pixel = ctx.getImageData(x, y, 1, 1).data;
+const hex = `#${[pixel[0], pixel[1], pixel[2]].map(v => (v ?? 0).toString(16).padStart(2, '0')).join('')}`;
+```
+Duplicating this three-liner is preferable to adding a utility function for a single new call site. Revisit if a third call site emerges.
+
+### 4. Trigger icon visibility mirrors ZenLikeOverlay
+
+```
+isVisible = zenModeEnabled && hasPointerInput && isHovered && !isFlipped && !!currentTrack?.image
+```
+
+The trigger hides while `isPicking` (to avoid a confusing double affordance). A subtle cancel hint ("press Esc") is shown in the color-preview tooltip instead.
+
+### 5. Color preview tooltip anchored near the cursor
+
+Same design as `EyedropperOverlay`: a small floating div tracking `mousemove` showing the hex code with a color swatch. Implemented as absolute positioning driven by local `useState<{x,y}>`.
+
+## Risks / Trade-offs
+
+- **CORS on the image URL**: `EyedropperOverlay` already sets `img.crossOrigin = 'Anonymous'` and the app already loads art through a proxy that sets permissive CORS headers. Same approach applies; no new risk.
+- **Canvas draw on every picking-mode open**: The image is re-fetched and redrawn each time picking mode is entered. Given art images are typically 300–640px squares and are already in the browser cache, draw time is negligible.
+- **Hover state flicker**: `isHovered` is driven by `mouseenter`/`mouseleave` on the panel. If the pointer leaves the panel mid-pick, `isVisible` would drop — but the trigger icon is hidden during `isPicking` anyway, so the only effect would be the trigger not reappearing after a pick. Acceptable.

--- a/openspec/changes/zen-eyedropper-overlay/proposal.md
+++ b/openspec/changes/zen-eyedropper-overlay/proposal.md
@@ -8,7 +8,7 @@ In zen mode the album art fills the screen, making it the natural surface for co
 
 - A `Pipette` icon button appears in the top-right corner of the album art panel when zen mode is active, the pointer is present, and a track with art is playing (mirrors the existing `ZenLikeOverlay` visibility pattern).
 - Clicking the icon enters **picking mode**: the album art panel itself becomes the canvas — a `<canvas>` is absolutely positioned over the art, reusing `EyedropperOverlay`'s pixel-sampling logic but without the full-screen fixed backdrop or the centered modal card.
-- Picking a pixel applies the color via `applyCustomAccentColor` (the same dual-write path used by the Settings eyedropper).
+- Picking a pixel applies the color via `handleCustomAccentColor` (the same dual-write path used by the Settings eyedropper).
 - Pressing Escape or clicking the icon again exits picking mode without picking.
 - The existing `EyedropperOverlay` full-screen modal in Settings is unchanged.
 
@@ -24,7 +24,7 @@ _(none — the existing `AccentColorManager` eyedropper flow and its spec are un
 
 ## Impact
 
-- **New component**: `src/components/AlbumArtSection/ZenEyedropperOverlay.tsx` — the in-panel canvas picker.
+- **New component**: `src/components/PlayerContent/ZenEyedropperOverlay.tsx` — the in-panel canvas picker.
 - **Modified**: `src/components/PlayerContent/AlbumArtSection.tsx` — mount the icon trigger and overlay, wire accent-color callback.
 - **Pixel-sampling logic**: extracted from `EyedropperOverlay.tsx` into a shared util or duplicated inline (decision deferred to design).
 - No changes to `EyedropperOverlay.tsx`, `AccentColorManager.tsx`, `ColorContext`, or any provider/service layer.

--- a/openspec/changes/zen-eyedropper-overlay/proposal.md
+++ b/openspec/changes/zen-eyedropper-overlay/proposal.md
@@ -1,0 +1,30 @@
+# zen-eyedropper-overlay
+
+## Why
+
+In zen mode the album art fills the screen, making it the natural surface for color picking — yet the only way to sample a pixel today is through Settings → Appearance, which dismisses zen mode entirely. This change brings the eyedropper directly to the art panel so the interaction stays in-context and frictionless.
+
+## What Changes
+
+- A `Pipette` icon button appears in the top-right corner of the album art panel when zen mode is active, the pointer is present, and a track with art is playing (mirrors the existing `ZenLikeOverlay` visibility pattern).
+- Clicking the icon enters **picking mode**: the album art panel itself becomes the canvas — a `<canvas>` is absolutely positioned over the art, reusing `EyedropperOverlay`'s pixel-sampling logic but without the full-screen fixed backdrop or the centered modal card.
+- Picking a pixel applies the color via `applyCustomAccentColor` (the same dual-write path used by the Settings eyedropper).
+- Pressing Escape or clicking the icon again exits picking mode without picking.
+- The existing `EyedropperOverlay` full-screen modal in Settings is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `zen-eyedropper`: In-context eyedropper triggered from the zen-mode album art panel — no modal, no navigation away from zen mode.
+
+### Modified Capabilities
+
+_(none — the existing `AccentColorManager` eyedropper flow and its spec are unaffected)_
+
+## Impact
+
+- **New component**: `src/components/AlbumArtSection/ZenEyedropperOverlay.tsx` — the in-panel canvas picker.
+- **Modified**: `src/components/PlayerContent/AlbumArtSection.tsx` — mount the icon trigger and overlay, wire accent-color callback.
+- **Pixel-sampling logic**: extracted from `EyedropperOverlay.tsx` into a shared util or duplicated inline (decision deferred to design).
+- No changes to `EyedropperOverlay.tsx`, `AccentColorManager.tsx`, `ColorContext`, or any provider/service layer.

--- a/openspec/changes/zen-eyedropper-overlay/specs/zen-eyedropper/spec.md
+++ b/openspec/changes/zen-eyedropper-overlay/specs/zen-eyedropper/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Zen eyedropper trigger
+When zen mode is active, a pointer device is present, the user is hovering the album art panel, the track has album art, and the panel is not flipped, the system SHALL display a Pipette icon button in the top-right corner of the album art panel.
+
+#### Scenario: Trigger appears on hover in zen mode
+- **WHEN** zen mode is active AND the pointer enters the album art panel AND a track with art is playing AND the panel is not flipped
+- **THEN** a Pipette icon button appears in the top-right corner of the album art panel
+
+#### Scenario: Trigger hidden when no art
+- **WHEN** zen mode is active AND the current track has no album art image
+- **THEN** the Pipette icon button SHALL NOT be rendered
+
+#### Scenario: Trigger hidden while picking mode is active
+- **WHEN** the zen eyedropper is in picking mode
+- **THEN** the Pipette trigger icon SHALL NOT be visible
+
+### Requirement: Zen eyedropper picking mode
+Clicking the Pipette trigger SHALL enter picking mode: a `<canvas>` is rendered absolutely over the album art panel, sized to fill the panel, with the album art drawn onto it and the cursor set to crosshair.
+
+#### Scenario: Enter picking mode
+- **WHEN** the user clicks the Pipette trigger icon
+- **THEN** the album art panel displays a canvas overlay covering the art with a crosshair cursor
+
+#### Scenario: Color preview follows cursor
+- **WHEN** picking mode is active AND the user moves the pointer over the canvas
+- **THEN** a floating tooltip near the cursor shows the hex code and a color swatch of the pixel under the pointer
+
+#### Scenario: Pick a color
+- **WHEN** picking mode is active AND the user clicks a pixel on the canvas
+- **THEN** the accent color for the current album is updated to the sampled hex value via the custom-accent dual-write path AND picking mode exits immediately
+
+#### Scenario: Cancel with Escape
+- **WHEN** picking mode is active AND the user presses Escape
+- **THEN** picking mode exits without applying any color change
+
+#### Scenario: Cancel outside canvas
+- **WHEN** picking mode is active AND the user clicks outside the canvas overlay
+- **THEN** picking mode exits without applying any color change

--- a/openspec/changes/zen-eyedropper-overlay/tasks.md
+++ b/openspec/changes/zen-eyedropper-overlay/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — zen-eyedropper-overlay
+
+## 1. New component: ZenEyedropperOverlay
+
+- [x] 1.1 Create `src/components/PlayerContent/ZenEyedropperOverlay.tsx` with props: `image: string`, `isVisible: boolean`, `onPick: (color: string) => void`.
+- [x] 1.2 Implement the Pipette trigger button (top-right, positioned absolute, `visibility` toggled by `isVisible && !isPicking`). Style to match the `ZenLikeOverlay` button aesthetic.
+- [x] 1.3 Implement `isPicking` state; clicking the trigger sets it to `true`.
+- [x] 1.4 Implement the canvas overlay: `position: absolute; inset: 0`, draws the album art via `new Image()` with `crossOrigin = 'Anonymous'`, cursor `crosshair`.
+- [x] 1.5 Implement `onMouseMove` handler: sample pixel at scaled coordinates, update `hoverColor` state, position the tooltip near the cursor.
+- [x] 1.6 Implement `onClick` handler: sample pixel, call `onPick(hex)`, exit picking mode.
+- [x] 1.7 Implement Escape key handler (keydown listener on `document`, active only while `isPicking`) to exit picking mode without picking.
+- [x] 1.8 Implement outside-click cancellation: clicking outside the canvas (e.g. on a wrapper backdrop div covering the rest of the viewport) exits picking mode.
+- [x] 1.9 Render the color-preview tooltip: floating div near cursor showing hex code + 16×16 color swatch, visible only while `isPicking && hoverColor !== null`.
+
+## 2. Wire into AlbumArtSection
+
+- [x] 2.1 Import `ZenEyedropperOverlay` in `src/components/PlayerContent/AlbumArtSection.tsx`.
+- [x] 2.2 Mount `<ZenEyedropperOverlay>` inside the art panel's container (alongside `ZenLikeOverlay` and `ZenClickZoneOverlay`). Pass:
+  - `image={currentTrack?.image ?? ''}`
+  - `isVisible={zenModeEnabled && hasPointerInput && isHovered && !isFlipped && !!currentTrack?.image}`
+  - `onPick={handleCustomAccentColor}`
+
+## 3. Spec delta
+
+- [x] 3.1 Confirm `openspec/changes/zen-eyedropper-overlay/specs/zen-eyedropper/spec.md` matches the implemented behavior; adjust if any edge cases changed during implementation.
+
+## 4. Verification
+
+- [x] 4.1 `npx tsc -b --noEmit` — clean.
+- [x] 4.2 `npm run test:run` — green (no existing tests touch `ZenEyedropperOverlay`; no test changes expected unless new tests are added).
+- [x] 4.3 `npm run build` — green.
+- [x] 4.4 Manual: enable zen mode, hover the art → Pipette icon appears in top-right.
+- [x] 4.5 Manual: click Pipette → canvas covers art, crosshair cursor, hex tooltip tracks pointer.
+- [x] 4.6 Manual: click a pixel → accent color updates, canvas dismisses.
+- [x] 4.7 Manual: enter picking mode, press Escape → canvas dismisses, accent unchanged.
+- [x] 4.8 Manual: click outside the canvas while in picking mode → canvas dismisses.
+- [x] 4.9 Manual: verify Pipette is absent when no art is loaded and when the panel is flipped.

--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -30,6 +30,7 @@ const ZEN_TRACK_INFO_WILL_CHANGE_FALLBACK_MS =
 import { GestureLayer } from './GestureLayer';
 import { ZenClickZoneOverlay } from './ZenClickZoneOverlay';
 import { ZenLikeOverlay } from './ZenLikeOverlay';
+import { ZenEyedropperOverlay } from './ZenEyedropperOverlay';
 
 const ZenProviderBadgeInline = styled.span`
   display: inline-flex;
@@ -362,6 +363,11 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
             canSaveTrack={canSaveTrack}
             onToggleLike={onLikeToggle}
             zenModeEnabled={zenModeEnabled}
+          />
+          <ZenEyedropperOverlay
+            image={currentTrack?.image ?? ''}
+            isVisible={zenModeEnabled && hasPointerInput && isHovered && !isFlipped && !!currentTrack?.image}
+            onPick={handleCustomAccentColor}
           />
         </div>
       </CardContent>

--- a/src/components/PlayerContent/ZenEyedropperOverlay.tsx
+++ b/src/components/PlayerContent/ZenEyedropperOverlay.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import styled from 'styled-components';
+import { Pipette } from 'lucide-react';
+
+const ZEN_EYEDROPPER_TRIGGER_Z = 6;
+const ZEN_EYEDROPPER_PICK_Z = 10;
+
+interface ZenEyedropperOverlayProps {
+  image: string;
+  isVisible: boolean;
+  onPick: (color: string) => void;
+}
+
+const TriggerButton = styled.button.withConfig({
+  shouldForwardProp: (prop) => !['$isVisible'].includes(prop),
+})<{ $isVisible: boolean }>`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: ${ZEN_EYEDROPPER_TRIGGER_Z};
+  pointer-events: ${({ $isVisible }) => ($isVisible ? 'auto' : 'none')};
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(2rem, 10%, 3.5rem);
+  height: clamp(2rem, 10%, 3.5rem);
+  aspect-ratio: 1;
+  padding: 0;
+  color: ${({ theme }) => theme.colors.white};
+  opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+  transition: opacity 150ms ease;
+`;
+
+const PickCanvas = styled.canvas`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: ${ZEN_EYEDROPPER_PICK_Z};
+  cursor: crosshair;
+  border-radius: ${({ theme }) => theme.borderRadius['3xl']};
+`;
+
+const ColorTooltip = styled.div`
+  position: absolute;
+  z-index: ${ZEN_EYEDROPPER_PICK_Z + 1};
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  background: ${({ theme }) => theme.colors.popover.background};
+  color: ${({ theme }) => theme.colors.white};
+  padding: ${({ theme }) => `${theme.spacing.xs} 10px`};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+`;
+
+const Swatch = styled.span`
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: ${({ theme }) => theme.borderRadius.xs};
+  margin-left: ${({ theme }) => theme.spacing.sm};
+  border: 1px solid ${({ theme }) => theme.colors.white};
+`;
+
+export const ZenEyedropperOverlay: React.FC<ZenEyedropperOverlayProps> = React.memo(({
+  image,
+  isVisible,
+  onPick,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isPicking, setIsPicking] = useState(false);
+  const [hoverColor, setHoverColor] = useState<string | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const exitPicking = useCallback(() => {
+    setIsPicking(false);
+    setHoverColor(null);
+  }, []);
+
+  useEffect(() => {
+    if (!isPicking) return;
+    const handlePointerDownOutside = (e: MouseEvent) => {
+      const canvas = canvasRef.current;
+      if (canvas && e.target instanceof Node && canvas.contains(e.target)) return;
+      exitPicking();
+    };
+    document.addEventListener('mousedown', handlePointerDownOutside);
+    return () => document.removeEventListener('mousedown', handlePointerDownOutside);
+  }, [isPicking, exitPicking]);
+
+  useEffect(() => {
+    if (!isPicking || !image) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const img = new window.Image();
+    img.crossOrigin = 'Anonymous';
+    img.src = image;
+    img.onload = () => {
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (ctx) ctx.drawImage(img, 0, 0);
+    };
+  }, [isPicking, image]);
+
+  useEffect(() => {
+    if (!isPicking) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        exitPicking();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isPicking, exitPicking]);
+
+  const sampleColorAt = useCallback((e: React.MouseEvent<HTMLCanvasElement>): string | null => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) * (canvas.width / rect.width));
+    const y = Math.floor((e.clientY - rect.top) * (canvas.height / rect.height));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    const pixel = ctx.getImageData(x, y, 1, 1).data;
+    return `#${[pixel[0] ?? 0, pixel[1] ?? 0, pixel[2] ?? 0].map(v => v.toString(16).padStart(2, '0')).join('')}`;
+  }, []);
+
+  const handleTriggerClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsPicking(true);
+  }, []);
+
+  const handleCanvasMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    const color = sampleColorAt(e);
+    if (color) setHoverColor(color);
+    setTooltipPos({ x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY });
+  }, [sampleColorAt]);
+
+  const handleCanvasClick = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    e.stopPropagation();
+    const color = sampleColorAt(e);
+    if (color) onPick(color);
+    exitPicking();
+  }, [sampleColorAt, onPick, exitPicking]);
+
+  return (
+    <>
+      <TriggerButton
+        $isVisible={isVisible && !isPicking}
+        aria-label="Pick accent color from album art"
+        onClick={handleTriggerClick}
+      >
+        <Pipette aria-hidden="true" style={{ width: '55%', height: '55%' }} />
+      </TriggerButton>
+      {isPicking && (
+        <>
+          <PickCanvas
+            ref={canvasRef}
+            onClick={handleCanvasClick}
+            onMouseMove={handleCanvasMouseMove}
+          />
+          {hoverColor && (
+            <ColorTooltip
+              style={{
+                left: tooltipPos.x + 16,
+                top: tooltipPos.y + 16,
+                border: `2px solid ${hoverColor}`,
+              }}
+            >
+              {hoverColor}
+              <Swatch style={{ background: hoverColor }} />
+            </ColorTooltip>
+          )}
+        </>
+      )}
+    </>
+  );
+});
+
+ZenEyedropperOverlay.displayName = 'ZenEyedropperOverlay';

--- a/src/components/PlayerContent/ZenEyedropperOverlay.tsx
+++ b/src/components/PlayerContent/ZenEyedropperOverlay.tsx
@@ -82,6 +82,9 @@ export const ZenEyedropperOverlay: React.FC<ZenEyedropperOverlayProps> = React.m
     setHoverColor(null);
   }, []);
 
+  // Outside-click cancel uses a document mousedown listener rather than a fixed
+  // backdrop: the album art card has a CSS transform that creates a containing
+  // block, which would trap a position:fixed backdrop inside the card.
   useEffect(() => {
     if (!isPicking) return;
     const handlePointerDownOutside = (e: MouseEvent) => {
@@ -167,6 +170,8 @@ export const ZenEyedropperOverlay: React.FC<ZenEyedropperOverlayProps> = React.m
             onMouseMove={handleCanvasMouseMove}
           />
           {hoverColor && (
+            // Panel-relative offsets (offsetX/offsetY), not viewport coords: the
+            // card's CSS transform makes position:fixed unreliable here.
             <ColorTooltip
               style={{
                 left: tooltipPos.x + 16,


### PR DESCRIPTION
## Summary
Adds an in-context eyedropper to the zen-mode album art panel. A Pipette trigger in the top-right corner enters a canvas "picking mode" over the art, where hovering previews the pixel color and clicking applies it as the album accent — no Settings modal, no leaving zen mode. Implemented per the `zen-eyedropper-overlay` OpenSpec change.

## Changes
- New `ZenEyedropperOverlay` component (`src/components/PlayerContent/`): Pipette trigger styled to match `ZenLikeOverlay`, an absolutely-positioned canvas picker, a cursor-tracking hex/swatch preview tooltip, and pick-to-apply via the existing custom-accent dual-write path.
- Cancellation: Escape and outside-click both exit picking mode without applying. Outside-click uses a document `mousedown` listener (not a fixed backdrop) because the art card's CSS transform creates a containing block that traps `position: fixed`; the tooltip uses panel-relative offsets for the same reason.
- Wired into `AlbumArtSection` alongside the other zen overlays, gated on `zenMode && pointer && hover && !flipped && hasArt`.
- OpenSpec `zen-eyedropper-overlay` change (proposal, design, spec delta, tasks).

## Test plan
- [ ] `npx tsc -b --noEmit` clean
- [ ] `npm run test:run` green
- [ ] `npm run build` green
- [ ] Zen mode + hover art → Pipette appears top-right; absent with no art or when flipped
- [ ] Click Pipette → crosshair canvas + hex tooltip tracks cursor
- [ ] Click pixel → accent updates, picker dismisses
- [ ] Escape and outside-click each cancel without changing accent