### PR TITLE
fix(volume): apply live volume/mute on provider switch instead of frozen mount value

### DIFF
--- a/src/hooks/__tests__/useVolume.test.ts
+++ b/src/hooks/__tests__/useVolume.test.ts
@@ -202,12 +202,7 @@ describe('useVolume', () => {
   });
 
   it('reapplies current volume (not mount-time value) on cross-provider handoff', () => {
-    // #given - mount with default volume 50, then change to 80
-    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
-      if (key === 'vorbis-player-volume') return '80';
-      return null;
-    });
-
+    // #given - app mounts at default volume 50
     const dropboxSetVolume = vi.fn().mockResolvedValue(undefined);
     const dropboxDescriptor = makeProviderDescriptor({
       id: 'dropbox',
@@ -231,19 +226,68 @@ describe('useVolume', () => {
       id === 'dropbox' ? dropboxDescriptor : undefined
     );
 
-    // activeDescriptor is spotify; currentTrackProvider starts as spotify
-    const { rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ provider }: { provider: 'spotify' | 'dropbox' }) => useVolume(provider),
       { wrapper: ProviderWrapper, initialProps: { provider: 'spotify' as const } }
     );
+
+    // #given - user drags volume to 80 mid-session (after mount)
+    act(() => {
+      result.current.setVolumeLevel(80);
+    });
 
     vi.clearAllMocks();
 
     // #when - queue advances from Spotify to Dropbox (cross-provider handoff)
     rerender({ provider: 'dropbox' });
 
-    // #then - Dropbox playback receives the current volume (80), not the mount-time value
+    // #then - Dropbox playback receives the current volume (80), not the mount-time value (50)
     expect(dropboxSetVolume).toHaveBeenCalledWith(0.8); // 80 / 100
     expect(dropboxSetVolume).not.toHaveBeenCalledWith(0.5); // mount-time 50 / 100 must not appear
+  });
+
+  it('stays muted on cross-provider handoff', () => {
+    // #given - app mounts at default volume 50, user mutes
+    const dropboxSetVolume = vi.fn().mockResolvedValue(undefined);
+    const dropboxDescriptor = makeProviderDescriptor({
+      id: 'dropbox',
+      playback: {
+        providerId: 'dropbox',
+        initialize: vi.fn().mockResolvedValue(undefined),
+        playTrack: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        seek: vi.fn().mockResolvedValue(undefined),
+        next: vi.fn().mockResolvedValue(undefined),
+        previous: vi.fn().mockResolvedValue(undefined),
+        setVolume: dropboxSetVolume,
+        getState: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockReturnValue(vi.fn()),
+        getLastPlayTime: vi.fn().mockReturnValue(Date.now()),
+      },
+    });
+
+    vi.mocked(providerRegistry.get).mockImplementation((id) =>
+      id === 'dropbox' ? dropboxDescriptor : undefined
+    );
+
+    const { result, rerender } = renderHook(
+      ({ provider }: { provider: 'spotify' | 'dropbox' }) => useVolume(provider),
+      { wrapper: ProviderWrapper, initialProps: { provider: 'spotify' as const } }
+    );
+
+    // #given - user mutes mid-session
+    act(() => {
+      result.current.handleMuteToggle();
+    });
+
+    vi.clearAllMocks();
+
+    // #when - queue advances from Spotify to Dropbox (cross-provider handoff)
+    rerender({ provider: 'dropbox' });
+
+    // #then - Dropbox playback receives 0 (muted), not the underlying volume
+    expect(dropboxSetVolume).toHaveBeenCalledWith(0);
+    expect(result.current.isMuted).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useVolume.test.ts
+++ b/src/hooks/__tests__/useVolume.test.ts
@@ -7,14 +7,72 @@ vi.mock('@/services/spotifyPlayer', () => ({
   },
 }));
 
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: vi.fn(),
+  ProviderProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    get: vi.fn().mockReturnValue(undefined),
+    getAll: vi.fn().mockReturnValue([]),
+    has: vi.fn().mockReturnValue(false),
+  },
+}));
+
 import { useVolume } from '../useVolume';
 import { spotifyPlayer } from '@/services/spotifyPlayer';
+import { useProviderContext } from '@/contexts/ProviderContext';
+import { providerRegistry } from '@/providers/registry';
 import { ProviderWrapper } from '@/test/providerTestUtils';
