### PR TITLE
Adjust zen mode track info margin based on zen state

### DIFF
--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -166,8 +166,8 @@ export const ZenTrackInfo = styled.div.withConfig({
   padding: 0 ${({ theme }) => theme.spacing.md};
   opacity: ${({ $zenMode }) => $zenMode ? 1 : 0};
   transition: ${({ $zenMode }) => $zenMode
-    ? `opacity ${ZEN_TRACK_INFO_ENTER_OPACITY_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_OPACITY_DELAY}ms, grid-template-rows ${ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_HEIGHT_DELAY}ms`
-    : `opacity ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease, grid-template-rows ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease`
+    ? `opacity ${ZEN_TRACK_INFO_ENTER_OPACITY_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_OPACITY_DELAY}ms, grid-template-rows ${ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_HEIGHT_DELAY}ms, margin-top ${ZEN_TRACK_INFO_ENTER_HEIGHT_DURATION}ms ease ${ZEN_TRACK_INFO_ENTER_HEIGHT_DELAY}ms`
+    : `opacity ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease, grid-template-rows ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease, margin-top ${ZEN_TRACK_INFO_EXIT_DURATION}ms ease`
   };
 `;
 

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -162,7 +162,7 @@ export const ZenTrackInfo = styled.div.withConfig({
   grid-template-rows: ${({ $zenMode }) => $zenMode ? '1fr' : '0fr'};
   text-align: center;
   pointer-events: none;
-  margin-top: ${({ theme }) => theme.spacing.sm};
+  margin-top: ${({ $zenMode, theme }) => $zenMode ? theme.spacing.xl : theme.spacing.sm};
   padding: 0 ${({ theme }) => theme.spacing.md};
   opacity: ${({ $zenMode }) => $zenMode ? 1 : 0};
   transition: ${({ $zenMode }) => $zenMode


### PR DESCRIPTION
## Summary
Adjusts the top margin of the zen mode track info container to provide better visual spacing when zen mode is active.

## Changes
- **`src/components/PlayerContent/styled.ts`**: Updated `ZenTrackInfo` margin-top to be responsive to zen mode state
  - When `$zenMode` is `true`: uses `theme.spacing.xl` for increased spacing
  - When `$zenMode` is `false`: uses `theme.spacing.sm` for minimal spacing
  - This provides better visual hierarchy and breathing room for the track info display in zen mode

## Implementation Details
The margin is now conditionally applied based on the `$zenMode` prop, allowing the component to adapt its spacing dynamically as the zen mode state changes. This complements the existing opacity and grid-template-rows transitions already in place for zen mode.

https://claude.ai/code/session_019Gesa3GM5t5EytMp5d2fgv