### PR TITLE
fix(queue): render context menu in a portal so it isn't positioned off-screen

### DIFF
--- a/playwright/specs/queue-context-menu.spec.ts
+++ b/playwright/specs/queue-context-menu.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+// Repro / regression guard for the queue-item context-menu (#1633 popover migration).
+// Desktop: right-click a queue row should open the menu.
+test('queue item context menu opens on right-click', async ({ page }) => {
+  await page.goto('/?provider=mock');
+
+  // Enter the player by loading a playlist (populates the queue + starts playback).
+  await page.getByRole('button', { name: 'Browse your library' }).click();
+  await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+  await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 15_000 });
+
+  // Open the queue drawer.
+  const queueBtn = page.locator('button[aria-label="Show Queue"]');
+  await queueBtn.waitFor({ state: 'visible', timeout: 15_000 });
+  await queueBtn.click();
+
+  // Right-click the second queue row (a non-playing track).
+  const row = page.locator('[data-testid="queue-track-row"]').nth(1);
+  await row.waitFor({ state: 'visible', timeout: 10_000 });
+  await row.click({ button: 'right' });
+
+  // #then - the queue context menu opens...
+  const menu = page.locator('[data-testid="queue-context-menu"]');
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+
+  // ...and lands INSIDE the viewport. The regression (#1633) rendered the menu
+  // far off-screen because its position:fixed anchor sat inside the queue
+  // drawer's transform:ed container. toBeVisible() alone does NOT catch that —
+  // an off-screen element is still "visible" to Playwright — so assert the
+  // bounding box is within the viewport.
+  const box = await menu.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+});

--- a/src/components/QueueContextMenu.tsx
+++ b/src/components/QueueContextMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
@@ -64,7 +65,13 @@ export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuPro
     }
   }, []);
 
-  return (
+  // Render the Popover (and its position:fixed VirtualAnchor) in a portal to
+  // document.body so it escapes any transform:ed ancestor (e.g. the queue
+  // drawer / bottom sheet, which use transform for their slide animation).
+  // A transform establishes a containing block for fixed-positioned children,
+  // which otherwise shifts the anchor — and the menu Radix pins to it — off
+  // the viewport.
+  return createPortal(
     <Popover open onOpenChange={(open) => { if (!open) onClose(); }}>
       <PopoverAnchor asChild>
         <VirtualAnchor aria-hidden style={anchorStyle} />
@@ -101,6 +108,7 @@ export function QueueContextMenu({ x, y, options, onClose }: QueueContextMenuPro
           ))}
         </MenuRoot>
       </PopoverContent>
-    </Popover>
+    </Popover>,
+    document.body,
   );
 }

