### PR TITLE
ci: gate every PR on lint, typecheck, unit, build, and e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+# Gate every PR and every push to main on the full test suite.
+# The mock provider needs no credentials, so this runs with zero secrets.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  # One run per ref; cancel superseded runs on the same branch/PR.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, typecheck, unit, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build
+
+  e2e:
+    name: Playwright (mock provider)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e specs
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ it.txt
 
 # Playwright
 test-results/
+playwright-report/
 
 # Capture toolkit
 playwright/capture/output/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'list',
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : 'list',
   use: {
     baseURL: 'http://127.0.0.1:3000',
     trace: 'on-first-retry',

--- a/playwright/specs/queue-context-menu.spec.ts
+++ b/playwright/specs/queue-context-menu.spec.ts
@@ -30,12 +30,23 @@ test('queue item context menu opens on right-click', async ({ page }) => {
   // drawer's transform:ed container. toBeVisible() alone does NOT catch that —
   // an off-screen element is still "visible" to Playwright — so assert the
   // bounding box is within the viewport.
-  const box = await menu.boundingBox();
+  //
+  // Radix/floating-ui mounts the popover at a default position and repositions
+  // it on the next frame, so a single boundingBox() snapshot can catch the
+  // pre-settle placement (observed y=-262 ~25% of runs). Poll until the box has
+  // settled inside the viewport — that settled position is what a user sees.
   const viewport = page.viewportSize();
-  expect(box).not.toBeNull();
   expect(viewport).not.toBeNull();
-  expect(box!.x).toBeGreaterThanOrEqual(0);
-  expect(box!.y).toBeGreaterThanOrEqual(0);
-  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
-  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+  await expect
+    .poll(async () => {
+      const box = await menu.boundingBox();
+      if (!box) return null;
+      const inside =
+        box.x >= 0 &&
+        box.y >= 0 &&
+        box.x + box.width <= viewport!.width + 1 &&
+        box.y + box.height <= viewport!.height + 1;
+      return inside;
+    }, { timeout: 5_000 })
+    .toBe(true);
 });


### PR DESCRIPTION
## Why

No workflow in `.github/workflows/` ran any test — not `npm test`, not `test:e2e`, not lint or build. The suite (198 files, 2,017 unit tests + 19 Playwright specs) only executed when a human remembered. That's the root cause behind bugs shipping despite good test coverage: the tests exist but nothing gates on them.

## What

- **`.github/workflows/ci.yml`** — two jobs on every PR and push to `main`:
  - `checks`: typecheck (`tsc -b`), lint, unit (`test:run`), build
  - `e2e`: Playwright specs against the mock provider
  - Runs with **zero secrets** — the build succeeds with no `.env.local` and the mock provider needs no credentials.
- **De-flake** `queue-context-menu` spec — it measured the popover bounding box in a single snapshot and caught Radix's pre-settle placement (`y=-262`) ~25% of runs, masked only by `retries: 2`. Now polls for the settled position. Verified 10/10 with retries disabled.
- **`playwright.config.ts`** — emit an HTML report in CI so failures are debuggable; uploaded as an artifact on failure.
- **`.gitignore`** — ignore `playwright-report/`.

## Verified locally (as CI runs)

| Check | Result |
|---|---|
| Typecheck | clean |
| Lint | 0 errors (34 warnings) |
| Unit | 2,017 passing (~13s) |
| Build (no `.env.local`) | succeeds |
| e2e | 19 passing |

First of three PRs. Follow-ups: make the e2e suite honest (fix hollow tests), and a race-condition test harness targeting the stale-async-write bug cluster.