### PR TITLE
test(e2e): make the Playwright suite assert real behavior

### DIFF
--- a/playwright/specs/player-controls.spec.ts
+++ b/playwright/specs/player-controls.spec.ts
@@ -3,6 +3,8 @@ import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type
 
 const hasContent = spotifySnapshot.playlists.length > 0;
 
+// Transport controls expose stable aria-labels ("Previous track", "Play"/"Pause",
+// "Next track") — assert those and the behavior behind them, not SVG path data.
 test.describe('Player Controls', () => {
   test.beforeEach(async ({ page }) => {
     test.skip(
@@ -11,42 +13,63 @@ test.describe('Player Controls', () => {
     );
     await page.goto('/');
     await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
-
-    if (hasContent) {
-      await page.locator('[data-testid^="library-card-playlist-"]').first().click();
-      await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
-    }
+    await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+    await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 15_000 });
   });
 
-  test('play/pause button is present in the player UI', async ({ page }) => {
-    const playSvg = page.locator('svg path[d="M8 5v14l11-7z"]');
-    const pauseSvg = page.locator('svg path[d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"]');
-    await expect(playSvg.or(pauseSvg).first()).toBeVisible({ timeout: 5000 });
+  test('play/pause button toggles playing state', async ({ page }) => {
+    // The play/pause control's aria-label reflects the state: "Pause" while
+    // playing, "Play" while paused. Clicking it must flip that state.
+    const playPause = page.getByRole('button', { name: /^(Play|Pause)$/ });
+    await expect(playPause).toBeVisible({ timeout: 5000 });
+
+    const before = await playPause.getAttribute('aria-label');
+    await playPause.click();
+    await expect(playPause).not.toHaveAttribute('aria-label', before!, { timeout: 5000 });
+
+    // ...and toggling back returns to the original state.
+    await playPause.click();
+    await expect(playPause).toHaveAttribute('aria-label', before!, { timeout: 5000 });
   });
 
-  test('next track button is present and clickable', async ({ page }) => {
-    const nextButton = page.locator('svg path[d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"]').locator('..');
-    await expect(nextButton).toBeVisible({ timeout: 5000 });
-    await nextButton.click();
+  test('next track button advances to a different track', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    const before = await trackName.textContent();
+
+    await page.getByRole('button', { name: 'Next track' }).click();
+
+    // The displayed track name must change — not merely that the button was clickable.
+    await expect(trackName).not.toHaveText(before ?? '', { timeout: 5000 });
   });
 
-  test('previous track button is present and clickable', async ({ page }) => {
-    const prevButton = page.locator('svg path[d="M6 6h2v12H6zm3.5 6l8.5 6V6z"]').locator('..');
-    await expect(prevButton).toBeVisible({ timeout: 5000 });
-    await prevButton.click();
+  test('previous track returns to the prior track', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    const first = await trackName.textContent();
+
+    // Advance, then go back — the round-trip must land on the original track.
+    await page.getByRole('button', { name: 'Next track' }).click();
+    await expect(trackName).not.toHaveText(first ?? '', { timeout: 5000 });
+
+    await page.getByRole('button', { name: 'Previous track' }).click();
+    await expect(trackName).toHaveText(first ?? '', { timeout: 5000 });
   });
 
-  test('track info displays current track name', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent track name test');
-      return;
-    }
-    await expect(page.locator('[data-testid="player-track-info-name"]')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-testid="player-track-info-name"]')).not.toHaveText('');
+  test('track info displays a non-empty current track name', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    await expect(trackName).toBeVisible({ timeout: 5000 });
+    await expect(trackName).not.toHaveText('');
   });
 
-  test('volume control is present in the bottom bar', async ({ page }) => {
-    const settingsButton = page.locator('button[title="App settings"]');
-    await expect(settingsButton).toBeVisible({ timeout: 5000 });
+  test('volume control opens its popover on click', async ({ page }) => {
+    // The bottom bar renders a real volume control: a button (aria-label="Volume")
+    // whose aria-pressed reflects the open state of its slider popover. (The prior
+    // version of this test asserted the App Settings button instead — it never
+    // touched volume at all.)
+    const volumeButton = page.locator('button[aria-label="Volume"]');
+    await expect(volumeButton).toBeVisible({ timeout: 5000 });
+    await expect(volumeButton).toHaveAttribute('aria-pressed', 'false');
+
+    await volumeButton.click();
+    await expect(volumeButton).toHaveAttribute('aria-pressed', 'true', { timeout: 5000 });
   });
 });

--- a/playwright/specs/zen-mode.spec.ts
+++ b/playwright/specs/zen-mode.spec.ts
@@ -11,16 +11,8 @@ test.describe('Zen Mode', () => {
     );
     await page.goto('/');
     await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
-
-    if (hasContent) {
-      await page.locator('[data-testid^="library-card-playlist-"]').first().click();
-      await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
-    }
-  });
-
-  test('zen mode button exists in the bottom bar', async ({ page }) => {
-    const zenButton = page.locator('button[title^="Zen Mode"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
+    await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+    await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 15_000 });
   });
 
   // Playwright's isVisible() checks the element's own opacity, not inherited opacity from
@@ -39,12 +31,12 @@ test.describe('Zen Mode', () => {
     }, { timeout: 2000 });
   }
 
-  test('clicking zen mode button hides player controls', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent zen mode test');
-      return;
-    }
+  test('zen mode button exists in the bottom bar', async ({ page }) => {
+    const zenButton = page.locator('button[title^="Zen Mode"]');
+    await expect(zenButton).toBeVisible({ timeout: 5000 });
+  });
 
+  test('clicking zen mode button hides player controls', async ({ page }) => {
     await expect(page.locator('[data-testid="player-track-info-album"]')).toBeVisible({ timeout: 5000 });
 
     const zenButton = page.locator('button[title="Zen Mode OFF"]');
@@ -57,11 +49,6 @@ test.describe('Zen Mode', () => {
   });
 
   test('escape key exits zen mode', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent zen mode test');
-      return;
-    }
-
     const zenButton = page.locator('button[title="Zen Mode OFF"]');
     await expect(zenButton).toBeVisible({ timeout: 5000 });
     await zenButton.click();
@@ -73,34 +60,43 @@ test.describe('Zen Mode', () => {
     await expect(page.locator('[data-testid="player-track-info-album"]')).toBeVisible({ timeout: 5000 });
   });
 
-  test('zen mode expands album art area', async ({ page }) => {
-    const zenButton = page.locator('button[title="Zen Mode OFF"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
+  test('zen mode enlarges the album art area', async ({ page }) => {
+    // Measure the album art before entering zen, then after. Zen mode reclaims
+    // the space freed by the hidden controls, so the art must grow — assert the
+    // actual size increase, not merely that some element still exists.
+    const art = page.locator('img[alt]').first();
+    const before = await art.boundingBox();
+    expect(before).not.toBeNull();
 
-    await zenButton.click();
-
-    const zenButtonOn = page.locator('button[title="Zen Mode ON"]');
-    await expect(zenButtonOn).toBeVisible({ timeout: 5000 });
-
-    const albumArtSvg = page.locator('img[alt]').first();
-    const artContainer = page.locator('[style*="position: relative"]').first();
-    const isArtVisible = await albumArtSvg.isVisible().catch(() => false);
-    const isContainerVisible = await artContainer.isVisible().catch(() => false);
-    expect(isArtVisible || isContainerVisible).toBe(true);
-  });
-
-  test('clicking album art in zen mode triggers play/pause (not flip)', async ({ page }) => {
-    const zenButton = page.locator('button[title="Zen Mode OFF"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
-    await zenButton.click();
+    await page.locator('button[title="Zen Mode OFF"]').click();
     await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 5000 });
 
-    await page.waitForTimeout(500);
+    await expect
+      .poll(async () => {
+        const box = await art.boundingBox();
+        if (!box) return 0;
+        return box.width * box.height;
+      }, { timeout: 5000 })
+      .toBeGreaterThan(before!.width * before!.height);
+  });
 
-    const artArea = page.locator('[style*="transform"]').first();
-    if (await artArea.isVisible()) {
-      await artArea.click();
-      await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 3000 });
-    }
+  test('clicking album art in zen mode toggles play/pause without flipping', async ({ page }) => {
+    await page.locator('button[title="Zen Mode OFF"]').click();
+    await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 5000 });
+
+    // The zen center click-zone overlays the album art and toggles play/pause.
+    const playPauseZone = page.locator('[data-testid="zen-playpause-zone"]');
+    await expect(playPauseZone).toBeVisible({ timeout: 5000 });
+
+    const before = await playPauseZone.getAttribute('aria-label'); // "Play" | "Pause"
+    await playPauseZone.click();
+
+    // Play/pause state must flip...
+    await expect(playPauseZone).not.toHaveAttribute('aria-label', before!, { timeout: 5000 });
+
+    // ...and the art must NOT have flipped to the menu: the zen click-zone is
+    // rendered only while the art shows its front (visible && !isFlipped), so its
+    // continued presence proves the click toggled playback rather than flipping.
+    await expect(playPauseZone).toBeVisible();
   });
 });

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -72,6 +72,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <IconButton
         onClick={(e) => { e.stopPropagation(); onPrevious(); }}
         aria-label="Previous track"