+import { makeProviderDescriptor } from '@/test/fixtures';
 
 describe('useVolume', () => {
+  let mockSpotifyDescriptor: ReturnType<typeof makeProviderDescriptor>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(window.localStorage.getItem).mockReturnValue(null);
+
+    mockSpotifyDescriptor = makeProviderDescriptor({
+      id: 'spotify',
+      playback: {
+        providerId: 'spotify',
+        initialize: vi.fn().mockResolvedValue(undefined),
+        playTrack: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        seek: vi.fn().mockResolvedValue(undefined),
+        next: vi.fn().mockResolvedValue(undefined),
+        previous: vi.fn().mockResolvedValue(undefined),
+        setVolume: vi.mocked(spotifyPlayer.setVolume),
+        getState: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockReturnValue(vi.fn()),
+        getLastPlayTime: vi.fn().mockReturnValue(Date.now()),
+      },
+    });
+
+    vi.mocked(useProviderContext).mockReturnValue({
+      chosenProviderId: 'spotify',
+      activeProviderId: 'spotify',
+      activeDescriptor: mockSpotifyDescriptor,
+      setActiveProviderId: vi.fn(),
+      setProviderSwitchInterceptor: vi.fn(),
+      registry: { get: vi.fn(), getAll: vi.fn().mockReturnValue([]), has: vi.fn() },
+      needsProviderSelection: false,
+      enabledProviderIds: ['spotify'],
+      toggleProvider: vi.fn(),
+      isProviderEnabled: vi.fn().mockReturnValue(true),
+      hasMultipleProviders: false,
+      getDescriptor: vi.fn(),
+      connectedProviderIds: ['spotify'],
+      fallthroughNotification: null,
+      dismissFallthroughNotification: vi.fn(),
+      disconnectToast: null,
+      dismissDisconnectToast: vi.fn(),
+    });
+
+    vi.mocked(providerRegistry.get).mockReturnValue(undefined);
   });
 
   it('defaults volume to 50 when localStorage is empty', () => {
@@ -141,5 +199,51 @@ describe('useVolume', () => {
       'vorbis-player-volume',
       '80'
     );
+  });
+
+  it('reapplies current volume (not mount-time value) on cross-provider handoff', () => {
+    // #given - mount with default volume 50, then change to 80
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === 'vorbis-player-volume') return '80';
+      return null;
+    });
+
+    const dropboxSetVolume = vi.fn().mockResolvedValue(undefined);
+    const dropboxDescriptor = makeProviderDescriptor({
+      id: 'dropbox',
+      playback: {
+        providerId: 'dropbox',
+        initialize: vi.fn().mockResolvedValue(undefined),
+        playTrack: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        seek: vi.fn().mockResolvedValue(undefined),
+        next: vi.fn().mockResolvedValue(undefined),
+        previous: vi.fn().mockResolvedValue(undefined),
+        setVolume: dropboxSetVolume,
+        getState: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockReturnValue(vi.fn()),
+        getLastPlayTime: vi.fn().mockReturnValue(Date.now()),
+      },
+    });
+
+    vi.mocked(providerRegistry.get).mockImplementation((id) =>
+      id === 'dropbox' ? dropboxDescriptor : undefined
+    );
+
+    // activeDescriptor is spotify; currentTrackProvider starts as spotify
+    const { rerender } = renderHook(
+      ({ provider }: { provider: 'spotify' | 'dropbox' }) => useVolume(provider),
+      { wrapper: ProviderWrapper, initialProps: { provider: 'spotify' as const } }
+    );
+
+    vi.clearAllMocks();
+
+    // #when - queue advances from Spotify to Dropbox (cross-provider handoff)
+    rerender({ provider: 'dropbox' });
+
+    // #then - Dropbox playback receives the current volume (80), not the mount-time value
+    expect(dropboxSetVolume).toHaveBeenCalledWith(0.8); // 80 / 100
+    expect(dropboxSetVolume).not.toHaveBeenCalledWith(0.5); // mount-time 50 / 100 must not appear
   });
 });

--- a/src/hooks/useVolume.ts
+++ b/src/hooks/useVolume.ts
@@ -11,7 +11,6 @@ export const useVolume = (currentTrackProvider?: ProviderId) => {
   const [volume, setVolume] = useLocalStorage<number>(STORAGE_KEYS.VOLUME, DEFAULT_VOLUME);
   const [isMuted, setIsMuted] = useLocalStorage<boolean>(STORAGE_KEYS.MUTED, false);
   const previousVolumeRef = useRef(volume > 0 ? volume : DEFAULT_VOLUME);
-  const initialVolumeRef = useRef(isMuted ? 0 : volume / 100);
 
   const { activeDescriptor } = useProviderContext();
 
@@ -24,8 +23,8 @@ export const useVolume = (currentTrackProvider?: ProviderId) => {
   }, [activeDescriptor, currentTrackProvider]);
 
   useEffect(() => {
-    getPlayingPlayback()?.setVolume(initialVolumeRef.current);
-  }, [getPlayingPlayback]);
+    getPlayingPlayback()?.setVolume(isMuted ? 0 : volume / 100);
+  }, [getPlayingPlayback, isMuted, volume]);
 
   const handleMuteToggle = useCallback(() => {
     setIsMuted((prev) => {


### PR DESCRIPTION
## Summary

`useVolume` was initializing a `ref` at mount time and reapplying that stale value whenever `getPlayingPlayback` changed identity (i.e., on every cross-provider track switch), silently clobbering any volume or mute changes the user made after mounting. The fix drops the frozen ref and computes the live value inline in the effect, so provider switches apply the current volume/mute state instead.

## Test plan

- [ ] Mount the app at volume 50, drag to 80, then advance queue from a Spotify track to a Dropbox track — volume stays at 80
- [ ] Same scenario with mute enabled — stays muted after provider switch
- [ ] Regression test in `useVolume.test.ts` covering cross-provider handoff
- [ ] `npm run test:run` passes
- [ ] `npx tsc -b --noEmit` clean

Closes #1648