### PR TITLE
docs(features): fix renamed components, stale contexts, and incorrect APIs

### DIFF
--- a/docs/features/album-art.md
+++ b/docs/features/album-art.md
@@ -16,7 +16,7 @@ The album art system handles display, color extraction, accent color propagation
 | `src/components/PlayerContent/GestureLayer.tsx` | Swipe/click/long-press routing; merges touch + pointer handlers |
 | `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons |
 | `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button |
-| `src/components/PlayerContent/styled.tsx` | `FlipInner`, `ClickableAlbumArtContainer`, zen track info styled components |
+| `src/components/PlayerContent/styled.ts` | `FlipInner`, `ClickableAlbumArtContainer`, zen track info styled components |
 | `src/hooks/useAccentColor.ts` | Auto-extract color on track change; manages override lifecycle |
 | `src/hooks/usePlayerSizing.ts` | Viewport-aware dimensions, breakpoints, device detection |
 | `src/hooks/useImageProcessingWorker.ts` | Hook wrapping the web worker for accent-mask image processing |
@@ -99,7 +99,7 @@ The component uses a custom `React.memo` comparator that checks: `currentTrack.i
 
 ### Architecture
 
-Album art has a front (artwork) and back (visual effects controls). The flip is a CSS 3D transform (`rotateY(180deg)`) applied via `FlipInner` in `src/components/PlayerContent/styled.tsx`.
+Album art has a front (artwork) and back (visual effects controls). The flip is a CSS 3D transform (`rotateY(180deg)`) applied via `FlipInner` in `src/components/PlayerContent/styled.ts`.
 
 ### Flip state
 
@@ -315,12 +315,12 @@ interface UsePlayerSizingReturn {
 
 ### Album art max-width calculation
 
-In `AlbumArt.tsx`, `AlbumArtContainer` uses CSS `max-width`:
-- Normal mode: `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - 120px))`
+In `src/components/PlayerContent/styled.ts`, the `PlayerStack` styled component uses CSS `max-width` (constants from `src/constants/zenAnimation.ts` and `BOTTOM_BAR_HEIGHT = 60`):
+- Normal mode: `min(calc(100vw - 48px), calc(100dvh - var(--player-controls-height, 220px) - 180px))`
 - Zen mode: `min(calc(100vw - 96px), calc(100dvh - 196px))`
 - Zen mode mobile: `min(calc(100vw - 32px), calc(100dvh - 120px))`
 
-The `aspect-ratio: 1` rule ensures square art. The `max-width` constraint is the sole sizing mechanism -- no explicit width or height is set.
+The `aspect-ratio: 1` rule on `AlbumArtContainer` ensures square art. The `max-width` constraint on the surrounding `PlayerStack` is the sole sizing mechanism -- no explicit width or height is set on the art itself.
 
 ### AlbumArtSection bounds reporting
 

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -1,6 +1,6 @@
 # Library Browser System
 
-> **Note:** This document predates the library redesign and partially describes legacy structure (`LibraryPage` / `useLibraryRoot`) that no longer exists. The current surface is `LibraryRoute` (`src/components/LibraryRoute/`) with section data hooks under `src/components/LibraryRoute/hooks/`. A full rewrite covering the new route is tracked as a follow-up issue.
+> **Note:** This document describes the current `LibraryRoute` surface (`src/components/LibraryRoute/`) with section data hooks under `src/components/LibraryRoute/hooks/`.
 
 ## Overview
 
@@ -9,7 +9,7 @@ The library browser shows the user's music collections (playlists, albums, liked
 It appears in two contexts:
 
 1. **Idle/home view** — rendered inline by `PlayerStateRenderer` when no track is loaded and QAP is disabled.
-2. **Full-screen library** — `LibraryRoute` opened during playback via swipe-down on album art, BottomBar library button, `L` key, or `↓`.
+2. **Full-screen library** — `LibraryRoute` opened during playback via swipe-down on album art or the BottomBar library button. (The `L` key and `↓` open the Quick Access Panel, not the library route.)
 
 Both contexts render the same `LibraryRoute` component (default export from `src/components/LibraryRoute/index.tsx`).
 
@@ -21,20 +21,20 @@ Both contexts render the same `LibraryRoute` component (default export from `src
 
 Internally `LibraryRoute` owns:
 
-- `view` — sub-route state (`home` | `recently-played` | `pinned` | `playlists` | `albums` | `liked` | `search`). Local to `LibraryRoute`, not in `usePlayerLogic`. Discarded when `currentView` swaps back to `'player'`.
+- `view` — sub-route state (`home` | `recently-played` | `pinned` | `playlists` | `albums` | `search`). Local to `LibraryRoute`, not in `usePlayerLogic`. Discarded when `currentView` swaps back to `'player'`.
 - `search` — the `LibrarySearchState` returned by `useLibrarySearch`. Active query forces `view === 'search'`.
 - `contextRequest` — the active virtual-anchor for `LibraryContextMenu` (long-press / right-click target).
-- `paletteOpen` — desktop-only Cmd-K palette open flag (gated by `useCommandPaletteShortcut`).
+
 
 The body picks one of three views:
 
 | Effective view | Component |
 |---|---|
 | `search` (any non-empty query) | `SearchResultsView` |
-| `home`, `liked` | `HomeView` |
+| `home` | `HomeView` |
 | `recently-played`, `pinned`, `playlists`, `albums` | `SeeAllView` |
 
-`SearchBar` mounts above (`desktop`) or below (`mobile`) the body. `MiniPlayer` is sticky-bottom. `CommandPalette` is desktop-only.
+`SearchBar` mounts above (`desktop`) or below (`mobile`) the body. `MiniPlayer` is sticky-bottom.
 
 ## Section taxonomy
 
@@ -43,22 +43,21 @@ The body picks one of three views:
 1. **Resume** — last session hero (`ResumeHero`), gated on a fresh `lastSession`.
 2. **Recently Played** — last 5 collections from `useRecentlyPlayedCollections`.
 3. **Pinned** — pinned playlists/albums.
-4. **Liked** — unified or per-provider liked tracks, from `useUnifiedLikedTracks`.
-5. **Playlists** — all playlists across enabled providers.
-6. **Albums** — all saved albums across enabled providers.
+4. **Playlists** — all playlists across enabled providers.
+5. **Albums** — all saved albums across enabled providers.
 
 Each section is a `Section` shell (header + horizontal/vertical card group) backed by a dedicated data hook in `LibraryRoute/hooks/`:
 
 | Hook | State |
 |---|---|
-| `useResumeSection` | `{ session, isReady }` |
+| `useResumeSection` | `{ session, hasResumable }` |
 | `useRecentlyPlayedSection` | `SectionState<RecentlyPlayedEntry>` |
-| `usePinnedSection` | `SectionState<PinnedItem>` |
+| `usePinnedSection` | `PinnedSectionState` ({ pinnedPlaylists, pinnedAlbums, combined, isLoading, isEmpty }) |
 | `useLikedSection` | `LikedSummary` |
 | `usePlaylistsSection` | `SectionState<CachedPlaylistInfo>` |
 | `useAlbumsSection` | `SectionState<AlbumInfo>` |
 
