### PR TITLE
chore: drop unused type re-exports surfaced by knip

### DIFF
--- a/src/components/LibraryRoute/types.ts
+++ b/src/components/LibraryRoute/types.ts
@@ -1,8 +1,4 @@
-import type { CollectionRef, ProviderId, MediaTrack } from '@/types/domain';
-import type { CachedPlaylistInfo } from '@/services/cache/cacheTypes';
-import type { AlbumInfo } from '@/services/spotify/types';
-import type { RecentlyPlayedEntry } from '@/hooks/useRecentlyPlayedCollections';
-import type { SessionSnapshot } from '@/services/sessionPersistence';
+import type { CollectionRef, ProviderId } from '@/types/domain';
 
 export interface UseCollectionSectionParams {
   providerFilter?: ProviderId[];
@@ -58,11 +54,4 @@ export type ContextMenuRequest = ContextMenuRequestBase &
       }
   );
 
-export type {
-  CachedPlaylistInfo,
-  AlbumInfo,
-  MediaTrack,
-  ProviderId,
-  RecentlyPlayedEntry,
-  SessionSnapshot,
-};
+export type { ProviderId };

--- a/src/services/cache/libraryCacheLifecycle.ts
+++ b/src/services/cache/libraryCacheLifecycle.ts
@@ -23,7 +23,7 @@ export const STORE_META = 'meta';
  * API has to serve any store, and IDB itself persists structured-cloneable
  * data without per-store typing.
  */
-export type FallbackStores = Record<string, Map<string, unknown>>;
+type FallbackStores = Record<string, Map<string, unknown>>;
 
 export const fallbackStores: FallbackStores = {
   [STORE_PLAYLISTS]: new Map(),


### PR DESCRIPTION
Removes the last actionable dead exports flagged by `knip` on `main`.

## Context
A dead-code sweep was run across the project (knip → per-finding adversarial verification). The bulk of the original 109 findings were already cleaned on `main` by #1616 ("remove exports from module-private types and trim barrel re-exports"). Re-running the analysis against current `main` left only these 6 genuinely-dead symbols in 2 files.

## Changes
- **`LibraryRoute/types.ts`** — remove 5 pass-through type re-exports (`CachedPlaylistInfo`, `AlbumInfo`, `MediaTrack`, `RecentlyPlayedEntry`, `SessionSnapshot`); every consumer imports these from their canonical source, never via this barrel. Their now-unused imports are dropped too. `ProviderId` is retained (still consumed via the barrel).
- **`services/cache/libraryCacheLifecycle.ts`** — drop `export` from `FallbackStores` (used only in-file to type the local `fallbackStores` const).

## Verification
- `npx tsc -b --noEmit` — passes.
- `npm run test:run` — 2049 passed.
- `knip` — only remaining finding is the `zenAnimation` ZEN_ART_DURATION/ZEN_EXIT_REENTRY_DELAY equal-value pair, which is a false positive (both constants are independently imported and used).