### PR TITLE
chore: un-export module-private LibraryRouteProps

### DIFF
--- a/src/components/LibraryRoute/index.tsx
+++ b/src/components/LibraryRoute/index.tsx
@@ -14,7 +14,7 @@ import { useLibrarySearch } from './search/useLibrarySearch';
 import LibraryContextMenu from './contextMenu/LibraryContextMenu';
 import { LibraryContextMenuOpenContext } from './contextMenu/LibraryContextMenuOpenContext';
 
-export interface LibraryRouteProps {
+interface LibraryRouteProps {
   onPlaylistSelect: (playlistId: string, playlistName: string, provider?: ProviderId) => void;
   onAddToQueue: (id: string, name?: string, provider?: ProviderId) => Promise<AddToQueueResult | null>;
   onPlayLikedTracks?: ((


### PR DESCRIPTION
Tail-end of the knip dead-code sweep (follow-up to #1625, surfaced by the final review).

`LibraryRouteProps` in `src/components/LibraryRoute/index.tsx` is consumed only in-file as the `LibraryRoute` component's own `React.FC<LibraryRouteProps>` annotation — nothing imports it. Removes the `export` keyword; the declaration stays.

## Verification
- `npx tsc -b --noEmit` — passes.
- `npm run test:run` — 2049 passed.