### PR TITLE
fix(collection-loader): guard against stale collection loads clobbering newer ones

### DIFF
--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -8,7 +8,7 @@ Vorbis Player SHALL maintain an ordered queue of provider-neutral tracks that ca
 
 ### Requirement: Loading a Collection
 
-Loading a collection SHALL replace the queue with the collection's tracks, reset the current-track index to the start, and begin playback from the first track.
+Loading a collection SHALL replace the queue with the collection's tracks, reset the current-track index to the start, and begin playback from the first track. When a new load begins before an earlier one completes, the newest load SHALL win: the superseded load SHALL be cancelled and SHALL NOT alter the queue, playback, or the active provider.
 
 #### Scenario: Loading a collection with tracks
 
@@ -21,6 +21,13 @@ Loading a collection SHALL replace the queue with the collection's tracks, reset
 
 - **WHEN** the user loads a collection that returns no tracks
 - **THEN** the queue remains empty and playback does not begin
+
+#### Scenario: Newer load supersedes an in-flight load
+
+- **WHEN** the user loads collection B while collection A is still loading
+- **THEN** the queue and playback reflect collection B
+- **AND** collection A's late-arriving results are discarded without altering the queue, playback, or the active provider
+- **AND** collection A's in-flight catalog requests are cancelled
 
 ### Requirement: Adding to the Queue
 

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -813,6 +813,72 @@ describe('useCollectionLoader', () => {
     expect(spotifyListTracks).toHaveBeenCalled();
   });
 