+        data-testid="zen-prev-zone"
       >
         <Icon>
           <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
@@ -80,6 +81,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <CenterIconButton
         onClick={(e) => { e.stopPropagation(); onPlayPause(); }}
         aria-label={isPlaying ? 'Pause' : 'Play'}
+        data-testid="zen-playpause-zone"
       >
         <Icon>
           {isPlaying
@@ -91,6 +93,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <IconButton
         onClick={(e) => { e.stopPropagation(); onNext(); }}
         aria-label="Next track"
+        data-testid="zen-next-zone"
       >
         <Icon>
           <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />


### PR DESCRIPTION
Stacked on #1673 (base is `ci/github-actions-gate`, not `main`). Merge #1673 first.

## Why

Several Playwright specs asserted *existence*, not *behavior* — a green run proved nothing. Some were actively misleading:

- **`volume control`** asserted `button[title="App settings"]` was visible — it never touched the volume control at all.
- **next / previous** clicked the buttons and asserted *nothing* afterward.
- **zen `clicking album art triggers play/pause (not flip)`** asserted only that the Zen button still existed, and wrapped its whole body in `if (await artArea.isVisible())` so it silently no-opped when the element wasn't found.
- **zen `expands album art area`** passed if *either* of two elements merely existed — no size check.

Selectors were keyed to SVG path data (`svg path[d="M8 5v14l11-7z"]`) and inline-style substrings (`[style*="transform"]`), which break on cosmetic changes and pass on broken behavior.

## What

Rewrote the hollow tests to assert real behavior via stable selectors (aria-labels + data-testids):

| Test | Now asserts |
|---|---|
| play/pause | aria-label toggles Play↔Pause and back |
| next track | displayed track name changes |
| previous track | next→prev round-trips to the original track |
| volume | button toggles `aria-pressed` (popover open state) |
| zen enlarges art | album-art bounding box measured before/after; area grows |
| zen click-zone | center zone toggles play/pause and stays present (proves not flipped) |

Adds `data-testid="zen-{prev,playpause,next}-zone"` to `ZenClickZoneOverlay` for unambiguous targeting (there are two "Play/Pause" buttons in zen — the hidden main control and the overlay zone — so a role selector was ambiguous).

## Verified

- Both specs: **40/40 across 4 repeats, `--retries=0`** (no flake).
- Full e2e suite: 19 passing.
- `tsc -b`: clean.

Part of the testing-hardening effort. Follow-up: race-condition test harness targeting the stale-async-write bug cluster.