### PR TITLE
chore: sync main ← develop (2026-05-30)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD036": false
+}

--- a/openspec/specs/auth-system/spec.md
+++ b/openspec/specs/auth-system/spec.md
@@ -11,10 +11,12 @@ Vorbis Player SHALL authenticate each music provider independently, expose a sin
 The app SHALL derive a **connected** provider set defined as the intersection of the enabled-provider set and the providers currently reporting authenticated. Cross-provider features SHALL operate on the connected set.
 
 #### Scenario: Enabled but not authenticated
+
 - **WHEN** a provider is enabled but reports not authenticated
 - **THEN** it is excluded from the connected set and from cross-provider features
 
 #### Scenario: Enabled and authenticated
+
 - **WHEN** a provider is enabled and reports authenticated
 - **THEN** it is included in the connected set
 
@@ -23,15 +25,18 @@ The app SHALL derive a **connected** provider set defined as the intersection of
 Each provider SHALL be controlled by a single on/off toggle in settings. There SHALL be no separate reconnect affordance.
 
 #### Scenario: Toggle on while already authenticated
+
 - **WHEN** the user toggles on a provider that is already authenticated
 - **THEN** the provider is added to the enabled set with no login prompt
 
 #### Scenario: Toggle on while not authenticated
+
 - **WHEN** the user toggles on a provider that is not authenticated
 - **THEN** an OAuth flow is initiated immediately
 - **AND** the provider is added to the enabled set only after the flow reports success
 
 #### Scenario: OAuth cancelled or failed
+
 - **WHEN** an OAuth flow opened by a toggle is cancelled or fails
 - **THEN** the toggle reverts to off and a "couldn't connect" notification is shown
 
@@ -40,14 +45,17 @@ Each provider SHALL be controlled by a single on/off toggle in settings. There S
 Disconnecting a provider SHALL prompt the user when its tracks are in the queue, and on confirmation SHALL log the provider out, remove it from the enabled set, and remove its tracks from the queue and playback state.
 
 #### Scenario: Toggle off with queued tracks
+
 - **WHEN** the user toggles off a provider whose tracks are in the queue
 - **THEN** a confirmation prompt is shown stating the provider name and the count of tracks that will be removed
 
 #### Scenario: Confirming disconnect
+
 - **WHEN** the user confirms the disconnect prompt
 - **THEN** the provider is logged out, removed from the enabled set, and its tracks are removed from the queue and playback state
 
 #### Scenario: Cancelling disconnect
+
 - **WHEN** the user cancels the disconnect prompt
 - **THEN** the enabled set, queue, and playback state are unchanged
 
@@ -56,6 +64,7 @@ Disconnecting a provider SHALL prompt the user when its tracks are in the queue,
 Each provider SHALL refresh its access token before expiry, within a per-provider refresh window, so authenticated requests do not fail due to expiry.
 
 #### Scenario: Token nearing expiry
+
 - **WHEN** an access token is within its provider's refresh window
 - **THEN** the token is refreshed before the next authenticated request
 
@@ -64,10 +73,12 @@ Each provider SHALL refresh its access token before expiry, within a per-provide
 A provider SHALL distinguish transient failures from terminal authentication failures so that refresh tokens are preserved across retryable network errors and the user is logged out only on terminal failures.
 
 #### Scenario: Transient failure
+
 - **WHEN** a provider request fails with a transient error (network failure or server-side error)
 - **THEN** the refresh token is preserved and the user is not logged out
 
 #### Scenario: Terminal authentication failure
+
 - **WHEN** a provider request fails with a terminal authentication error
 - **THEN** the provider performs a full logout
 
@@ -76,5 +87,6 @@ A provider SHALL distinguish transient failures from terminal authentication fai
 When a provider's session becomes unrecoverable during normal use, the app SHALL log the provider out automatically and notify the user.
 
 #### Scenario: Provider returns terminal auth error during use
+
 - **WHEN** a provider reports an unrecoverable authentication failure during normal use
 - **THEN** the provider is logged out automatically and a "session expired" notification is shown

