### PR TITLE
fix(queue): preserve originalTracks when appending while shuffle is on

### DIFF
--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -74,7 +74,7 @@ Reordering the queue SHALL move a track from one position to another and SHALL k
 
 ### Requirement: Shuffle Mode
 
-Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue order while keeping the currently playing track at the front; disabling shuffle SHALL restore the queue's original order with the current track's index pointing at its original position. The user's preference SHALL persist across sessions.
+Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue order while keeping the currently playing track at the front; disabling shuffle SHALL restore the queue's original order with the current track's index pointing at its original position. Tracks added to the queue while shuffle is enabled SHALL be appended to the preserved original order, so the true unshuffled order remains recoverable. The user's preference SHALL persist across sessions.
 
 #### Scenario: Enabling shuffle
 
@@ -88,6 +88,12 @@ Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue 
 - **WHEN** the user disables shuffle
 - **THEN** the queue's original order is restored
 - **AND** the current-track index points to the currently playing track's position in the original order
+
+#### Scenario: Disabling shuffle after adding tracks while shuffled
+
+- **WHEN** the user adds tracks to the queue while shuffle is enabled and then disables shuffle
+- **THEN** the queue's original (unshuffled) order is restored with the added tracks appended after it
+- **AND** the restored order is not the shuffled arrangement
 
 #### Scenario: Shuffle preference persists
 

--- a/src/contexts/__tests__/TrackContext.test.tsx
+++ b/src/contexts/__tests__/TrackContext.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import React from 'react';
+import React, { useRef } from 'react';
 import { TrackProvider, useTrackListContext, useCurrentTrackContext } from '../TrackContext';
+import { useQueueManagement } from '@/hooks/useQueueManagement';
 import { makeTrack } from '@/test/fixtures';
+import type { MediaTrack } from '@/types/domain';
 
 vi.mock('@/contexts/ProfilingContext', () => ({
   isProfilingEnabled: () => false,
@@ -128,5 +130,83 @@ describe('TrackContext', () => {
       'vorbis-player-shuffle-enabled',
       'true'
     );
+  });
+
+  it('add-while-shuffled then un-shuffle restores original order with added tracks appended', () => {
+    // Composes the full OpenSpec scenario:
+    // WHEN the user adds tracks while shuffle is enabled and then disables shuffle,
+    // THEN the queue restores the original unshuffled order with the added tracks
+    // appended after it, AND the restored order is not the shuffled arrangement.
+
+    function useComposed() {
+      const ctx = useTrackContext();
+      // mediaTracksRef mirrors what usePlayerLogic provides to useQueueManagement;
+      // its contents are kept in sync below but are not the subject of this test.
+      const mediaTracksRef = useRef<MediaTrack[]>([]);
+      const queueOps = useQueueManagement({
+        trackOps: {
+          setTracks: ctx.setTracks,
+          setOriginalTracks: ctx.setOriginalTracks,
+          setCurrentTrackIndex: ctx.setCurrentTrackIndex,
+          mediaTracksRef,
+        },
+        tracks: ctx.tracks,
+        currentTrackIndex: ctx.currentTrackIndex,
+        shuffleEnabled: ctx.shuffleEnabled,
+        loadCollection: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+        handleBackToLibrary: vi.fn(),
+        activeDescriptor: undefined,
+        getDescriptor: vi.fn().mockReturnValue(undefined),
+        getDrivingProviderDescriptor: vi.fn().mockReturnValue(undefined),
+      });
+      return { ...ctx, ...queueOps, mediaTracksRef };
+    }
+
+    // #given — ordered queue [t1, t2, t3], shuffle is OFF
+    const { result } = renderHook(() => useComposed(), { wrapper });
+    const originalTracks = [
+      makeTrack({ id: 't1' }),
+      makeTrack({ id: 't2' }),
+      makeTrack({ id: 't3' }),
+    ];
+
+    act(() => {
+      result.current.setTracks(originalTracks);
+      result.current.setOriginalTracks(originalTracks);
+      result.current.mediaTracksRef.current = [...originalTracks];
+      result.current.setCurrentTrackIndex(0);
+    });
+
+    // #when — enable shuffle (t1 moves to front; rest is shuffled)
+    act(() => {
+      result.current.handleShuffleToggle();
+    });
+
+    expect(result.current.shuffleEnabled).toBe(true);
+    // Capture the shuffled arrangement so we can assert the final order differs from it
+    const shuffledIds = result.current.tracks.map((t) => t.id);
+
+    // #when — add new tracks via queueTracksDirectly while shuffle is ON
+    const newTracks = [makeTrack({ id: 'n1' }), makeTrack({ id: 'n2' })];
+
+    act(() => {
+      result.current.queueTracksDirectly(newTracks);
+    });
+
+    // #when — disable shuffle (restore original order + appended tracks)
+    act(() => {
+      result.current.handleShuffleToggle();
+    });
+
+    // #then — shuffle is off
+    expect(result.current.shuffleEnabled).toBe(false);
+
+    // #then — final queue is the original unshuffled order with added tracks appended
+    const finalIds = result.current.tracks.map((t) => t.id);
+    expect(finalIds).toEqual(['t1', 't2', 't3', 'n1', 'n2']);
+
+    // #then — final order is not the shuffled arrangement with new tracks appended
+    const shuffledPlusNew = [...shuffledIds, 'n1', 'n2'];
+    expect(finalIds).not.toEqual(shuffledPlusNew);
   });
 });

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -1012,6 +1012,222 @@ describe('useQueueManagement', () => {
     });
   });
 