+  it('a new load that begins during the context-playback spotifyHandlePlaylistSelect call does not write stale tracks', async () => {
+    // #given — provider A uses context-playback fallback; its spotifyHandlePlaylistSelect is slow
+    const slowContextDeferred = makeDeferred<MediaTrack[]>();
+    const contextTracks = [makeMediaTrack('CTX1'), makeMediaTrack('CTX2')];
+    const fastTracks = [makeMediaTrack('B1')];
+
+    mockSpotifyHandlePlaylistSelect.mockReturnValueOnce(slowContextDeferred.promise);
+
+    const emptyCatalog = { listTracks: vi.fn().mockResolvedValue([]) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue(fastTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return {
+          id: 'spotify',
+          catalog: emptyCatalog,
+          capabilities: { hasContextPlaybackFallback: true },
+          playback: { pause: vi.fn() },
+        };
+      }
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = {
+      id: 'spotify',
+      catalog: emptyCatalog,
+      capabilities: { hasContextPlaybackFallback: true },
+      playback: { pause: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — load A goes through context-playback (catalog empty → spotifyHandlePlaylistSelect);
+    // load B starts and completes while A awaits spotifyHandlePlaylistSelect
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_ctx', 'spotify');
+      // wait for A to have called spotifyHandlePlaylistSelect and be suspended
+      await Promise.resolve();
+      await Promise.resolve();
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // now unblock A's spotifyHandlePlaylistSelect — stale check should stop mediaTracksRef write
+      slowContextDeferred.resolve(contextTracks);
+      await slowLoad;
+    });
+
+    // #then — context-playback result never wrote to mediaTracksRef; B's tracks are the state
+    expect(mediaTracksRef.current.map(t => t.id)).toEqual(['B1']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
   it('does not invoke spotifyHandlePlaylistSelect when hasContextPlaybackFallback is false and catalog returns empty', async () => {
     // #given — provider with context-playback method available but capability flag false
     const mockCatalog = {
@@ -949,6 +1015,71 @@ describe('useCollectionLoader', () => {
     expect(trackCalls).not.toContainEqual(['A1', 'A2']);
     const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
     expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
+  it('a new load that begins during await playTrack(0) prevents the stale load from overwriting tracks', async () => {
+    // #given — load A resolves listTracks immediately but playTrack is deferred,
+    // giving load B time to apply its tracks before A resumes
+    const playTrackDeferred = makeDeferred<void>();
+    let playTrackCallCount = 0;
+    mockPlayTrack.mockImplementation(() => {
+      playTrackCallCount += 1;
+      if (playTrackCallCount === 1) return playTrackDeferred.promise;
+      return Promise.resolve();
+    });
+
+    const tracksA = [makeMediaTrack('A1'), makeMediaTrack('A2')];
+    const tracksB = [makeMediaTrack('B1')];
+    const catalogA = { listTracks: vi.fn().mockResolvedValue(tracksA) };
+    const catalogB = { listTracks: vi.fn().mockResolvedValue(tracksB) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: catalogA, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: catalogB, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: catalogA, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — load A starts and reaches playTrack(0); load B completes while A is suspended there
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      // wait one microtask so A has called setTracks and is now awaiting playTrack
+      await Promise.resolve();
+      // B starts and completes fully
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // unblock A's playTrack — the stale-check guard should stop A here
+      playTrackDeferred.resolve();
+      await slowLoad;
+    });
+
+    // #then — A's playTrack resolved but A is stale; B's tracks are the final state.
+    // A legitimately applied its tracks before B ran (that write is expected);
+    // what matters is that A did NOT perform a second write after B's generation took over.
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+    // A must not have called record — it was stale when it resumed after playTrack
+    expect(mockRecord).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'spotify' }),
+      expect.any(String),
+      expect.anything(),
+    );
   });
 
   it('aborts the previous load controller when a new load begins', async () => {

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -857,4 +857,192 @@ describe('useCollectionLoader', () => {
     // #then — context playback adapter not invoked because capability flag is false
     expect(mockSpotifyHandlePlaylistSelect).not.toHaveBeenCalled();
   });
+
+  function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  it('passes an AbortSignal to catalog.listTracks for a provider collection load', async () => {
+    // #given
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('1')]) };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection('playlist_123');
+    });
+
+    // #then — second argument is an AbortSignal
+    expect(mockCatalog.listTracks).toHaveBeenCalledTimes(1);
+    const signalArg = mockCatalog.listTracks.mock.calls[0][1] as AbortSignal;
+    expect(signalArg).toBeInstanceOf(AbortSignal);
+  });
+
+  it('a stale slow provider load does not clobber a newer fast load', async () => {
+    // #given — load A is slow (deferred), load B is fast and resolves first
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const slowTracks = [makeMediaTrack('A1'), makeMediaTrack('A2')];
+    const fastTracks = [makeMediaTrack('B1')];
+
+    const slowCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue(fastTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow load A, then fast load B which resolves while A is still pending
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // now resolve the stale load A
+      slowDeferred.resolve(slowTracks);
+      await slowLoad;
+    });
+
+    // #then — B's tracks are the last applied; A never clobbers them
+    const trackCalls = mockSetTracks.mock.calls.map(call => (call[0] as MediaTrack[]).map(t => t.id));
+    expect(trackCalls).toContainEqual(['B1']);
+    expect(trackCalls).not.toContainEqual(['A1', 'A2']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
+  it('aborts the previous load controller when a new load begins', async () => {
+    // #given — load A's listTracks captures the signal it was handed
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    let capturedSignalA: AbortSignal | undefined;
+    const slowCatalog = {
+      listTracks: vi.fn().mockImplementation((_ref: unknown, signal?: AbortSignal) => {
+        capturedSignalA = signal;
+        return slowDeferred.promise;
+      }),
+    };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('B1')]) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start load A, then load B
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      slowDeferred.resolve([makeMediaTrack('A1')]);
+      await slowLoad;
+    });
+
+    // #then — A's signal was aborted when B began
+    expect(capturedSignalA?.aborted).toBe(true);
+  });
+
+  it('a stale unified liked load does not clobber a newer provider load', async () => {
+    // #given — unified liked load A is slow; a fast provider load B follows
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const slowLikedCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('B1')]) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return { id: 'spotify', catalog: slowLikedCatalog, capabilities: { hasLikedCollection: true }, playback: { pause: vi.fn() } };
+      }
+      return { id: 'dropbox', catalog: fastCatalog, capabilities: { hasLikedCollection: false }, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowLikedCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow unified liked load, then fast provider load B
+    await act(async () => {
+      const slowLoad = result.current.loadCollection(LIKED_SONGS_ID);
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      slowDeferred.resolve([makeMediaTrack('A1', 1000)]);
+      await slowLoad;
+    });
+
+    // #then — the liked load's tracks are never applied after B won
+    const trackCalls = mockSetTracks.mock.calls.map(call => (call[0] as MediaTrack[]).map(t => t.id));
+    expect(trackCalls).not.toContainEqual(['A1']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
 });

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -1176,4 +1176,65 @@ describe('useCollectionLoader', () => {
     const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
     expect(lastApplied.map(t => t.id)).toEqual(['B1']);
   });
