### PR TITLE
docs: correct top-level guides (keyboard, user guide, testing, contributing)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,7 +45,7 @@ npm run deploy:preview # Deploy preview (Vercel)
 src/
 ├── components/              # React components
 │   ├── AudioPlayer.tsx      # Main orchestrator with centralized state
-│   ├── PlayerContent.tsx    # Main player layout (centering, responsive sizing)
+│   ├── PlayerContent/       # Main player layout (centering, responsive sizing)
 │   ├── PlayerStateRenderer.tsx  # Loading/error and library collection selection states
 │   ├── AlbumArt.tsx         # Album artwork with filters & glow effects
 │   ├── LibraryRoute/        # Sections-first library route (home + sub-routes, search, mini-player)
@@ -53,20 +53,20 @@ src/
 │   ├── QueueDrawer.tsx      # Queue (up-next) side drawer (desktop/tablet)
 │   ├── QueueBottomSheet.tsx # Queue bottom sheet (mobile)
 │   ├── QueueTrackList.tsx   # Queue track list (reorder/remove); lazy-loaded by queue surfaces
-│   ├── ColorPickerPopover.tsx   # Per-album color picker
-│   ├── AlbumArtBackside.tsx     # Flip menu back face
+│   ├── AlbumArtQuickSwapBack.tsx # Flip menu back face
 │   ├── BottomBar/               # Bottom bar components
 │   ├── controls/            # Player control sub-components
 │   ├── styled/              # Reusable styled-components library
 │   ├── icons/               # SVG icon components
 │   ├── visualizers/         # Background visualizer components
-│   └── VisualEffectsMenu/   # Visual effects configuration panel
+│   └── ui/                  # shadcn/ui primitives
 ├── constants/               # Shared constants (playlist IDs, prefixes)
-├── hooks/                   # 30 custom React hooks
+├── hooks/                   # 45 custom React hooks
 ├── providers/               # Multi-provider system
 │   ├── registry.ts          # Singleton ProviderRegistry
 │   ├── spotify/             # Spotify auth, catalog, playback adapters
-│   └── dropbox/             # Dropbox auth, catalog, playback adapters + art/catalog cache
+│   ├── dropbox/             # Dropbox auth, catalog, playback adapters + art/catalog cache
+│   └── mock/                # Mock provider (Playwright/dev; tree-shaken from prod)
 ├── services/                # Spotify API, Playback SDK, IndexedDB cache
 ├── utils/                   # Utility functions (color, sizing, filters)
 ├── styles/                  # Theme, global styles, CSS animations
@@ -83,7 +83,7 @@ src/
 - **Authentication**: PKCE OAuth 2.0 (Spotify and Dropbox)
 - **Testing**: Vitest + React Testing Library + jsdom
 - **Performance**: Web Workers, LRU caching, IndexedDB persistence, lazy loading, container queries
-- **Build**: ES2020 target, esbuild, manual chunks (vendor/radix/styled)
+- **Build**: ES2022 target, esbuild, manual chunks (vendor/radix/styled)
 
 ## Coding Conventions
 
@@ -113,7 +113,7 @@ Guidelines:
 
 ## Git Workflow
 