+  describe('shuffle-safe originalTracks preservation', () => {
+    it('handleAddToQueue while shuffled appends new tracks to originalTracks, not the shuffled snapshot', async () => {
+      // #given — queue is shuffled [b, a]; originalTracks is [a, b] (the true order)
+      mediaTracksRef.current = [makeMediaTrack('b'), makeMediaTrack('a')];
+      const tracks = [makeTrack({ id: 'b' }), makeTrack({ id: 'a' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('c')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then — originalTracks gets [a, b, c], not [b, a, c] (the shuffled snapshot)
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('handleAddToQueue while shuffle is OFF overwrites originalTracks with the full queue (existing behavior)', async () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('c')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then — setOriginalTracks called with the full nextTracks array directly (not a functional updater)
+      expect(mockSetOriginalTracks).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'a' }),
+          expect.objectContaining({ id: 'b' }),
+          expect.objectContaining({ id: 'c' }),
+        ]),
+      );
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+    });
+
+    it('queueTracksDirectly while shuffled appends new tracks to originalTracks, not the shuffled snapshot', () => {
+      // #given — queue is shuffled [b, a]; true originalTracks order is [a, b]
+      mediaTracksRef.current = [makeMediaTrack('b'), makeMediaTrack('a')];
+      const tracks = [makeTrack({ id: 'b' }), makeTrack({ id: 'a' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b')];
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('c')]);
+      });
+
+      // #then — originalTracks is [a, b, c], not the shuffled snapshot [b, a, c]
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('queueTracksDirectly while shuffle is OFF overwrites originalTracks with the full queue (existing behavior)', () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('c')]);
+      });
+
+      // #then — setOriginalTracks called with a plain array (not a functional updater)
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('insertTracksNext while shuffled appends new tracks to originalTracks, not the shuffled snapshot', () => {
+      // #given — queue is shuffled [c, a, b]; true originalTracks order is [a, b, c]
+      mediaTracksRef.current = [makeMediaTrack('c'), makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'c' }), makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then — originalTracks is [a, b, c, x], not the shuffled snapshot with x spliced in
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c', 'x']);
+    });
+
+    it('insertTracksNext while shuffle is OFF splices into originalTracks at currentTrackIndex+1 (existing behavior)', () => {
+      // #given — playing index 0; original and queue order both [a, b, c]
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then — originalTracks is set to the full spliced array [a, x, b, c]
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'x', 'b', 'c']);
+    });
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -1226,6 +1226,40 @@ describe('useQueueManagement', () => {
       expect(typeof callArg).not.toBe('function');
       expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'x', 'b', 'c']);
     });
