### PR TITLE
refactor(queue): migrate QueueContextMenu to ui/popover virtual anchor

### DIFF
--- a/src/components/QueueContextMenu.tsx
+++ b/src/components/QueueContextMenu.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 
 interface ContextMenuOption {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
-  destructive?: boolean;
+  destructive?: boolean | undefined;
 }
 
 interface QueueContextMenuProps {
@@ -16,114 +17,124 @@ interface QueueContextMenuProps {
   onClose: () => void;
 }
 
-const Overlay = styled.div`
+const VirtualAnchor = styled.div`
   position: fixed;
-  inset: 0;
-  z-index: ${({ theme }) => theme.zIndex.modal};
+  width: 0;
+  height: 0;
+  pointer-events: none;
 `;
 
-const MenuContainer = styled.div<{ $x: number; $y: number }>`
-  position: fixed;
-  left: ${({ $x }) => $x}px;
-  top: ${({ $y }) => $y}px;
-  z-index: ${({ theme }) => theme.zIndex.popover};
+const MenuRoot = styled.div`
+  display: flex;
+  flex-direction: column;
   min-width: 180px;
-  background: ${({ theme }) => theme.colors.popover.background};
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
-  border-radius: ${({ theme }) => theme.borderRadius.xl};
-  box-shadow: ${({ theme }) => theme.shadows.popover};
-  padding: ${({ theme }) => theme.spacing.xs};
-  animation: contextMenuFadeIn ${({ theme }) => theme.transitions.fast} ease-out;
-
-  @keyframes contextMenuFadeIn {
-    from {
-      opacity: 0;
-      transform: scale(0.96) translateY(-4px);
-    }
-    to {
-      opacity: 1;
-      transform: scale(1) translateY(0);
-    }
-  }
+  padding: ${theme.spacing.xs};
+  gap: 1px;
 `;
 
-const MenuItem = styled.button<{ $destructive?: boolean | undefined }>`
+const MenuItemButton = styled.button<{ $destructive?: boolean | undefined }>`
   display: flex;
   align-items: center;
   gap: 0.625rem;
   width: 100%;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.lg};
-  background: none;
-  border: none;
-  color: ${({ theme, $destructive }) =>
-    $destructive ? theme.colors.error : theme.colors.foreground};
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  font-weight: ${({ theme }) => theme.fontWeight.medium};
-  cursor: pointer;
-  border-radius: ${({ theme }) => theme.borderRadius.lg};
-  transition: background ${({ theme }) => theme.transitions.fast} ease;
-  white-space: nowrap;
   text-align: left;
+  background: transparent;
+  border: none;
+  padding: ${theme.spacing.sm} ${theme.spacing.lg};
+  font-size: ${theme.fontSize.sm};
+  font-weight: ${theme.fontWeight.medium};
+  color: ${({ $destructive }) =>
+    $destructive ? theme.colors.error : theme.colors.foreground};
+  border-radius: ${theme.borderRadius.lg};
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background ${theme.transitions.fast};
 
