### PR TITLE
fix(queue): collection-load race, shuffled-add order corruption, drag-reorder ID stability

### DIFF
--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -74,7 +74,7 @@ Reordering the queue SHALL move a track from one position to another and SHALL k
 
 ### Requirement: Shuffle Mode
 
-Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue order while keeping the currently playing track at the front; disabling shuffle SHALL restore the queue's original order with the current track's index pointing at its original position. The user's preference SHALL persist across sessions.
+Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue order while keeping the currently playing track at the front; disabling shuffle SHALL restore the queue's original order with the current track's index pointing at its original position. Tracks added to the queue while shuffle is enabled SHALL be appended to the preserved original order, so the true unshuffled order remains recoverable. The user's preference SHALL persist across sessions.
 
 #### Scenario: Enabling shuffle
 
@@ -88,6 +88,12 @@ Shuffle SHALL be a persisted toggle. Enabling shuffle SHALL randomize the queue 
 - **WHEN** the user disables shuffle
 - **THEN** the queue's original order is restored
 - **AND** the current-track index points to the currently playing track's position in the original order
+
+#### Scenario: Disabling shuffle after adding tracks while shuffled
+
+- **WHEN** the user adds tracks to the queue while shuffle is enabled and then disables shuffle
+- **THEN** the queue's original (unshuffled) order is restored with the added tracks appended after it
+- **AND** the restored order is not the shuffled arrangement
 
 #### Scenario: Shuffle preference persists
 

--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -64,13 +64,19 @@ Removing a queued track SHALL preserve the playing track's position. Removing th
 
 ### Requirement: Reordering the Queue
 
-Reordering the queue SHALL move a track from one position to another and SHALL keep the currently playing track's index aligned with its new position.
+Reordering the queue SHALL move a track from one position to another and SHALL keep the currently playing track's index aligned with its new position. Reorder operations SHALL identify tracks by their immutable track id, so an asynchronous metadata update (such as a title enrichment) cannot invalidate an in-progress drag.
 
 #### Scenario: Reordering relative to the current track
 
 - **WHEN** a track is moved to a new position in the queue
 - **THEN** the track order reflects the move
 - **AND** the current-track index now points to the same track that was playing before the reorder
+
+#### Scenario: Track metadata updates during a drag
+
+- **WHEN** a queued track's display name updates while the user is dragging a queue row
+- **THEN** the drag gesture is not interrupted
+- **AND** dropping the row still applies the reorder
 
 ### Requirement: Shuffle Mode
 

--- a/openspec/specs/queue-management/spec.md
+++ b/openspec/specs/queue-management/spec.md
@@ -8,7 +8,7 @@ Vorbis Player SHALL maintain an ordered queue of provider-neutral tracks that ca
 
 ### Requirement: Loading a Collection
 
-Loading a collection SHALL replace the queue with the collection's tracks, reset the current-track index to the start, and begin playback from the first track.
+Loading a collection SHALL replace the queue with the collection's tracks, reset the current-track index to the start, and begin playback from the first track. When a new load begins before an earlier one completes, the newest load SHALL win: the superseded load SHALL be cancelled and SHALL NOT alter the queue, playback, or the active provider.
 
 #### Scenario: Loading a collection with tracks
 
@@ -21,6 +21,13 @@ Loading a collection SHALL replace the queue with the collection's tracks, reset
 
 - **WHEN** the user loads a collection that returns no tracks
 - **THEN** the queue remains empty and playback does not begin
+
+#### Scenario: Newer load supersedes an in-flight load
+
+- **WHEN** the user loads collection B while collection A is still loading
+- **THEN** the queue and playback reflect collection B
+- **AND** collection A's late-arriving results are discarded without altering the queue, playback, or the active provider
+- **AND** collection A's in-flight catalog requests are cancelled
 
 ### Requirement: Adding to the Queue
 

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -181,7 +181,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: `${track.name}-${track.id}` });
+  } = useSortable({ id: track.id });
 
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),

--- a/src/components/QueueTrackList.tsx
+++ b/src/components/QueueTrackList.tsx
@@ -129,7 +129,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
     })
   );
 