-Hook params accept the active provider filter / kind filter / sort, so the same hooks back both `HomeView` and `SeeAllView`.
+The collection hooks (`usePlaylistsSection`, `useAlbumsSection`) accept `UseCollectionSectionParams` (`providerFilter`, `excludePinned`), so the same hooks back both `HomeView` and `SeeAllView`.
 
 `SectionSkeleton` renders shimmer cards while loading. Sections collapse when `isEmpty === true`.
 
@@ -102,24 +101,24 @@ Long-press is implemented by `useLongPress` (500 ms hold, 8 px move tolerance). 
 
 - `SearchBar` — text input + filter button. Renders different chrome on mobile (bottom dock) vs desktop (top of body).
 - `FilterSheet` — Radix `Sheet` (mobile) / `Popover` (desktop) with provider checkboxes, kind toggles, sort radio.
-- `CommandPalette` — desktop-only Cmd-K palette. Built on `cmdk@^1.1.1`. Triggered by `useCommandPaletteShortcut`.
+- The desktop-only Cmd-K palette is a separate component, `CmdKPalette` (`src/components/CmdKPalette/`), built on the shadcn `CommandDialog` (`cmdk@^1.1.1`). It registers its own Cmd/Ctrl+K listener and is rendered by `AudioPlayer`, not by `LibraryRoute`.
 - `searchMatch.ts` — case- and diacritic-insensitive substring match used by both `useLibrarySearch` results and the palette.
 
 ## Context menu
 
 **File:** `src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx`
 
-Single-instance virtual-anchored Popover (NOT Radix `ContextMenu`). Reads `request: ContextMenuRequest | null` from `LibraryRoute`, anchors at `request.anchorRect`. Items are derived per `LibraryItemKind` by `menuItemsForKind`.
+Single-instance virtual-anchored Popover (NOT Radix `ContextMenu`). Reads `request: ContextMenuRequest | null` from `LibraryRoute`, anchors at `request.anchorRect`. Items are derived by the `useMenuItems` hook (which calls `buildMenuItems` in `menuItemsForKind.ts`).
 
 Common actions:
 
 - Play
 - Add to queue
-- Play next *(rendered disabled — wiring deferred)*
-- Start radio for collection *(rendered disabled — wiring deferred)*
+- Play next (disabled when no `onPlayNext` handler, or for the liked kind)
+- Start radio for collection (disabled when no `onStartRadioForCollection` handler, or for the liked kind)
 - Pin / Unpin (playlists, albums)
-- Save / Unsave album (albums) — uses `useAlbumSavedStatus`
-- Like / Unlike all tracks (liked) — uses `useLikedTracksForProvider`
+- Like / Unlike album (albums) — uses `useAlbumSavedStatus`
+- Play All + per-provider Play (liked) — uses `useLikedTracksForProvider` to load tracks
 - Remove from history (recently-played)
 
 The "Save album" path no longer pre-populates an optimistic `AlbumInfo` — newly-saved albums appear after the next library sync. Acceptable trade-off per the redesign blueprint.
@@ -156,14 +155,14 @@ Sub-components: `MiniArt`, `MiniControls`. Wired via `onMini*` props on `Library
 | `src/components/LibraryRoute/card/LibraryCard.tsx` | Universal card primitive |
 | `src/components/LibraryRoute/card/useLongPress.ts` | Long-press detection |
 | `src/components/LibraryRoute/search/useLibrarySearch.ts` | Query + filter state |
-| `src/components/LibraryRoute/search/CommandPalette.tsx` | Desktop Cmd-K palette |
+| `src/components/CmdKPalette/index.tsx` | Desktop Cmd-K palette (rendered by AudioPlayer, not LibraryRoute) |
 | `src/components/LibraryRoute/contextMenu/LibraryContextMenu.tsx` | Single-instance virtual-anchored menu |
 | `src/components/LibraryRoute/MiniPlayer/MiniPlayer.tsx` | Sticky mini-player |
 | `src/components/LibraryRoute/types.ts` | `SectionState`, `LibraryRouteView`, `LibraryItemKind`, `ContextMenuRequest` |
 
 ## Architectural notes
 
-- **Sections-first taxonomy**: Resume → Recently Played → Pinned → Liked → Playlists → Albums (fixed order).
+- **Sections-first taxonomy**: Resume → Recently Played → Pinned → Playlists → Albums (fixed order).
 - **Mobile = horizontal-scroll rows + "See all" sub-route**; **desktop = vertical wrapped grids**.
 - **Sub-route nav state is local** to `LibraryRoute` (not in `usePlayerLogic`) — discarded naturally when `currentView` swaps.
 - **Native overflow-x with scroll-snap** on mobile (NOT Radix `ScrollArea` — preserves iOS momentum).

--- a/docs/features/player-controls.md
+++ b/docs/features/player-controls.md
@@ -24,8 +24,8 @@ Key concept: **active provider** (selected for browsing/catalog) vs **driving pr
 | `src/components/PlayerContent/ZenClickZoneOverlay.tsx` | Desktop zen: hover-reveal prev/play/next buttons over album art |
 | `src/components/PlayerContent/ZenLikeOverlay.tsx` | Desktop zen: hover-reveal like button (bottom-right of album art) |
 | `src/providers/errors.ts` | `AuthExpiredError`, `UnavailableTrackError` |
-| `src/types/providers.ts` | `PlaybackProvider` interface (line 66) |
-| `src/types/domain.ts` | `PlaybackState` interface (line 81) |
+| `src/types/providers.ts` | `PlaybackProvider` interface (line 113) |
+| `src/types/domain.ts` | `PlaybackState` interface (line 105) |
 
 ## usePlayerLogic
 
@@ -38,9 +38,11 @@ return {
   state: { isLoading, error, selectedPlaylistId, tracks, currentView, isPlaying, playbackPosition },
   handlers: {
     loadCollection, playTracksDirectly, handleAddToQueue, queueTracksDirectly,
+    insertTracksNext, insertCollectionNext,
     handlePlay, handlePause, handleNext, handlePrevious, playTrack,
     handleOpenLibrary, handleCloseLibrary, handleBackToLibrary,
     handleStartRadio, handleRemoveFromQueue, handleReorderQueue,
+    handleHydrate, setCurrentView,
   },
   radio: { radioState, isRadioAvailable, stopRadio, authExpired, clearAuthExpired, isActive, radioProgress, dismissRadioProgress },
   mediaTracksRef,         // imperative mirror of tracks[]
@@ -57,7 +59,7 @@ return {
 
 ### handleNext / handlePrevious
 
-Both wrap around the queue circularly (`% tracks.length`). Before calling `playTrack`, they set `expectedTrackIdRef.current` to the target track's ID. This tells `usePlaybackSubscription` to ignore any stale provider index updates until the expected track arrives.
+Both wrap around the queue circularly (`% tracks.length`). They call `setCurrentTrackIndex(targetIndex)`, then `await playTrack(targetIndex, true)`, then `ensurePlaybackResumed()` (manual skip auto-resumes, matching Spotify/Apple Music). The `expectedTrackIdRef` guard is not set here — `playTrack` itself raises it (to the target track's ID) before any adapter call, telling `usePlaybackSubscription` to ignore stale provider index updates until the expected track arrives.
 
 ### handlePlay / handlePause
 
@@ -69,7 +71,7 @@ Pauses playback, stops radio, clears all queue state (`tracks`, `originalTracks`
 
 ### Queue change notification
 
-An effect watches `tracks` and `currentTrackIndex` and calls `descriptor.playback.onQueueChanged?.(tracks, currentTrackIndex)` on the driving provider. Spotify uses this to sync its native queue.
+On every track transition, `playTrack` (in useProviderPlayback) pushes the latest queue snapshot via `descriptor.playback.onQueueChanged?.(tracks, index)` — but only for providers whose `descriptor.capabilities.hasNativeQueueSync` is true. Spotify declares this capability and uses the signal to build its native upcoming-queue; providers without it never receive the call. User-driven queue mutations are handled separately in `useQueueManagement`.
 
 ## useProviderPlayback
 
@@ -80,9 +82,11 @@ An effect watches `tracks` and `currentTrackIndex` and calls `descriptor.playbac
 ```ts
 interface UseProviderPlaybackProps {
   setCurrentTrackIndex: (index: number) => void;
-  activeDescriptor?: ProviderDescriptor | null;
+  activeDescriptor?: ProviderDescriptor | null | undefined;
   mediaTracksRef: React.MutableRefObject<MediaTrack[]>;
-  onAuthExpired?: (providerId: ProviderId) => void;
+  currentTrackIndexRef?: React.MutableRefObject<number> | undefined;
+  onAuthExpired?: ((providerId: ProviderId) => void) | undefined;
+  expectedTrackIdRef?: React.MutableRefObject<string | null> | undefined;
 }
 ```
 