-  &:hover {
-    background: ${({ theme }) => theme.colors.control.background};
+  &:hover:not(:disabled) {
+    background: ${theme.colors.control.background};
   }
 
-  &:active {
-    background: ${({ theme }) => theme.colors.control.backgroundHover};
+  &:active:not(:disabled) {
+    background: ${theme.colors.control.backgroundHover};
+  }
+
+  &:focus-visible {
+    background: ${theme.colors.control.background};
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: -2px;
   }
 
   svg {
     flex-shrink: 0;
     width: 16px;
     height: 16px;
-    color: ${({ theme, $destructive }) =>
+    color: ${({ $destructive }) =>
       $destructive ? theme.colors.error : theme.colors.muted.foreground};
   }
 `;
 
-function clampToViewport(x: number, y: number, menuWidth = 200, menuHeight = 120): { x: number; y: number } {
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-  return {
-    x: Math.min(x, vw - menuWidth - 8),
-    y: Math.min(y, vh - menuHeight - 8),
-  };
-}
-
 export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  const { x: cx, y: cy } = clampToViewport(x, y);
+  const anchorStyle: React.CSSProperties = { left: x, top: y };
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  const handleMenuKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = Array.from(
+      e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
+    );
+    if (!items.length) return;
+    const idx = items.indexOf(document.activeElement as HTMLButtonElement);
 
-  return createPortal(
-    <>
-      <Overlay onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
-      <MenuContainer ref={menuRef} $x={cx} $y={cy}>
-        {options.map((option, index) => (
-          <MenuItem
-            key={index}
-            $destructive={option.destructive}
-            onClick={() => {
-              option.onClick();
-              onClose();
-            }}
-          >
-            {option.icon}
-            {option.label}
-          </MenuItem>
-        ))}
-      </MenuContainer>
-    </>,
-    document.body
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      items[(idx + 1) % items.length]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      items[(idx - 1 + items.length) % items.length]?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      items[0]?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      items[items.length - 1]?.focus();
+    }
+  }, []);
+
+  return (
+    <Popover open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <PopoverAnchor asChild>
+        <VirtualAnchor aria-hidden style={anchorStyle} />
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={4}
+        data-testid="queue-context-menu"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          const container = e.currentTarget as HTMLElement | null;
+          const first = container?.querySelector<HTMLButtonElement>(
+            '[role="menuitem"]:not(:disabled)',
+          );
+          first?.focus();
+        }}
+      >
+        <MenuRoot role="menu" aria-label="Queue track actions" onKeyDown={handleMenuKeyDown}>
+          {options.map((option, index) => (
+            <MenuItemButton
+              key={index}
+              type="button"
+              role="menuitem"
+              $destructive={option.destructive}
+              onClick={() => {
+                option.onClick();
+                onClose();
+              }}
+            >
+              {option.icon}
+              {option.label}
+            </MenuItemButton>
+          ))}
+        </MenuRoot>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/QueueContextMenu.tsx
+++ b/src/components/QueueContextMenu.tsx
@@ -2,6 +2,11 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import {
+  MenuItemButton,
+  MenuRoot,
+  VirtualAnchor,
+} from './LibraryRoute/contextMenu/LibraryContextMenu.styled';
 
 interface ContextMenuOption {
   label: string;
@@ -17,59 +22,20 @@ interface QueueContextMenuProps {
   onClose: () => void;
 }
 
-const VirtualAnchor = styled.div`
-  position: fixed;
-  width: 0;
-  height: 0;
-  pointer-events: none;
-`;
-
-const MenuRoot = styled.div`
-  display: flex;
-  flex-direction: column;
-  min-width: 180px;
-  padding: ${theme.spacing.xs};
-  gap: 1px;
-`;
-
-const MenuItemButton = styled.button<{ $destructive?: boolean | undefined }>`
+const QueueMenuItemButton = styled(MenuItemButton)`
   display: flex;
   align-items: center;
   gap: 0.625rem;
-  width: 100%;
-  text-align: left;
-  background: transparent;
-  border: none;
-  padding: ${theme.spacing.sm} ${theme.spacing.lg};
-  font-size: ${theme.fontSize.sm};
-  font-weight: ${theme.fontWeight.medium};
-  color: ${({ $destructive }) =>
-    $destructive ? theme.colors.error : theme.colors.foreground};
-  border-radius: ${theme.borderRadius.lg};
-  cursor: pointer;
   white-space: nowrap;
-  transition: background ${theme.transitions.fast};
-
-  &:hover:not(:disabled) {
-    background: ${theme.colors.control.background};
-  }
-
-  &:active:not(:disabled) {
-    background: ${theme.colors.control.backgroundHover};
-  }
-
-  &:focus-visible {
-    background: ${theme.colors.control.background};
-    outline: 2px solid rgba(255, 255, 255, 0.6);
-    outline-offset: -2px;
-  }
 
   svg {
     flex-shrink: 0;
     width: 16px;
     height: 16px;
-    color: ${({ $destructive }) =>
-      $destructive ? theme.colors.error : theme.colors.muted.foreground};
+    color: ${({ $variant }) =>
+      $variant === 'destructive'
+        ? theme.colors.menu.destructiveText
+        : theme.colors.muted.foreground};
   }
 `;
 
@@ -119,11 +85,11 @@ export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuPro
       >
         <MenuRoot role="menu" aria-label="Queue track actions" onKeyDown={handleMenuKeyDown}>
           {options.map((option, index) => (
-            <MenuItemButton
+            <QueueMenuItemButton
               key={index}
               type="button"
               role="menuitem"
-              $destructive={option.destructive}
+              $variant={option.destructive ? 'destructive' : 'default'}
               onClick={() => {
                 option.onClick();
                 onClose();
@@ -131,7 +97,7 @@ export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuPro
             >
               {option.icon}
               {option.label}
-            </MenuItemButton>
+            </QueueMenuItemButton>
           ))}
         </MenuRoot>
       </PopoverContent>

--- a/src/components/__tests__/QueueContextMenu.test.tsx
+++ b/src/components/__tests__/QueueContextMenu.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { QueueContextMenu } from '../QueueContextMenu';
+
+interface Option {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  destructive?: boolean;
+}
+
+function makeOptions(overrides: Option[] = []): Option[] {
+  if (overrides.length) return overrides;
+  return [
+    { label: 'Play next', icon: <svg data-testid="icon-play" />, onClick: vi.fn() },
+    { label: 'Like', icon: <svg data-testid="icon-like" />, onClick: vi.fn() },
+    {
+      label: 'Remove from queue',
+      icon: <svg data-testid="icon-remove" />,
+      onClick: vi.fn(),
+      destructive: true,
+    },
+  ];
+}
+
+function renderMenu(props: Partial<React.ComponentProps<typeof QueueContextMenu>> = {}) {
+  const merged = {
+    x: 100,
+    y: 120,
+    options: makeOptions(),
+    onClose: vi.fn(),
+    ...props,
+  };
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <QueueContextMenu {...merged} />
+    </ThemeProvider>,
+  );
+  return { ...result, props: merged };
+}
+
+function getMenuItems(): HTMLButtonElement[] {
+  return screen.getAllByRole('menuitem') as HTMLButtonElement[];
+}
+
+describe('QueueContextMenu', () => {
+  it('renders one menu item per option, preserving labels', () => {
+    // #when
+    renderMenu();
+
+    // #then
+    const items = getMenuItems();
+    expect(items).toHaveLength(3);
+    expect(items.map((b) => b.textContent)).toEqual([
+      'Play next',
+      'Like',
+      'Remove from queue',
+    ]);
+  });
+
+  it('renders the popover content within an accessible menu container', () => {
+    // #when
+    renderMenu();
+
+    // #then
+    expect(screen.getByTestId('queue-context-menu')).toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'Queue track actions' })).toBeInTheDocument();
+  });
+
+  it('invokes the option handler and onClose when an item is clicked', () => {
+    // #given
+    const onPlayNext = vi.fn();
+    const onClose = vi.fn();
+    const options = makeOptions([
+      { label: 'Play next', icon: <svg />, onClick: onPlayNext },
+    ]);
+
+    // #when
+    renderMenu({ options, onClose });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Play next' }));
+
+    // #then
+    expect(onPlayNext).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the destructive option as a normal, clickable menu item', () => {
+    // #given
+    const onRemove = vi.fn();
+    const options = makeOptions([
+      { label: 'Remove from queue', icon: <svg />, onClick: onRemove, destructive: true },
+    ]);
+
+    // #when
+    renderMenu({ options });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove from queue' }));
+
+    // #then
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  describe('keyboard navigation', () => {
+    it('ArrowDown moves focus to the next item', () => {
+      // #given
+      renderMenu();
+      const items = getMenuItems();
+      items[0]?.focus();
+
+      // #when
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+
+      // #then
+      expect(document.activeElement).toBe(items[1]);
+    });
+
+    it('ArrowDown wraps from the last item to the first', () => {
+      // #given
+      renderMenu();
+      const items = getMenuItems();
+      items[items.length - 1]?.focus();
+
+      // #when
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+
+      // #then
+      expect(document.activeElement).toBe(items[0]);
+    });
+
+    it('ArrowUp wraps from the first item to the last', () => {
+      // #given
+      renderMenu();
+      const items = getMenuItems();
+      items[0]?.focus();
+
+      // #when
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+
+      // #then
+      expect(document.activeElement).toBe(items[items.length - 1]);
+    });
+
+    it('Home and End jump to the first and last items', () => {
+      // #given
+      renderMenu();
+      const items = getMenuItems();
+      items[1]?.focus();
+
+      // #when / #then — Home
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Home' });
+      expect(document.activeElement).toBe(items[0]);
+
+      // #when / #then — End
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'End' });
+      expect(document.activeElement).toBe(items[items.length - 1]);
+    });
+  });
+
+  describe('dismissal', () => {
+    it('calls onClose on Escape', () => {
+      // #given
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+
+      // #when
+      fireEvent.keyDown(screen.getByTestId('queue-context-menu'), { key: 'Escape' });
+
+      // #then
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Migrates `QueueContextMenu` from a hand-rolled `createPortal` + fixed-overlay styled-components menu to the canonical `ui/popover` virtual-anchor pattern, mirroring `LibraryContextMenu`. A zero-size `aria-hidden` `PopoverAnchor` is positioned at the pointer coordinates and Radix handles portaling, placement, and outside-click + Escape dismissal via a single `onOpenChange`. Adds `role="menu"`/`role="menuitem"` semantics, arrow/Home/End keyboard navigation, and first-item autofocus. The public component API (`x`, `y`, `options`, `onClose`) is unchanged, so `QueueTrackItem` call sites and every menu item/handler are preserved; the bespoke `Overlay`/`MenuContainer` styled-components and the manual viewport clamp are deleted.

## Test plan
- New colocated test `src/components/__tests__/QueueContextMenu.test.tsx` covers: one menu item per option with preserved labels, handler + `onClose` dispatch on click, the destructive item rendering and firing, arrow/Home/End keyboard navigation (with wrap), and Escape dismissal calling `onClose`.
- Placement: virtual anchor at `{ left: x, top: y }` with `align="start" side="bottom" sideOffset={4}`.
- Dismissal: outside-click and Escape both route through Radix `onOpenChange(false)` → `onClose` (no double-wired handlers).
- `npx tsc -b --noEmit` — clean.
- `npm run test:run` — 2058 passed (199 files).

Closes #1630