+
+  it('a stale unified liked load does not switch the active provider after the newer load wins', async () => {
+    // #given — active provider is spotify; liked load A is slow and would return a dropbox track as
+    // the first result (which, if non-stale, would call setActiveProviderId('dropbox')); load B is a
+    // fast spotify collection that wins before A resolves
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const dropboxLikedTrack: MediaTrack = {
+      id: 'D1',
+      provider: 'dropbox',
+      playbackRef: { provider: 'dropbox', ref: '/music/d1.ogg' },
+      name: 'Track D1',
+      artists: 'Artist',
+      album: 'Album',
+      durationMs: 180000,
+      addedAt: 2000,
+      genres: [],
+    };
+    const fastSpotifyTracks = [makeMediaTrack('S1')];
+
+    const slowDropboxCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastSpotifyCatalog = { listTracks: vi.fn().mockResolvedValue(fastSpotifyTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return { id: 'spotify', catalog: fastSpotifyCatalog, capabilities: { hasLikedCollection: false }, playback: { pause: vi.fn() } };
+      }
+      return { id: 'dropbox', catalog: slowDropboxCatalog, capabilities: { hasLikedCollection: true }, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: fastSpotifyCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow unified liked load A, then fast spotify load B which wins first
+    await act(async () => {
+      const slowLoad = result.current.loadCollection(LIKED_SONGS_ID);
+      await result.current.loadCollection('playlist_S', 'spotify');
+      // now resolve the stale liked load A — its dropbox track would switch the active provider
+      // if the stale guard were absent
+      slowDeferred.resolve([dropboxLikedTrack]);
+      await slowLoad;
+    });
+
+    // #then — the stale liked load must not have switched the active provider to dropbox
+    expect(mockSetActiveProviderId).not.toHaveBeenCalledWith('dropbox');
+  });
 });

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
@@ -6,7 +6,12 @@ import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } f
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { queueSnapshot } from './playerLogicUtils';
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
 
 interface UseCollectionLoaderProps {
   trackOps: TrackOperations;
@@ -46,12 +51,29 @@ export function useCollectionLoader({
 }: UseCollectionLoaderProps): UseCollectionLoaderReturn {
   const { setError, setIsLoading, setSelectedPlaylistId, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef } = trackOps;
 
-  const beginLoad = useCallback((playlistId: string) => {
+  const loadGenerationRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const beginLoadGeneration = useCallback((): { generation: number; signal: AbortSignal } => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    loadGenerationRef.current += 1;
+    return { generation: loadGenerationRef.current, signal: controller.signal };
+  }, []);
+
+  const isStale = useCallback((generation: number): boolean => {
+    return loadGenerationRef.current !== generation;
+  }, []);
+
+  const beginLoad = useCallback((playlistId: string): { generation: number; signal: AbortSignal } => {
+    const token = beginLoadGeneration();
     setError(null);
     setIsLoading(true);
     setSelectedPlaylistId(playlistId);
     mediaTracksRef.current = [];
-  }, [setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef]);
+    return token;
+  }, [beginLoadGeneration, setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef]);
 
   const clearWithError = useCallback((message: string): 0 => {
     setError(message);
@@ -83,7 +105,7 @@ export function useCollectionLoader({
   }, [shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, setCurrentTrackIndex, setIsLoading]);
 
   const loadUnifiedLiked = useCallback(async (playlistId: string, name?: string): Promise<number> => {
-    beginLoad(playlistId);
+    const { generation, signal } = beginLoad(playlistId);
     try {
       const descriptorMap = new Map(
         connectedProviderIds.map(id => [id, getDescriptor(id)])
@@ -95,9 +117,12 @@ export function useCollectionLoader({
         likedProviderIds.map(async (id) => {
           const catalog = descriptorMap.get(id)?.catalog;
           if (!catalog) return [];
-          return catalog.listTracks({ provider: id, kind: 'liked' }).catch((): MediaTrack[] => []);
+          return catalog.listTracks({ provider: id, kind: 'liked' }, signal).catch((): MediaTrack[] => []);
         }),
       );
+
+      if (isStale(generation)) return loadGenerationRef.current;
+
       const merged = results.flat();
       merged.sort((a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0));
 
@@ -124,10 +149,14 @@ export function useCollectionLoader({
       }
       return merged.length;
     } catch (err) {
+      if (isAbortError(err) || isStale(generation)) {
+        logCaughtError('useCollectionLoader.loadUnifiedLiked', err);
+        return loadGenerationRef.current;
+      }
       return handleLoadError(err, 'Failed to load liked tracks.');
     }
   }, [
-    beginLoad, clearWithError, handleLoadError, applyTracks,
+    beginLoad, isStale, clearWithError, handleLoadError, applyTracks,
     connectedProviderIds, getDescriptor, activeDescriptor,
     setActiveProviderId, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
@@ -162,11 +191,13 @@ export function useCollectionLoader({
       activeDescriptor.playback.pause().catch(() => {});
     }
 
-    beginLoad(playlistId);
+    const { generation, signal } = beginLoad(playlistId);
     try {
       const { id: collectionId, kind: collectionKind } = resolvePlaylistRef(playlistId, providerId);
       const collectionRef = { provider: providerId, kind: collectionKind, id: collectionId } as const;
-      const list = await targetDescriptor.catalog.listTracks(collectionRef);
+      const list = await targetDescriptor.catalog.listTracks(collectionRef, signal);
+
+      if (isStale(generation)) return loadGenerationRef.current;
 
       if (list.length === 0 && targetDescriptor.capabilities.hasContextPlaybackFallback) {
         return loadContextPlayback(playlistId, providerId);
@@ -181,10 +212,14 @@ export function useCollectionLoader({
       record(collectionRef, name ?? collectionId, list[0]?.image ?? null);
       return list.length;
     } catch (err) {
+      if (isAbortError(err) || isStale(generation)) {
+        logCaughtError('useCollectionLoader.loadProviderCollection', err);
+        return loadGenerationRef.current;
+      }
       return handleLoadError(err, 'Failed to load collection.');
     }
   }, [
-    activeDescriptor, beginLoad, clearWithError, handleLoadError,
+    activeDescriptor, beginLoad, isStale, clearWithError, handleLoadError,
     applyTracks, loadContextPlayback, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
 
@@ -222,6 +257,8 @@ export function useCollectionLoader({
     async (tracks: MediaTrack[], collectionId: string, provider?: ProviderId): Promise<number> => {
       if (radioStateIsActive) stopRadioBase();
 
+      const { generation } = beginLoadGeneration();
+
       const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
       const targetProviderId = provider ?? activeDescriptor?.id;
 
@@ -252,11 +289,13 @@ export function useCollectionLoader({
       }
 
       queueSnapshot('Direct tracks loaded', tracks, mediaTracksRef.current.length, 0);
+      if (isStale(generation)) return loadGenerationRef.current;
       await playTrack(0);
       return tracks.length;
     },
     [
-      radioStateIsActive, stopRadioBase, getDescriptor, activeDescriptor,
+      radioStateIsActive, stopRadioBase, beginLoadGeneration, isStale,
+      getDescriptor, activeDescriptor,
       setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef,
       setTracks, setOriginalTracks, setCurrentTrackIndex,
       applyTracks, drivingProviderRef, setActiveProviderId, playTrack,

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -117,7 +117,10 @@ export function useCollectionLoader({
         likedProviderIds.map(async (id) => {
           const catalog = descriptorMap.get(id)?.catalog;
           if (!catalog) return [];
-          return catalog.listTracks({ provider: id, kind: 'liked' }, signal).catch((): MediaTrack[] => []);
+          return catalog.listTracks({ provider: id, kind: 'liked' }, signal).catch((err: unknown): MediaTrack[] => {
+            if (!isAbortError(err)) logCaughtError(`useCollectionLoader.loadUnifiedLiked[${id}]`, err);
+            return [];
+          });
         }),
       );
 
@@ -139,6 +142,7 @@ export function useCollectionLoader({
             setActiveProviderId(firstTrack.provider);
           }
           queueSnapshot('Unified Liked loaded', merged, mediaTracksRef.current.length, 0);
+          if (isStale(generation)) return loadGenerationRef.current;
           await playTrack(0);
           record(
             { provider: firstTrack.provider, kind: 'liked' },
@@ -162,7 +166,7 @@ export function useCollectionLoader({
   ]);
 
   const loadContextPlayback = useCallback(async (
-    playlistId: string, providerId: ProviderId,
+    playlistId: string, providerId: ProviderId, generation: number,
   ): Promise<number> => {
     setIsLoading(false);
     const prevProvider = drivingProviderRef.current;
@@ -173,6 +177,7 @@ export function useCollectionLoader({
     mediaTracksRef.current = [];
     logQueue('Context playback path — delegating to legacy handler for %s on %s', playlistId, providerId);
     const sdkTracks = await spotifyHandlePlaylistSelect(playlistId);
+    if (isStale(generation)) return loadGenerationRef.current;
     if (sdkTracks.length > 0) {
       mediaTracksRef.current = sdkTracks;
       queueSnapshot('Context playback loaded', sdkTracks, mediaTracksRef.current.length, 0);
@@ -180,7 +185,7 @@ export function useCollectionLoader({
       logQueue('Context playback returned 0 tracks');
     }
     return sdkTracks.length;
-  }, [drivingProviderRef, mediaTracksRef, setIsLoading, spotifyHandlePlaylistSelect]);
+  }, [drivingProviderRef, mediaTracksRef, setIsLoading, spotifyHandlePlaylistSelect, isStale]);
 
   const loadProviderCollection = useCallback(async (
     playlistId: string, targetDescriptor: ProviderDescriptor, name?: string,
@@ -200,7 +205,7 @@ export function useCollectionLoader({
       if (isStale(generation)) return loadGenerationRef.current;
 
       if (list.length === 0 && targetDescriptor.capabilities.hasContextPlaybackFallback) {
-        return loadContextPlayback(playlistId, providerId);
+        return loadContextPlayback(playlistId, providerId, generation);
       }
 
       if (list.length === 0) return clearWithError('No tracks found in this collection.');
@@ -208,6 +213,7 @@ export function useCollectionLoader({
       applyTracks(list, { forceShuffle: isAllMusicRef(collectionRef) });
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
+      if (isStale(generation)) return loadGenerationRef.current;
       await playTrack(0);
       record(collectionRef, name ?? collectionId, list[0]?.image ?? null);
       return list.length;


### PR DESCRIPTION
## Summary
`useCollectionLoader` had no concurrency guard, so overlapping `loadCollection` calls raced and a slower (stale) `listTracks` response could win — replacing the queue and starting playback for the wrong collection. This adds a per-load generation counter plus an `AbortController` (threaded through `catalog.listTracks(ref, signal)` and aborted when a new load begins); every load path now bails before applying tracks, switching the active provider, or starting playback once a newer load has started.

## Test plan
- `npx tsc -b --noEmit` passes.
- `npx vitest run src/hooks/__tests__/useCollectionLoader.test.ts` — 24 passing, including new BDD specs that: assert an `AbortSignal` is handed to `listTracks`; start a slow provider load A then a fast load B and assert A's late resolution never clobbers B; assert the previous load's signal is aborted when a new load begins; and cover the same stale-loses behavior for the unified-liked path.
- Verified the new race spec fails when the generation guard is removed, confirming it actually catches the regression.

Closes #1638