@@ -116,7 +120,7 @@ interface UseProviderPlaybackProps {
 | `UnavailableTrackError` | Logs warning. If `skipOnError` and not at end of queue, schedules `playTrack(index + 1)` after 500ms. |
 | Generic error | Logs error. Same skip logic as `UnavailableTrackError`. |
 
-The 500ms delay before skip prevents rapid-fire skipping through consecutive unavailable tracks.
+The skip delay (`SKIP_ON_ERROR_DELAY_MS` from `src/constants/timing.ts`, currently 500ms) prevents rapid-fire skipping through consecutive unavailable tracks.
 
 ## usePlaybackSubscription
 
@@ -318,21 +322,24 @@ From `src/constants/zenAnimation.ts`:
 
 **Location:** `src/components/PlayerStateRenderer.tsx`
 
-Renders the idle/home view when no track is loaded (`selectedPlaylistId === null || tracks.length === 0`).
+Renders the idle/home view when no track is loaded (`selectedPlaylistId === null || tracks.length === 0`). Beyond the loading / auth-error / generic-error cards, the idle view also has a 'welcome' route (WelcomeScreen, first run until dismissed) and a 'hydrate' route (a 'Restoring Your Session' spinner that fires `onHydrate` to restore the last queue).
 
 ### View routing
 
+Idle routing is resolved by `resolveIdleRoute(welcomeSeen, qapEnabled, hasValidSession)`:
+
 ```
-qapEnabled (from useQapEnabled) ?
-  -> QuickAccessPanel (with browseLibrary callback)
-  : -> PlaylistSelection (lazy-loaded via React.lazy)
+!welcomeSeen      -> 'welcome'  (WelcomeScreen)
+qapEnabled        -> 'qap'      (QuickAccessPanel)
+hasValidSession   -> 'hydrate'  (session-restore spinner; fires onHydrate)
+else              -> 'library'  (LibraryRoute, lazy-loaded via React.lazy as LibraryRouteLazy)
 ```
 
-`showLibrary` state initializes to `!qapEnabled`. When the user selects a playlist from the library browser, `showLibrary` is set to `false` and the selection callback fires.
+A `libraryOverride` state is a one-way door: once "Browse Library" is engaged it pins the idle view to the library browser even if routing inputs would otherwise pick QAP. Selecting a playlist resets `libraryOverride` to `false` and fires the selection callback.
 
 ### QAP preference
 
-Stored in `localStorage` under key `vorbis-player-qap-enabled` (default `false`). Toggled via the settings panel (`VisualEffectsMenu`). The `useQapEnabled()` hook wraps `useLocalStorage`.
+Stored in `localStorage` under key `vorbis-player-qap-enabled` (default `false`). Toggled via the Advanced settings section (`src/components/SettingsV2/sections/AdvancedSection.tsx`). The `useQapEnabled()` hook wraps `useLocalStorage`.
 
 ### Other states
 

--- a/docs/features/profiler.md
+++ b/docs/features/profiler.md
@@ -1,6 +1,6 @@
 # Profiling and Debug Tools
 
-The app has four independent debug/profiling systems. They are activated differently and serve different purposes.
+The app has five independent debug/profiling systems. They are activated differently and serve different purposes.
 
 ## 1. Performance Profiler
 
@@ -21,7 +21,7 @@ State is persisted in localStorage at `vorbis-player-profiling` (raw string `'tr
 
 **Context**: `src/contexts/ProfilingContext.tsx`
 
-- `ProfilingProvider` wraps the app (in `src/App.tsx` via context providers)
+- `ProfilingProvider` wraps the player content (in `src/components/AudioPlayer.tsx`, alongside `ProfilingOverlay`)
 - `useProfilingContext()` returns `{ enabled, collector, toggle }`
 - When disabled, `collector` is `null` and `ProfiledComponent` renders children without a `React.Profiler` wrapper (zero overhead)
 
@@ -41,7 +41,7 @@ Note: `recordContextUpdate` and `recordOperation` are available on the collector
 
 | Profiler ID | Location |
 |---|---|
-| `app-settings-menu` | `VisualEffectsMenu/index.tsx` |
+| `app-settings-menu` | `AppSettingsMenu/index.tsx` |
 | `PlayerStateRenderer` | `AudioPlayer.tsx` |
 | `PlayerContent` | `AudioPlayer.tsx` |
 | `AccentColorBackground` | `AudioPlayer.tsx` |
@@ -64,7 +64,7 @@ Fixed-position panel at top-left (`z-index: 999980`). Polls the collector every 
 - Heap size (Chrome only)
 - Long task count and max duration
 - Recent render events (last 20)
-- Buttons: Reset, Export JSON, Copy to clipboard
+- Buttons: Reset, Export JSON, Copy
 
 ### Mutual Exclusivity with Visualizer Debug
 
@@ -144,7 +144,7 @@ File: `src/components/DebugOverlay.tsx`
 - `useDebugActivator()` hook: tracks tap timestamps, toggles after 5 taps within 2 seconds
 - `DebugOverlay` component: patches `console.warn` and `console.error` to capture output. Shows a fixed badge (bottom-left, `z-index: 999999`) with log count; click to expand full-screen log viewer
 - Max 200 log entries retained
-- Buttons: Close, Clear, Copy all
+- Buttons: Close, Clear, Copy
 
 ### Not Connected to Profiler
 
@@ -183,6 +183,7 @@ Defined in `src/lib/debugLog.ts`:
 | `logSw` | `vorbis:sw` | Service worker events |
 | `logLibrary` | `vorbis:library` | Library loading and caching |
 | `logSession` | `vorbis:session` | Session persistence |
+| `logArtRace` | `vorbis:art-race` | Fresh-load album-art race tracing (timestamps every event that can flip `currentTrackIndex` during a `playTrack` transition) |
 
 ### Relationship to Other Tools
 

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -123,7 +123,7 @@ interface PlaybackProvider {
 
 - `subscribe` returns an unsubscribe function. Multiple subscribers are supported.
 - `getLastPlayTime` returns epoch ms of the last `playTrack` call. Used by `useAutoAdvance` to implement a 5-second cooldown (`PLAY_COOLDOWN_MS`) that prevents false end-of-track triggers during buffering.
-- `onQueueChanged` is called by `usePlayerLogic` whenever `tracks` or `currentTrackIndex` change. Spotify uses this to build upcoming URIs for native queue sync.
+- `onQueueChanged` is invoked on track transitions (`useProviderPlayback.playTrack`) and on user-driven queue mutations (`useQueueManagement`), and only for providers whose descriptor declares `hasNativeQueueSync`. Spotify uses this to build upcoming URIs for native queue sync.
 
 ### PlaybackState
 
@@ -334,7 +334,7 @@ Like `usePlaybackSubscription`, auto-advance subscribes to **all** registered pr
 
 The Spotify Web Playback SDK (`https://sdk.scdn.co/spotify-player.js`) is NOT loaded via a `<script>` tag in `index.html`. Instead:
 
-1. `SpotifyPlayerService.loadSDK()` (in `spotifyPlayerSdk.ts`) dynamically creates a `<script>` element
+1. `loadSpotifySDK()` (an exported function in `spotifyPlayerSdk.ts`, called from `SpotifyPlayerService.initialize()`) dynamically creates a `<script>` element
 2. Waits for `window.onSpotifyWebPlaybackSDKReady` callback (10s timeout)
 3. Only called when the Spotify provider activates (first `initialize()` call)
 4. The pending promise is stored in a ref to deduplicate concurrent calls
@@ -363,7 +363,7 @@ This prevents 429 rate limiting when rendering a playlist with many tracks.
 
 `SpotifyPlaybackAdapter.playWithRetry()` handles:
 - **401**: Throws `AuthExpiredError` (no retry)
-- **429**: Respects `Retry-After` header, exponential backoff, up to `MAX_PLAY_RETRIES` (5)
+- **429**: Respects `Retry-After` header, exponential backoff, up to `SPOTIFY_MAX_RETRIES` (5)
 - **403 + "Restriction violated"**: Throws `UnavailableTrackError` (no retry)
 - **403 (other)**: Re-transfers playback to device, exponential backoff, retries
 
@@ -373,9 +373,9 @@ After the first successful `playTrack`, `playbackSessionActive` is set to `true`
 
 ### Native Queue Sync
 
-`SpotifyQueueSyncService` (`src/providers/spotify/spotifyQueueSync.ts`):
-- `onQueueChanged` calls `buildUpcomingUris(tracks, fromIndex)` to build a list of upcoming Spotify URIs
-- These URIs are stored in `pendingUpcomingUris` and passed to `spotifyPlayer.playTrack(uri, upcomingUris)` on the next play call
+`SpotifyQueueSyncService` (`src/providers/spotify/spotifyQueueSync.ts`) provides `buildUpcomingUris(tracks, fromIndex)` and `resolveTracksInBackground()`. The adapter (`spotifyPlaybackAdapter.ts`) wires them up:
+- `SpotifyPlaybackAdapter.onQueueChanged` calls `spotifyQueueSync.buildUpcomingUris(tracks, fromIndex)` to build a list of upcoming Spotify URIs
+- These URIs are stored on the adapter's `pendingUpcomingUris` field and passed to `spotifyPlayer.playTrack(uri, upcomingUris)` on the next play call
 - Non-Spotify tracks are included only if a cached Spotify URI exists (from background resolution)
 - `resolveTracksInBackground()` searches Spotify for non-Spotify tracks, caching results
 - Settings: `STORAGE_KEYS.SPOTIFY_QUEUE_SYNC` (sync on/off), `STORAGE_KEYS.SPOTIFY_QUEUE_CROSS_PROVIDER` (cross-provider resolution on/off)
@@ -392,7 +392,7 @@ After the first successful `playTrack`, `playbackSessionActive` is set to `true`
 | `src/providers/dropbox/dropboxPlaybackAdapter.ts` | HTML5 Audio, ID3 metadata enrichment |
 | `src/providers/dropbox/dropboxApiClient.ts` | Authenticated Dropbox API calls |
 | `src/providers/dropbox/dropboxArtworkResolver.ts` | Album art resolution (folder images, IndexedDB cache) |
-| `src/providers/dropbox/dropboxArtCache.ts` | IndexedDB database (`vorbis-dropbox-art` v3) |
+| `src/providers/dropbox/dropboxArtCache.ts` | IndexedDB database (`vorbis-dropbox-art` v7) |
 | `src/providers/dropbox/dropboxCatalogCache.ts` | Catalog cache in IndexedDB |
 | `src/providers/dropbox/dropboxCatalogHelpers.ts` | Audio file detection, path parsing, track creation |
 | `src/providers/dropbox/dropboxLikesCache.ts` | IndexedDB `likes` store, `LIKES_CHANGED_EVENT` |
@@ -417,7 +417,7 @@ Dropbox root/
 - Parent folder = artist name
 - Track ID = lowercase file path
 - Album ID = lowercase folder path
-- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list. It is rendered by `AllMusicCard` in the playlist grid (not the album grid) and always plays shuffled. See [Library — All Music Card](./library.md#all-music-card) for placement, pin behavior (`ALL_MUSIC_PIN_ID = 'dropbox-all-music'`), and shuffle-by-default semantics.
+- A synthetic "All Music" collection (kind `'folder'`, id `''`) is always prepended to the collection list. It is surfaced in the playlist grid (not the album grid) via `useLibrarySync` (`allMusicCount`) and always plays shuffled. Pin behavior uses `ALL_MUSIC_PIN_ID = 'dropbox-all-music'` (distinct from the underlying collection id `''`).
 
 ### Token Refresh
 
@@ -453,7 +453,7 @@ After starting playback, `enrichMetadataInBackground()`:
 
 ### Liked Songs
 
-Stored in IndexedDB (`vorbis-dropbox-art` database v3, `likes` store). Each entry is `{ trackId, track: MediaTrack, likedAt: number }`.
+Stored in IndexedDB (`vorbis-dropbox-art` database v7, `likes` store). Each entry is `{ trackId, track: MediaTrack, likedAt: number }`.
 
 Mutations dispatch `vorbis-dropbox-likes-changed` (the `LIKES_CHANGED_EVENT` constant) as a window event. The descriptor sets `likesChangedEvent` to this value, enabling real-time UI updates.
 
@@ -519,7 +519,7 @@ Currently only Spotify has `hasTrackSearch: true`. This means a Dropbox-seeded r
 
 ```ts
 class AuthExpiredError extends Error {
-  readonly providerId: string;
+  readonly providerId: ProviderId;
 }
 
 class UnavailableTrackError extends Error {

--- a/docs/features/queue.md
+++ b/docs/features/queue.md
@@ -20,7 +20,7 @@ interface TrackListContextValue {
   originalTracks: MediaTrack[];      // pre-shuffle order, used to restore on unshuffle
   isLoading: boolean;
   error: string | null;
-  shuffleEnabled: boolean;           // persisted via useLocalStorage (key: vorbis-player-shuffle)
+  shuffleEnabled: boolean;           // persisted via useLocalStorage (key: vorbis-player-shuffle-enabled)
   selectedPlaylistId: string | null; // ID of the loaded collection
   // + setters for all above
   handleShuffleToggle: () => void;
@@ -82,7 +82,7 @@ Constructed once in `usePlayerLogic` via `useMemo` and passed to `useCollectionL
    - `LIKED_SONGS_ID` + unified liked active + no explicit provider -> `loadUnifiedLiked()` (merges liked tracks from all connected providers, sorted by `addedAt` descending).
    - Otherwise -> `loadProviderCollection()`.
 3. `loadProviderCollection` resolves the collection ref via `resolvePlaylistRef(playlistId, providerId)` -> `{ id, kind }`, then calls `catalog.listTracks(collectionRef)`.
-4. If `listTracks` returns 0 tracks and `playback.playCollection` exists (Spotify context playback), falls back to `loadContextPlayback`.
+4. If `listTracks` returns 0 tracks and the target descriptor declares `capabilities.hasContextPlaybackFallback` (Spotify only), falls back to `loadContextPlayback`.
 5. `applyTracks(tracks)` stores `originalTracks`, optionally shuffles if `shuffleEnabled`, sets `tracks` + `mediaTracksRef`, resets `currentTrackIndex` to 0, then calls `playTrack(0)`.
 
 **Invariant:** `loadCollection` always resets `currentTrackIndex` to 0. The previous queue is fully replaced.
@@ -145,7 +145,7 @@ Constructed once in `usePlayerLogic` via `useMemo` and passed to `useCollectionL
 
 **Invariant:** `originalTracks` represents the canonical order. Shuffle only reorders `tracks`. Queue additions append to both.
 
-**Persistence:** `shuffleEnabled` is stored in localStorage via `useLocalStorage` (key: `vorbis-player-shuffle`).
+**Persistence:** `shuffleEnabled` is stored in localStorage via `useLocalStorage` (key: `vorbis-player-shuffle-enabled`).
 
 ## Cross-Provider Queue
 
@@ -160,17 +160,22 @@ The **driving provider** (the one currently controlling audio output) can differ
 
 ## Queue Change Notification
 
-`usePlayerLogic` calls the driving provider's `onQueueChanged` whenever `tracks` or `currentTrackIndex` change:
+The driving provider's `onQueueChanged` is invoked only when that provider declares the `hasNativeQueueSync` capability. Two call sites:
+
+- **Track transitions** (`useProviderPlayback.playTrack`, `src/hooks/useProviderPlayback.ts`):
 
 ```ts
-// src/hooks/usePlayerLogic.ts ~line 142
-descriptor?.playback.onQueueChanged?.(tracks, currentTrackIndex);
+if (descriptor.capabilities.hasNativeQueueSync) {
+  descriptor.playback.onQueueChanged?.(tracks, index);
+}
 ```
+
+- **User-driven mutations** (`useQueueManagement.ts`, via the `notifyQueueChanged` helper) for add/remove/reorder, which also checks `driving.capabilities?.hasNativeQueueSync` before calling.
 
 - **Spotify adapter** (`src/providers/spotify/spotifyPlaybackAdapter.ts`): uses this to build upcoming URIs for Spotify's native queue sync.
 - **Dropbox adapter** (`src/providers/dropbox/dropboxPlaybackAdapter.ts`): no-op.
 
-The `onQueueChanged` method is optional on `PlaybackProvider` (`src/types/providers.ts` line 89).
+The `onQueueChanged` method is optional on `PlaybackProvider` (`src/types/providers.ts` line 144).
 
 ## UI Components
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -4,12 +4,12 @@ The settings panel is a right-side sliding drawer rendered via `createPortal` to
 
 ## Entry Point
 
-Component: `src/components/VisualEffectsMenu/index.tsx` (exported as `AppSettingsMenu`).
+Component: `src/components/AppSettingsMenu/index.tsx` (default export, `AppSettingsMenu`).
 
 Opened via:
 - Gear icon on the flip menu back face
-- Keyboard shortcut `O`
-- `useVisualEffectsContext().setShowVisualEffects(true)`
+- Keyboard shortcut `Shift+S`
+- `useVisualEffectsToggle().setShowVisualEffects(true)`
 
 The drawer is lazy-loaded (`React.lazy`) in two places:
 - `src/components/PlayerContent/PlayerControlsSection.tsx` (when a track is loaded)
@@ -39,7 +39,7 @@ The drawer content is structured top-to-bottom:
 
 ### 1. Music Sources (`MusicSourcesSection`)
 
-File: `src/components/VisualEffectsMenu/SourcesSections.tsx`
+File: `src/components/AppSettingsMenu/SourcesSections.tsx`
 
 Only renders when 2+ providers are registered. Shows each provider with:
 - Name
@@ -51,7 +51,7 @@ Uses `useProviderContext()` for `registry`, `enabledProviderIds`, `toggleProvide
 
 ### 2. Native Queue Sync (`NativeQueueSyncSection`)
 
-File: `src/components/VisualEffectsMenu/SourcesSections.tsx`
+File: `src/components/AppSettingsMenu/SourcesSections.tsx`
 
 Only renders when a connected provider has `capabilities.hasNativeQueueSync` (currently only Spotify). Shows:
 - **Queue sync toggle**: keeps Spotify's native queue synced with Vorbis playback. Key: `STORAGE_KEYS.SPOTIFY_QUEUE_SYNC` (default: `true`).
@@ -63,7 +63,7 @@ Inline in `index.tsx`. On/Off `OptionButton` pair that toggles the QAP preferenc
 
 ### 4. Advanced (Collapsible)
 
-Wrapped in `CollapsibleSection` (file: `src/components/VisualEffectsMenu/CollapsibleSection.tsx`). Starts collapsed by default.
+Rendered with a shadcn `Accordion` (`type="single" collapsible`) from `@/components/ui/accordion`, wrapped in a `FilterSection` styled component (from `./styled`) in `src/components/AppSettingsMenu/index.tsx`. Starts collapsed by default.
 
 Contains:
 
@@ -96,7 +96,7 @@ Invariant: enabling visualizer debug disables the profiler (`profilerToggle()`).
 
 #### Provider Data Sections
 
-File: `src/components/VisualEffectsMenu/ProviderDataSection.tsx`
+File: `src/components/AppSettingsMenu/ProviderDataSection.tsx`
 
 One `ProviderDataSection` per enabled provider that has `catalog.clearArtCache` or `catalog.exportLikes`. Each is a collapsible section titled "{ProviderName} Data". Controls depend on which `CatalogProvider` capabilities exist:
 
@@ -248,6 +248,7 @@ All keys from `src/constants/storage.ts` (`STORAGE_KEYS`) plus standalone keys:
 | `vorbis-player-visualizer-debug-overrides` | -- | `JSON` | Visualizer param overrides |
 | `vorbis-player-devbug` | `false` | `boolean` | DevBug FAB enabled |
 | `vorbis-player-qap-enabled` | `false` | `boolean` | Quick Access Panel enabled (NOT in STORAGE_KEYS) |
+| `vorbis-player-settings-v2-enabled` | -- | `boolean` | Render the SettingsV2 drawer instead of AppSettingsMenu |
 
 ### Gotcha: Raw vs JSON Storage
 
@@ -263,14 +264,13 @@ These are compatible because `JSON.parse('"true"')` and `'true' === 'true'` both
 
 | File | Role |
 |---|---|
-| `src/components/VisualEffectsMenu/index.tsx` | Settings drawer component |
-| `src/components/VisualEffectsMenu/SourcesSections.tsx` | Music Sources + Queue Sync sections |
-| `src/components/VisualEffectsMenu/ProviderDataSection.tsx` | Per-provider data management |
-| `src/components/VisualEffectsMenu/CollapsibleSection.tsx` | Generic collapsible section wrapper |
-| `src/components/VisualEffectsMenu/styled.ts` | All styled-components for the drawer |
+| `src/components/AppSettingsMenu/index.tsx` | Settings drawer component |
+| `src/components/AppSettingsMenu/SourcesSections.tsx` | Music Sources + Queue Sync sections |
+| `src/components/AppSettingsMenu/ProviderDataSection.tsx` | Per-provider data management |
+| `src/components/AppSettingsMenu/styled.ts` | All styled-components for the drawer |
 | `src/constants/storage.ts` | `STORAGE_KEYS` constant object |
 | `src/hooks/useLocalStorage.ts` | Generic localStorage hook with cross-tab sync |
 | `src/hooks/useQapEnabled.ts` | QAP preference hook |
-| `src/contexts/VisualEffectsContext.tsx` | Visual effects state (glow, visualizer, translucence, zen) |
+| `src/contexts/visualEffects/VisualEffectsToggleContext.tsx` | Visual effects drawer open/close state (`showVisualEffects` / `setShowVisualEffects`) |
 | `src/providers/dropbox/dropboxPreferencesSync.ts` | Dropbox preferences sync service |
 | `src/components/PlayerContent/PlayerControlsSection.tsx` | Wires settings props from contexts to the drawer |

--- a/docs/features/visual-effects.md
+++ b/docs/features/visual-effects.md
@@ -4,9 +4,20 @@ The visual effects system controls ambient visual enhancements around the player
 
 ## VisualEffectsContext
 
-**File**: `src/contexts/VisualEffectsContext.tsx`
+**Directory**: `src/contexts/visualEffects/`
 
-Central state store for all visual effect preferences. Wraps the app and provides both state values and setters.
+Visual effect state is split across six focused context modules, each with its own provider and `use*` hook:
+
+| Context module | Hook | Owns |
+|---|---|---|
+| `VisualEffectsToggleContext.tsx` | `useVisualEffectsToggle` | `visualEffectsEnabled` (master toggle), `showVisualEffects` (transient menu-open state) |
+| `AccentColorBackgroundContext.tsx` | `useAccentColorBackground` | `accentColorBackgroundPreferred`, derived `accentColorBackgroundEnabled` |
+| `VisualizerContext.tsx` | `useVisualizer` | `backgroundVisualizerEnabled/Style/Intensity/Speed` + legacy-style migration |
+| `TranslucenceContext.tsx` | `useTranslucence` | `translucenceEnabled`, `translucenceOpacity` |
+| `ZenModeContext.tsx` | `useZenMode` | `zenModeEnabled` |
+| `GlowContext.tsx` | `useGlow` | `perAlbumGlow` |
+
+`src/contexts/visualEffects/index.tsx` re-exports these hooks and composes them via the `VisualEffectsProvider`.
 
 ### State Shape
 
@@ -59,12 +70,10 @@ All persisted fields use `useLocalStorage` with keys from `src/constants/storage
 
 ### Migration
 
-On mount, the context runs a one-time migration for old style names:
+On mount, `VisualizerContext` runs a one-time migration for old style names:
 - `'particles'` -> `'fireflies'`
 - `'trail'` -> `'comet'`
 - `'geometric'` -> `'fireflies'`
-
-It also removes the deprecated `vorbis-player-album-filters` key.
 
 ## Glow Effect
 
@@ -99,14 +108,14 @@ interface AccentColorGlowOverlayProps {
 
 ### Per-Album Glow
 
-`perAlbumGlow` in `VisualEffectsContext` is a `Record<string, { intensity: number; rate: number }>` keyed by some track/album identifier. This allows different glow settings per album. The data is persisted but the per-album override logic lives in the consuming components.
+`perAlbumGlow` in `GlowContext` is a `Record<string, { intensity: number; rate: number }>` keyed by some track/album identifier. This allows different glow settings per album. The data is persisted but the per-album override logic lives in the consuming components.
 
 ### Master Toggle Behavior
 
 The `visualEffectsEnabled` flag is the master glow toggle:
 - When toggled off: glow intensity passed to `AccentColorGlowOverlay` becomes 0
 - When toggled back on: `restoreGlowSettings()` restores the last user-set intensity/rate
-- Keyboard shortcut: `G` key (via `handleGlowToggle` in `PlayerControlsSection.tsx`)
+- Keyboard shortcut: `G` key (via `handleGlowToggle` in `PlayerControlsSection.tsx`); `visualEffectsEnabled` lives in `VisualEffectsToggleContext`
 
 ## Translucence
 
@@ -152,7 +161,7 @@ interface AccentColorBackgroundProps {
 
 ### Activation
 
-Controlled by `accentColorBackgroundEnabled` in `VisualEffectsContext`, which requires both:
+Controlled by `accentColorBackgroundEnabled` in `AccentColorBackgroundContext`, which requires both:
 1. `accentColorBackgroundPreferred` is `true` (user opted in)
 2. `visualEffectsEnabled` is `true` (master toggle is on)
 
@@ -164,9 +173,9 @@ The `backgroundVisualizerSpeed` value (default `1.0`) is a global speed multipli
 
 Controlled via a slider on the flip menu back (`QuickEffectsRow`). Persisted under `vorbis-player-background-visualizer-speed`.
 
-## Settings Menu (VisualEffectsMenu)
+## Settings Menu (AppSettingsMenu)
 
-**File**: `src/components/VisualEffectsMenu/index.tsx`
+**File**: `src/components/AppSettingsMenu/index.tsx` (imported in `AudioPlayer.tsx` under the local alias `VisualEffectsMenu`)
 
 Despite the name, this is the **app settings drawer**, not just visual effects. It renders as a right-side drawer via `createPortal` to `document.body`.
 
@@ -188,8 +197,8 @@ The glow, visualizer style, visualizer speed/intensity, translucence, and accent
 ### Opening
 
 - Gear icon in player controls
-- `O` keyboard shortcut
-- `showVisualEffects` state in `VisualEffectsContext` (transient, not persisted)
+- `Shift+S` keyboard shortcut
+- `showVisualEffects` state in `VisualEffectsToggleContext` (transient, not persisted)
 
 ## Keyboard Shortcuts
 
@@ -198,8 +207,8 @@ The glow, visualizer style, visualizer speed/intensity, translucence, and accent
 | `V` | Cycle visualizer style (fireflies -> comet -> wave -> grid -> fireflies) | `PlayerControlsSection.tsx` `handleCycleVisualizerStyle` |
 | `G` | Toggle glow (master visual effects toggle) | `PlayerControlsSection.tsx` `handleGlowToggle` |
 | `T` | Toggle translucence | `PlayerControlsSection.tsx` `handleTranslucenceToggle` |
-| `O` | Toggle settings menu | `PlayerControlsSection.tsx` `handleToggleVisualEffectsMenu` |
-| `Z` | Toggle zen mode | `PlayerControlsSection.tsx` |
+| `Shift+S` | Toggle settings menu | `PlayerControlsSection.tsx` `handleToggleVisualEffectsMenu` |
+| `Z` | Toggle zen mode | toggle defined in `PlayerContent/index.tsx`, forwarded via `onToggleZenMode` |
 
 ## Z-Index Stacking
 
@@ -215,7 +224,7 @@ From back to front:
 |---------|-------------|
 | **ColorContext** | Provides `accentColor` used by glow overlay and accent background gradient |
 | **Visualizers** | Speed multiplier and enabled/style/intensity flow from this context to `BackgroundVisualizer` |
-| **Zen mode** | `zenModeEnabled` stored here; glow and translucence remain active in zen mode |
+| **Zen mode** | `zenModeEnabled` stored in `ZenModeContext`; glow and translucence remain active in zen mode |
 | **Flip menu** | Primary UI surface for effect controls (`QuickEffectsRow` in `AlbumArtQuickSwapBack`) |
 | **Player sizing** | Settings drawer width adapts to viewport via `usePlayerSizingContext` |
 | **Dropbox preferences sync** | Clearing accent colors triggers a Dropbox preferences sync reset |
@@ -224,11 +233,11 @@ From back to front:
 
 | File | Role |
 |------|------|
-| `src/contexts/VisualEffectsContext.tsx` | Central state provider for all visual effect settings |
+| `src/contexts/visualEffects/` | Six split context modules + `VisualEffectsProvider` (index.tsx) for all visual effect settings |
 | `src/hooks/useVisualEffectsState.ts` | Glow intensity/rate state with save/restore |
 | `src/components/AccentColorGlowOverlay.tsx` | Pulsing glow layer behind album art |
 | `src/components/AccentColorBackground.tsx` | Full-viewport accent color gradient |
-| `src/components/VisualEffectsMenu/index.tsx` | Settings drawer (gear icon) |
+| `src/components/AppSettingsMenu/index.tsx` | Settings drawer (gear icon); aliased as `VisualEffectsMenu` in `AudioPlayer.tsx` |
 | `src/components/AlbumArtQuickSwapBack.tsx` | Flip menu back face, hosts `QuickEffectsRow` |
 | `src/components/controls/QuickEffectsRow.tsx` | Actual effect controls (glow, visualizer, translucence, accent color) |
 | `src/styles/animations.ts` | `breatheGlow` keyframes for glow animation |

--- a/docs/features/visualizers.md
+++ b/docs/features/visualizers.md
@@ -9,7 +9,7 @@ Four canvas-based animated backgrounds that render behind the player UI. Each is
 | `fireflies` | `ParticleVisualizer` | `src/components/visualizers/ParticleVisualizer.tsx` | `Particle` | Drifting circles with pulsing radius and opacity |
 | `comet` | `TrailVisualizer` | `src/components/visualizers/TrailVisualizer.tsx` | `TrailParticle` | A "ship" moves along a curving path, spawning trail particles that fade |
 | `wave` | `WaveVisualizer` | `src/components/visualizers/WaveVisualizer.tsx` | `Wave` | Layered sine waves rendered as filled regions from wave crest to canvas bottom |
-| `grid` | `GridWaveVisualizer` | `src/components/visualizers/GridWaveVisualizer.tsx` | `GridWaveState` | A dot grid displaced by traveling sine waves |
+| `grid` | `GridWaveVisualizer` | `src/components/visualizers/GridWaveVisualizer.tsx` | `GridParticle` | A dot grid displaced by traveling sine waves |
 
 The type union is `VisualizerStyle` in `src/types/visualizer.ts`:
 
@@ -34,7 +34,6 @@ interface UseCanvasVisualizerProps<T> {
   initializeItems: (count: number, width: number, height: number, color: string) => T[];
   updateItems: (items: T[], deltaTime: number, isPlaying: boolean, width: number, height: number) => void;
   renderItems: (ctx: CanvasRenderingContext2D, items: T[], width: number, height: number, intensity: number) => void;
-  onColorChange: (items: T[], color: string) => void;
 }
 ```
 
@@ -60,7 +59,7 @@ Returns `React.RefObject<HTMLCanvasElement>`. The caller attaches this to a `<ca
 
 ### Invariants and Gotchas
 
-- **Re-initialization on color change**: When `accentColor` changes, the entire item array is re-created (the effect depends on `accentColor`). The `onColorChange` callback is declared in the interface but **not called** by the hook -- it exists for future incremental color updates. Currently, color changes trigger full re-init.
+- **Re-initialization on color change**: When `accentColor` changes, the entire item array is re-created (the effect depends on `accentColor`). Currently, color changes trigger full re-init.
 - **Canvas sizing uses `window.innerWidth/Height`**, not CSS dimensions. The canvas element is styled `width: 100%; height: 100%` with `display: block`. The pixel dimensions are set imperatively on the canvas element, so there is **no DPI scaling** (`devicePixelRatio` is not applied). This means on high-DPI screens, the canvas renders at 1x resolution, which is intentional for performance -- these are ambient backgrounds, not crisp UI elements.
 - **Delta time normalization**: All visualizers normalize deltaTime by dividing by 16 (`dt = deltaTime / 16`), treating 16ms (~60fps) as the baseline.
 - **`useAnimationFrame`** (`src/hooks/useAnimationFrame.ts`) wraps `requestAnimationFrame` with cleanup. It skips the first frame to establish a baseline timestamp. The `callback` is a dependency of its internal effect, so it must be stable (wrapped in `useCallback`).
@@ -81,7 +80,8 @@ interface BackgroundVisualizerProps {
   speed?: number;            // multiplier, default 1.0
   accentColor: string;       // hex color from current track
   isPlaying: boolean;
-  albumArtBounds?: AlbumArtBounds | null;  // only used by 'comet' style
+  dimmed?: boolean | undefined;            // fades the container to 0.2 opacity (e.g. when library view is open)
+  albumArtBounds?: AlbumArtBounds | null | undefined;  // only used by 'comet' style
 }
 ```
 
@@ -92,6 +92,7 @@ Wrapped in a `VisualizerContainer` styled-component:
 - `z-index: 1` (below ContentWrapper at z-index 2, above AccentColorBackground at z-index 0)
 - `pointer-events: none` -- never intercepts clicks
 - `overflow: hidden`
+- `opacity` 1, or 0.2 when `dimmed` (with a 250ms ease transition and `will-change: opacity`)
 
 ### Wiring in AudioPlayer
 
@@ -100,6 +101,7 @@ Wrapped in a `VisualizerContainer` styled-component:
 - `style`, `intensity`, `speed` from `VisualEffectsContext`
 - `accentColor` from `ColorContext`
 - `isPlaying` from player state
+- `dimmed` = `state.currentView === 'library'`
 
 Note: `albumArtBounds` is declared in the props interface but is **not currently wired** from `AudioPlayer`. The `TrailVisualizer` supports it (constraining the ship to the album art rect) but falls back to viewport center when not provided.
 
@@ -129,7 +131,7 @@ Note: `albumArtBounds` is declared in the props interface but is **not currently
 - Each wave has a unique phase speed distributed via golden ratio (`PHI^(i/count*2)`)
 - Waves render back-to-front as filled shapes from the sine curve down to the bottom of the canvas
 - `yBase` distributes waves vertically across the canvas (`yBaseStart` to `yBaseStart + yBaseLayerScale`)
-- Amplitude scales by 0.65x on mobile (`width < 768`)
+- Amplitude scales by 0.65x on mobile (`width < BREAKPOINTS_PX.lg`, i.e. 700px)
 - Item count is fixed (always `waveCount`), not dependent on screen area
 
 ### Grid (`GridWaveVisualizer`)
@@ -138,8 +140,8 @@ Note: `albumArtBounds` is declared in the props interface but is **not currently
 - Multiple `WaveState` objects (default 2) travel through the grid
 - Dot displacement is the average of all wave sine projections
 - Edge and depth factors create a perspective-like intensity gradient
-- **Unusual `T` usage**: The generic type is `GridWaveState[]` but the hook always creates a single-element array (`[{ particles, waves, width, height }]`). The hook's `getItemCount` returns 1 (mobile or desktop), and `initializeItems` returns one `GridWaveState` containing all grid particles and wave states. This is a pattern to pack multiple data structures into the generic slot.
-- `void count` on line 87 suppresses the unused-parameter warning for the count arg
+- **Item type and metadata split**: The generic type is `GridParticle` (`useCanvasVisualizer<GridParticle>`); `initializeItems` returns a `GridParticle[]` with one entry per grid dot. The traveling `WaveState[]` plus `rows`/`cols` are stored in a separate `metaRef` (not in the generic item slot), so `updateItems` advances the wave phases on `metaRef.current.waves` while `renderItems` reads `metaRef.current` to displace each particle.
+- `getItemCount` returns `countBaseMobile`/`countBaseDesktop` from config (both default to 1)
 
 ## Debug Panel System
 
@@ -161,8 +163,8 @@ Profiler and Visualizer Debug are mutually exclusive: enabling one disables the 
 
 ```ts
 interface VisualizerDebugConfig {
-  particle: ParticleVisualizerConfig;  // 14 params
-  trail: TrailVisualizerConfig;        // 20 params
+  particle: ParticleVisualizerConfig;  // 15 params
+  trail: TrailVisualizerConfig;        // 21 params
   wave: WaveVisualizerConfig;          // 12 params
   grid: GridWaveVisualizerConfig;      // 17 params
 }
@@ -177,7 +179,7 @@ Default values are in `DEFAULT_VISUALIZER_DEBUG_CONFIG` (exported from `visualiz
    - Merged config (defaults + overrides) when debug mode is on
 2. Overrides are stored in localStorage under `STORAGE_KEYS.VISUALIZER_DEBUG_OVERRIDES` (`vorbis-player-visualizer-debug-overrides`)
 3. `mergeVisualizerConfig()` does a shallow merge per section (override keys replace defaults, unset keys keep defaults)
-4. The debug panel exposes per-param sliders for `particle` and `trail` sections only (wave and grid are not yet in the panel UI but their overrides are loaded/saved)
+4. The debug panel exposes per-param sliders/number inputs for all four sections: Fireflies (`particle`), Comet (`trail`), Wave (`wave`), and Grid Wave (`grid`)
 
 ### Export/Import
 


### PR DESCRIPTION
Part of a documentation accuracy sweep (one PR per doc area). This PR covers `docs/features/` — the largest batch (78 verified findings across 9 files). Findings came from a vetting workflow that checked each claim against the code and adversarially re-verified it.

## Highlights

**Renames / moved code (appears across multiple files)**
- `VisualEffectsMenu/` → `AppSettingsMenu/` (the settings drawer dir).
- `VisualEffectsContext.tsx` → six split modules under `src/contexts/visualEffects/` (toggle, accent-bg, visualizer, translucence, zen, glow).
- The settings/effects-menu shortcut is **Shift+S**, not `O` (no `KeyO` handler exists).

**settings.md** — `CollapsibleSection` replaced by a shadcn `Accordion`; `useVisualEffectsContext` → `useVisualEffectsToggle`; added the `vorbis-player-settings-v2-enabled` key; corrected all Key Files paths.

**library.md** — no `liked` home section / `LibraryRouteView` value; `L`/`↓` open the **Quick Access Panel**, not the library; `CommandPalette`/`useCommandPaletteShortcut` don't exist (Cmd-K is `CmdKPalette`); corrected context-menu actions and section-hook return shapes.

**player-controls.md** — rewrote the `PlayerStateRenderer` routing description; corrected `providers.ts`/`domain.ts` line numbers; fixed `usePlayerLogic`/`useProviderPlayback` return shapes and `expectedTrackIdRef` ownership.

**queue.md** — corrected the `onQueueChanged` flow; shuffle key is `vorbis-player-shuffle-enabled`; `onQueueChanged` signature is at `providers.ts:144`.

**providers.md** — Dropbox art DB is **v7**; `loadSpotifySDK()` (not a service method); retry cap is `SPOTIFY_MAX_RETRIES`; `AuthExpiredError.providerId: ProviderId`; queue-sync fields live on `SpotifyPlaybackAdapter`.

**visualizers.md** — `useCanvasVisualizer` has no `onColorChange`; Grid uses `GridParticle` (not `GridWaveState`); debug panel covers all four styles; corrected param counts, the Wave breakpoint (`BREAKPOINTS_PX.lg`), and the `dimmed` prop.

**profiler.md** — correct profiler-ID directory; `ProfilingProvider` is rendered in `AudioPlayer.tsx`; five instrumented systems (not four); added the `vorbis:art-race` namespace; corrected overlay button labels.

**album-art.md** — `styled.ts` (not `.tsx`); the album-art max-width lives in the sizing layer, not `AlbumArt.tsx`.

Documentation-only.