-  const sortableIds = tracks.map(t => `${t.name}-${t.id}`);
+  const sortableIds = tracks.map(t => t.id);
 
   const handleDragStart = useCallback((_event: DragStartEvent) => {
     setIsDragActive(true);
@@ -181,7 +181,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
               <QueueListItems>
                 {tracks.map((track, index) => (
                   <SwipeableQueueItem
-                    key={`${track.name}-${track.id}`}
+                    key={track.id}
                     track={track}
                     index={index}
                     isSelected={index === currentTrackIndex}
@@ -223,7 +223,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
                   <QueueListItems>
                     {tracks.map((track, index) => (
                       <SortableQueueItem
-                        key={`${track.name}-${track.id}`}
+                        key={track.id}
                         track={track}
                         index={index}
                         isSelected={index === currentTrackIndex}
@@ -257,7 +257,7 @@ const QueueTrackList = memo<QueueTrackListProps>(({
             <QueueListItems>
               {tracks.map((track: MediaTrack, index: number) => (
                 <QueueListItem
-                  key={`${track.name}-${track.id}`}
+                  key={track.id}
                   ref={index === currentTrackIndex ? currentTrackRef : undefined}
                   onClick={() => onTrackSelect(index)}
                   $isSelected={index === currentTrackIndex}

--- a/src/components/__tests__/QueueTrackList.drag.test.tsx
+++ b/src/components/__tests__/QueueTrackList.drag.test.tsx
@@ -100,6 +100,7 @@ async function flush(): Promise<void> {
 
 beforeAll(() => {
   global.PointerEvent = FakePointerEvent as unknown as typeof PointerEvent;
+  HTMLElement.prototype.scrollIntoView = vi.fn();
   Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
     configurable: true,
     value: ROW_HEIGHT,

--- a/src/components/__tests__/QueueTrackList.drag.test.tsx
+++ b/src/components/__tests__/QueueTrackList.drag.test.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+import type { MediaTrack } from '@/types/domain';
+
+// Mock only the leaf hooks/components that transitively pull in the Spotify SDK
+// and other heavy dependencies. @dnd-kit is intentionally NOT mocked — this test
+// drives a real PointerSensor drag gesture end to end.
+vi.mock('@/hooks/useLikeTrack', () => ({
+  useLikeTrack: vi.fn(() => ({
+    isLiked: false,
+    canSaveTrack: false,
+    handleLikeToggle: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useLongPress', () => ({
+  useLongPress: vi.fn(() => ({
+    onPointerDown: vi.fn(),
+    onPointerUp: vi.fn(),
+    onPointerLeave: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useHorizontalSwipeToRemove', () => ({
+  useHorizontalSwipeToRemove: vi.fn(() => ({
+    ref: { current: null },
+    offsetX: 0,
+    isSwiping: false,
+    isRevealed: false,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock('./QueueContextMenu', () => ({
+  QueueContextMenu: () => null,
+}));
+
+vi.mock('@/components/ProviderIcon', () => ({
+  default: () => null,
+}));
+
+const { default: QueueTrackList } = await import('../QueueTrackList');
+
+// jsdom ships no usable PointerEvent (clientX/clientY are dropped), and
+// @dnd-kit's PointerSensor activator requires isPrimary === true && button === 0.
+// Extending MouseEvent lets coordinates ride through and defaults isPrimary true.
+class FakePointerEvent extends MouseEvent {
+  isPrimary = true;
+  pointerId = 1;
+  pointerType = 'mouse';
+  width = 1;
+  height = 1;
+  pressure = 0;
+  tangentialPressure = 0;
+  tiltX = 0;
+  tiltY = 0;
+  twist = 0;
+
+  constructor(type: string, params: PointerEventInit = {}) {
+    super(type, params);
+    if (params.isPrimary != null) this.isPrimary = params.isPrimary;
+    if (params.pointerId != null) this.pointerId = params.pointerId;
+    if (params.pointerType != null) this.pointerType = params.pointerType;
+  }
+}
+
+const ROW_HEIGHT = 50;
+const ROW_WIDTH = 300;
+
+function stubRowRect(el: HTMLElement, index: number): void {
+  const top = index * ROW_HEIGHT;
+  el.getBoundingClientRect = (): DOMRect =>
+    ({
+      x: 0,
+      y: top,
+      top,
+      left: 0,
+      bottom: top + ROW_HEIGHT,
+      right: ROW_WIDTH,
+      width: ROW_WIDTH,
+      height: ROW_HEIGHT,
+      toJSON() {},
+    }) as DOMRect;
+}
+
+function centerOf(el: HTMLElement): { x: number; y: number } {
+  const r = el.getBoundingClientRect();
+  return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeAll(() => {
+  global.PointerEvent = FakePointerEvent as unknown as typeof PointerEvent;
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    value: ROW_HEIGHT,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: ROW_WIDTH,
+  });
+});
+
+/**
+ * Harness that owns the queue order so a reorder callback actually mutates the
+ * rendered list, and exposes a setter to mutate a track's display name
+ * mid-gesture (mimicking async Dropbox ID3 enrichment landing during a drag).
+ */
+function DragHarness({
+  initialTracks,
+  onReorderSpy,
+  renameRef,
+}: {
+  initialTracks: MediaTrack[];
+  onReorderSpy: (from: number, to: number) => void;
+  renameRef: { current: ((id: string, name: string) => void) | null };
+}) {
+  const [tracks, setTracks] = useState(initialTracks);
+
+  renameRef.current = (id: string, name: string) => {
+    setTracks((prev) => prev.map((t) => (t.id === id ? { ...t, name } : t)));
+  };
+
+  const handleReorder = (from: number, to: number) => {
+    onReorderSpy(from, to);
+    setTracks((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      if (moved) next.splice(to, 0, moved);
+      return next;
+    });
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <QueueTrackList
+        tracks={tracks}
+        currentTrackIndex={0}
+        onTrackSelect={vi.fn()}
+        onRemoveTrack={vi.fn()}
+        onReorderTracks={handleReorder}
+        canEdit
+        isOpen
+      />
+    </ThemeProvider>
+  );
+}
+
+/**
+ * The dnd-kit sortable element is the QueueListItem rendered with
+ * role="button" + aria-roledescription="sortable" once edit mode spreads the
+ * sortable attributes/listeners. dnd-kit measures the setNodeRef wrapper (its
+ * parent), so rects are stubbed there.
+ */
+function getDraggables(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '[role="button"][aria-roledescription="sortable"]',
+    ),
+  );
+}
+
+function nodeRefWrapper(draggable: HTMLElement): HTMLElement {
+  const parent = draggable.parentElement;
+  if (!parent) throw new Error('sortable draggable has no setNodeRef wrapper');
+  return parent;
+}
+
+describe('QueueTrackList — drag gesture survives mid-drag rename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the drag active when a dragged track is renamed, and still applies the reorder on drop', async () => {
+    // #given — a 3-track queue in edit mode, with the current track pinned at
+    // index 0 (so the row we drag, index 1, exposes drag listeners)
+    const onReorderSpy = vi.fn<(from: number, to: number) => void>();
+    const renameRef: { current: ((id: string, name: string) => void) | null } = {
+      current: null,
+    };
+    const initialTracks = [
+      makeMediaTrack({ id: 'track-1', name: 'Song A' }),
+      makeMediaTrack({ id: 'track-2', name: 'filename-derived.flac' }),
+      makeMediaTrack({ id: 'track-3', name: 'Song C' }),
+    ];
+
+    render(
+      <DragHarness
+        initialTracks={initialTracks}
+        onReorderSpy={onReorderSpy}
+        renameRef={renameRef}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Edit'));
+
+    // The track at index 1 starts with a filename-style name; rename targets it.
+    // dnd-kit caches drag-start rects, so stub the setNodeRef wrappers once up front.
+    let draggables = getDraggables();
+    draggables.forEach((d, i) => stubRowRect(nodeRefWrapper(d), i));
+
+    const dragHandle = draggables[1];
+    const dropWrapper = draggables[2] ? nodeRefWrapper(draggables[2]) : undefined;
+    if (!dragHandle || !dropWrapper) throw new Error('expected at least 3 rows');
+
+    const from = centerOf(nodeRefWrapper(dragHandle));
+    const to = centerOf(dropWrapper);
+
+    // #when — lift the second row and move it past the 8px activation distance
+    fireEvent.pointerDown(dragHandle, {
+      clientX: from.x,
+      clientY: from.y,
+      button: 0,
+      isPrimary: true,
+    });
+    fireEvent.pointerMove(document, { clientX: from.x, clientY: from.y + 9 });
+    await flush();
+
+    // ...and MID-GESTURE the dragged track's display name is enriched.
+    // Pre-fix code keyed sortable IDs by `${name}-${id}`, so this rename would
+    // orphan active.id and cancel the drag.
+    act(() => {
+      renameRef.current?.('track-2', 'Real Album Title');
+    });
+    await flush();
+
+    // Re-stub rects after the rename rerender so any freshly-created row nodes
+    // still report live rects (dnd-kit reuses its cached drag-start rect map for
+    // the active drag; this just keeps the DOM measurable for the helper).
+    draggables = getDraggables();
+    draggables.forEach((d, i) => stubRowRect(nodeRefWrapper(d), i));
+
+    // continue the gesture to the third row's center, then drop
+    fireEvent.pointerMove(document, { clientX: to.x, clientY: to.y });
+    await flush();
+    fireEvent.pointerUp(document, { clientX: to.x, clientY: to.y });
+    await flush();
+
+    // #then — the rename did not interrupt the gesture: the reorder still fired,
+    // moving the renamed track from index 1 to index 2
+    expect(onReorderSpy).toHaveBeenCalledTimes(1);
+    expect(onReorderSpy).toHaveBeenCalledWith(1, 2);
+
+    // ...and the renamed track is now visible in its new position
+    expect(screen.getByText('Real Album Title')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/QueueTrackList.test.tsx
+++ b/src/components/__tests__/QueueTrackList.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+
+// Capture the `items` array passed to every <SortableContext> render so tests
+// can assert the exact IDs without simulating drag gestures.
+const capturedSortableContextItems: string[][] = [];
+
+vi.mock('@dnd-kit/sortable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/sortable')>();
+  return {
+    ...actual,
+    SortableContext: ({ items, children }: { items: string[]; children: React.ReactNode }) => {
+      capturedSortableContextItems.push(items);
+      return <>{children}</>;
+    },
+    useSortable: (args: { id: string }) => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: undefined,
+      isDragging: false,
+      // Expose the id so tests can inspect which id was forwarded.
+      _capturedId: args.id,
+    }),
+    verticalListSortingStrategy: actual.verticalListSortingStrategy,
+  };
+});
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock('@/hooks/useLikeTrack', () => ({
+  useLikeTrack: vi.fn(() => ({
+    isLiked: false,
+    canSaveTrack: false,
+    handleLikeToggle: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/useLongPress', () => ({
+  useLongPress: vi.fn(() => ({ onPointerDown: vi.fn(), onPointerUp: vi.fn(), onPointerLeave: vi.fn() })),
+}));
+
+vi.mock('@/hooks/useHorizontalSwipeToRemove', () => ({
+  useHorizontalSwipeToRemove: vi.fn(() => ({
+    ref: { current: null },
+    offsetX: 0,
+    isSwiping: false,
+    isRevealed: false,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock('./QueueContextMenu', () => ({
+  QueueContextMenu: () => null,
+}));
+
+vi.mock('@/components/ProviderIcon', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/styled', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    Avatar: ({ alt }: { alt?: string | undefined }) => <img alt={alt ?? ''} />,
+    Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import QueueTrackList from '../QueueTrackList';
+
+function renderList(overrides?: {
+  tracks?: ReturnType<typeof makeMediaTrack>[];
+  currentTrackIndex?: number;
+  onReorderTracks?: (from: number, to: number) => void;
+}) {
+  const tracks = overrides?.tracks ?? [
+    makeMediaTrack({ id: 'track-1', name: 'Song A' }),
+    makeMediaTrack({ id: 'track-2', name: 'Song B' }),
+    makeMediaTrack({ id: 'track-3', name: 'Song C' }),
+  ];
+  render(
+    <ThemeProvider theme={theme}>
+      <QueueTrackList
+        tracks={tracks}
+        currentTrackIndex={overrides?.currentTrackIndex ?? 0}
+        onTrackSelect={vi.fn()}
+        onReorderTracks={overrides?.onReorderTracks ?? vi.fn()}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('QueueTrackList — sortable ID contract', () => {
+  beforeEach(() => {
+    capturedSortableContextItems.length = 0;
+  });
+
+  describe('SortableContext items', () => {
+    it('passes track.id (not a composite) as each sortable item', () => {
+      // #given
+      const tracks = [
+        makeMediaTrack({ id: 'track-1', name: 'Song A' }),
+        makeMediaTrack({ id: 'track-2', name: 'Song B' }),
+        makeMediaTrack({ id: 'track-3', name: 'Song C' }),
+      ];
+
+      // #when
+      renderList({ tracks });
+
+      // #then — SortableContext received bare IDs, no name-based composite
+      expect(capturedSortableContextItems.length).toBeGreaterThan(0);
+      const items = capturedSortableContextItems[0];
+      expect(items).toEqual(['track-1', 'track-2', 'track-3']);
+    });
+
+    it('items remain stable when a track name changes (simulates ID3 enrichment)', () => {
+      // #given — initial render with one track
+      const track = makeMediaTrack({ id: 'abc', name: 'filename-derived.flac' });
+      renderList({ tracks: [track] });
+
+      const itemsBefore = [...(capturedSortableContextItems[0] ?? [])];
+      capturedSortableContextItems.length = 0;
+
+      // #when — re-render with same track but mutated name
+      renderList({ tracks: [{ ...track, name: 'Real Album Title' }] });
+
+      const itemsAfter = capturedSortableContextItems[0];
+
+      // #then — sortable IDs are unaffected by the name mutation
+      expect(itemsBefore).toEqual(['abc']);
+      expect(itemsAfter).toEqual(['abc']);
+    });
+
+    it('items contain only the track id with no name prefix', () => {
+      // #given — track whose name and id share no substring (guards against composite patterns)
+      const tracks = [
+        makeMediaTrack({ id: 'xk9-unique', name: 'Completely Different Name' }),
+      ];
+
+      // #when
+      renderList({ tracks });
+
+      // #then — no item is of the form `${name}-${id}` or `${id}-${name}`
+      const items = capturedSortableContextItems[0] ?? [];
+      for (const item of items) {
+        expect(item).toBe('xk9-unique');
+        expect(item).not.toContain('Completely Different Name');
+      }
+    });
+  });
+});

--- a/src/contexts/__tests__/TrackContext.test.tsx
+++ b/src/contexts/__tests__/TrackContext.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import React from 'react';
+import React, { useRef } from 'react';
 import { TrackProvider, useTrackListContext, useCurrentTrackContext } from '../TrackContext';
+import { useQueueManagement } from '@/hooks/useQueueManagement';
 import { makeTrack } from '@/test/fixtures';
+import type { MediaTrack } from '@/types/domain';
 
 vi.mock('@/contexts/ProfilingContext', () => ({
   isProfilingEnabled: () => false,
@@ -128,5 +130,83 @@ describe('TrackContext', () => {
       'vorbis-player-shuffle-enabled',
       'true'
     );
+  });
+
+  it('add-while-shuffled then un-shuffle restores original order with added tracks appended', () => {
+    // Composes the full OpenSpec scenario:
+    // WHEN the user adds tracks while shuffle is enabled and then disables shuffle,
+    // THEN the queue restores the original unshuffled order with the added tracks
+    // appended after it, AND the restored order is not the shuffled arrangement.
+
+    function useComposed() {
+      const ctx = useTrackContext();
+      // mediaTracksRef mirrors what usePlayerLogic provides to useQueueManagement;
+      // its contents are kept in sync below but are not the subject of this test.
+      const mediaTracksRef = useRef<MediaTrack[]>([]);
+      const queueOps = useQueueManagement({
+        trackOps: {
+          setTracks: ctx.setTracks,
+          setOriginalTracks: ctx.setOriginalTracks,
+          setCurrentTrackIndex: ctx.setCurrentTrackIndex,
+          mediaTracksRef,
+        },
+        tracks: ctx.tracks,
+        currentTrackIndex: ctx.currentTrackIndex,
+        shuffleEnabled: ctx.shuffleEnabled,
+        loadCollection: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+        handleBackToLibrary: vi.fn(),
+        activeDescriptor: undefined,
+        getDescriptor: vi.fn().mockReturnValue(undefined),
+        getDrivingProviderDescriptor: vi.fn().mockReturnValue(undefined),
+      });
+      return { ...ctx, ...queueOps, mediaTracksRef };
+    }
+
+    // #given — ordered queue [t1, t2, t3], shuffle is OFF
+    const { result } = renderHook(() => useComposed(), { wrapper });
+    const originalTracks = [
+      makeTrack({ id: 't1' }),
+      makeTrack({ id: 't2' }),
+      makeTrack({ id: 't3' }),
+    ];
+
+    act(() => {
+      result.current.setTracks(originalTracks);
+      result.current.setOriginalTracks(originalTracks);
+      result.current.mediaTracksRef.current = [...originalTracks];
+      result.current.setCurrentTrackIndex(0);
+    });
+
+    // #when — enable shuffle (t1 moves to front; rest is shuffled)
+    act(() => {
+      result.current.handleShuffleToggle();
+    });
+
+    expect(result.current.shuffleEnabled).toBe(true);
+    // Capture the shuffled arrangement so we can assert the final order differs from it
+    const shuffledIds = result.current.tracks.map((t) => t.id);
+
+    // #when — add new tracks via queueTracksDirectly while shuffle is ON
+    const newTracks = [makeTrack({ id: 'n1' }), makeTrack({ id: 'n2' })];
+
+    act(() => {
+      result.current.queueTracksDirectly(newTracks);
+    });
+
+    // #when — disable shuffle (restore original order + appended tracks)
+    act(() => {
+      result.current.handleShuffleToggle();
+    });
+
+    // #then — shuffle is off
+    expect(result.current.shuffleEnabled).toBe(false);
+
+    // #then — final queue is the original unshuffled order with added tracks appended
+    const finalIds = result.current.tracks.map((t) => t.id);
+    expect(finalIds).toEqual(['t1', 't2', 't3', 'n1', 'n2']);
+
+    // #then — final order is not the shuffled arrangement with new tracks appended
+    const shuffledPlusNew = [...shuffledIds, 'n1', 'n2'];
+    expect(finalIds).not.toEqual(shuffledPlusNew);
   });
 });

--- a/src/contexts/__tests__/TrackContext.test.tsx
+++ b/src/contexts/__tests__/TrackContext.test.tsx
@@ -177,14 +177,19 @@ describe('TrackContext', () => {
       result.current.setCurrentTrackIndex(0);
     });
 
-    // #when — enable shuffle (t1 moves to front; rest is shuffled)
+    // #when — enable shuffle (t1 moves to front; rest is shuffled).
+    // Math.random pinned to 0 forces the Fisher-Yates swap so the shuffled
+    // order is deterministically [t1, t3, t2] — never the identity permutation,
+    // which a 2-element shuffle would otherwise produce 50% of the time.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     act(() => {
       result.current.handleShuffleToggle();
     });
+    randomSpy.mockRestore();
 
     expect(result.current.shuffleEnabled).toBe(true);
-    // Capture the shuffled arrangement so we can assert the final order differs from it
     const shuffledIds = result.current.tracks.map((t) => t.id);
+    expect(shuffledIds).toEqual(['t1', 't3', 't2']);
 
     // #when — add new tracks via queueTracksDirectly while shuffle is ON
     const newTracks = [makeTrack({ id: 'n1' }), makeTrack({ id: 'n2' })];

--- a/src/hooks/__tests__/useCollectionLoader.test.ts
+++ b/src/hooks/__tests__/useCollectionLoader.test.ts
@@ -813,6 +813,72 @@ describe('useCollectionLoader', () => {
     expect(spotifyListTracks).toHaveBeenCalled();
   });
 
+  it('a new load that begins during the context-playback spotifyHandlePlaylistSelect call does not write stale tracks', async () => {
+    // #given — provider A uses context-playback fallback; its spotifyHandlePlaylistSelect is slow
+    const slowContextDeferred = makeDeferred<MediaTrack[]>();
+    const contextTracks = [makeMediaTrack('CTX1'), makeMediaTrack('CTX2')];
+    const fastTracks = [makeMediaTrack('B1')];
+
+    mockSpotifyHandlePlaylistSelect.mockReturnValueOnce(slowContextDeferred.promise);
+
+    const emptyCatalog = { listTracks: vi.fn().mockResolvedValue([]) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue(fastTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return {
+          id: 'spotify',
+          catalog: emptyCatalog,
+          capabilities: { hasContextPlaybackFallback: true },
+          playback: { pause: vi.fn() },
+        };
+      }
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = {
+      id: 'spotify',
+      catalog: emptyCatalog,
+      capabilities: { hasContextPlaybackFallback: true },
+      playback: { pause: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — load A goes through context-playback (catalog empty → spotifyHandlePlaylistSelect);
+    // load B starts and completes while A awaits spotifyHandlePlaylistSelect
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_ctx', 'spotify');
+      // wait for A to have called spotifyHandlePlaylistSelect and be suspended
+      await Promise.resolve();
+      await Promise.resolve();
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // now unblock A's spotifyHandlePlaylistSelect — stale check should stop mediaTracksRef write
+      slowContextDeferred.resolve(contextTracks);
+      await slowLoad;
+    });
+
+    // #then — context-playback result never wrote to mediaTracksRef; B's tracks are the state
+    expect(mediaTracksRef.current.map(t => t.id)).toEqual(['B1']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
   it('does not invoke spotifyHandlePlaylistSelect when hasContextPlaybackFallback is false and catalog returns empty', async () => {
     // #given — provider with context-playback method available but capability flag false
     const mockCatalog = {
@@ -856,5 +922,319 @@ describe('useCollectionLoader', () => {
 
     // #then — context playback adapter not invoked because capability flag is false
     expect(mockSpotifyHandlePlaylistSelect).not.toHaveBeenCalled();
+  });
+
+  function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  it('passes an AbortSignal to catalog.listTracks for a provider collection load', async () => {
+    // #given
+    const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('1')]) };
+    mockActiveDescriptor.catalog = mockCatalog;
+    mockActiveDescriptor.playback = { pause: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when
+    await act(async () => {
+      await result.current.loadCollection('playlist_123');
+    });
+
+    // #then — second argument is an AbortSignal
+    expect(mockCatalog.listTracks).toHaveBeenCalledTimes(1);
+    const signalArg = mockCatalog.listTracks.mock.calls[0][1] as AbortSignal;
+    expect(signalArg).toBeInstanceOf(AbortSignal);
+  });
+
+  it('a stale slow provider load does not clobber a newer fast load', async () => {
+    // #given — load A is slow (deferred), load B is fast and resolves first
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const slowTracks = [makeMediaTrack('A1'), makeMediaTrack('A2')];
+    const fastTracks = [makeMediaTrack('B1')];
+
+    const slowCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue(fastTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow load A, then fast load B which resolves while A is still pending
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // now resolve the stale load A
+      slowDeferred.resolve(slowTracks);
+      await slowLoad;
+    });
+
+    // #then — B's tracks are the last applied; A never clobbers them
+    const trackCalls = mockSetTracks.mock.calls.map(call => (call[0] as MediaTrack[]).map(t => t.id));
+    expect(trackCalls).toContainEqual(['B1']);
+    expect(trackCalls).not.toContainEqual(['A1', 'A2']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
+  it('a new load that begins during await playTrack(0) prevents the stale load from overwriting tracks', async () => {
+    // #given — load A resolves listTracks immediately but playTrack is deferred,
+    // giving load B time to apply its tracks before A resumes
+    const playTrackDeferred = makeDeferred<void>();
+    let playTrackCallCount = 0;
+    mockPlayTrack.mockImplementation(() => {
+      playTrackCallCount += 1;
+      if (playTrackCallCount === 1) return playTrackDeferred.promise;
+      return Promise.resolve();
+    });
+
+    const tracksA = [makeMediaTrack('A1'), makeMediaTrack('A2')];
+    const tracksB = [makeMediaTrack('B1')];
+    const catalogA = { listTracks: vi.fn().mockResolvedValue(tracksA) };
+    const catalogB = { listTracks: vi.fn().mockResolvedValue(tracksB) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: catalogA, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: catalogB, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: catalogA, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — load A starts and reaches playTrack(0); load B completes while A is suspended there
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      // wait one microtask so A has called setTracks and is now awaiting playTrack
+      await Promise.resolve();
+      // B starts and completes fully
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      // unblock A's playTrack — the stale-check guard should stop A here
+      playTrackDeferred.resolve();
+      await slowLoad;
+    });
+
+    // #then — A's playTrack resolved but A is stale; B's tracks are the final state.
+    // A legitimately applied its tracks before B ran (that write is expected);
+    // what matters is that A did NOT perform a second write after B's generation took over.
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+    // A must not have called record — it was stale when it resumed after playTrack
+    expect(mockRecord).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'spotify' }),
+      expect.any(String),
+      expect.anything(),
+    );
+  });
+
+  it('aborts the previous load controller when a new load begins', async () => {
+    // #given — load A's listTracks captures the signal it was handed
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    let capturedSignalA: AbortSignal | undefined;
+    const slowCatalog = {
+      listTracks: vi.fn().mockImplementation((_ref: unknown, signal?: AbortSignal) => {
+        capturedSignalA = signal;
+        return slowDeferred.promise;
+      }),
+    };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('B1')]) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') return { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn() } };
+      return { id: 'dropbox', catalog: fastCatalog, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: false,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start load A, then load B
+    await act(async () => {
+      const slowLoad = result.current.loadCollection('playlist_A', 'spotify');
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      slowDeferred.resolve([makeMediaTrack('A1')]);
+      await slowLoad;
+    });
+
+    // #then — A's signal was aborted when B began
+    expect(capturedSignalA?.aborted).toBe(true);
+  });
+
+  it('a stale unified liked load does not clobber a newer provider load', async () => {
+    // #given — unified liked load A is slow; a fast provider load B follows
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const slowLikedCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('B1')]) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return { id: 'spotify', catalog: slowLikedCatalog, capabilities: { hasLikedCollection: true }, playback: { pause: vi.fn() } };
+      }
+      return { id: 'dropbox', catalog: fastCatalog, capabilities: { hasLikedCollection: false }, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: slowLikedCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow unified liked load, then fast provider load B
+    await act(async () => {
+      const slowLoad = result.current.loadCollection(LIKED_SONGS_ID);
+      await result.current.loadCollection('playlist_B', 'dropbox');
+      slowDeferred.resolve([makeMediaTrack('A1', 1000)]);
+      await slowLoad;
+    });
+
+    // #then — the liked load's tracks are never applied after B won
+    const trackCalls = mockSetTracks.mock.calls.map(call => (call[0] as MediaTrack[]).map(t => t.id));
+    expect(trackCalls).not.toContainEqual(['A1']);
+    const lastApplied = mockSetTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastApplied.map(t => t.id)).toEqual(['B1']);
+  });
+
+  it('a stale unified liked load does not switch the active provider after the newer load wins', async () => {
+    // #given — active provider is spotify; liked load A is slow and would return a dropbox track as
+    // the first result (which, if non-stale, would call setActiveProviderId('dropbox')); load B is a
+    // fast spotify collection that wins before A resolves
+    const slowDeferred = makeDeferred<MediaTrack[]>();
+    const dropboxLikedTrack: MediaTrack = {
+      id: 'D1',
+      provider: 'dropbox',
+      playbackRef: { provider: 'dropbox', ref: '/music/d1.ogg' },
+      name: 'Track D1',
+      artists: 'Artist',
+      album: 'Album',
+      durationMs: 180000,
+      addedAt: 2000,
+      genres: [],
+    };
+    const fastSpotifyTracks = [makeMediaTrack('S1')];
+
+    const slowDropboxCatalog = { listTracks: vi.fn().mockReturnValue(slowDeferred.promise) };
+    const fastSpotifyCatalog = { listTracks: vi.fn().mockResolvedValue(fastSpotifyTracks) };
+
+    mockGetDescriptor.mockImplementation((id: string) => {
+      if (id === 'spotify') {
+        return { id: 'spotify', catalog: fastSpotifyCatalog, capabilities: { hasLikedCollection: false }, playback: { pause: vi.fn() } };
+      }
+      return { id: 'dropbox', catalog: slowDropboxCatalog, capabilities: { hasLikedCollection: true }, playback: { pause: vi.fn() } };
+    });
+    mockActiveDescriptor = { id: 'spotify', catalog: fastSpotifyCatalog, playback: { pause: vi.fn().mockResolvedValue(undefined) } };
+
+    const { result } = renderHook(() =>
+      useCollectionLoader({
+        trackOps: { setError: mockSetError, setIsLoading: mockSetIsLoading, setSelectedPlaylistId: mockSetSelectedPlaylistId, setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+        activeDescriptor: mockActiveDescriptor,
+        getDescriptor: mockGetDescriptor,
+        setActiveProviderId: mockSetActiveProviderId,
+        connectedProviderIds: ['spotify', 'dropbox'],
+        shuffleEnabled: false,
+        isUnifiedLikedActive: true,
+        drivingProviderRef,
+        playTrack: mockPlayTrack,
+        spotifyHandlePlaylistSelect: mockSpotifyHandlePlaylistSelect,
+        stopRadioBase: mockStopRadioBase,
+        record: mockRecord,
+        radioStateIsActive: false,
+      })
+    );
+
+    // #when — start slow unified liked load A, then fast spotify load B which wins first
+    await act(async () => {
+      const slowLoad = result.current.loadCollection(LIKED_SONGS_ID);
+      await result.current.loadCollection('playlist_S', 'spotify');
+      // now resolve the stale liked load A — its dropbox track would switch the active provider
+      // if the stale guard were absent
+      slowDeferred.resolve([dropboxLikedTrack]);
+      await slowLoad;
+    });
+
+    // #then — the stale liked load must not have switched the active provider to dropbox
+    expect(mockSetActiveProviderId).not.toHaveBeenCalledWith('dropbox');
   });
 });

--- a/src/hooks/__tests__/useQueueManagement.test.ts
+++ b/src/hooks/__tests__/useQueueManagement.test.ts
@@ -1012,6 +1012,256 @@ describe('useQueueManagement', () => {
     });
   });
 
+  describe('shuffle-safe originalTracks preservation', () => {
+    it('handleAddToQueue while shuffled appends new tracks to originalTracks, not the shuffled snapshot', async () => {
+      // #given — queue is shuffled [b, a]; originalTracks is [a, b] (the true order)
+      mediaTracksRef.current = [makeMediaTrack('b'), makeMediaTrack('a')];
+      const tracks = [makeTrack({ id: 'b' }), makeTrack({ id: 'a' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('c')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then — originalTracks gets [a, b, c], not [b, a, c] (the shuffled snapshot)
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('handleAddToQueue while shuffle is OFF overwrites originalTracks with the full queue (existing behavior)', async () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const mockCatalog = { listTracks: vi.fn().mockResolvedValue([makeMediaTrack('c')]) };
+      mockActiveDescriptor.catalog = mockCatalog;
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      await act(async () => {
+        await result.current.handleAddToQueue('playlist_id');
+      });
+
+      // #then — setOriginalTracks called with the full nextTracks array directly (not a functional updater)
+      expect(mockSetOriginalTracks).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'a' }),
+          expect.objectContaining({ id: 'b' }),
+          expect.objectContaining({ id: 'c' }),
+        ]),
+      );
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+    });
+
+    it('queueTracksDirectly while shuffled appends new tracks to originalTracks, not the shuffled snapshot', () => {
+      // #given — queue is shuffled [b, a]; true originalTracks order is [a, b]
+      mediaTracksRef.current = [makeMediaTrack('b'), makeMediaTrack('a')];
+      const tracks = [makeTrack({ id: 'b' }), makeTrack({ id: 'a' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b')];
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('c')]);
+      });
+
+      // #then — originalTracks is [a, b, c], not the shuffled snapshot [b, a, c]
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('queueTracksDirectly while shuffle is OFF overwrites originalTracks with the full queue (existing behavior)', () => {
+      // #given
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.queueTracksDirectly([makeMediaTrack('c')]);
+      });
+
+      // #then — setOriginalTracks called with a plain array (not a functional updater)
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('insertTracksNext while shuffled appends new tracks to originalTracks, not the shuffled snapshot', () => {
+      // #given — queue is shuffled [c, a, b]; true originalTracks order is [a, b, c]
+      mediaTracksRef.current = [makeMediaTrack('c'), makeMediaTrack('a'), makeMediaTrack('b')];
+      const tracks = [makeTrack({ id: 'c' }), makeTrack({ id: 'a' }), makeTrack({ id: 'b' })];
+      const originalTracksState = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+
+      let capturedOriginalTracks = originalTracksState;
+      mockSetOriginalTracks.mockImplementation((updater: unknown) => {
+        if (typeof updater === 'function') {
+          capturedOriginalTracks = (updater as (prev: MediaTrack[]) => MediaTrack[])(capturedOriginalTracks);
+        } else {
+          capturedOriginalTracks = updater as MediaTrack[];
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then — originalTracks is [a, b, c, x], not the shuffled snapshot with x spliced in
+      expect(capturedOriginalTracks.map((t) => t.id)).toEqual(['a', 'b', 'c', 'x']);
+    });
+
+    it('insertTracksNext while shuffle is OFF splices into originalTracks at currentTrackIndex+1 (existing behavior)', () => {
+      // #given — playing index 0; original and queue order both [a, b, c]
+      mediaTracksRef.current = [makeMediaTrack('a'), makeMediaTrack('b'), makeMediaTrack('c')];
+      const tracks = [makeTrack({ id: 'a' }), makeTrack({ id: 'b' }), makeTrack({ id: 'c' })];
+
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks,
+          currentTrackIndex: 0,
+          shuffleEnabled: false,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      act(() => {
+        result.current.insertTracksNext([makeMediaTrack('x')]);
+      });
+
+      // #then — originalTracks is set to the full spliced array [a, x, b, c]
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['a', 'x', 'b', 'c']);
+    });
+
+    it('insertTracksNext with shuffle ON and empty queue sets originalTracks to the inserted batch', () => {
+      // #given — empty queue with shuffle enabled (fast-path at the top of insertTracksNext)
+      const { result } = renderHook(() =>
+        useQueueManagement({
+          tracks: [],
+          currentTrackIndex: 0,
+          shuffleEnabled: true,
+          trackOps: { setTracks: mockSetTracks, setOriginalTracks: mockSetOriginalTracks, setCurrentTrackIndex: mockSetCurrentTrackIndex, mediaTracksRef },
+          loadCollection: mockHandlePlaylistSelect,
+          handleBackToLibrary: mockHandleBackToLibrary,
+          activeDescriptor: mockActiveDescriptor,
+          getDescriptor: mockGetDescriptor,
+          getDrivingProviderDescriptor: mockGetDrivingProviderDescriptor,
+        })
+      );
+
+      // #when
+      let response: ReturnType<typeof result.current.insertTracksNext> = null;
+      act(() => {
+        response = result.current.insertTracksNext([makeMediaTrack('1'), makeMediaTrack('2')], 'Fresh');
+      });
+
+      // #then — originalTracks receives the inserted batch directly (plain array, not functional updater)
+      // because this is a fresh queue: there is no prior unshuffled order to merge with.
+      expect(response).toEqual({ added: 2, collectionName: 'Fresh' });
+      const callArg = mockSetOriginalTracks.mock.calls[0][0];
+      expect(typeof callArg).not.toBe('function');
+      expect((callArg as MediaTrack[]).map((t) => t.id)).toEqual(['1', '2']);
+      expect(mockSetTracks).toHaveBeenCalledWith([
+        expect.objectContaining({ id: '1' }),
+        expect.objectContaining({ id: '2' }),
+      ]);
+    });
+  });
+
   it('queueTracksDirectly toasts the duplicate message when every track is already queued', () => {
     // #given — queue already contains every incoming track
     mediaTracksRef.current = [makeMediaTrack('1'), makeMediaTrack('2')];

--- a/src/hooks/useCollectionLoader.ts
+++ b/src/hooks/useCollectionLoader.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { CollectionRef, MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
@@ -6,7 +6,12 @@ import { LIKED_SONGS_ID, LIKED_SONGS_NAME, isAllMusicRef, resolvePlaylistRef } f
 import { shuffleArray } from '@/utils/shuffleArray';
 import { providerRegistry } from '@/providers/registry';
 import { logQueue } from '@/lib/debugLog';
+import { logCaughtError } from '@/utils/logCaughtError';
 import { queueSnapshot } from './playerLogicUtils';
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
 
 interface UseCollectionLoaderProps {
   trackOps: TrackOperations;
@@ -46,12 +51,29 @@ export function useCollectionLoader({
 }: UseCollectionLoaderProps): UseCollectionLoaderReturn {
   const { setError, setIsLoading, setSelectedPlaylistId, setTracks, setOriginalTracks, setCurrentTrackIndex, mediaTracksRef } = trackOps;
 
-  const beginLoad = useCallback((playlistId: string) => {
+  const loadGenerationRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const beginLoadGeneration = useCallback((): { generation: number; signal: AbortSignal } => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    loadGenerationRef.current += 1;
+    return { generation: loadGenerationRef.current, signal: controller.signal };
+  }, []);
+
+  const isStale = useCallback((generation: number): boolean => {
+    return loadGenerationRef.current !== generation;
+  }, []);
+
+  const beginLoad = useCallback((playlistId: string): { generation: number; signal: AbortSignal } => {
+    const token = beginLoadGeneration();
     setError(null);
     setIsLoading(true);
     setSelectedPlaylistId(playlistId);
     mediaTracksRef.current = [];
-  }, [setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef]);
+    return token;
+  }, [beginLoadGeneration, setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef]);
 
   const clearWithError = useCallback((message: string): 0 => {
     setError(message);
@@ -83,7 +105,7 @@ export function useCollectionLoader({
   }, [shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, setCurrentTrackIndex, setIsLoading]);
 
   const loadUnifiedLiked = useCallback(async (playlistId: string, name?: string): Promise<number> => {
-    beginLoad(playlistId);
+    const { generation, signal } = beginLoad(playlistId);
     try {
       const descriptorMap = new Map(
         connectedProviderIds.map(id => [id, getDescriptor(id)])
@@ -95,9 +117,15 @@ export function useCollectionLoader({
         likedProviderIds.map(async (id) => {
           const catalog = descriptorMap.get(id)?.catalog;
           if (!catalog) return [];
-          return catalog.listTracks({ provider: id, kind: 'liked' }).catch((): MediaTrack[] => []);
+          return catalog.listTracks({ provider: id, kind: 'liked' }, signal).catch((err: unknown): MediaTrack[] => {
+            if (!isAbortError(err)) logCaughtError(`useCollectionLoader.loadUnifiedLiked[${id}]`, err);
+            return [];
+          });
         }),
       );
+
+      if (isStale(generation)) return loadGenerationRef.current;
+
       const merged = results.flat();
       merged.sort((a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0));
 
@@ -114,6 +142,7 @@ export function useCollectionLoader({
             setActiveProviderId(firstTrack.provider);
           }
           queueSnapshot('Unified Liked loaded', merged, mediaTracksRef.current.length, 0);
+          if (isStale(generation)) return loadGenerationRef.current;
           await playTrack(0);
           record(
             { provider: firstTrack.provider, kind: 'liked' },
@@ -124,16 +153,20 @@ export function useCollectionLoader({
       }
       return merged.length;
     } catch (err) {
+      if (isAbortError(err) || isStale(generation)) {
+        logCaughtError('useCollectionLoader.loadUnifiedLiked', err);
+        return loadGenerationRef.current;
+      }
       return handleLoadError(err, 'Failed to load liked tracks.');
     }
   }, [
-    beginLoad, clearWithError, handleLoadError, applyTracks,
+    beginLoad, isStale, clearWithError, handleLoadError, applyTracks,
     connectedProviderIds, getDescriptor, activeDescriptor,
     setActiveProviderId, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
 
   const loadContextPlayback = useCallback(async (
-    playlistId: string, providerId: ProviderId,
+    playlistId: string, providerId: ProviderId, generation: number,
   ): Promise<number> => {
     setIsLoading(false);
     const prevProvider = drivingProviderRef.current;
@@ -144,6 +177,7 @@ export function useCollectionLoader({
     mediaTracksRef.current = [];
     logQueue('Context playback path — delegating to legacy handler for %s on %s', playlistId, providerId);
     const sdkTracks = await spotifyHandlePlaylistSelect(playlistId);
+    if (isStale(generation)) return loadGenerationRef.current;
     if (sdkTracks.length > 0) {
       mediaTracksRef.current = sdkTracks;
       queueSnapshot('Context playback loaded', sdkTracks, mediaTracksRef.current.length, 0);
@@ -151,7 +185,7 @@ export function useCollectionLoader({
       logQueue('Context playback returned 0 tracks');
     }
     return sdkTracks.length;
-  }, [drivingProviderRef, mediaTracksRef, setIsLoading, spotifyHandlePlaylistSelect]);
+  }, [drivingProviderRef, mediaTracksRef, setIsLoading, spotifyHandlePlaylistSelect, isStale]);
 
   const loadProviderCollection = useCallback(async (
     playlistId: string, targetDescriptor: ProviderDescriptor, name?: string,
@@ -162,14 +196,16 @@ export function useCollectionLoader({
       activeDescriptor.playback.pause().catch(() => {});
     }
 
-    beginLoad(playlistId);
+    const { generation, signal } = beginLoad(playlistId);
     try {
       const { id: collectionId, kind: collectionKind } = resolvePlaylistRef(playlistId, providerId);
       const collectionRef = { provider: providerId, kind: collectionKind, id: collectionId } as const;
-      const list = await targetDescriptor.catalog.listTracks(collectionRef);
+      const list = await targetDescriptor.catalog.listTracks(collectionRef, signal);
+
+      if (isStale(generation)) return loadGenerationRef.current;
 
       if (list.length === 0 && targetDescriptor.capabilities.hasContextPlaybackFallback) {
-        return loadContextPlayback(playlistId, providerId);
+        return loadContextPlayback(playlistId, providerId, generation);
       }
 
       if (list.length === 0) return clearWithError('No tracks found in this collection.');
@@ -177,14 +213,19 @@ export function useCollectionLoader({
       applyTracks(list, { forceShuffle: isAllMusicRef(collectionRef) });
       drivingProviderRef.current = providerId;
       queueSnapshot(`${providerId} playlist loaded`, list, mediaTracksRef.current.length, 0);
+      if (isStale(generation)) return loadGenerationRef.current;
       await playTrack(0);
       record(collectionRef, name ?? collectionId, list[0]?.image ?? null);
       return list.length;
     } catch (err) {
+      if (isAbortError(err) || isStale(generation)) {
+        logCaughtError('useCollectionLoader.loadProviderCollection', err);
+        return loadGenerationRef.current;
+      }
       return handleLoadError(err, 'Failed to load collection.');
     }
   }, [
-    activeDescriptor, beginLoad, clearWithError, handleLoadError,
+    activeDescriptor, beginLoad, isStale, clearWithError, handleLoadError,
     applyTracks, loadContextPlayback, drivingProviderRef, mediaTracksRef, playTrack, record,
   ]);
 
@@ -222,6 +263,8 @@ export function useCollectionLoader({
     async (tracks: MediaTrack[], collectionId: string, provider?: ProviderId): Promise<number> => {
       if (radioStateIsActive) stopRadioBase();
 
+      const { generation } = beginLoadGeneration();
+
       const targetDescriptor = provider ? getDescriptor(provider) : activeDescriptor;
       const targetProviderId = provider ?? activeDescriptor?.id;
 
@@ -252,11 +295,13 @@ export function useCollectionLoader({
       }
 
       queueSnapshot('Direct tracks loaded', tracks, mediaTracksRef.current.length, 0);
+      if (isStale(generation)) return loadGenerationRef.current;
       await playTrack(0);
       return tracks.length;
     },
     [
-      radioStateIsActive, stopRadioBase, getDescriptor, activeDescriptor,
+      radioStateIsActive, stopRadioBase, beginLoadGeneration, isStale,
+      getDescriptor, activeDescriptor,
       setError, setIsLoading, setSelectedPlaylistId, mediaTracksRef,
       setTracks, setOriginalTracks, setCurrentTrackIndex,
       applyTracks, drivingProviderRef, setActiveProviderId, playTrack,

--- a/src/hooks/useQueueManagement.ts
+++ b/src/hooks/useQueueManagement.ts
@@ -135,7 +135,14 @@ export function useQueueManagement({
         );
         const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
         mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-        setOriginalTracks(nextTracks);
+        // When shuffle is ON, preserve the true unshuffled order by appending only the
+        // new tracks to originalTracks. Overwriting with nextTracks (the shuffled queue
+        // snapshot) would corrupt the restore-on-unshuffle path — mirrors handleReorderQueue.
+        if (shuffleEnabled) {
+          setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+        } else {
+          setOriginalTracks(nextTracks);
+        }
         setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
         notifyQueueChanged(nextTracks, currentTrackIndex);
         logQueue(
@@ -151,7 +158,7 @@ export function useQueueManagement({
       }
     },
     // mediaTracksRef included for exhaustive-deps; ref identity is stable so it does not cause callback re-creation.
-    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex]
+    [tracks.length, loadCollection, activeDescriptor, getDescriptor, setTracks, setOriginalTracks, mediaTracksRef, notifyQueueChanged, currentTrackIndex, shuffleEnabled]
   );
 
   const handleRemoveFromQueue = useCallback(
@@ -256,12 +263,17 @@ export function useQueueManagement({
       );
       const nextTracks = [...tracksRef.current, ...uniqueNewTracks];
       mediaTracksRef.current = appendMediaTracks(mediaTracksRef.current, uniqueNewTracks);
-      setOriginalTracks(nextTracks);
+      // When shuffle is ON, preserve the true unshuffled order — mirrors handleReorderQueue.
+      if (shuffleEnabled) {
+        setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+      } else {
+        setOriginalTracks(nextTracks);
+      }
       setTracks((prev: MediaTrack[]) => [...prev, ...uniqueNewTracks]);
       notifyQueueChanged(nextTracks, currentTrackIndex);
       return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
-    [mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
+    [shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged, currentTrackIndex]
   );
 
   /**
@@ -302,7 +314,15 @@ export function useQueueManagement({
       const nextTracks = [...tracksRef.current];
       nextTracks.splice(insertAt, 0, ...uniqueNewTracks);
       mediaTracksRef.current = insertMediaTracksAt(mediaTracksRef.current, insertAt, uniqueNewTracks);
-      setOriginalTracks(nextTracks);
+      // When shuffle is ON, append to originalTracks to preserve the true unshuffled
+      // order. Splicing into originalTracks at currentTrackIndex+1 is not meaningful
+      // because the shuffled queue position does not correspond to an unshuffled slot.
+      // Appending keeps the collection's natural order intact for restore-on-unshuffle.
+      if (shuffleEnabled) {
+        setOriginalTracks((prev) => [...prev, ...uniqueNewTracks]);
+      } else {
+        setOriginalTracks(nextTracks);
+      }
       setTracks(nextTracks);
 
       notifyQueueChanged(nextTracks, currentTrackIndex);
@@ -314,7 +334,7 @@ export function useQueueManagement({
       );
       return { added: uniqueNewTracks.length, ...(collectionName !== undefined && { collectionName }) };
     },
-    [currentTrackIndex, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
+    [currentTrackIndex, shuffleEnabled, mediaTracksRef, setOriginalTracks, setTracks, notifyQueueChanged],
   );
 
   /**


### PR DESCRIPTION
## Summary

Fixes three queue/collection bugs found in the 2026-06-11 swarm, each with its OpenSpec delta in `openspec/specs/queue-management/spec.md`:

- **Stale collection load clobbers newer one** — `useCollectionLoader` now carries a per-load generation guard checked after every awaited boundary (including before `playTrack(0)` and inside the context-playback fallback) plus an `AbortController` threaded through `listTracks`, so the newest load always wins and superseded network work is cancelled. Spec: newest-load-wins under *Loading a Collection*.
- **Add-to-queue while shuffled corrupts originalTracks** — the three append paths in `useQueueManagement` (`handleAddToQueue`, `queueTracksDirectly`, `insertTracksNext`) now append to the preserved original order while shuffle is ON instead of overwriting it with the shuffled snapshot, so un-shuffle restores the collection's true order. Spec: original-order preservation under *Shuffle Mode*.
- **Queue drag-reorder silently fails on mid-drag rename** — dnd-kit sortable IDs and React keys in `QueueTrackList`/`QueueTrackItem` are keyed by immutable `track.id` instead of `${name}-${id}`, so async ID3 title enrichment can no longer orphan an in-flight drag. Spec: id-keyed reordering under *Reordering the Queue*.

## Test plan

- Unit: 2003 tests across 195 files green (`npm run test:run`), including new coverage for every spec scenario: stale-load races at the `listTracks`, `playTrack(0)`, and context-playback boundaries plus abort + active-provider suppression; originalTracks preservation across all three append paths plus a composed add-while-shuffled → un-shuffle restore test; a real dnd-kit PointerSensor drag simulation with a mid-gesture rename (verified to fail against the pre-fix keying).
- E2E: 18/18 Playwright specs green against the mock provider (`npm run test:e2e`).
- `npx tsc -b --noEmit` clean.

Closes #1638
Closes #1639
Closes #1640