### PR TITLE
fix(playback): stop manual next/prev at queue boundaries instead of wrapping

### DIFF
--- a/openspec/changes/stop-at-queue-end/.openspec.yaml
+++ b/openspec/changes/stop-at-queue-end/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/stop-at-queue-end/design.md
+++ b/openspec/changes/stop-at-queue-end/design.md
@@ -1,0 +1,32 @@
+# Design: stop-at-queue-end
+
+## Context
+
+Two end-of-queue behaviors coexist. Manual navigation in `src/hooks/usePlayerLogic.ts` wraps: `handleNext` computes `(current + 1) % tracks.length` and `handlePrevious` computes `current === 0 ? tracks.length - 1 : current - 1`. Auto-advance in `src/hooks/useAutoAdvance.ts:87-90` explicitly stops when `currentIdx >= totalTracks - 1`. Issue #1566 selected Option B: both paths stop at the queue boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make manual Next a no-op at the last track, matching auto-advance.
+- Make manual Previous clamp at the first track instead of wrapping to the last.
+- Document the canonical boundary behavior in the playback-engine spec.
+
+**Non-Goals:**
+
+- No repeat-mode concept (Option C) — flagged in the issue as out of scope.
+- No change to auto-advance logic, shuffle, radio queue generation, or provider adapters.
+- No UI affordance changes (e.g., disabling the Next button at queue end).
+
+## Decisions
+
+**Next at last track is a no-op.** `handleNext` returns early when `currentTrackIndexRef.current >= tracks.length - 1`, leaving the current track playing (or paused) untouched. Alternative considered: stop playback entirely — rejected because pressing Next mid-track and getting silence is harsher than ignoring the press, and auto-advance's "stop" is just the absence of an advance, which the no-op mirrors exactly.
+
+**Previous at first track restarts the first track.** `handlePrevious` clamps `newIndex` to `0` instead of wrapping to `tracks.length - 1`. Since the existing code path calls `playTrack(newIndex, true)`, clamping to the current index naturally restarts the track from the beginning — the convention in Spotify, Apple Music, and most players. Alternative considered: no-op like Next — rejected because restart-on-previous is the dominant platform convention and falls out of the existing code path for free.
+
+**Spec documents both paths.** The Auto-Advance requirement gains an explicit end-of-queue stop scenario (current behavior, previously unspecified), and a new requirement covers manual navigation boundaries, so the reconciled behavior is durable.
+
+## Risks / Trade-offs
+
+- [Users accustomed to wrap-around lose a shortcut to jump from last to first track] → Acceptable; the behavior was an accident of modulo arithmetic, and queue UI (drawer/bottom sheet) provides direct track selection.
+- [Tests asserting wrap-around will fail] → Update them as part of the change; the failures are the verification that the change landed.

--- a/openspec/changes/stop-at-queue-end/proposal.md
+++ b/openspec/changes/stop-at-queue-end/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: stop-at-queue-end
+
+## Why
+
+Manual next/previous (`handleNext`/`handlePrevious` in `src/hooks/usePlayerLogic.ts`) wrap around the queue via modulo arithmetic, while auto-advance (`src/hooks/useAutoAdvance.ts`) stops at the end of the queue. The asymmetry is surprising: letting the last track finish stops playback, but pressing Next on the last track jumps back to track 1. Issue #1566 asks for one canonical end-of-queue behavior; Option B (both stop) was chosen — it matches most music apps and respects the queue as finite.
+
+## What Changes
+
+- `handleNext` no longer wraps from the last track to the first; at the end of the queue it becomes a no-op.
+- `handlePrevious` no longer wraps from the first track to the last; at the start of the queue it restarts the current (first) track from the beginning, matching platform conventions.
+- Auto-advance behavior is unchanged (already stops at queue end) but becomes spec-documented as the canonical behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `playback-engine`: Auto-Advance gains an explicit end-of-queue stop scenario, and a new requirement documents manual next/previous boundary behavior (no wrap-around).
+
+## Impact
+
+- `src/hooks/usePlayerLogic.ts` — `handleNext` / `handlePrevious` index computation.
+- Unit tests covering manual navigation boundaries (update wrap expectations to stop expectations).
+- No provider adapter, queue-management, or UI surface changes.

