### PR TITLE
docs: fix README & CLAUDE.md accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,11 +94,11 @@ src/
 ├── contexts/        # React context providers (TrackContext, ColorContext, etc.)
 ├── providers/       # Multi-provider system; spotify/ and dropbox/ subdirs
 ├── hooks/           # Custom hooks
-├── services/        # spotify.ts (auth + API), spotifyPlayer.ts (lazy SDK + playback), cache/ (IndexedDB)
+├── services/        # spotify/ (auth + API), spotifyPlayer.ts (lazy SDK + playback), cache/ (IndexedDB)
 ├── constants/       # playlist.ts, zenAnimation.ts, storage.ts
-├── utils/           # colorExtractor, sizingUtils, playlistFilters, etc.
+├── utils/           # colorExtractor, sizingUtils, logCaughtError, etc.
 ├── workers/         # imageProcessor.worker.ts
-├── types/           # domain.ts, providers.ts, filters.ts
+├── types/           # domain.ts, providers.ts, radio.ts
 ├── styles/          # theme.ts, ThemeProvider, shadcn-tokens.css, global styles
 └── lib/utils.ts
 ```
@@ -106,11 +106,11 @@ src/
 ## Terminology
 
 - **Queue** — tracks scheduled to play next (reorder/remove in `QueueDrawer` / `QueueBottomSheet`; list UI in `QueueTrackList.tsx`).
-- **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `LibraryRoute` and loaded through `usePlaylistManager` / catalog APIs.
+- **Playlist** — a library **collection** from a provider (Spotify playlist, Dropbox folder-as-album, Liked Songs, etc.), browsed via `LibraryRoute` and loaded through `useSpotifyPlaylistManager` / catalog APIs.
 
 ## Tech Stack
 
-See README.md for the full tech stack. Build: ES2020, esbuild, manual chunks (vendor/radix/styled).
+See README.md for the full tech stack. Build: ES2022, esbuild, manual chunks (vendor/radix/styled).
 
 ## Environment Configuration
 
@@ -140,7 +140,7 @@ VITE_MOCK_PROVIDER="true"
 ```
 
 Vite dev server: host `127.0.0.1`, port `3000` (required for Spotify OAuth).
-Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/usePlayerState'`).
+Path alias: `@/` → `./src/` (e.g. `import { x } from '@/hooks/useKeyboardShortcuts'`).
 
 ## Coding Conventions
 
@@ -268,14 +268,6 @@ See `docs/troubleshooting.md` for layout, provider, and radio issues. Layout inv
 - `/commit` — Commit current changes, split into logical commits
 - `/doc` — Update README.md
 - `/comdoc` — Update README.md then commit
-
-## AI Workflow Rules
-
-For structured feature development, see `.claude/rules/`:
-
-- `generate_prd.md` — PRD creation process: asks clarifying questions, then generates a structured requirements doc
-- `generate_tasks_from_prd.md` — breaks a PRD into a detailed parent/subtask list; waits for "Go" confirmation before generating subtasks
-- `process_tasks.md` — task execution protocol: one subtask at a time, with test + commit gates before marking parent complete
 
 ## OpenSpec
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ playlists/albums get captured before generating the snapshot.
 2. **Edit `playwright/fixtures/data/snapshot.config.json`** to include the IDs and
    folder paths you want to curate. Aim for a small, representative set — about
    5–10 playlists, a few saved albums, and the most-played folders. The committed
-   file ships with empty arrays so you can populate from scratch.
+   file already contains a representative set; adjust the IDs to match your own library.
 
 3. **Generate the snapshot** (writes JSON + downloads art):
    ```


### PR DESCRIPTION
Part of a documentation accuracy sweep. Each PR covers one doc area; this one covers the **root docs** (README.md, CLAUDE.md). Findings were produced by a vetting workflow that checked every concrete claim against the current code, then adversarially re-verified each one.

## Changes

**CLAUDE.md**
- **Removed the `AI Workflow Rules` section** — it pointed at `.claude/rules/` with `generate_prd.md`, `generate_tasks_from_prd.md`, `process_tasks.md`. None of these exist anymore; the structured-workflow tooling is OpenSpec (already documented in the OpenSpec section).
- **Build target ES2020 → ES2022** — `vite.config.ts` (`target: 'es2022'`) and `tsconfig.app.json` (`"target": "ES2022"`).
- **Source Layout fixes**: `services/spotify.ts` → `services/spotify/` (split into a directory); `types/filters.ts` → `radio.ts` (filters.ts removed); `utils/playlistFilters` → `logCaughtError` (playlistFilters gone).
- **`usePlaylistManager` → `useSpotifyPlaylistManager`** (actual export name).
- Example import path now references a module that exists (`@/hooks/useKeyboardShortcuts`).

**README.md**
- Curating-fixtures step no longer claims `snapshot.config.json` ships with empty arrays — it ships populated (7 playlist IDs, 6 album IDs).

All changes are documentation-only.