### PR TITLE
fix(library-cache): flip fallback mode on IDB write failure to prevent read/write split-brain

### DIFF
--- a/src/services/cache/__tests__/libraryCache.test.ts
+++ b/src/services/cache/__tests__/libraryCache.test.ts
@@ -472,4 +472,96 @@ describe('libraryCache', () => {
       vi.mocked(indexedDB.open).mockImplementation(originalOpen);
     });
   });
+
+  describe('runtime write-path IDB failure', () => {
+    /**
+     * Helper: after initCache succeeds, mock IDBDatabase.prototype.transaction so
+     * that readwrite transactions throw, simulating a QuotaExceededError or closed
+     * connection. readonly transactions are left intact so beforeEach/afterEach can
+     * still use clearAll and close without hanging.
+     */
+    function mockWriteTransactionFailure(db: IDBDatabase): () => void {
+      const original = db.transaction.bind(db);
+      const spy = vi.spyOn(db, 'transaction').mockImplementation(
+        (storeNames: string | string[], mode?: IDBTransactionMode) => {
+          if (mode === 'readwrite') {
+            throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+          }
+          return original(storeNames, mode);
+        },
+      );
+      return () => spy.mockRestore();
+    }
+
+    it('should flip to fallback mode when a put fails at runtime', async () => {
+      // #given — IDB opens successfully, then readwrite transactions start failing
+      await initCache();
+      expect(_testing.fallbackMode).toBe(false);
+      const restore = mockWriteTransactionFailure(_testing.db!);
+
+      // #when — write fails at runtime (IDB was healthy at init)
+      await putPlaylist(makePlaylist('p1', 'Fallback Playlist'));
+
+      // #then — fallback mode is now active
+      expect(_testing.fallbackMode).toBe(true);
+
+      restore();
+    });
+
+    it('should serve the written value from the in-memory map after a runtime put failure', async () => {
+      // #given — IDB opens, then readwrite transactions start throwing
+      await initCache();
+      expect(_testing.fallbackMode).toBe(false);
+      const restore = mockWriteTransactionFailure(_testing.db!);
+
+      // #when — write fails at runtime; the value lands in the fallback Map
+      await putPlaylist(makePlaylist('p1', 'Quota Playlist'));
+
+      // #then — fallback mode flipped and the subsequent read returns the in-memory value,
+      //          not stale IDB data
+      expect(_testing.fallbackMode).toBe(true);
+      const result = await getAllPlaylists();
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe('Quota Playlist');
+
+      restore();
+    });
+
+    it('should flip to fallback mode when a putAll fails at runtime', async () => {
+      // #given — IDB opens successfully, then readwrite transactions start throwing
+      await initCache();
+      expect(_testing.fallbackMode).toBe(false);
+      const restore = mockWriteTransactionFailure(_testing.db!);
+
+      // #when — putAll touches multiple items; the entire batch goes to fallback
+      const batch = [makePlaylist('p2', 'Batch A'), makePlaylist('p3', 'Batch B')];
+      await putAllPlaylists(batch);
+
+      // #then
+      expect(_testing.fallbackMode).toBe(true);
+      const result = await getAllPlaylists();
+      expect(result.map((p) => p.id).sort()).toEqual(['p2', 'p3']);
+
+      restore();
+    });
+
+    it('should keep fallback mode true for all subsequent reads after a write failure', async () => {
+      // #given — IDB opens; one write fails
+      await initCache();
+      const restore = mockWriteTransactionFailure(_testing.db!);
+      await putPlaylist(makePlaylist('p1'));
+      restore();
+      expect(_testing.fallbackMode).toBe(true);
+
+      // #when — subsequent reads and writes (IDB transaction mock removed)
+      await putPlaylist(makePlaylist('p2', 'After Failure'));
+      const playlists = await getAllPlaylists();
+      const albums = await getAllAlbums();
+
+      // #then — still in fallback; reads come from the in-memory map, not IDB
+      expect(_testing.fallbackMode).toBe(true);
+      expect(playlists.map((p) => p.id).sort()).toEqual(['p1', 'p2']);
+      expect(albums).toEqual([]);
+    });
+  });
 });

--- a/src/services/cache/libraryCacheLifecycle.ts
+++ b/src/services/cache/libraryCacheLifecycle.ts
@@ -44,6 +44,10 @@ export function isFallback(): boolean {
   return fallbackMode;
 }
 
+export function enterFallback(): void {
+  fallbackMode = true;
+}
+
 export function getFallbackMap(storeName: string): Map<string, unknown> {
   const store = fallbackStores[storeName];
   if (!store) throw new Error(`[libraryCache] Unknown store: ${storeName}`);

--- a/src/services/cache/libraryCacheStorage.ts
+++ b/src/services/cache/libraryCacheStorage.ts
@@ -8,6 +8,7 @@
 
 import { logCaughtError } from '@/utils/logCaughtError';
 import {
+  enterFallback,
   fallbackStores,
   getDb,
   getFallbackMap,
@@ -146,6 +147,7 @@ export function getStore<T>(storeName: string): KVStore<T> {
         await idbPut(storeName, value);
       } catch (err) {
         logCaughtError(`libraryCacheStorage.${storeName}.put`, err);
+        enterFallback();
         fallback().set(key, value);
       }
     },
@@ -162,6 +164,7 @@ export function getStore<T>(storeName: string): KVStore<T> {
         await idbPutAll(storeName, items);
       } catch (err) {
         logCaughtError(`libraryCacheStorage.${storeName}.putAll`, err);
+        enterFallback();
         const map = fallback();
         for (const [key, value] of entries) map.set(key, value);
       }
@@ -177,6 +180,7 @@ export function getStore<T>(storeName: string): KVStore<T> {
         await idbDelete(storeName, key);
       } catch (err) {
         logCaughtError(`libraryCacheStorage.${storeName}.remove`, err);
+        enterFallback();
         fallback().delete(key);
       }
     },
@@ -194,6 +198,7 @@ export function getStore<T>(storeName: string): KVStore<T> {
         await idbReplaceAll(storeName, items);
       } catch (err) {
         logCaughtError(`libraryCacheStorage.${storeName}.replaceAll`, err);
+        enterFallback();
         const map = fallback();
         map.clear();
         for (const [key, value] of entries) map.set(key, value);
@@ -210,6 +215,7 @@ export function getStore<T>(storeName: string): KVStore<T> {
         await idbClear(storeName);
       } catch (err) {
         logCaughtError(`libraryCacheStorage.${storeName}.clear`, err);
+        enterFallback();
         fallback().clear();
       }
     },


### PR DESCRIPTION
## Summary

When an IndexedDB write failed at runtime, the library cache wrote the value to its in-memory fallback `Map` but never set `fallbackMode = true`. Subsequent reads still targeted IndexedDB and returned stale data, splitting the backing stores for the rest of the session. The fix exports `enterFallback()` from the lifecycle module and calls it on every write-failure path (`put`, `putAll`, `remove`, `replaceAll`, `clear`) so reads and writes stay on the same store.

Closes #1650.

## History

Revives the work from #1654 (closed unmerged on 2026-06-18 during a branch-cleanup sweep, with no review or merit-based rejection). The bug was still live on `main` and the issue remained open. Branch rebased onto current `main` (clean, no conflicts).

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — full suite green (2010); 33 in `libraryCache.test.ts`, including new coverage for a runtime IDB write failure flipping fallback mode