--- a/openspec/changes/stop-at-queue-end/specs/playback-engine/spec.md
+++ b/openspec/changes/stop-at-queue-end/specs/playback-engine/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Manual Navigation Queue Boundaries
+
+Manual next and previous controls SHALL treat the queue as finite and SHALL NOT wrap around its boundaries. Invoking next on the last track SHALL be a no-op that leaves the current track and playback state untouched. Invoking previous on the first track SHALL restart the first track from the beginning.
+
+#### Scenario: Next on the last track
+
+- **WHEN** the user invokes next while the last track in the queue is current
+- **THEN** the current track index is unchanged
+- **AND** no new playback is initiated
+
+#### Scenario: Previous on the first track
+
+- **WHEN** the user invokes previous while the first track in the queue is current
+- **THEN** the first track restarts from the beginning
+
+#### Scenario: Next within the queue
+
+- **WHEN** the user invokes next while a track before the last is current
+- **THEN** playback advances to the following track
+
+#### Scenario: Previous within the queue
+
+- **WHEN** the user invokes previous while a track after the first is current
+- **THEN** playback moves to the preceding track
+
+## MODIFIED Requirements
+
+### Requirement: Auto-Advance on Track End
+
+The engine SHALL detect track end and advance to the next track in the queue. Track end SHALL be recognized from either of two signals: a near-end signal when remaining time falls below a threshold, or a natural-end signal when the driving provider transitions from playing to paused at position zero. When the ended track is the last track in the queue, the engine SHALL stop instead of wrapping to the first track.
+
+#### Scenario: Near-end signal
+
+- **WHEN** the driving provider reports remaining time below the near-end threshold
+- **THEN** the engine advances to the next track
+
+#### Scenario: Natural-end signal
+
+- **WHEN** the driving provider transitions from playing to paused at position zero
+- **THEN** the engine advances to the next track
+
+#### Scenario: Cooldown suppresses false trigger
+
+- **WHEN** an auto-advance signal fires within the cooldown window of a fresh track start
+- **THEN** the signal is ignored
+
+#### Scenario: Last track ends
+
+- **WHEN** the last track in the queue ends
+- **THEN** playback stops
+- **AND** the current track index is unchanged

--- a/openspec/changes/stop-at-queue-end/tasks.md
+++ b/openspec/changes/stop-at-queue-end/tasks.md
@@ -1,0 +1,14 @@
+## 1. Manual navigation boundary behavior
+
+- [x] 1.1 Update `handleNext` in `src/hooks/usePlayerLogic.ts` to return early when the current track is the last (`currentTrackIndexRef.current >= tracks.length - 1`) instead of wrapping via modulo
+- [x] 1.2 Update `handlePrevious` in `src/hooks/usePlayerLogic.ts` to clamp `newIndex` to `0` at the first track instead of wrapping to `tracks.length - 1`
+
+## 2. Tests
+
+- [x] 2.1 Replace the wrap-around test at `src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx:246` ("handleNext wraps around to the first track at the end of the queue") with a test asserting handleNext is a no-op on the last track (index unchanged, no playTrack call)
+- [x] 2.2 Replace the wrap-around test at `src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx:260` ("handlePrevious wraps to the last track from index 0") with a test asserting handlePrevious at index 0 restarts the first track (playTrack called with index 0)
+- [x] 2.3 Run the full suite (`npm run test:run`) and TypeScript check (`npx tsc -b --noEmit`); confirm `useAutoAdvance.test.ts` end-of-queue test still passes unchanged
+
+## 3. Spec sync
+
+- [x] 3.1 Verify the delta spec at `openspec/changes/stop-at-queue-end/specs/playback-engine/spec.md` matches the implemented behavior (no-op next at last track, restart-from-start previous at first track, auto-advance stop documented)

