### PR TITLE
docs(deployment): fix Spotify SDK label typo, drop inapplicable image optimization

### DIFF
--- a/docs/deployment/deploy-to-vercel.md
+++ b/docs/deployment/deploy-to-vercel.md
@@ -17,7 +17,7 @@ This guide will help you deploy your Vorbis Player to Vercel in just a few simpl
    - **App Description**: Modern Spotify music player
    - **Website**: Your Vercel URL (you'll update this after deployment)
    - **Redirect URI**: `https://your-app-name.vercel.app/auth/spotify/callback`
-   - **Which API/SDKs are you planning to use?**: Web Playbook SDK
+   - **Which API/SDKs are you planning to use?**: Web Playback SDK
 4. Save your app and copy the **Client ID**
 
 ## Step 2: Deploy to Vercel
@@ -166,7 +166,6 @@ For ongoing development:
 Your app is already optimized for Vercel with:
 - ✅ Static site generation
 - ✅ Automatic code splitting
-- ✅ Image optimization
 - ✅ Edge caching
 - ✅ Gzip compression
 - ✅ Security headers


### PR DESCRIPTION
Part of a documentation accuracy sweep (one PR per doc area). This PR covers `docs/deployment/`.

## Changes

- **Web Playbook SDK → Web Playback SDK** — typo for the actual Spotify Developer Dashboard option label.
- Removed **"Image optimization"** from the Vercel optimizations list — Vercel Image Optimization only applies to Next.js / the Vercel Image API; this is a static Vite SPA, so the claim is misleading.

Documentation-only.