### PR TITLE
Display album name in zen mode track info

### DIFF
--- a/src/components/PlayerContent/AlbumArtSection.tsx
+++ b/src/components/PlayerContent/AlbumArtSection.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/constants/zenAnimation';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { VisualizerStyle, AlbumArtBounds } from '@/types/visualizer';
-import { FlipInner, ZenTrackInfo, ZenTrackInfoInner, ZenTrackName, ZenTrackArtist } from './styled';
+import { FlipInner, ZenTrackInfo, ZenTrackInfoInner, ZenTrackName, ZenTrackAlbum, ZenTrackArtist } from './styled';
 
 const ZEN_TRACK_INFO_WILL_CHANGE_FALLBACK_MS =
   ZEN_TRACK_INFO_ENTER_OPACITY_DURATION + ZEN_TRACK_INFO_ENTER_OPACITY_DELAY + 100;
@@ -381,6 +381,9 @@ export const AlbumArtSection: React.FC<AlbumArtSectionProps> = React.memo(({
               </ZenProviderBadgeInline>
             )}
           </ZenTrackName>
+          {currentTrack?.album && (
+            <ZenTrackAlbum>{currentTrack.album}</ZenTrackAlbum>
+          )}
           {currentTrack?.artists && (
             <ZenTrackArtist>{currentTrack.artists}</ZenTrackArtist>
           )}

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -193,6 +193,18 @@ export const ZenTrackName = styled.div.withConfig({
   width: 100%;
 `;
 
+export const ZenTrackAlbum = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  line-height: 1.4;
+  color: ${({ theme }) => theme.colors.gray[400]};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+`;
+
 export const ZenTrackArtist = styled.div`
   font-size: ${({ theme }) => theme.fontSize.base};
   line-height: 1.4;

--- a/src/components/PlayerContent/styled.ts
+++ b/src/components/PlayerContent/styled.ts
@@ -199,6 +199,7 @@ export const ZenTrackAlbum = styled.div`
   color: ${({ theme }) => theme.colors.gray[400]};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   letter-spacing: 0.02em;
+  text-shadow: ${({ theme }) => theme.shadows.textSm};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
Add album name display to the zen mode track information section, positioned between the track name and artist name.

## Changes
- **styled.ts**: Added `ZenTrackAlbum` styled component with small font size, gray color, and text truncation matching the design of other track info elements
- **AlbumArtSection.tsx**: 
  - Imported the new `ZenTrackAlbum` component
  - Conditionally render album name when available on the current track, positioned between track name and artist

## Implementation Details
The `ZenTrackAlbum` component follows the established styling pattern for zen mode track info:
- Uses theme tokens for font size (`sm`), color (`gray[400]`), and font weight (`medium`)
- Applies text truncation with ellipsis for long album names
- Maintains consistent line height and letter spacing with other track info elements

https://claude.ai/code/session_01WczHPMbp98PtxDLsPQgDYL