### PR TITLE
fix(playback): gate onQueueChanged on hasNativeQueueSync

### DIFF
--- a/src/hooks/__tests__/useProviderPlayback.playTrack.test.ts
+++ b/src/hooks/__tests__/useProviderPlayback.playTrack.test.ts
@@ -1,0 +1,123 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import type { ProviderCapabilities } from '@/types/providers';
+
+const mockOnQueueChanged = vi.fn();
+const mockPlayTrack = vi.fn().mockResolvedValue(undefined);
+const mockPause = vi.fn().mockResolvedValue(undefined);
+const mockResume = vi.fn().mockResolvedValue(undefined);
+
+function makeDescriptor(capabilities: Partial<ProviderCapabilities> = {}) {
+  return {
+    id: 'spotify' as ProviderId,
+    capabilities: {
+      hasNativeQueueSync: false,
+      hasExternalLink: false,
+      ...capabilities,
+    },
+    playback: {
+      providerId: 'spotify' as ProviderId,
+      playTrack: mockPlayTrack,
+      onQueueChanged: mockOnQueueChanged,
+      pause: mockPause,
+      resume: mockResume,
+      seek: vi.fn(),
+      next: vi.fn(),
+      previous: vi.fn(),
+      setVolume: vi.fn(),
+      getState: vi.fn(),
+      subscribe: vi.fn(),
+    },
+  };
+}
+
+const mockRegistryGet = vi.fn();
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: { get: (...args: unknown[]) => mockRegistryGet(...args) },
+}));
+
+vi.mock('@/services/sessionPersistence', () => ({
+  loadSession: () => null,
+}));
+
+import { useProviderPlayback } from '../useProviderPlayback';
+
+function makeTrack(id = 'track-1', provider: ProviderId = 'spotify' as ProviderId): MediaTrack {
+  return {
+    id,
+    provider,
+    playbackRef: { provider, ref: `spotify:track:${id}` },
+    name: 'Test Track',
+    artists: 'Test Artist',
+    album: 'Test Album',
+    durationMs: 180000,
+    image: '',
+  };
+}
+
+describe('useProviderPlayback — onQueueChanged capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls onQueueChanged when hasNativeQueueSync is true', async () => {
+    // #given — provider declares hasNativeQueueSync
+    const track = makeTrack();
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [track] };
+    mockRegistryGet.mockReturnValue(makeDescriptor({ hasNativeQueueSync: true }));
+
+    const { result } = renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex: vi.fn(), mediaTracksRef }),
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.playTrack(0);
+    });
+
+    // #then
+    expect(mockOnQueueChanged).toHaveBeenCalledTimes(1);
+    expect(mockOnQueueChanged).toHaveBeenCalledWith([track], 0);
+  });
+
+  it('does NOT call onQueueChanged when hasNativeQueueSync is false', async () => {
+    // #given — provider does not declare hasNativeQueueSync
+    const track = makeTrack();
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [track] };
+    mockRegistryGet.mockReturnValue(makeDescriptor({ hasNativeQueueSync: false }));
+
+    const { result } = renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex: vi.fn(), mediaTracksRef }),
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.playTrack(0);
+    });
+
+    // #then
+    expect(mockOnQueueChanged).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onQueueChanged when hasNativeQueueSync is absent', async () => {
+    // #given — provider omits hasNativeQueueSync entirely
+    const track = makeTrack();
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: [track] };
+    mockRegistryGet.mockReturnValue(makeDescriptor({}));
+
+    const { result } = renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex: vi.fn(), mediaTracksRef }),
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.playTrack(0);
+    });
+
+    // #then
+    expect(mockOnQueueChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -138,13 +138,14 @@ export const useProviderPlayback = ({
       return;
     }
 
-    // Push the latest queue snapshot to the driving provider before invoking
-    // playTrack so adapters that build their native queue from this signal
-    // (Spotify's upcomingUris) see the current list for the imminent
-    // playback call. User-driven queue mutations notify separately via
-    // useQueueManagement.ts; this call covers track transitions
-    // (next/previous/hydrate/auto-advance) that bypass that hook.
-    descriptor.playback.onQueueChanged?.(tracks, index);
+    // Push the latest queue snapshot before invoking playTrack, but only for
+    // providers that declare hasNativeQueueSync. Spotify builds upcomingUris
+    // from this signal; providers without the capability must not receive it
+    // (spec Req 8). User-driven mutations go through useQueueManagement.ts;
+    // this covers track transitions (next/previous/hydrate/auto-advance).
+    if (descriptor.capabilities.hasNativeQueueSync) {
+      descriptor.playback.onQueueChanged?.(tracks, index);
+    }
 
     try {
       await descriptor.playback.playTrack(mediaTrack, options);


### PR DESCRIPTION
## Summary
Gates the `onQueueChanged` notification in `useProviderPlayback` on the driving provider's `hasNativeQueueSync` capability, aligning with `playback-engine` spec Requirement 8 (Native Queue Sync). Previously the call fired unconditionally for all providers; non-sync providers (Dropbox, mock) relied on optional-chaining/no-ops to ignore it — behaviorally fine but contractually loose.

## Changes
- `useProviderPlayback.ts` — wrap `descriptor.playback.onQueueChanged?.(tracks, index)` in `if (descriptor.capabilities.hasNativeQueueSync)`; update the comment to cite spec Req 8.
- Add `useProviderPlayback.playTrack.test.ts` — covers capability true → called, false → not called, absent → not called.

Originally implemented on the orphaned branch `claude/issue-1565-20260523-1958`; cherry-picked onto current develop (sibling queue-mutation path was already gated by #1571 in `useQueueManagement.ts`). The stale "useEffect-based onQueueChanged in usePlayerLogic" comment the issue also flagged is already gone from develop.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] new test passes (3/3)
- [x] `npm run build` green (verified pre-cherry-pick)

Closes #1565