-- Feature branches from `develop`: `feature/name`, `fix/name`
+- Feature branches from `main`: `feature/name`, `fix/name`
 - Atomic commits with conventional format (`feat:`, `fix:`, `refactor:`, etc.)
 - Reference issue numbers in commit messages
 - Run `npm run test:run` and `npm run build` before pushing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ Open [http://127.0.0.1:3000](http://127.0.0.1:3000) in your browser.
 
 ## First Run
 
-1. Click **Connect Spotify** to authenticate with Spotify, **or** open App Settings (gear icon) and connect Dropbox
+1. On the **Welcome to Vorbis Player** screen, click **Connect** on the Spotify and/or Dropbox provider card to authenticate
 2. Choose from your playlists/albums (Spotify) or browse your Dropbox folders
 3. Start playing music!
 

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -10,7 +10,7 @@ Centralized in `useKeyboardShortcuts.ts`. Uses `pointer: fine` / `hover: hover` 
 | `↓` / `L` | Toggle library | Volume down (↓ only) |
 | `V` / `G` / `S` / `T` | Visualizer / Glow / Shuffle / Translucence | same |
 | `Z` | Toggle zen mode | same |
-| `O` / `K` / `M` | Effects menu / Like / Mute | same |
+| `Shift+S` / `K` / `M` | Effects menu / Like / Mute | same |
 | `Cmd+K` / `Ctrl+K` | Open command palette (search library) | not bound |
 | `?` / `/` | Keyboard help | same |
 | `Escape` | Close all menus | same |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,9 +9,9 @@ Run with `npm run test:run`. Tests are colocated with source files in `__tests__
 
 | File | Purpose |
 |------|---------|
-| `setup.ts` | Global test setup: mocks `localStorage`, `sessionStorage`, `window.location`, `history`, `fetch`, `crypto` (for PKCE), `btoa`/`atob`; imports `fake-indexeddb/auto` and `@testing-library/jest-dom`; clears all mocks in `afterEach` |
-| `fixtures.ts` | Factory functions for domain objects: `makeTrack()`, `makeMediaTrack()`, `makePlaylistInfo()`, `makeAlbumInfo()`, `makeProviderDescriptor()` — all accept partial overrides |
-| `testWrappers.tsx` | `TestWrapper` component that nests all app context providers (`ProviderProvider`, `PlayerSizingProvider`, `TrackProvider`, `ColorProvider`, `VisualEffectsProvider`, `PinnedItemsProvider`) for component/hook tests |
+| `setup.ts` | Global test setup: mocks `localStorage`, `sessionStorage`, `window.location`, `history`, `window.matchMedia`, `fetch`, `crypto` (for PKCE), `btoa`/`atob`; imports `fake-indexeddb/auto` and `@testing-library/jest-dom`; clears all mocks in `afterEach` |
+| `fixtures.ts` | Factory functions for domain objects: `makeTrack()`, `makeMediaTrack()`, `makeProviderDescriptor()` — all accept partial overrides |
+| `testWrappers.tsx` | `TestWrapper` component that nests all app context providers (`ThemeProvider`, `ProviderProvider`, `PlayerSizingProvider`, `TrackProvider`, `ColorProvider`, `VisualEffectsProvider`, `PinnedItemsProvider`) for component/hook tests |
 | `providerTestUtils.tsx` | `ProviderWrapper` — lighter wrapper with only `ProviderProvider`, for hooks that only need provider context |
 
 ## BDD comment convention

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,7 +39,7 @@ For the full Spotify setup walkthrough, see the [Spotify Setup Guide](./provider
 
 ### No Albums / No Tracks
 
-- Ensure your Dropbox contains audio files (MP3, FLAC, OGG, M4A, WAV) organized in folders
+- Ensure your Dropbox contains audio files (MP3, FLAC, OGG, M4A, WAV, AAC, WMA, OPUS) organized in folders
 - Expected structure: `/<Artist>/<Album>/<track.mp3>` or `/<Album>/<track.mp3>`
 - Folders with no audio files are not listed as albums
 - After connecting, give the app a moment to scan your Dropbox (the first load enumerates all files recursively)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,7 +13,7 @@ Tap or click the album art to flip it and reveal quick-access controls:
 - **Accent color swatches** — extracted from art, custom, eyedropper, reset
 - **Glow effect toggle**
 - **Background visualizer toggle**
-- **Visualizer style selector** — Particles / Geometric
+- **Visualizer style selector** — Fireflies / Comet / Wave / Grid
 
 ### Bottom Bar
 
@@ -59,7 +59,7 @@ The library drawer supports:
 - **Sort** — Sort by recently added, name, artist, or release date
 - **Filter** — Filter albums by decade or by artist (click artist name in album grid)
 - **View Modes** — Toggle between Playlists and Albums tabs
-- **Pinning** — Pin up to 12 playlists and 12 albums to the top of their tabs
+- **Pinning** — Pin up to 12 collections total (playlists and albums combined) to the top of their tabs
 - **Liked Songs** — Special entry with shuffle indicator
 - **Play Liked / Queue Liked** — Long-press or right-click a collection to play or queue only your liked tracks from it
 
@@ -94,13 +94,8 @@ Opened via the gear icon in the bottom bar. Provides full control over:
 
 ### Background Visualizer
 
-- **Style** — Particles or Geometric
-- **Intensity** — 0-100%
-
-### Album Art Filters
-
-- Brightness, Saturation, Sepia, Contrast
-- One-click reset to defaults
+- **Style** — Fireflies, Comet, Wave, or Grid
+- **Intensity** — Less / Normal / More
 
 ## Keyboard Shortcuts
 
@@ -110,13 +105,14 @@ Opened via the gear icon in the bottom bar. Provides full control over:
 | `ArrowRight` / `ArrowLeft` | Next / Previous track | Next / Previous track |
 | `ArrowUp` / `Q` | Toggle queue drawer | Volume up (ArrowUp only) |
 | `ArrowDown` / `L` | Toggle library drawer | Volume down (ArrowDown only) |
-| `V` | Toggle background visualizer | Toggle background visualizer |
+| `V` | Cycle visualizer style | Cycle visualizer style |
 | `G` | Toggle glow effect | Toggle glow effect |
 | `S` | Toggle shuffle | Toggle shuffle |
 | `T` | Toggle translucence | Toggle translucence |
-| `O` | Open visual effects menu | Open visual effects menu |
+| `Shift+S` | Open visual effects menu | Open visual effects menu |
 | `K` | Like/unlike current track | Like/unlike current track |
 | `M` | Mute/unmute | Mute/unmute |
+| `Z` | Toggle zen mode | Toggle zen mode |
 | `/` or `?` | Show keyboard shortcuts help | Show keyboard shortcuts help |
 | `Escape` | Close all menus | Close all menus |
 


### PR DESCRIPTION
Part of a documentation accuracy sweep (one PR per doc area). This PR covers the **top-level guides** under `docs/`. Findings came from a vetting workflow that checked each claim against the code and adversarially re-verified it.

## Changes

**docs/keyboard.md & docs/user-guide.md**
- `O` is not bound anywhere — the visual effects menu opens with **Shift+S** (`useKeyboardShortcuts.ts`).
- Added the **Z → zen mode** row (implemented but undocumented).
- `V` **cycles** the visualizer style (Fireflies → Comet → Wave → Grid); it does not toggle the visualizer on/off.

**docs/user-guide.md**
- Visualizer styles are **Fireflies / Comet / Wave / Grid**, not "Particles / Geometric".
- Removed the **Album Art Filters** section (Brightness/Saturation/Sepia/Contrast) — that feature no longer exists.
- Background visualizer intensity is **Less / Normal / More**, not "0–100%".
- Pinning cap is **12 collections total** (playlists + albums combined), not 12 of each.

**docs/getting-started.md**
- First run is the **Welcome to Vorbis Player** provider grid with **Connect** cards, not a single "Connect Spotify" button.

**docs/testing.md**
- `fixtures.ts` does not export `makePlaylistInfo()` / `makeAlbumInfo()`.
- `TestWrapper` also nests `ThemeProvider`.
- `setup.ts` also mocks `window.matchMedia`.

**docs/troubleshooting.md**
- Audio-format list now matches the scanner (`AUDIO_EXTENSIONS`): adds AAC, WMA, OPUS.

**docs/contributing.md**
- Default branch is **main**, not `develop`.
- Build target **ES2022**.
- `PlayerContent` is a directory; `ColorPickerPopover.tsx`/`AlbumArtBackside.tsx` renamed/removed; `VisualEffectsMenu/` dir gone; ~45 hooks; `providers/` has a `mock/` subdir.

Documentation-only.