--- a/openspec/specs/library/REFERENCES.md
+++ b/openspec/specs/library/REFERENCES.md
@@ -1,0 +1,418 @@
+# library — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `src/components/LibraryRoute/` unless prefixed otherwise.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Home view section order
+
+**Sources**
+
+- `views/HomeView.tsx:41-72` — `HomeView` renders `<ResumeSection>`, `<RecentlyPlayedSection>`, `<PinnedSection>`, `<PlaylistsSection>`, `<AlbumsSection>` in that order inside `<HomeStack>`.
+- `sections/RecentlyPlayedSection.tsx:27` — `if (!isLoading && isEmpty) return null` — section hides when empty and loaded.
+- `sections/PinnedSection.tsx:27` — same guard: `if (!isLoading && isEmpty) return null`.
+- `sections/ResumeSection.tsx:13` — `if (!hasResumable || !session || !onResume) return null`.
+
+**Notes**
+
+- PlaylistsSection and AlbumsSection delegate their empty-state guards to `Section` via the `hidden` prop; the same pattern applies.
+
+### Scenario: All sections have content
+
+**Source:** `views/HomeView.tsx:41-72` — all five section components are unconditionally rendered; each manages its own visibility.
+Interpolated from absence; no direct integration test.
+
+### Scenario: Section is empty after loading completes
+
+**Source:** `sections/RecentlyPlayedSection.tsx:27`, `sections/PinnedSection.tsx:27` — `if (!isLoading && isEmpty) return null`.
+Verified by test at `sections/__tests__/RecentlyPlayedSection.test.tsx` (hidden when empty).
+
+### Scenario: Resume section with no last session
+
+**Source:** `sections/ResumeSection.tsx:13` — `if (!hasResumable || !session || !onResume) return null`.
+`hooks/useResumeSection.ts:13` — `hasResumable = !!lastSession && !isSessionStale(lastSession)`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:136` ("does not mount mini-player when no current track" — separate concern; resume behavior interpolated from absence).
+
+---
+
+## Requirement: Pinned section item ordering
+
+**Sources**
+
+- `hooks/usePinnedSection.ts:65-83` — `combined` is built as `[...likedEntries, ...pinnedPlaylists, ...pinnedAlbums]`.
+- `hooks/usePinnedSection.ts:44-63` — `likedEntries` builds single or per-provider liked items.
+
+### Scenario: Unified liked songs with user-pinned items
+
+**Source:** `hooks/usePinnedSection.ts:65-83` — liked first, playlists second, albums last.
+Verified by test at `hooks/__tests__/usePinnedSection.test.ts:367-391` ("liked entries are prepended before pinned playlists").
+
+### Scenario: Multi-provider liked songs, not unified
+
+**Source:** `hooks/usePinnedSection.ts:46-52` — when `!isUnified && perProvider.length > 1`, maps `perProvider` to one entry per provider with `id: 'liked-${provider}'`.
+Verified by test at `hooks/__tests__/usePinnedSection.test.ts:290-319` ("expands into per-provider liked entries when not unified and multiple providers").
+
+### Scenario: Liked songs count subtitle grammar
+
+**Source:** `hooks/usePinnedSection.ts:27` — `formatLikedSubtitle = (n) => \`${n} song${n === 1 ? '' : 's'}\``.
+Verified by tests at`hooks/**tests**/usePinnedSection.test.ts:283-288` ("1 song") and `:393-411` ("1 song" singular).
+
+### Scenario: Pinned id not in loaded library
+
+**Source:** `hooks/usePinnedSection.ts:34-36` — `playlists.filter((p) => pinnedSet.has(p.id))` — mismatched ids are silently dropped.
+Verified by test at `hooks/__tests__/usePinnedSection.test.ts:229-246` ("ignores playlist id in pinnedPlaylistIds that is not in library").
+
+---
+
+## Requirement: See All navigation
+
+**Sources**
+
+- `sections/PlaylistsSection.tsx:9,31` — `SEE_ALL_THRESHOLD = 8`; `showSeeAll = layout === 'row' && items.length > SEE_ALL_THRESHOLD`.
+- `sections/AlbumsSection.tsx:9,31` — same threshold (8).
+- `sections/PinnedSection.tsx:9,29` — `SEE_ALL_THRESHOLD = 6`.
+- `sections/RecentlyPlayedSection.tsx:9,29` — `SEE_ALL_THRESHOLD = 4`.
+- `views/HomeView.tsx:47-48,52,57,63` — each section's `onSeeAll` calls `onNavigate('recently-played' | 'pinned' | 'playlists' | 'albums')`.
+- `views/SeeAllView.tsx:42-46` — SeeAll always uses `layout: 'grid'`.
+- `views/SeeAllView.tsx:52` — `<BackButton onClick={onBack}>` returns to home.
+
+### Scenario: Playlist section exceeds threshold in row layout
+
+**Source:** `sections/PlaylistsSection.tsx:31` — `items.length > SEE_ALL_THRESHOLD` (8) with `layout === 'row'`.
+Verified by test at `sections/__tests__/PlaylistsSection.test.tsx` (threshold boundary). **Interpolated; no direct named test found at time of writing.**
+
+### Scenario: Playlist section at or below threshold in row layout
+
+**Source:** `sections/PlaylistsSection.tsx:31` — `items.length > SEE_ALL_THRESHOLD` — equality means no See All.
+**Interpolated; no direct test.**
+
+### Scenario: Album section threshold
+
+**Source:** `sections/AlbumsSection.tsx:9,31` — same logic as Playlists with threshold 8.
+**Interpolated; no direct test.**
+
+### Scenario: Pinned section threshold
+
+**Source:** `sections/PinnedSection.tsx:9,29` — threshold 6.
+**Interpolated; no direct test.**
+
+### Scenario: Recently Played section threshold
+
+**Source:** `sections/RecentlyPlayedSection.tsx:9,29` — threshold 4.
+**Interpolated; no direct test.**
+
+### Scenario: See all not shown in grid layout
+
+**Source:** `sections/PlaylistsSection.tsx:31` — `layout === 'row'` guard; grid layout never passes.
+**Interpolated from absence of grid-layout See All call.**
+
+### Scenario: Back from SeeAll view
+
+**Source:** `views/SeeAllView.tsx:52` — `<BackButton onClick={onBack}>`.
+Verified by test at `views/__tests__/SeeAllView.test.tsx` (back button). **Interpolated; not separately confirmed.**
+
+---
+
+## Requirement: Search query routing
+
+**Sources**
+
+- `index.tsx:166` — `effectiveView = search.isSearching ? 'search' : view` — search always wins.
+- `index.tsx:169-171` — `SearchResultsView` rendered when `effectiveView === 'search'`.
+- `search/useLibrarySearch.ts:61` — `isSearching = query.trim().length > 0`.
+- `index.tsx:103-106` — `handleSelectCollection` calls `search.setQuery('')` when search is active.
+
+### Scenario: Non-empty query entered
+
+**Source:** `search/useLibrarySearch.ts:61` and `index.tsx:166` — `isSearching` becomes true, `effectiveView` switches to `'search'`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:184-195` ("pre-fills search input and shows search results view when initialSearchQuery is provided").
+
+### Scenario: Query cleared
+
+**Source:** `search/useLibrarySearch.ts:61` — `isSearching` becomes false when query is empty; `index.tsx:166` reverts to `view`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:197-208` ("leaves search input empty and shows home view").
+
+### Scenario: Initial search query seed
+
+**Source:** `index.tsx:86` — `useLibrarySearch(initialSearchQuery)`; `search/useLibrarySearch.ts:36` — `useState(initialQuery ?? '')`.
+`index.tsx:84-85` — comment explains seed-once contract.
+Verified by test at `__tests__/LibraryRoute.test.tsx:184-195`.
+
+---
+
+## Requirement: Search text matching
+
+**Sources**
+
+- `search/searchMatch.ts:8-16` — `matchesQuery`: empty query returns true; otherwise `name.toLowerCase().includes(normalizedQuery)` or `ownerName.toLowerCase().includes(normalizedQuery)`.
+- `search/SearchResultsView.tsx:88` — albums pass `ownerName: a.artists` to `matchesQuery`.
+- `search/searchMatch.ts:4-6` — `normalizeQuery` trims and lowercases.
+
+### Scenario: Case-insensitive name match
+
+**Source:** `search/searchMatch.ts:13` — `item.name.toLowerCase().includes(normalizedQuery)`.
+Verified by test at `search/__tests__/searchMatch.test.ts:24-29` ("matches case-insensitive substring").
+
+### Scenario: Artist name match for albums
+
+**Source:** `search/SearchResultsView.tsx:88` and `search/searchMatch.ts:14-15` — `ownerName` field carries artist names for albums.
+Verified by test at `search/__tests__/searchMatch.test.ts:55-63` ("matches on ownerName when name does not match").
+
+### Scenario: Empty query matches everything
+
+**Source:** `search/searchMatch.ts:11` — `if (!normalizedQuery) return true`.
+Verified by test at `search/__tests__/searchMatch.test.ts:38-44` ("returns true for empty query").
+
+### Scenario: No match
+
+**Source:** `search/searchMatch.ts:16` — `return false` after both checks fail.
+Verified by test at `search/__tests__/searchMatch.test.ts:45-51` ("returns false on no match").
+
+### Scenario: No results message
+
+**Source:** `views/SearchResultsView.tsx:97-105` — `if (totalResults === 0)` renders `No results for "<query>"`.
+**Interpolated; no direct test for the exact zero-results path.**
+
+---
+
+## Requirement: Search filter persistence
+
+**Sources**
+
+- `search/useLibrarySearch.ts:9-13` — storage keys `'vorbis-player-library-route-provider-filter'`, `'vorbis-player-library-route-kind-filter'`, `'vorbis-player-library-route-sort'`.
+- `search/useLibrarySearch.ts:37-45` — `useLocalStorage` for all three.
+- `search/useLibrarySearch.ts:47-59` — `toggleProvider` and `toggleKind` via `toggleInArray`.
+- `search/useLibrarySearch.ts:62-66` — `hasActiveFilters` true when any filter differs from default.
+- `search/useLibrarySearch.ts:68-73` — `clearAll` resets all three to defaults.
+- `search/searchMatch.ts:18-25` — `passesProviderFilter`: empty array = pass all; filters by `provider ?? 'spotify'`.
+- `search/FilterSheet.tsx:44` — source group hidden when `enabledProviderIds.length <= 1`.
+
+### Scenario: Provider filter toggles
+
+**Source:** `search/useLibrarySearch.ts:47-51` — `toggleProvider` wraps `toggleInArray`.
+`search/searchMatch.ts:18-25` — items excluded when not in filter.
+Verified by test at `search/__tests__/useLibrarySearch.test.ts` (toggleProvider). **Interpolated; test name not confirmed.**
+
+### Scenario: Kind filter restricts collection types
+
+**Source:** `views/SearchResultsView.tsx:43-44` — `showPlaylists = kindFilter.length === 0 || kindFilter.includes('playlist')`.
+**Interpolated; no direct test observed.**
+
+### Scenario: Sort order applied
+
+**Source:** `search/searchMatch.ts:27-36` — `sortItems`: `name-asc` uses `localeCompare`, `name-desc` reverses.
+Verified by test at `search/__tests__/searchMatch.test.ts:115-122` ("sorts ascending by name (case-insensitive via localeCompare)").
+
+### Scenario: Sort order name-desc
+
+**Source:** `search/searchMatch.ts:32-33` — reverses ascending sort.
+Verified by test at `search/__tests__/searchMatch.test.ts:124-130` ("sorts descending by name").
+
+### Scenario: Sort order recent
+
+**Source:** `search/searchMatch.ts:30` — `if (sort === 'recent') return items` — identity return.
+Verified by test at `search/__tests__/searchMatch.test.ts:107-113` ("returns items unchanged for recent sort").
+
+### Scenario: Filter state active indicator
+
+**Source:** `search/useLibrarySearch.ts:62-66` — `hasActiveFilters` used in `search/SearchBar.tsx:51` via `$hasActive={search.hasActiveFilters}`.
+**Interpolated; no direct test for visual indicator.**
+
+### Scenario: Clear all resets all state
+
+**Source:** `search/useLibrarySearch.ts:68-73` — `clearAll` calls `setQuery('')`, resets provider/kind/sort to defaults.
+`search/FilterSheet.tsx:88-94` — "Clear all" button disabled when `!hasActiveFilters && !isSearching`.
+**Interpolated; no direct test for clearAll behavior.**
+
+### Scenario: Provider filter hidden for single provider
+
+**Source:** `search/FilterSheet.tsx:44` — `{enabledProviderIds.length > 1 && <Group>…Source…</Group>}`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Collection context menu
+
+**Sources**
+
+- `card/LibraryCard.tsx:59-64` — `fireContextMenu` via `useLongPress.onLongPress`.
+- `card/LibraryCard.tsx:77-84` — `handleContextMenu` for right-click (`e.preventDefault()`).
+- `contextMenu/LibraryContextMenu.tsx:76-96` — `handleMenuKeyDown`: ArrowDown, ArrowUp, Home, End.
+- `contextMenu/LibraryContextMenu.tsx:147-157` — `onEscapeKeyDown` sets `closeReasonRef.current = 'return'`; on close `onReturnFocusClose` is called.
+- `contextMenu/menuItemsForKind.ts:45-61,63-108,110-122,124-151` — `buildMenuItems` dispatches by kind.
+
+### Scenario: Context menu opens on right-click
+
+**Source:** `card/LibraryCard.tsx:77-84` — `onContextMenu` handler calls `onContextMenuRequest` with pointer coordinates.
+Verified by test at `contextMenu/__tests__/LibraryContextMenu.test.tsx`. **Interpolated; test name not confirmed.**
+
+### Scenario: Context menu opens on long press
+
+**Source:** `card/LibraryCard.tsx:59-64` and `card/useLongPress.ts`.
+Verified by test at `card/__tests__/useLongPress.test.ts`.
+
+### Scenario: Playlist menu items
+
+**Source:** `contextMenu/menuItemsForKind.ts:63-79` — `buildPlaylistItems`: play, add-to-queue, play-next, toggle-pin, start-radio.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:26-39` ("builds 5 items for playlist kind").
+
+### Scenario: Album menu items
+
+**Source:** `contextMenu/menuItemsForKind.ts:81-108` — `buildAlbumItems`: adds toggle-save (labelled "Unlike") and start-radio.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:43-59` ("builds 6 items for album kind when toggleSave provided").
+
+### Scenario: Liked Songs menu items
+
+**Source:** `contextMenu/menuItemsForKind.ts:110-122` — `buildLikedItems`: play-all + per-provider.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:73-91` ("builds Play All + per-provider entries for liked kind").
+
+### Scenario: Recently-played appends Remove from history
+
+**Source:** `contextMenu/menuItemsForKind.ts:141-148` — `isRecentlyPlayed && actions.onRemoveFromHistory` appends `remove-from-history` with `variant: 'destructive'`.
+Verified by tests at `contextMenu/__tests__/menuItemsForKind.test.ts:108-123` (appends) and `:109-123` (destructive variant).
+
+### Scenario: Pin/Unpin label reflects current state
+
+**Source:** `contextMenu/menuItemsForKind.ts:53-58` — `label: actions.isPinned ? 'Unpin' : 'Pin'`.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:139-148` ("flips Pin label to Unpin when isPinned=true").
+
+### Scenario: Start Radio disabled when unavailable
+
+**Source:** `contextMenu/menuItemsForKind.ts:66-70` — `disabled: actions.startRadioDisabled === true`.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:160-170` ("marks Start Radio disabled when startRadioDisabled=true").
+
+### Scenario: Play Next disabled when unavailable
+
+**Source:** `contextMenu/menuItemsForKind.ts:50-54` — `disabled: actions.playNextDisabled === true`.
+Verified by test at `contextMenu/__tests__/menuItemsForKind.test.ts:171-181` ("marks Play Next disabled when playNextDisabled=true").
+
+### Scenario: Queue Liked Songs optional item
+
+**Source:** `contextMenu/menuItemsForKind.ts:71-77` (playlist) and `:100-106` (album) — appended only when `onQueueLikedFromCollection` is defined.
+Verified by tests at `contextMenu/__tests__/menuItemsForKind.test.ts:183-193` (playlist) and `:194-204` (album).
+
+### Scenario: Arrow key navigation in menu
+
+**Source:** `contextMenu/LibraryContextMenu.tsx:83-95` — ArrowDown advances index mod length; ArrowUp decrements.
+**Interpolated; no direct test for arrow key navigation.**
+
+### Scenario: Escape dismisses menu and returns focus
+
+**Source:** `contextMenu/LibraryContextMenu.tsx:147-157` — `onEscapeKeyDown` sets reason to `'return'`; close handler calls `onReturnFocusClose` which runs `triggerRef.current?.focus()` (`index.tsx:131-133`).
+Verified by test at `contextMenu/__tests__/LibraryContextMenu.a11y.test.tsx`. **Interpolated; test name not confirmed.**
+
+### Scenario: Action error shown as toast
+
+**Source:** `contextMenu/LibraryContextMenu.tsx:56-73` — `closeAfter` catches promise rejections and calls `toast(message)`.
+Verified by test at `contextMenu/__tests__/LibraryContextMenu.edges.test.tsx`. **Interpolated; test name not confirmed.**
+
+---
+
+## Requirement: Provider badge display
+
+**Sources**
+
+- `views/HomeView.tsx:37-38` — `showProviderBadges = hasMultipleProviders`.
+- `card/LibraryCard.tsx:103-107` — badge rendered only when `showProviderBadge && provider`.
+
+### Scenario: Multiple providers connected
+
+**Source:** `views/HomeView.tsx:37-38` — `hasMultipleProviders` from `useProviderContext()` gates badge display.
+**Interpolated; no direct test for badge visibility.**
+
+### Scenario: Single provider connected
+
+**Source:** Same — `hasMultipleProviders` is false; `showProviderBadges` is false; badge branch skipped.
+**Interpolated from absence.**
+
+---
+
+## Requirement: Mini-player during library browsing
+
+**Sources**
+
+- `MiniPlayer/MiniPlayer.tsx:38` — `if (!currentTrack) return null`.
+- `MiniPlayer/MiniPlayer.tsx:45` — `data-testid="library-mini-player"`.
+- `MiniPlayer/MiniPlayer.tsx:49-52` — `<TapTarget onClick={onExpand}>` wraps art + text.
+
+### Scenario: Mini-player visible with active track
+
+**Source:** `MiniPlayer/MiniPlayer.tsx:38` — returns early only when `!currentTrack`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:148-165` ("mounts mini-player when a current track is loaded").
+
+### Scenario: Mini-player hidden with no active track
+
+**Source:** `MiniPlayer/MiniPlayer.tsx:38` — `if (!currentTrack) return null`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:136-146` ("does not mount mini-player when no current track").
+
+### Scenario: Expand tap navigates to full player
+
+**Source:** `MiniPlayer/MiniPlayer.tsx:49-52` — `TapTarget` calls `onExpand` on click.
+Verified by test at `__tests__/LibraryRoute.test.tsx:167-181` ("forwards onMiniExpand from the mini-player tap region").
+
+---
+
+## Requirement: Escape key dismissal
+
+**Sources**
+
+- `index.tsx:87-100` — `useEffect` adds `keydown` listener; filters out `Escape` presses from `INPUT`, `TEXTAREA`, or `contentEditable` targets; calls `onClose()`.
+- `index.tsx:87-89` — listener not added when `onClose` is undefined.
+
+### Scenario: Escape outside input closes library
+
+**Source:** `index.tsx:93-97` — tag check excludes INPUT/TEXTAREA/contentEditable; `onClose()` called otherwise.
+Verified by test at `__tests__/LibraryRoute.test.tsx:216-226` ("calls onClose when Escape is pressed outside an input").
+
+### Scenario: Escape inside input does not close library
+
+**Source:** `index.tsx:93-96` — `if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return`.
+Verified by test at `__tests__/LibraryRoute.test.tsx:228-239` ("does not call onClose when Escape is pressed while focus is inside an input").
+
+### Scenario: No close callback provided
+
+**Source:** `index.tsx:87-89` — `if (!onClose) return` skips adding the listener entirely.
+Verified by test at `__tests__/LibraryRoute.test.tsx:241-250` ("does not call onClose when onClose prop is not provided").
+
+---
+
+## Requirement: Responsive layout
+
+**Sources**
+
+- `index.tsx:162-164` — `layout = isMobile ? 'row' : 'grid'`; `Layout = isMobile ? MobileLayout : DesktopLayout`.
+- `index.tsx:207-208` — desktop: `<SearchBar variant="desktop">` inside layout; mobile: `<SearchBar variant="mobile">` outside (after) layout.
+
+### Scenario: Mobile layout
+
+**Source:** `index.tsx:162-164` — `isMobile` selects row layout and `MobileLayout`.
+`index.tsx:207-208` — mobile search bar rendered after the layout container.
+Verified by test at `__tests__/LibraryRoute.test.tsx:101-111` ("renders mobile layout testid when isMobile is true").
+
+### Scenario: Desktop layout
+
+**Source:** `index.tsx:162-164` — `!isMobile` selects grid layout and `DesktopLayout`.
+`index.tsx:207` — desktop search bar rendered inside the layout container (above sections).
+Verified by test at `__tests__/LibraryRoute.test.tsx:113-123` ("renders desktop layout testid when isMobile is false").
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **Section "See all" thresholds are not tested with exact boundary values.** The thresholds (RecentlyPlayed: 4, Pinned: 6, Playlists/Albums: 8) are read from source constants but no tests assert the `count === threshold` (no See All) vs `count === threshold + 1` (See All) boundary. Claimed from source constants only.
+
+2. **No results message exact wording.** `SearchResultsView.tsx:100` renders `No results for "<query>"` but no test verifies this copy. Interpolated from absence of a test.
+
+3. **Provider badge visibility** is derived from `hasMultipleProviders` but no test exercises the badge rendering path. Interpolated from prop-threaded logic.
+
+4. **Kind filter exclusion in search results** (`showAlbums`/`showPlaylists` gates) is not directly tested. Claimed from `SearchResultsView.tsx:43-44`.
+
+5. **Arrow key and Home/End navigation inside the context menu** is implemented in `LibraryContextMenu.tsx:76-96` but no unit test was found verifying focus movement. Interpolated.
+
+6. **Escape-dismisses-context-menu-and-returns-focus** is implemented (`closeReasonRef` pattern) but the a11y test file was not read in full. Marked interpolated pending full test read.
+
+7. **Filter/sort persistence across sessions** relies on `useLocalStorage` with known keys. Persistence behavior not directly end-to-end tested in the unit suite — only toggle logic is unit-tested. Interpolated.
+
+8. **Clear all "Clear all" button disabled state** — `FilterSheet.tsx:89` disables button when `!hasActiveFilters && !isSearching`. No test observed for disabled state. Interpolated.

--- a/openspec/specs/library/spec.md
+++ b/openspec/specs/library/spec.md
@@ -1,0 +1,323 @@
+# library
+
+## Purpose
+
+The library capability provides the user's primary collection-browsing surface: a multi-section home view of their playlists, albums, liked songs, recently played, and pinned items; a full-text search with persistent filters; a per-collection action menu; and an inline mini-player for continuing playback without leaving the view.
+
+## Requirements
+
+### Requirement: Home view section order
+
+The home view SHALL present sections in a fixed top-to-bottom order: Resume, Recently Played, Pinned, Playlists, Albums. Any section with no items and no pending load SHALL be hidden. The Resume section SHALL additionally be hidden when no resumable session exists.
+
+#### Scenario: All sections have content
+
+- **WHEN** all sections have at least one item and a resumable session exists
+- **THEN** all five sections appear in order: Resume, Recently Played, Pinned, Playlists, Albums
+
+#### Scenario: Section is empty after loading completes
+
+- **WHEN** a section finishes loading and has zero items
+- **THEN** that section is not rendered
+
+#### Scenario: Resume section with no last session
+
+- **WHEN** no session snapshot is provided or the session is stale
+- **THEN** the Resume section is not rendered
+
+### Requirement: Pinned section item ordering
+
+The Pinned section SHALL list Liked Songs entries before user-pinned playlists, and user-pinned playlists before user-pinned albums.
+
+#### Scenario: Unified liked songs with user-pinned items
+
+- **WHEN** liked songs are unified across providers and there are also pinned playlists and albums
+- **THEN** the single Liked Songs entry appears first, followed by pinned playlists, then pinned albums
+
+#### Scenario: Multi-provider liked songs, not unified
+
+- **WHEN** the user has liked songs on multiple providers and unified mode is not active
+- **THEN** one Liked Songs entry per provider appears at the top of the Pinned section, each showing a per-provider song count
+
+#### Scenario: Liked songs count subtitle grammar
+
+- **WHEN** the liked songs count is exactly 1
+- **THEN** the subtitle reads "1 song"
+- **WHEN** the count is any other number
+- **THEN** the subtitle reads "`<n>` songs"
+
+#### Scenario: Pinned id not in loaded library
+
+- **WHEN** a pinned collection id does not match any item in the synced library
+- **THEN** that id is silently omitted from the Pinned section
+
+### Requirement: See All navigation
+
+In row (mobile) layout, sections with item counts above their threshold SHALL display a "See all" button. Activating "See all" SHALL navigate to the SeeAll view for that section. In SeeAll view the user SHALL be able to return to the home view. The SeeAll view SHALL always use grid layout regardless of the host device layout.
+
+#### Scenario: Playlist section exceeds threshold in row layout
+
+- **WHEN** the Playlists section contains more than 8 items and the layout is row
+- **THEN** a "See all" control is shown for Playlists
+
+#### Scenario: Playlist section at or below threshold in row layout
+
+- **WHEN** the Playlists section contains 8 or fewer items
+- **THEN** no "See all" control is shown for Playlists
+
+#### Scenario: Album section threshold
+
+- **WHEN** the Albums section contains more than 8 items and the layout is row
+- **THEN** a "See all" control is shown for Albums
+
+#### Scenario: Pinned section threshold
+
+- **WHEN** the Pinned section contains more than 6 items and the layout is row
+- **THEN** a "See all" control is shown for Pinned
+
+#### Scenario: Recently Played section threshold
+
+- **WHEN** the Recently Played section contains more than 4 items and the layout is row
+- **THEN** a "See all" control is shown for Recently Played
+
+#### Scenario: See all not shown in grid layout
+
+- **WHEN** the layout is grid (desktop)
+- **THEN** no "See all" control is shown for any section regardless of item count
+
+#### Scenario: Back from SeeAll view
+
+- **WHEN** the user activates the back control in SeeAll view
+- **THEN** the view returns to the home view
+
+### Requirement: Search query routing
+
+Entering a non-empty search query SHALL replace the home (or SeeAll) view with a search results view. Clearing the query SHALL restore the previous non-search view.
+
+#### Scenario: Non-empty query entered
+
+- **WHEN** the user types a non-empty string into the search input
+- **THEN** the search results view replaces any currently displayed home or SeeAll view
+
+#### Scenario: Query cleared
+
+- **WHEN** the search input is cleared to empty
+- **THEN** the home view is restored
+
+#### Scenario: Initial search query seed
+
+- **WHEN** the library is opened with a pre-supplied query string
+- **THEN** the search input is pre-populated with that string and the search results view is displayed immediately
+
+### Requirement: Search text matching
+
+The search capability SHALL match items case-insensitively on collection name. For albums, it SHALL also match on artist names. An empty (or whitespace-only) query SHALL match all items.
+
+#### Scenario: Case-insensitive name match
+
+- **WHEN** the normalized query is a substring of the collection name (case-insensitive)
+- **THEN** the item appears in results
+
+#### Scenario: Artist name match for albums
+
+- **WHEN** the normalized query matches the album's artist string (case-insensitive)
+- **THEN** the album appears in results even if its title does not match
+
+#### Scenario: Empty query matches everything
+
+- **WHEN** the query is empty or contains only whitespace
+- **THEN** all items pass the text match check
+
+#### Scenario: No match
+
+- **WHEN** neither name nor artist contains the query
+- **THEN** the item is excluded from results
+
+#### Scenario: No results message
+
+- **WHEN** all filter and text criteria yield zero matching items
+- **THEN** a "No results" message is shown instead of empty sections
+
+### Requirement: Search filter persistence
+
+Provider filter, kind filter, and sort preference SHALL be persisted across sessions in local storage using fixed keys. Filter and sort state SHALL survive closing and reopening the library.
+
+#### Scenario: Provider filter toggles
+
+- **WHEN** the user toggles a provider in the filter sheet
+- **THEN** that provider is added to or removed from the active provider filter
+- **AND** only items from selected providers appear in search results
+
+#### Scenario: Kind filter restricts collection types
+
+- **WHEN** the user selects only "playlist" in the kind filter
+- **THEN** album items are excluded from search results
+
+#### Scenario: Sort order applied
+
+- **WHEN** the sort is set to "A → Z"
+- **THEN** results within a section are ordered alphabetically ascending by name using locale-aware comparison
+
+#### Scenario: Sort order name-desc
+
+- **WHEN** the sort is set to "Z → A"
+- **THEN** results within a section are ordered alphabetically descending
+
+#### Scenario: Sort order recent
+
+- **WHEN** the sort is set to "Recently Added" (the default)
+- **THEN** item order within sections is unchanged (provider-supplied order)
+
+#### Scenario: Filter state active indicator
+
+- **WHEN** any filter (provider, kind, or sort) differs from its default
+- **THEN** the filter button is visually marked as having active filters
+
+#### Scenario: Clear all resets all state
+
+- **WHEN** the user activates "Clear all"
+- **THEN** the query is cleared, all provider and kind filters are removed, and the sort is reset to "Recently Added"
+
+#### Scenario: Provider filter hidden for single provider
+
+- **WHEN** exactly one provider is connected
+- **THEN** the source filter group is not shown in the filter sheet
+
+### Requirement: Collection context menu
+
+Each collection card SHALL support a context menu accessible via right-click (pointer) or long press (touch). The menu SHALL present actions appropriate to the collection kind. Keyboard users SHALL be able to navigate menu items with arrow keys and dismiss with Escape.
+
+#### Scenario: Context menu opens on right-click
+
+- **WHEN** the user right-clicks a library card
+- **THEN** the context menu opens anchored near the pointer position
+
+#### Scenario: Context menu opens on long press
+
+- **WHEN** the user long-presses a library card on a touch device
+- **THEN** the context menu opens
+
+#### Scenario: Playlist menu items
+
+- **WHEN** the context menu is opened for a playlist collection
+- **THEN** the menu contains: Play, Add to Queue, Play Next, Pin/Unpin, Start Radio
+
+#### Scenario: Album menu items
+
+- **WHEN** the context menu is opened for an album collection
+- **THEN** the menu contains: Play, Add to Queue, Play Next, Pin/Unpin, Unlike, Start Radio
+
+#### Scenario: Liked Songs menu items
+
+- **WHEN** the context menu is opened for a Liked Songs collection
+- **THEN** the menu contains a "Play All" item plus one "Play (Provider)" item per connected provider
+
+#### Scenario: Recently-played appends Remove from history
+
+- **WHEN** the context menu is opened from the Recently Played section
+- **THEN** a "Remove from history" item (destructive) is appended after the kind-specific items
+
+#### Scenario: Pin/Unpin label reflects current state
+
+- **WHEN** the collection is already pinned
+- **THEN** the menu item label is "Unpin"
+- **WHEN** the collection is not pinned
+- **THEN** the menu item label is "Pin"
+
+#### Scenario: Start Radio disabled when unavailable
+
+- **WHEN** radio generation is not available (e.g. Last.fm key absent)
+- **THEN** the Start Radio item is rendered disabled
+
+#### Scenario: Play Next disabled when unavailable
+
+- **WHEN** the play-next action is not available
+- **THEN** the Play Next item is rendered disabled
+
+#### Scenario: Queue Liked Songs optional item
+
+- **WHEN** the queue-liked-tracks action is available for a playlist or album
+- **THEN** a "Queue Liked Songs" item is included in the menu
+
+#### Scenario: Arrow key navigation in menu
+
+- **WHEN** the context menu is open and the user presses Arrow Down
+- **THEN** focus moves to the next enabled menu item (wrapping to first)
+- **WHEN** the user presses Arrow Up
+- **THEN** focus moves to the previous enabled menu item (wrapping to last)
+
+#### Scenario: Escape dismisses menu and returns focus
+
+- **WHEN** the context menu is open and the user presses Escape
+- **THEN** the menu closes and focus returns to the card that triggered it
+
+#### Scenario: Action error shown as toast
+
+- **WHEN** a menu action fails
+- **THEN** a toast message describing the failure is shown to the user
+
+### Requirement: Provider badge display
+
+When multiple providers are connected, collection cards SHALL display a provider badge so the user can identify which service a collection belongs to.
+
+#### Scenario: Multiple providers connected
+
+- **WHEN** two or more providers are active
+- **THEN** each collection card shows a small badge identifying its provider
+
+#### Scenario: Single provider connected
+
+- **WHEN** only one provider is active
+- **THEN** no provider badge is shown on collection cards
+
+### Requirement: Mini-player during library browsing
+
+While the library is visible and a track is currently loaded, a compact mini-player SHALL be shown. The mini-player SHALL display the track name, artist, and artwork. Tapping the mini-player expand area SHALL navigate to the full player. When no track is loaded, the mini-player SHALL not be shown.
+
+#### Scenario: Mini-player visible with active track
+
+- **WHEN** a track is currently loaded and the library is open
+- **THEN** the mini-player is visible with the track name and artist
+
+#### Scenario: Mini-player hidden with no active track
+
+- **WHEN** no track is currently loaded
+- **THEN** the mini-player is not rendered
+
+#### Scenario: Expand tap navigates to full player
+
+- **WHEN** the user taps the mini-player expand area
+- **THEN** the library closes and the full player is shown
+
+### Requirement: Escape key dismissal
+
+The library SHALL close when the user presses Escape, provided focus is not inside a text input or content-editable element.
+
+#### Scenario: Escape outside input closes library
+
+- **WHEN** the user presses Escape and focus is not in an input, textarea, or content-editable element
+- **THEN** the library close callback is invoked
+
+#### Scenario: Escape inside input does not close library
+
+- **WHEN** the user presses Escape while focus is inside the search input
+- **THEN** the library close callback is not invoked
+
+#### Scenario: No close callback provided
+
+- **WHEN** no close callback is wired
+- **THEN** pressing Escape has no effect and produces no error
+
+### Requirement: Responsive layout
+
+On mobile viewports the library SHALL use a row card layout and position the search bar below the section content. On desktop viewports it SHALL use a grid card layout and position the search bar above the section content.
+
+#### Scenario: Mobile layout
+
+- **WHEN** the viewport is classified as mobile
+- **THEN** cards are rendered in row layout and the search bar is positioned at the bottom
+
+#### Scenario: Desktop layout
+
+- **WHEN** the viewport is classified as desktop
+- **THEN** cards are rendered in grid layout and the search bar is positioned above the content area

--- a/openspec/specs/playback-engine/spec.md
+++ b/openspec/specs/playback-engine/spec.md
@@ -11,10 +11,12 @@ The playback engine SHALL turn user playback intent into audio output across mul
 The app SHALL distinguish two provider roles at any moment: an **active provider** used for browsing and catalog actions, and a **driving provider** producing audio. The two MAY differ when the queue mixes tracks from multiple providers. Exactly one provider SHALL hold the driving role at any time.
 
 #### Scenario: Queue contains a single provider
+
 - **WHEN** every track in the queue belongs to the same provider
 - **THEN** that provider holds the driving role
 
 #### Scenario: Queue mixes providers
+
 - **WHEN** the queue contains tracks from multiple providers
 - **THEN** the driving role belongs to the provider owning the currently playing track
 
@@ -23,6 +25,7 @@ The app SHALL distinguish two provider roles at any moment: an **active provider
 When playback advances to a track whose provider differs from the current driving provider, the outgoing provider SHALL be paused before the incoming provider begins playback. Only one provider SHALL produce audio at a time.
 
 #### Scenario: Advancing to a track from a different provider
+
 - **WHEN** the next track belongs to a different provider than the current driving provider
 - **THEN** the outgoing provider is paused
 - **AND** the incoming provider takes the driving role
@@ -33,6 +36,7 @@ When playback advances to a track whose provider differs from the current drivin
 Play, pause, next, and previous controls SHALL be dispatched to the driving provider, regardless of which provider is active for browsing.
 
 #### Scenario: Control invoked while driving and active differ
+
 - **WHEN** the user invokes play, pause, next, or previous while the driving provider differs from the active provider
 - **THEN** the control is dispatched to the driving provider
 
@@ -41,14 +45,17 @@ Play, pause, next, and previous controls SHALL be dispatched to the driving prov
 The engine SHALL detect track end and advance to the next track in the queue. Track end SHALL be recognized from either of two signals: a near-end signal when remaining time falls below a threshold, or a natural-end signal when the driving provider transitions from playing to paused at position zero.
 
 #### Scenario: Near-end signal
+
 - **WHEN** the driving provider reports remaining time below the near-end threshold
 - **THEN** the engine advances to the next track
 
 #### Scenario: Natural-end signal
+
 - **WHEN** the driving provider transitions from playing to paused at position zero
 - **THEN** the engine advances to the next track
 
 #### Scenario: Cooldown suppresses false trigger
+
 - **WHEN** an auto-advance signal fires within the cooldown window of a fresh track start
 - **THEN** the signal is ignored
 
@@ -57,10 +64,12 @@ The engine SHALL detect track end and advance to the next track in the queue. Tr
 The engine SHALL handle playback adapter errors without leaving the queue stuck on an unplayable track.
 
 #### Scenario: Track is unavailable
+
 - **WHEN** the driving provider reports a track as unavailable
 - **THEN** the engine skips to the next track
 
 #### Scenario: Provider authentication expired during playback
+
 - **WHEN** the driving provider reports authentication has expired
 - **THEN** the engine surfaces a re-authentication prompt and does not auto-skip
 
@@ -69,6 +78,7 @@ The engine SHALL handle playback adapter errors without leaving the queue stuck 
 After a track begins playing successfully, the engine SHALL pre-warm the next track on its owning provider so playback transitions have minimal latency. Pre-warming SHALL NOT change the current-track index or any visible state.
 
 #### Scenario: Pre-warming next track
+
 - **WHEN** a track begins playing successfully and a next track exists in the queue
 - **THEN** the engine pre-warms the next track on its owning provider
 - **AND** the current-track index is unchanged
@@ -79,10 +89,12 @@ After a track begins playing successfully, the engine SHALL pre-warm the next tr
 UI play status, playback position, and current-track index SHALL track the driving provider's emitted state. State from non-driving providers SHALL be ignored.
 
 #### Scenario: Non-driving provider emits state
+
 - **WHEN** a registered but non-driving provider emits a playback state
 - **THEN** the UI state is not updated
 
 #### Scenario: Tab returns to foreground
+
 - **WHEN** the browser tab returns to foreground while audio is playing
 - **THEN** the engine resyncs from the driving provider so track info, artwork, and position match audio output
 
@@ -91,9 +103,11 @@ UI play status, playback position, and current-track index SHALL track the drivi
 A provider that declares a native-queue-sync capability SHALL be notified when the app's queue or current index changes, so the provider can keep its native queue aligned with the app.
 
 #### Scenario: App queue changes while a native-sync provider is driving
+
 - **WHEN** the app's queue or current-track index changes and the driving provider declares the native-queue-sync capability
 - **THEN** the provider is notified of the new queue and current index
 
 #### Scenario: Provider without native-sync capability
+
 - **WHEN** the app's queue changes and the driving provider does not declare native-queue-sync
 - **THEN** no native-sync notification is dispatched

--- a/openspec/specs/provider-system/spec.md
+++ b/openspec/specs/provider-system/spec.md
@@ -3,16 +3,20 @@
 ## Purpose
 
 Vorbis Player SHALL support multiple music providers (streaming services, personal file sources, test doubles) behind one provider-neutral contract, so the queue, library, and player UI can mix providers without coupling to any specific source.
+
 ## Requirements
+
 ### Requirement: Three-Adapter Provider Contract
 
 A provider SHALL be expressed as a bundle of three adapters — auth, catalog, playback — registered as a single descriptor in the provider registry. The registry SHALL enforce this contract at registration time by throwing a typed error when any of the three required adapters is missing or non-object, so a malformed descriptor never enters the registry.
 
 #### Scenario: Provider registered at startup
+
 - **WHEN** the app starts and a provider's module loads
 - **THEN** the provider becomes resolvable by id from the registry
 
 #### Scenario: Provider missing a required adapter
+
 - **WHEN** a descriptor is registered without one of the three required adapters
 - **THEN** registration throws an `InvalidProviderDescriptorError` naming the provider id and the missing adapter, and the provider is not exposed by the registry
 
@@ -21,14 +25,17 @@ A provider SHALL be expressed as a bundle of three adapters — auth, catalog, p
 All track and collection data exchanged between providers, the queue, the library, and the player UI SHALL use provider-neutral shapes — `MediaTrack`, `MediaCollection`, `CollectionRef`, and `PlaybackState` — so data from any provider is interchangeable.
 
 #### Scenario: Collection reference round-trips through serialization
+
 - **WHEN** a collection reference is serialized to a string and parsed back
 - **THEN** the parsed reference equals the original
 
 #### Scenario: Unparseable serialized reference
+
 - **WHEN** an unparseable string is passed to the reference parser
 - **THEN** the parser returns a null result rather than throwing
 
 #### Scenario: Track carries a playback reference
+
 - **WHEN** a catalog returns a track
 - **THEN** the track carries an opaque playback reference that only its owning provider needs to resolve
 
@@ -37,10 +44,12 @@ All track and collection data exchanged between providers, the queue, the librar
 A provider SHALL be available only when the build-time credentials or feature flags it depends on are set. Providers without their prerequisites SHALL NOT register.
 
 #### Scenario: Provider without credentials at build time
+
 - **WHEN** a provider's required build-time credential is unset
 - **THEN** the provider is not registered and not exposed in the UI
 
 #### Scenario: Provider with credentials at build time
+
 - **WHEN** a provider's required build-time credentials are set
 - **THEN** the provider registers and becomes resolvable from the registry
 
@@ -49,10 +58,12 @@ A provider SHALL be available only when the build-time credentials or feature fl
 Each provider SHALL declare which optional behaviors its adapters support. Callers SHALL check a capability before invoking the corresponding optional adapter method.
 
 #### Scenario: Capability declared and supported
+
 - **WHEN** a provider declares an optional capability as supported
 - **THEN** callers may invoke the corresponding optional adapter method
 
 #### Scenario: Capability not declared
+
 - **WHEN** a provider does not declare an optional capability
 - **THEN** callers SHALL NOT invoke the corresponding optional adapter method
 
@@ -61,10 +72,11 @@ Each provider SHALL declare which optional behaviors its adapters support. Calle
 The app SHALL maintain a persisted set of **enabled** providers representing which providers the user has opted into. The app SHALL never operate with zero enabled providers.
 
 #### Scenario: Enabled set persists across sessions
+
 - **WHEN** the user opts a provider into or out of the enabled set
 - **THEN** the change persists across page reloads
 
 #### Scenario: Last enabled provider cannot be removed
+
 - **WHEN** only one provider remains in the enabled set
 - **THEN** removing that provider is blocked so the app never reaches a zero-enabled-provider state
-

--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -11,12 +11,14 @@ Vorbis Player SHALL maintain an ordered queue of provider-neutral tracks that ca
 Loading a collection SHALL replace the queue with the collection's tracks, reset the current-track index to the start, and begin playback from the first track.
 
 #### Scenario: Loading a collection with tracks
+
 - **WHEN** the user loads a collection
 - **THEN** the queue is replaced by the collection's tracks
 - **AND** the current-track index resets to the start
 - **AND** playback begins from the first track
 
 #### Scenario: Loading an empty collection
+
 - **WHEN** the user loads a collection that returns no tracks
 - **THEN** the queue remains empty and playback does not begin
 
@@ -25,12 +27,14 @@ Loading a collection SHALL replace the queue with the collection's tracks, reset
 Adding a collection to the queue SHALL append its tracks to the existing queue without resetting the current-track index, deduplicating by track id so a track already in the queue is not added twice. When the queue is empty, adding SHALL behave as loading a collection.
 
 #### Scenario: Adding to a non-empty queue
+
 - **WHEN** the user adds a collection to a non-empty queue
 - **THEN** the collection's tracks are appended to the existing queue
 - **AND** the current-track index is unchanged
 - **AND** any tracks already in the queue are skipped
 
 #### Scenario: Adding to an empty queue
+
 - **WHEN** the user adds a collection to an empty queue
 - **THEN** the queue is loaded with the collection's tracks and playback begins from the first track
 
@@ -39,18 +43,22 @@ Adding a collection to the queue SHALL append its tracks to the existing queue w
 Removing a queued track SHALL preserve the playing track's position. Removing the currently playing track SHALL be blocked. Removing the last track SHALL reset the queue to its empty state.
 
 #### Scenario: Removing a track before the current one
+
 - **WHEN** a track positioned before the currently playing track is removed
 - **THEN** the current-track index decrements so the same track continues playing
 
 #### Scenario: Removing a track after the current one
+
 - **WHEN** a track positioned after the currently playing track is removed
 - **THEN** the current-track index is unchanged
 
 #### Scenario: Removing the currently playing track
+
 - **WHEN** the user attempts to remove the currently playing track
 - **THEN** the removal is blocked and the queue is unchanged
 
 #### Scenario: Removing the last track
+
 - **WHEN** the only remaining track in the queue is removed
 - **THEN** the queue resets to its empty state
 
@@ -59,6 +67,7 @@ Removing a queued track SHALL preserve the playing track's position. Removing th
 Reordering the queue SHALL move a track from one position to another and SHALL keep the currently playing track's index aligned with its new position.
 
 #### Scenario: Reordering relative to the current track
+
 - **WHEN** a track is moved to a new position in the queue
 - **THEN** the track order reflects the move
 - **AND** the current-track index now points to the same track that was playing before the reorder
@@ -68,16 +77,19 @@ Reordering the queue SHALL move a track from one position to another and SHALL k
 Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue order while keeping the currently playing track at the front; disabling shuffle SHALL restore the queue's original order with the current track's index pointing at its original position. The user's preference SHALL persist across sessions.
 
 #### Scenario: Enabling shuffle
+
 - **WHEN** the user enables shuffle
 - **THEN** the queue's non-current tracks are shuffled
 - **AND** the currently playing track is placed at the front of the queue
 - **AND** the current-track index becomes zero
 
 #### Scenario: Disabling shuffle
+
 - **WHEN** the user disables shuffle
 - **THEN** the queue's original order is restored
 - **AND** the current-track index points to the currently playing track's position in the original order
 
 #### Scenario: Shuffle preference persists
+
 - **WHEN** the user enables or disables shuffle
 - **THEN** the preference persists across sessions


### PR DESCRIPTION
## Summary

- Syncs `main` up to `develop`'s tip as part of the flowkit v4 migration to single-trunk GitHub Flow on `main`
- Brings in the two `docs(specs)` commits that landed on `develop` since the last release

## Commits

- `docs(specs): fix markdownlint violations and add config`
- `docs(specs): add library capability spec`

## Context

Part of the v4 migration: once merged, `main` will be caught up to `develop` and the default branch can be flipped from `develop` → `main`.