### PR TITLE
docs(architecture): correct queue-sync flow, provider paths, shadcn status

### DIFF
--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -26,7 +26,7 @@ The queue drawers (`QueueDrawer`, `QueueBottomSheet`) render `QueueSkeleton` (`s
 
 The library browser opens as `LibraryRoute` (a full-screen view, `src/components/LibraryRoute/`), not a drawer. `currentView === 'library'` in `usePlayerLogic` state gates the active-player overlay; `handleOpenLibrary` / `handleCloseLibrary` toggle it. `LibraryRoute` is rendered via `React.lazy` from `AudioPlayer.tsx` (active-player overlay, when `currentView === 'library'`) and from `PlayerStateRenderer.tsx` (idle route).
 
-**Opening the library**: swipe down on album art, BottomBar library button, or keyboard `↓` / `L`. Opening library closes the queue drawer.
+**Opening the library**: BottomBar library button, or swipe down on album art when the Quick Access Panel is disabled (with QAP enabled, swipe down opens the QAP instead). Keyboard `↓` / `L` open the Quick Access Panel, not the library. Opening library closes the queue drawer.
 
 **Recently Played history** is tracked by `useRecentlyPlayedCollections` (`src/hooks/useRecentlyPlayedCollections.ts`). It exposes `history: RecentlyPlayedEntry[]` and `record(ref, name)`. Successful collection loads via `useCollectionLoader.loadCollection` call `record` automatically. History is stored under `vorbis-player-recently-played` (localStorage), capped at 5 entries, deduped by `CollectionRef` key, newest first. The Recently Played section in `LibraryRoute` reads from this hook via `useRecentlyPlayedSection`.
 

--- a/docs/architecture/playback.md
+++ b/docs/architecture/playback.md
@@ -24,7 +24,7 @@ Queue state lives in `TrackContext` (`tracks`, `originalTracks`, `currentTrackIn
 
 - Resolves the target provider and collection ref
 - Fetches tracks via `catalog.listTracks(collectionRef)`
-- Calls `applyTracks()` which stores `originalTracks`, optionally shuffles, sets `tracks` + `mediaTracksRef`, resets `currentTrackIndex` to 0, then calls `playTrack(0)`
+- Calls `applyTracks()` which stores `originalTracks`, optionally shuffles, sets `tracks` + `mediaTracksRef`, and resets `currentTrackIndex` to 0; the loader then calls `playTrack(0)`
 - Unified Liked Songs path merges tracks from all connected providers sorted by `addedAt`
 
 ### Adding to queue (`useQueueManagement.handleAddToQueue`)
@@ -48,10 +48,10 @@ Queue state lives in `TrackContext` (`tracks`, `originalTracks`, `currentTrackIn
 
 ### Shuffle interaction (`TrackContext.handleShuffleToggle`)
 
-- Enable: shuffles `originalTracks` (excluding current track), places current track first, resets index to 0
+- Enable: shuffles the current `tracks` (excluding the current track; not `originalTracks`, whose objects may be stale), places current track first, resets index to 0
 - Disable: restores `originalTracks`, finds current track's original index
 - Persisted via `useLocalStorage`
 
 ### Queue change notification
 
-`usePlayerLogic` calls `descriptor.playback.onQueueChanged?(tracks, currentTrackIndex)` whenever `tracks` or `currentTrackIndex` change, allowing providers with native queue sync (Spotify) to stay aligned.
+Two call sites push queue snapshots to the driving provider, both gated on `descriptor.capabilities.hasNativeQueueSync`: `useQueueManagement.notifyQueueChanged` fires on user-driven mutations (add/remove/reorder/insert), and `useProviderPlayback.playTrack` fires on track transitions (next/previous/hydrate/auto-advance). Each calls `descriptor.playback.onQueueChanged?.(tracks, index)` so providers with native queue sync (Spotify) stay aligned; providers without the capability never receive it.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -26,7 +26,7 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 - Toggle-ON when not authenticated: calls `beginLogin({ popup: true })` immediately. The provider is added to `enabledProviderIds` only after the OAuth popup reports success via `AUTH_COMPLETE_EVENT`.
 - OAuth cancel/failure: toggle reverts; a toast shows `"Couldn't connect to {provider}. Try again."`.
 - Mid-session unrecoverable 401: `logout()` is called automatically; a toast shows `"{Provider} disconnected — session expired."`.
-- Implementation: `src/components/VisualEffectsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
+- Implementation: `src/components/AppSettingsMenu/SourcesSections.tsx` (`MusicSourcesSection`).
 
 ## Unified playback across providers
 
@@ -47,7 +47,7 @@ Defined in `src/types/providers.ts` and `src/types/domain.ts`.
 
 - Radio is a one-shot action (not a sticky toggle) that builds a playlist from the current track.
 - `useRadio` + `radioService` generate suggestions from Last.fm, then match against the active provider catalog.
-- Unmatched suggestions can be resolved via Spotify search (`spotifyResolver`) when authenticated and Spotify is in `connectedProviderIds`.
+- Unmatched suggestions can be resolved via catalog search against any search-capable authenticated provider (`searchCapableProviders` filtered by `capabilities.hasTrackSearch` in `src/services/radioPipeline.ts`, calling each provider's `catalog.searchTrack`).
 - Provider switches during radio now follow the same driving-provider routing (no special queue handoff modal).
 - **Track name context menu**: clicking the track name (in both normal and zen mode) opens a `TrackRadioPopover` with a single "Play {trackName} Radio" option. This mirrors the existing artist/album popover pattern (`TrackInfoPopover`). The option is disabled with a tooltip when Last.fm is not configured. Components: `TrackRadioPopover.tsx` (popover wrapper), `TrackInfo.tsx` (normal mode), `AlbumArtSection.tsx` (zen mode).
 
@@ -100,7 +100,7 @@ Folders containing audio files become albums; parent folder = artist. A syntheti
 
 ### Dropbox "All Music" card
 
-`useLibrarySync.splitCollections` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. `AllMusicCard` (`src/components/PlaylistSelection/AllMusicCard.tsx`) renders the row in the **playlist grid** at the top anchor slot, alongside `LikedSongsCard`. The card uses a Dropbox-tinted gradient and a crossed-arrows shuffle SVG glyph in both grid and list layouts; subtitle is `"{N} tracks • Shuffled"`. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
+`splitCollections` in `src/hooks/useCatalogLibrarySync.ts` intercepts the All Music collection and exposes its track total as `allMusicCount` instead of pushing it into the album list. The library UI is rendered by `src/components/LibraryRoute` (cards via `LibraryRoute/card/LibraryCard.tsx`); the All Music row is surfaced through the LibraryRoute sections rather than a dedicated `AllMusicCard` component. Hidden when Dropbox is not in `enabledProviderIds` or excluded by the provider filter chip. Pin/unpin uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (a stable identifier distinct from the underlying collection id `''`) and persists through `PinnedItemsContext` like any other pin. The legacy `id === ''` entries in `LIBRARY_PLAYLIST_SORT_ANCHOR_IDS` and `LIBRARY_ALBUM_SORT_ANCHOR_IDS` are retired — All Music is no longer mixed into the sortable lists, so it does not need a sort-anchor exemption.
 
 ### All Music shuffle-by-default
 
@@ -108,7 +108,7 @@ Loading or appending the All Music aggregate always shuffles, independently of t
 
 ### Dropbox Liked Songs
 
-Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
+Stored in IndexedDB (`vorbis-dropbox-art` database v7, `likes` store). Mutations dispatch `vorbis-dropbox-likes-changed` events for real-time UI updates. Settings menu exposes Export/Import (JSON) and Refresh Metadata operations.
 
 ### Dropbox preferences sync
 
@@ -120,7 +120,7 @@ Both providers preserve refresh tokens during transient failures and proactively
 
 ### Spotify SDK loading
 
-The Spotify Web Playback SDK is loaded lazily by `SpotifyPlayerService.loadSDK()` — no global script tag in `index.html`. The SDK is only injected when the Spotify provider activates.
+The Spotify Web Playback SDK is loaded lazily by `loadSpotifySDK()` in `src/services/spotifyPlayerSdk.ts` — no global script tag in `index.html`. The SDK is only injected when the Spotify provider activates.
 
 ### Spotify API batching
 

--- a/docs/architecture/shadcn.md
+++ b/docs/architecture/shadcn.md
@@ -8,7 +8,7 @@ vorbis-player uses a hybrid styling stack: **styled-components for bespoke surfa
 |---|---|---|
 | Visualizers, animations, gestures | styled-components (forever) | `BackgroundVisualizer`, zen-mode orchestration in `PlayerContent/styled.ts`, swipe gestures, album-art flip menu, `BottomBar` |
 | Standard chrome (modals, sliders, popovers, switches, toasts) | shadcn primitives | `src/components/ui/*.tsx`: `dialog.tsx`, `button.tsx`, `slider.tsx`, `switch.tsx`, `accordion.tsx`, `popover.tsx`, `sonner.tsx` |
-| Whole-screen redesigns | shadcn, gated behind `?ui=v2` | future `SettingsV2`, `OnboardingV2`, command palette |
+| Whole-screen redesigns | shadcn, gated behind `?ui=v2` | `SettingsV2` (`src/components/SettingsV2/`), command palette (`src/components/CmdKPalette/`) |
 
 ## Theme bridge — `--accent-color` is player chrome ONLY
 
@@ -20,18 +20,19 @@ The runtime `--accent-color` / `--accent-contrast-color` (injected on `document.
 - `VolumeSlider` (fill + thumb gradient — wraps shadcn `slider.tsx`, vertical orientation)
 - `Switch` accent variant (`controls/QuickEffectsRow.tsx` glow/visualizer/translucence toggles — uses default `variant="accent"` of `src/components/ui/switch.tsx`, retints checked-state track with `var(--accent-color)`)
 - Glow effects (`--glow-intensity`, `--glow-rate`, `--glow-opacity`)
-- Accent color overrides menu in `VisualEffectsMenu`
+- Accent color overrides menu (`SettingsV2/sections/appearance/AccentColorManager.tsx`)
 
 **shadcn primitives use the neutral palette** defined in `src/styles/shadcn-tokens.css` (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, etc.). shadcn's `--accent` token is a static neutral surface and is **not** the same as the player's `--accent-color`. Never wire shadcn's `--primary` or `--accent` to `var(--accent-color)` — dialogs, popovers, and other chrome must stay neutral so they don't retint per track.
 
 ## `?ui=v2` flag mechanism
 
-The `useUiV2()` hook (`src/hooks/useUiV2.ts`) returns `true` when EITHER:
+The `useUiV2()` hook (`src/hooks/useUiV2.ts`) returns `true` when ANY of:
 
 - `import.meta.env.VITE_UI_V2 === 'true'` (build-time opt-in for staging deploys), OR
-- the URL contains `?ui=v2` (per-session opt-in for testing).
+- the URL contains `?ui=v2` (per-session opt-in for testing), OR
+- the `vorbis-player-settings-v2-enabled` localStorage key is `true` (cross-session persistence, set by the "Keep v2 enabled" toggle in `SettingsV2/sections/AdvancedSection.tsx`).
 
-It subscribes to `popstate` so SPA navigation flips the flag without a reload. SSR-safe.
+It subscribes to `popstate` so SPA navigation flips the flag without a reload, and to `storage` so cross-tab toggles propagate. SSR-safe.
 
 Convention for flagged screens:
 
@@ -43,7 +44,7 @@ Convention for flagged screens:
 
 | Primitive | File | Notes |
 |---|---|---|
-| `Dialog` | `dialog.tsx` | Used by `ProviderDisconnectDialog`, `ConfirmDeleteDialog`, `SaveQueueDialog`, `KeyboardShortcutsHelp`. Unflagged. |
+| `Dialog` | `dialog.tsx` | Used by `ProviderDisconnectDialog`, `SaveQueueDialog`, `KeyboardShortcutsHelp`, and `SettingsV2`. Unflagged. |
 | `Slider` | `slider.tsx` | Wrapped by `TimelineSlider` (horizontal, accent fill/thumb gradient) and `VolumeSlider` (vertical). Per-part `trackStyle` / `thumbStyle` / `rangeStyle` escape hatches preserve accent retinting. |
 | `Switch` | `switch.tsx` | Dual variants: `accent` (default, player chrome) and `neutral` (settings toggles). |
 | `Toast` (Sonner) | `sonner.tsx` | `<Toaster />` mounted at app root in `App.tsx`. `RadioProgressContent` rendered via `toast.custom()`. |
@@ -54,8 +55,11 @@ Convention for flagged screens:
 | `Select` | `select.tsx` | Per-part escape hatches: `triggerStyle` → `SelectTrigger`, `contentStyle` → `SelectContent` panel, `itemStyle` → `SelectItem` row. z-index 1500 (matches `theme.zIndex.popover`). |
 | `ScrollArea` | `scroll-area.tsx` | Per-part escape hatches: `viewportStyle` → viewport, `scrollbarStyle` → scrollbar track, `thumbStyle` → scrollbar thumb. |
 | `Separator` | `separator.tsx` | Per-part escape hatch: `separatorStyle` → separator element. |
+| `Command` | `command.tsx` | Powers the desktop Cmd-K palette (`CmdKPalette/index.tsx`). |
+| `Sheet` | `sheet.tsx` | Side panel used by `FilterSheet` (`LibraryRoute/search/`). |
+| `Input` | `input.tsx` | Text input primitive; used by `SearchBar` (`LibraryRoute/search/`). |
 
-**Next-wave primitives** (tracked as on-hold epics; need decomposition via `/speckit:interview`): #1265 (FilterSidebar — shadcn wave 3), #1262 (Settings v2), #1263 (Cmd-K palette), #1264 (Onboarding v2).
+**Shipped follow-on work**: #1265 (FilterSidebar — shipped as `FilterSheet`, `src/components/LibraryRoute/search/FilterSheet.tsx`, uses `sheet.tsx`), #1262 (Settings v2 — `src/components/SettingsV2/`), #1263 (Cmd-K palette — `src/components/CmdKPalette/`, uses `command.tsx`), #1264 (Onboarding v2). All four epics are closed.
 
 ## Canonical patterns for new shadcn primitives
 


### PR DESCRIPTION
Part of a documentation accuracy sweep (one PR per doc area). This PR covers `docs/architecture/`. Findings came from a vetting workflow that checked each claim against the code and adversarially re-verified it.

## Changes

**playback.md**
- The queue-change notification is **not** fired by `usePlayerLogic` on every `tracks`/`currentTrackIndex` change. It's pushed from **two capability-gated call sites**: `useQueueManagement.notifyQueueChanged` (user mutations) and `useProviderPlayback.playTrack` (track transitions), both gated on `descriptor.capabilities.hasNativeQueueSync`.
- Shuffle-on-enable shuffles the current `tracks`, not `originalTracks`; `applyTracks()` does not call `playTrack(0)`.

**layout.md**
- Keyboard `↓` / `L` open the **Quick Access Panel**, not the library route.

**providers.md**
- `MusicSourcesSection` lives in `AppSettingsMenu/`, not `VisualEffectsMenu/`.
- Radio unmatched-suggestion resolution is **provider-agnostic** (any `hasTrackSearch` provider via `radioPipeline.ts`), not Spotify-only.
- `splitCollections` is in `useCatalogLibrarySync.ts`; `AllMusicCard` / `PlaylistSelection/` no longer exist (library UI is `LibraryRoute`).
- Dropbox art-cache IndexedDB is **v7** (was documented as v3).
- SDK loads via standalone `loadSpotifySDK()` in `spotifyPlayerSdk.ts`, not `SpotifyPlayerService.loadSDK()`.

**shadcn.md**
- `SettingsV2` and the Cmd-K palette have **shipped** (no longer "future").
- `useUiV2()` returns true on **three** signals — added the `vorbis-player-settings-v2-enabled` localStorage signal + `storage` event subscription.
- `ConfirmDeleteDialog` removed from the Dialog consumers list.
- Added `Command` / `Sheet` / `Input` primitive rows.
- The four "next-wave / on-hold" epics are **closed**; FilterSidebar shipped as `FilterSheet`.

Documentation-only.