### PR TITLE
Position toasts above bottom bar with CSS variable offset

### DIFF
--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBackdrop, BOTTOM_BAR_HEIGHT } from './styled';
+import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBackdrop, BOTTOM_BAR_HEIGHT, TOAST_BAR_GAP } from './styled';
 import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
@@ -152,14 +152,18 @@ const BottomBar = React.memo(function BottomBar() {
    * and drop near the bottom edge when it is not. The bar is "visible" when it is mounted
    * (`!hidden`) and not slid away by zen auto-hide; in normal mode `barVisible` is forced
    * true so this reduces to `!hidden`.
+   *
+   * `zenExiting` is excluded because during the zen → normal re-entry delay the bar is still
+   * translated off-screen (its transition is deferred by ZEN_EXIT_REENTRY_DELAY); publishing
+   * the offset early would float a toast above a bar that has not yet slid into view.
    */
-  const barOccupiesSpace = !hidden && (barVisible || !zenModeEnabled);
+  const barOccupiesSpace = !hidden && !zenExiting && (barVisible || !zenModeEnabled);
   useEffect(() => {
     const root = document.documentElement;
     if (barOccupiesSpace) {
       root.style.setProperty(
         '--vp-toast-offset',
-        `calc(${BOTTOM_BAR_HEIGHT}px + env(safe-area-inset-bottom, 0px) + 12px)`,
+        `calc(${BOTTOM_BAR_HEIGHT}px + env(safe-area-inset-bottom, 0px) + ${TOAST_BAR_GAP}px)`,
       );
     } else {
       root.style.removeProperty('--vp-toast-offset');

--- a/src/components/BottomBar/index.tsx
+++ b/src/components/BottomBar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBackdrop } from './styled';
+import { BottomBarContainer, BottomBarInner, ZenGripPill, ZenTriggerZone, ZenBackdrop, BOTTOM_BAR_HEIGHT } from './styled';
 import { ControlButton } from '../controls/styled';
 import VolumeControl from '../controls/VolumeControl';
 import { usePlayerSizingContext } from '@/contexts/PlayerSizingContext';
@@ -145,6 +145,29 @@ const BottomBar = React.memo(function BottomBar() {
       zenExitingTimerRef.current = null;
     }
   }, []);
+
+  /*
+   * Publish the vertical space the bar occupies as `--vp-toast-offset` on :root so toasts
+   * (mounted at the app root, see ui/sonner.tsx) can sit above the bar while it is visible
+   * and drop near the bottom edge when it is not. The bar is "visible" when it is mounted
+   * (`!hidden`) and not slid away by zen auto-hide; in normal mode `barVisible` is forced
+   * true so this reduces to `!hidden`.
+   */
+  const barOccupiesSpace = !hidden && (barVisible || !zenModeEnabled);
+  useEffect(() => {
+    const root = document.documentElement;
+    if (barOccupiesSpace) {
+      root.style.setProperty(
+        '--vp-toast-offset',
+        `calc(${BOTTOM_BAR_HEIGHT}px + env(safe-area-inset-bottom, 0px) + 12px)`,
+      );
+    } else {
+      root.style.removeProperty('--vp-toast-offset');
+    }
+    return () => {
+      root.style.removeProperty('--vp-toast-offset');
+    };
+  }, [barOccupiesSpace]);
 
   if (hidden) return null;
 

--- a/src/components/BottomBar/styled.ts
+++ b/src/components/BottomBar/styled.ts
@@ -4,6 +4,9 @@ import { TOUCH_TARGET_MIN_PX } from '@/constants/a11y';
 
 export const BOTTOM_BAR_HEIGHT = 60;
 
+/** Gap between the top of the bottom bar and a toast resting above it (issue #1664). */
+export const TOAST_BAR_GAP = 12;
+
 const ZEN_GRIP_PILL_WIDTH = '36px';
 const ZEN_GRIP_PILL_HEIGHT = '4px';
 const ZEN_GRIP_PILL_BOTTOM_OFFSET = '10px';

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -6,7 +6,12 @@ import { theme } from '@/styles/theme';
  *
  * - z-index 1410: clears BottomBar (theme.zIndex.modal = 1400) and Dialog overlay (1405).
  *   Matches the prior hand-rolled Toast.tsx (`theme.zIndex.modal + 10`).
- * - position="top-center": preserves prior Toast.tsx fixed top-center placement.
+ * - position="bottom-center": toasts rise from the bottom (issue #1664). The bottom offset
+ *   reads `--vp-toast-offset`, a variable the BottomBar publishes on `:root` while it is
+ *   visible (see `BottomBar/index.tsx`). When the bar is absent the variable is unset and
+ *   the `var()` fallback (sonner's default viewport offset) keeps the toast near the bottom
+ *   edge. This keeps toasts clear of the interactive bottom bar without wiring BottomBar
+ *   context up to this app-root component.
  * - theme="dark": app is dark-mode-only.
  * - Surface uses neutral player-chrome tokens (overlay.dark + popover.border) — never
  *   the runtime --accent-color, per the shadcn coexistence rule in CLAUDE.md.
@@ -17,7 +22,9 @@ export function Toaster(): React.ReactElement {
   return (
     <Sonner
       theme="dark"
-      position="top-center"
+      position="bottom-center"
+      offset={{ bottom: 'var(--vp-toast-offset, 24px)' }}
+      mobileOffset={{ bottom: 'var(--vp-toast-offset, 16px)' }}
       closeButton
       toastOptions={{
         style: {


### PR DESCRIPTION
## Summary

Repositions toasts from top-center to bottom-center and dynamically offsets them to sit above the BottomBar when visible. Uses a CSS variable (`--vp-toast-offset`) published by BottomBar to coordinate toast placement without wiring context up to the app-root Toaster component.

## Changes

- **BottomBar** (`src/components/BottomBar/index.tsx`):
  - Export `BOTTOM_BAR_HEIGHT` constant from styled module
  - Add `useEffect` hook that publishes `--vp-toast-offset` CSS variable on `:root` when the bar occupies space (not hidden and either visible in normal mode or not auto-hidden in zen mode)
  - Variable value: `calc(${BOTTOM_BAR_HEIGHT}px + env(safe-area-inset-bottom, 0px) + 12px)` to account for bar height, safe area inset, and spacing
  - Clean up variable on unmount or when bar no longer occupies space

- **Toaster** (`src/components/ui/sonner.tsx`):
  - Change position from `"top-center"` to `"bottom-center"` (issue #1664)
  - Add `offset` prop with bottom offset reading `--vp-toast-offset` CSS variable, falling back to `24px` when unset
  - Add `mobileOffset` prop with same variable reference, falling back to `16px` for mobile
  - Update comments to explain the coordination mechanism

## Implementation Details

The solution decouples toast positioning from BottomBar context by using a CSS custom property. When BottomBar is visible, it sets `--vp-toast-offset` to the space it occupies (including safe area inset and spacing). When hidden or auto-hidden in zen mode, the variable is removed and sonner's fallback offset keeps toasts near the bottom edge. This keeps toasts clear of the interactive bar without prop drilling or context coupling.

https://claude.ai/code/session_01UTSEhaycKLDv9ix4FM777i