+
+    it('insertTracksNext with shuffle ON and empty queue sets originalTracks to the inserted batch', () => {
+      // #given — empty queue with shuffle enabled (fast-path at the top of insertTracksNext)
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks: [],
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      let response: ReturnType<typeof result.current.insertTracksNext> = null;
+      act(() => {
+        response = result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')], 'Fresh');
+      });
+
+      // #then — originalTracks receives the inserted batch directly (plain array, not functional updater)
+      // because this is a fresh queue: there is no prior unshuffled order to merge with.
+      expect(response).toEqual({ added: 2, collectionName: 'Fresh' });
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2']);
+      expect(mockSetTracks).toHaveBeenCalledWith([
+        expect.objectContaining({ id: '1' }),
+        expect.objectContaining({ id: '2' }),
+      ]);
+    });
   });
 
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -135,7 +135,14 @@ export function useQueueManagement({
         );
         const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-        setOriginalTracks(nextTracks);
+        // When shuffle is ON, preserve the true unshuffled order by appending only the
+        // new tracks to originalTracks. Overwriting with nextTracks (the shuffled queue
+        // snapshot) would corrupt the restore-on-unshuffle path — mirrors handleReorderQueue.
+        if (shuffleEnabled) {
+          setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+        } else {
+          setOriginalTracks(nextTracks);
+        }
         setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
         notifyQueueChanged(nextTracks, currentTrackIndex);
         logQueue(
@@ -151,7 +158,7 @@ export function useQueueManagement({
       }
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex, shuffleEnabled]
   );
 
   const handleRemoveFromQueue = useCallback(
@@ -256,12 +263,17 @@ export function useQueueManagement({
       );
       const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
       mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-      setOriginalTracks(nextTracks);
+      // When shuffle is ON, preserve the true unshuffled order — mirrors handleReorderQueue.
+      if (shuffleEnabled) {
+        setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+      } else {
+        setOriginalTracks(nextTracks);
+      }
       setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
       notifyQueueChanged(nextTracks, currentTrackIndex);
       return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
-    [mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
+    [shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
   );
 
   /**
@@ -302,7 +314,15 @@ export function useQueueManagement({
       const nextTracks = [...tracksRef.current];
       nextTracks.splice(insertAt, 0, ...uniqueNewTracks);
       mediaTracksRef.current = insertMediaTracksAt(mediaTracksRef.current, insertAt, uniqueNewTracks);
-      setOriginalTracks(nextTracks);
+      // When shuffle is ON, append to originalTracks to preserve the true unshuffled
+      // order. Splicing into originalTracks at currentTrackIndex+1 is not meaningful
+      // because the shuffled queue position does not correspond to an unshuffled slot.
+      // Appending keeps the collection's natural order intact for restore-on-unshuffle.
+      if (shuffleEnabled) {
+        setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+      } else {
+        setOriginalTracks(nextTracks);
+      }
       setTracks(nextTracks);
 
       notifyQueueChanged(nextTracks, currentTrackIndex);
@@ -314,7 +334,7 @@ export function useQueueManagement({
       );
       return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
-    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
+    [currentTrackIndex, shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
   );
 
   /**


### PR DESCRIPTION
## Summary

The three queue-append paths (`handleAddToQueue`, `queueTracksDirectly`, `insertTracksNext`) unconditionally overwrote `originalTracks` with the current queue snapshot, which is shuffled when shuffle is enabled. This caused `handleShuffleToggle`'s restore logic to reconstruct the shuffled order instead of the true collection order. The fix mirrors the `if (!shuffleEnabled)` convention already used by `handleReorderQueue`: when shuffle is on, append only the new tracks to `originalTracks` via a functional updater; when off, overwrite as before.

## Test plan

- Add-to-queue while shuffled: `originalTracks` receives `[...prev, ...newTracks]` (functional updater), not a snapshot of the shuffled queue — verified for all three paths.
- Un-shuffle after queue-add restores the correct collection order, not the shuffled order.
- Shuffle-off paths still call `setOriginalTracks` with the full queue array directly (no regression).

Closes #1639