--- a/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.hydrate.test.tsx
@@ -289,8 +289,8 @@ describe('usePlayerLogic — handleHydrate', () => {
   });
 
   it('discards a pending hydrate when handleNext runs first', async () => {
-    // #given
-    const session = makeSession();
+    // #given — hydrate at index 0 so handleNext has a next track to advance to
+    const session = makeSession({ trackIndex: 0, trackId: 'track-a' });
     const { result } = renderHook(() => usePlayerLogic(), { wrapper: AllProviders });
 
     await act(async () => {
@@ -309,7 +309,7 @@ describe('usePlayerLogic — handleHydrate', () => {
     });
 
     // #then — handleNext took over; subsequent handlePlay uses resume, not a hydrated start
-    expect(nextCall?.[0]).toBe(0); // wrapped around from index 1 -> 0 in a 2-track queue
+    expect(nextCall?.[0]).toBe(1); // advanced from index 0 -> 1 in a 2-track queue
     expect(playTrackSpy).not.toHaveBeenCalled();
     expect(mockDescriptor.playback.resume).toHaveBeenCalled();
   });

--- a/src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx
+++ b/src/hooks/__tests__/usePlayerLogic.nextPrevious.test.tsx
@@ -243,7 +243,7 @@ describe.each([
     expect(descriptor.playback.resume).toHaveBeenCalled();
   });
 
-  it('handleNext wraps around to the first track at the end of the queue', async () => {
+  it('handleNext is a no-op at the end of the queue', async () => {
     // #given — paused player at the last index
     const result = await setupPausedQueue(2);
 
@@ -252,12 +252,12 @@ describe.each([
       await result.current.handlers.handleNext();
     });
 
-    // #then
-    expect(playTrackSpy.mock.calls[0][0]).toBe(0);
-    expect(descriptor.playback.resume).toHaveBeenCalled();
+    // #then — queue is finite: no playback initiated, index unchanged
+    expect(playTrackSpy).not.toHaveBeenCalled();
+    expect(descriptor.playback.resume).not.toHaveBeenCalled();
   });
 
-  it('handlePrevious wraps to the last track from index 0', async () => {
+  it('handlePrevious restarts the first track from index 0', async () => {
     // #given — paused player at the first index
     const result = await setupPausedQueue(0);
 
@@ -266,8 +266,8 @@ describe.each([
       await result.current.handlers.handlePrevious();
     });
 
-    // #then
-    expect(playTrackSpy.mock.calls[0][0]).toBe(2);
+    // #then — clamps at the queue start and replays track 0
+    expect(playTrackSpy.mock.calls[0][0]).toBe(0);
     expect(descriptor.playback.resume).toHaveBeenCalled();
   });
 

--- a/src/hooks/usePlayerLogic.ts
+++ b/src/hooks/usePlayerLogic.ts
@@ -231,7 +231,11 @@ export function usePlayerLogic() {
 
   const handleNext = useCallback(async () => {
     if (tracks.length === 0) return;
-    const nextIndex = (currentTrackIndexRef.current + 1) % tracks.length;
+    if (currentTrackIndexRef.current >= tracks.length - 1) {
+      logQueue('handleNext — at end of queue (%d/%d), stopping', currentTrackIndexRef.current, tracks.length);
+      return;
+    }
+    const nextIndex = currentTrackIndexRef.current + 1;
     logQueue(
       'handleNext — %d → %d, target=%s, queueLen=%d, mediaLen=%d',
       currentTrackIndexRef.current,
@@ -247,7 +251,7 @@ export function usePlayerLogic() {
 
   const handlePrevious = useCallback(async () => {
     if (tracks.length === 0) return;
-    const newIndex = currentTrackIndexRef.current === 0 ? tracks.length - 1 : currentTrackIndexRef.current - 1;
+    const newIndex = Math.max(0, currentTrackIndexRef.current - 1);
     logQueue(
       'handlePrevious — %d → %d, target=%s, queueLen=%d, mediaLen=%d',
       currentTrackIndexRef.current,


### PR DESCRIPTION
## Summary

Reconciles the end-of-queue asymmetry between manual navigation and auto-advance (Option B from #1566 — both stop):

- `handleNext` is now a no-op on the last track, mirroring auto-advance's existing stop behavior, instead of wrapping to track 1 via modulo.
- `handlePrevious` clamps at the first track, restarting it from the beginning (standard platform convention), instead of wrapping to the last track.
- Auto-advance code is untouched; its stop-at-end behavior is now spec-documented as canonical.

Includes the `stop-at-queue-end` OpenSpec change (proposal, design, tasks) with a `playback-engine` delta spec adding a **Manual Navigation Queue Boundaries** requirement and an explicit **Last track ends → stop** scenario to Auto-Advance.

## Test plan

- Replaced the two wrap-around tests in `usePlayerLogic.nextPrevious.test.tsx` with boundary-behavior assertions (no-op Next at last track; Previous at index 0 restarts track 0).
- Updated the hydrate-discard test to hydrate at index 0, since Next at the last track no longer initiates playback.
- `npx tsc -b --noEmit` clean; `npm run test:run` 2049/2049 passing.

Closes #1566