### PR TITLE
fix(library-sync): guard start() against re-entrancy during async cold load

### DIFF
--- a/src/services/cache/__tests__/librarySyncEngine.test.ts
+++ b/src/services/cache/__tests__/librarySyncEngine.test.ts
@@ -164,6 +164,48 @@ describe('SpotifyLibrarySyncEngine', () => {
       expect(emittedPlaylists![0].name).toBe('Fresh');
       expect(mockGetUserLibraryInterleaved).toHaveBeenCalledOnce();
     });
+
+    it('should deduplicate concurrent start() calls during cold load', async () => {
+      // #given — make the cold load block until we explicitly unblock it
+      // Create the deferred gate before start() is called so it's available immediately
+      let unblockLoad!: () => void;
+      const gate = new Promise<void>((resolve) => { unblockLoad = resolve; });
+      mockGetUserLibraryInterleaved.mockImplementation(() => gate);
+      mockGetLikedSongsCount.mockResolvedValue(0);
+
+      // #when — two concurrent start() calls while cold load is in flight
+      const p1 = engine.start();
+      const p2 = engine.start();
+
+      // unblock the cold load and wait for both to settle
+      unblockLoad();
+      await Promise.all([p1, p2]);
+
+      // #then — getUserLibraryInterleaved must have been called exactly once
+      expect(mockGetUserLibraryInterleaved).toHaveBeenCalledOnce();
+    });
+
+    it('should allow restart after stop() is called between start cycles', async () => {
+      // #given — use a fresh engine with empty cache for both start cycles
+      mockGetUserLibraryInterleaved.mockImplementation(async (onPlaylists, onAlbums) => {
+        onPlaylists([makePlaylist('p1', 'Cycle1')], true);
+        onAlbums([], true);
+      });
+      mockGetLikedSongsCount.mockResolvedValue(0);
+
+      // Complete the first cycle
+      await engine.start();
+      engine.stop();
+
+      // Clear the cache so the second start() also takes the cold path
+      await cache.clearAll();
+
+      // #when — second start() after stop(); must not be blocked by a stale startPromise
+      await engine.start();
+
+      // #then — cold load ran twice (once per cycle)
+      expect(mockGetUserLibraryInterleaved).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('change detection', () => {

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -42,6 +42,7 @@ const OPTIMISTIC_GRACE_MS = 30 * 1000;
 export class SpotifyLibrarySyncEngine {
   readonly providerId = 'spotify' as const;
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private startPromise: Promise<void> | null = null;
   private listeners = new Set<SyncListener>();
   private abortController: AbortController | null = null;
   private pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
@@ -72,16 +73,22 @@ export class SpotifyLibrarySyncEngine {
 
   /** Start the background polling loop and perform initial load. */
   async start(intervalMs?: number): Promise<void> {
-    if (this.intervalId) return;
+    if (this.intervalId ?? this.startPromise) return this.startPromise ?? undefined;
 
-    this.pollIntervalMs = intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.startPromise = (async () => {
+      this.pollIntervalMs = intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 
-    if (typeof document !== 'undefined') {
-      document.addEventListener('visibilitychange', this.handleVisibilityChange);
-    }
+      if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', this.handleVisibilityChange);
+      }
 
-    await this.initialLoad();
-    this.startPollingInterval();
+      await this.initialLoad();
+      this.startPollingInterval();
+    })().finally(() => {
+      this.startPromise = null;
+    });
+
+    return this.startPromise;
   }
 
   /** Stop polling and cancel any in-flight requests. */

--- a/src/services/cache/librarySyncEngine.ts
+++ b/src/services/cache/librarySyncEngine.ts
@@ -73,7 +73,8 @@ export class SpotifyLibrarySyncEngine {
 
   /** Start the background polling loop and perform initial load. */
   async start(intervalMs?: number): Promise<void> {
-    if (this.intervalId ?? this.startPromise) return this.startPromise ?? undefined;
+    if (this.intervalId) return;
+    if (this.startPromise) return this.startPromise;
 
     this.startPromise = (async () => {
       this.pollIntervalMs = intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
@@ -93,6 +94,7 @@ export class SpotifyLibrarySyncEngine {
 
   /** Stop polling and cancel any in-flight requests. */
   stop(): void {
+    this.startPromise = null;
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;


### PR DESCRIPTION
## Summary

`SpotifyLibrarySyncEngine.start()` only set `intervalId` after `await this.initialLoad()` resolved, so any concurrent `start()` call made during the cold load — React 18 StrictMode's double-mount in dev, or an `engineProviderId` change in prod — bypassed the `intervalId` guard and kicked off a second concurrent cold load. The fix tracks the in-flight start as a `startPromise`: re-entrant calls return that promise instead of starting again, and `stop()` clears it.

Closes #1649.

## History

Revives the work from #1655 (closed unmerged on 2026-06-18 during a branch-cleanup sweep, with no review or merit-based rejection). The bug was still live on `main` and the issue remained open. Branch rebased onto current `main` (clean, no conflicts).

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — full suite green (2008); 16 in `librarySyncEngine.test.ts`, including new re-entrancy coverage