### PR TITLE
docs(providers): complete audio format list, fix Connect button label

### DIFF
--- a/docs/providers/dropbox-setup.md
+++ b/docs/providers/dropbox-setup.md
@@ -24,7 +24,7 @@ Dropbox/
 - Each folder containing audio files becomes an **album**
 - The parent folder name is used as the **artist**
 - Audio files at the root of your Dropbox (not in a subfolder) are skipped
-- Supported formats: **MP3, FLAC, OGG/Vorbis, M4A/AAC, WAV**
+- Supported formats: **MP3, FLAC, OGG/Vorbis, M4A/AAC, WAV, WMA, Opus**
 
 **Album art**: Place an image file named `cover.jpg`, `cover.png`, `folder.jpg`, `album.jpg`, or `front.jpg` alongside your audio files. Track metadata (title, artist, track number) is read from embedded ID3 tags when available.
 

--- a/docs/providers/spotify-setup.md
+++ b/docs/providers/spotify-setup.md
@@ -48,7 +48,7 @@ Open [http://127.0.0.1:3000](http://127.0.0.1:3000) in your browser (not `localh
 
 ## Step 5: Connect Spotify
 
-1. Click **Connect Spotify** on the welcome screen
+1. Click **Connect** on the Spotify card on the welcome screen
 2. You'll be redirected to Spotify to authorize the app
 3. After authorizing, you'll be sent back to the player
 4. Your playlists and Liked Songs will load automatically


### PR DESCRIPTION
Part of a documentation accuracy sweep (one PR per doc area). This PR covers `docs/providers/` setup guides.

## Changes

- **dropbox-setup.md** — supported audio formats also include **WMA** and **Opus** (the scanner's `AUDIO_EXTENSIONS` is `.mp3 .flac .ogg .m4a .wav .aac .wma .opus`).
- **spotify-setup.md** — the welcome screen renders a Spotify **card with a "Connect" button**, not a "Connect Spotify" button.

Documentation-only.