--- a/src/components/QueueTrackItem.tsx
+++ b/src/components/QueueTrackItem.tsx
@@ -212,6 +212,7 @@ export const SortableQueueItem = memo<QueueItemProps>(({
         ref={itemRef}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
+        data-testid="queue-track-row"
         $isSelected={isSelected}
         {...longPressHandlers}
         {...(isEditMode && onRemove ? { ...attributes, ...listeners } : {})}
@@ -316,6 +317,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             if (!isEditMode) onSelect(index);
           }}
           onContextMenu={handleContextMenu}
+          data-testid="queue-track-row"
           $isSelected={isSelected}
           {...longPressHandlers}
         >
@@ -385,6 +387,7 @@ export const SwipeableQueueItem = memo<QueueItemProps>(({
             ref={itemRef}
             onClick={() => !isRevealed && !isEditMode && onSelect(index)}
             onContextMenu={handleContextMenu}
+            data-testid="queue-track-row"
             $isSelected={isSelected}
             {...longPressHandlers}
           >

--- a/src/components/__tests__/QueueTrackList.contextmenu.test.tsx
+++ b/src/components/__tests__/QueueTrackList.contextmenu.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import { makeMediaTrack } from '@/test/fixtures';
+
+// Render rows plainly (no real dnd-kit gestures), but keep the REAL useLongPress
+// and REAL QueueContextMenu so the trigger path is exercised end-to-end.
+vi.mock('@dnd-kit/sortable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/sortable')>();
+  return {
+    ...actual,
+    SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: undefined,
+      isDragging: false,
+    }),
+    verticalListSortingStrategy: actual.verticalListSortingStrategy,
+  };
+});
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock('@/hooks/useLikeTrack', () => ({
+  useLikeTrack: vi.fn(() => ({
+    isLiked: false,
+    canSaveTrack: false,
+    handleLikeToggle: vi.fn(),
+  })),
+}));
+
+import QueueTrackList from '../QueueTrackList';
+
+function renderList() {
+  const tracks = [
+    makeMediaTrack({ id: 'track-1', name: 'Song A' }),
+    makeMediaTrack({ id: 'track-2', name: 'Song B' }),
+  ];
+  render(
+    <ThemeProvider theme={theme}>
+      <QueueTrackList
+        tracks={tracks}
+        currentTrackIndex={0}
+        onTrackSelect={vi.fn()}
+        onReorderTracks={vi.fn()}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('QueueTrackList — context-menu trigger (regression for #1633)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('opens the menu on desktop right-click', () => {
+    renderList();
+    expect(screen.queryByTestId('queue-context-menu')).not.toBeInTheDocument();
+
+    // #when - right-click a non-playing row (index 1, so "Remove" is present)
+    fireEvent.contextMenu(screen.getByText('Song B'));
+
+    // #then
+    expect(screen.getByTestId('queue-context-menu')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Play next/ })).toBeInTheDocument();
+  });
+
+  it('opens the menu on mobile long-press', () => {
+    renderList();
+    const row = screen.getByText('Song B');
+
+    // #when - press and hold past the long-press threshold
+    fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 50, clientY: 60 });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // #then
+    expect(screen.getByTestId('queue-context-menu')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The queue item context menu (right-click on desktop / long-press on mobile) stopped appearing. **Root cause:** #1633 migrated `QueueContextMenu` to a Radix popover whose `VirtualAnchor` is `position: fixed` at the pointer's viewport coordinates. But `QueueContextMenu` renders **inside** the queue drawer / bottom sheet, both of which use `transform` for their slide animation (`QueueDrawer.tsx:22`, `QueueBottomSheet.tsx:45`). A `transform` establishes a containing block for `position: fixed` descendants, so the anchor's `left/top` resolved relative to the *drawer panel* instead of the viewport — pushing the menu (which Radix pins to the anchor) off-screen.

The menu mounted, was `display:block` / `visibility:visible` / `opacity:1` / `zIndex:1500` and not dismissed — it just landed outside the viewport (observed at `rectX=1140` in a 940px-wide viewport), so nothing appeared. The Library context menu was unaffected because it renders at the route level, outside any transformed container.

**Fix:** render the menu's `Popover` (and its anchor) in a portal to `document.body`, so `position: fixed` is viewport-relative again.

## Diagnosis

Pinned via temporary trace logging in a live session: handler fired, state set, menu mounted and stayed, and a DOM probe reported the element present + visible + on-top but `offscreen=true`. Confirmed fixed in the real environment before finalizing. (Logging has been removed.)

## Why it regressed silently

Nothing tested the trigger. This PR adds:
- `data-testid="queue-track-row"` on all three `QueueListItem` render branches
- **unit test** — right-click + long-press both open the menu
- **e2e** — right-click opens the menu **and asserts it lands inside the viewport**. `toBeVisible()` alone does *not* catch off-screen positioning (an off-screen element is still "visible" to Playwright) — that's the exact gap that hid this regression. Verified the new assertion fails pre-fix (menu off-screen) and passes post-fix.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run test:run` — 2017 passed
- [x] e2e verified against the mock provider: fails pre-fix (off-screen), passes post-fix
- [x] Confirmed working in a real desktop Chrome session