### PR TITLE
fix(spotify): don't throw when a successful write returns a non-JSON body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+# Gate every PR and every push to main on the full test suite.
+# The mock provider needs no credentials, so this runs with zero secrets.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  # One run per ref; cancel superseded runs on the same branch/PR.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, typecheck, unit, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build
+
+  e2e:
+    name: Playwright (mock provider)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e specs
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ it.txt
 
 # Playwright
 test-results/
+playwright-report/
 
 # Capture toolkit
 playwright/capture/output/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'list',
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : 'list',
   use: {
     baseURL: 'http://127.0.0.1:3000',
     trace: 'on-first-retry',

--- a/playwright/specs/player-controls.spec.ts
+++ b/playwright/specs/player-controls.spec.ts
@@ -3,6 +3,8 @@ import spotifySnapshot from '../fixtures/data/spotify-snapshot.json' with { type
 
 const hasContent = spotifySnapshot.playlists.length > 0;
 
+// Transport controls expose stable aria-labels ("Previous track", "Play"/"Pause",
+// "Next track") — assert those and the behavior behind them, not SVG path data.
 test.describe('Player Controls', () => {
   test.beforeEach(async ({ page }) => {
     test.skip(
@@ -11,42 +13,63 @@ test.describe('Player Controls', () => {
     );
     await page.goto('/');
     await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
-
-    if (hasContent) {
-      await page.locator('[data-testid^="library-card-playlist-"]').first().click();
-      await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
-    }
+    await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+    await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 15_000 });
   });
 
-  test('play/pause button is present in the player UI', async ({ page }) => {
-    const playSvg = page.locator('svg path[d="M8 5v14l11-7z"]');
-    const pauseSvg = page.locator('svg path[d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"]');
-    await expect(playSvg.or(pauseSvg).first()).toBeVisible({ timeout: 5000 });
+  test('play/pause button toggles playing state', async ({ page }) => {
+    // The play/pause control's aria-label reflects the state: "Pause" while
+    // playing, "Play" while paused. Clicking it must flip that state.
+    const playPause = page.getByRole('button', { name: /^(Play|Pause)$/ });
+    await expect(playPause).toBeVisible({ timeout: 5000 });
+
+    const before = await playPause.getAttribute('aria-label');
+    await playPause.click();
+    await expect(playPause).not.toHaveAttribute('aria-label', before!, { timeout: 5000 });
+
+    // ...and toggling back returns to the original state.
+    await playPause.click();
+    await expect(playPause).toHaveAttribute('aria-label', before!, { timeout: 5000 });
   });
 
-  test('next track button is present and clickable', async ({ page }) => {
-    const nextButton = page.locator('svg path[d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"]').locator('..');
-    await expect(nextButton).toBeVisible({ timeout: 5000 });
-    await nextButton.click();
+  test('next track button advances to a different track', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    const before = await trackName.textContent();
+
+    await page.getByRole('button', { name: 'Next track' }).click();
+
+    // The displayed track name must change — not merely that the button was clickable.
+    await expect(trackName).not.toHaveText(before ?? '', { timeout: 5000 });
   });
 
-  test('previous track button is present and clickable', async ({ page }) => {
-    const prevButton = page.locator('svg path[d="M6 6h2v12H6zm3.5 6l8.5 6V6z"]').locator('..');
-    await expect(prevButton).toBeVisible({ timeout: 5000 });
-    await prevButton.click();
+  test('previous track returns to the prior track', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    const first = await trackName.textContent();
+
+    // Advance, then go back — the round-trip must land on the original track.
+    await page.getByRole('button', { name: 'Next track' }).click();
+    await expect(trackName).not.toHaveText(first ?? '', { timeout: 5000 });
+
+    await page.getByRole('button', { name: 'Previous track' }).click();
+    await expect(trackName).toHaveText(first ?? '', { timeout: 5000 });
   });
 
-  test('track info displays current track name', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent track name test');
-      return;
-    }
-    await expect(page.locator('[data-testid="player-track-info-name"]')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-testid="player-track-info-name"]')).not.toHaveText('');
+  test('track info displays a non-empty current track name', async ({ page }) => {
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    await expect(trackName).toBeVisible({ timeout: 5000 });
+    await expect(trackName).not.toHaveText('');
   });
 
-  test('volume control is present in the bottom bar', async ({ page }) => {
-    const settingsButton = page.locator('button[title="App settings"]');
-    await expect(settingsButton).toBeVisible({ timeout: 5000 });
+  test('volume control opens its popover on click', async ({ page }) => {
+    // The bottom bar renders a real volume control: a button (aria-label="Volume")
+    // whose aria-pressed reflects the open state of its slider popover. (The prior
+    // version of this test asserted the App Settings button instead — it never
+    // touched volume at all.)
+    const volumeButton = page.locator('button[aria-label="Volume"]');
+    await expect(volumeButton).toBeVisible({ timeout: 5000 });
+    await expect(volumeButton).toHaveAttribute('aria-pressed', 'false');
+
+    await volumeButton.click();
+    await expect(volumeButton).toHaveAttribute('aria-pressed', 'true', { timeout: 5000 });
   });
 });

--- a/playwright/specs/queue-context-menu.spec.ts
+++ b/playwright/specs/queue-context-menu.spec.ts
@@ -30,12 +30,23 @@ test('queue item context menu opens on right-click', async ({ page }) => {
   // drawer's transform:ed container. toBeVisible() alone does NOT catch that —
   // an off-screen element is still "visible" to Playwright — so assert the
   // bounding box is within the viewport.
-  const box = await menu.boundingBox();
+  //
+  // Radix/floating-ui mounts the popover at a default position and repositions
+  // it on the next frame, so a single boundingBox() snapshot can catch the
+  // pre-settle placement (observed y=-262 ~25% of runs). Poll until the box has
+  // settled inside the viewport — that settled position is what a user sees.
   const viewport = page.viewportSize();
-  expect(box).not.toBeNull();
   expect(viewport).not.toBeNull();
-  expect(box!.x).toBeGreaterThanOrEqual(0);
-  expect(box!.y).toBeGreaterThanOrEqual(0);
-  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
-  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+  await expect
+    .poll(async () => {
+      const box = await menu.boundingBox();
+      if (!box) return null;
+      const inside =
+        box.x >= 0 &&
+        box.y >= 0 &&
+        box.x + box.width <= viewport!.width + 1 &&
+        box.y + box.height <= viewport!.height + 1;
+      return inside;
+    }, { timeout: 5_000 })
+    .toBe(true);
 });

--- a/playwright/specs/zen-mode.spec.ts
+++ b/playwright/specs/zen-mode.spec.ts
@@ -11,16 +11,8 @@ test.describe('Zen Mode', () => {
     );
     await page.goto('/');
     await page.locator('[data-testid="library-home"]').waitFor({ state: 'visible', timeout: 30_000 });
-
-    if (hasContent) {
-      await page.locator('[data-testid^="library-card-playlist-"]').first().click();
-      await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 10_000 });
-    }
-  });
-
-  test('zen mode button exists in the bottom bar', async ({ page }) => {
-    const zenButton = page.locator('button[title^="Zen Mode"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
+    await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+    await page.locator('[data-testid="player-track-info-name"]').waitFor({ state: 'visible', timeout: 15_000 });
   });
 
   // Playwright's isVisible() checks the element's own opacity, not inherited opacity from
@@ -39,12 +31,12 @@ test.describe('Zen Mode', () => {
     }, { timeout: 2000 });
   }
 
-  test('clicking zen mode button hides player controls', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent zen mode test');
-      return;
-    }
+  test('zen mode button exists in the bottom bar', async ({ page }) => {
+    const zenButton = page.locator('button[title^="Zen Mode"]');
+    await expect(zenButton).toBeVisible({ timeout: 5000 });
+  });
 
+  test('clicking zen mode button hides player controls', async ({ page }) => {
     await expect(page.locator('[data-testid="player-track-info-album"]')).toBeVisible({ timeout: 5000 });
 
     const zenButton = page.locator('button[title="Zen Mode OFF"]');
@@ -57,11 +49,6 @@ test.describe('Zen Mode', () => {
   });
 
   test('escape key exits zen mode', async ({ page }) => {
-    if (!hasContent) {
-      test.skip(true, 'Snapshot has no playlists — skipping content-dependent zen mode test');
-      return;
-    }
-
     const zenButton = page.locator('button[title="Zen Mode OFF"]');
     await expect(zenButton).toBeVisible({ timeout: 5000 });
     await zenButton.click();
@@ -73,34 +60,43 @@ test.describe('Zen Mode', () => {
     await expect(page.locator('[data-testid="player-track-info-album"]')).toBeVisible({ timeout: 5000 });
   });
 
-  test('zen mode expands album art area', async ({ page }) => {
-    const zenButton = page.locator('button[title="Zen Mode OFF"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
+  test('zen mode enlarges the album art area', async ({ page }) => {
+    // Measure the album art before entering zen, then after. Zen mode reclaims
+    // the space freed by the hidden controls, so the art must grow — assert the
+    // actual size increase, not merely that some element still exists.
+    const art = page.locator('img[alt]').first();
+    const before = await art.boundingBox();
+    expect(before).not.toBeNull();
 
-    await zenButton.click();
-
-    const zenButtonOn = page.locator('button[title="Zen Mode ON"]');
-    await expect(zenButtonOn).toBeVisible({ timeout: 5000 });
-
-    const albumArtSvg = page.locator('img[alt]').first();
-    const artContainer = page.locator('[style*="position: relative"]').first();
-    const isArtVisible = await albumArtSvg.isVisible().catch(() => false);
-    const isContainerVisible = await artContainer.isVisible().catch(() => false);
-    expect(isArtVisible || isContainerVisible).toBe(true);
-  });
-
-  test('clicking album art in zen mode triggers play/pause (not flip)', async ({ page }) => {
-    const zenButton = page.locator('button[title="Zen Mode OFF"]');
-    await expect(zenButton).toBeVisible({ timeout: 5000 });
-    await zenButton.click();
+    await page.locator('button[title="Zen Mode OFF"]').click();
     await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 5000 });
 
-    await page.waitForTimeout(500);
+    await expect
+      .poll(async () => {
+        const box = await art.boundingBox();
+        if (!box) return 0;
+        return box.width * box.height;
+      }, { timeout: 5000 })
+      .toBeGreaterThan(before!.width * before!.height);
+  });
 
-    const artArea = page.locator('[style*="transform"]').first();
-    if (await artArea.isVisible()) {
-      await artArea.click();
-      await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 3000 });
-    }
+  test('clicking album art in zen mode toggles play/pause without flipping', async ({ page }) => {
+    await page.locator('button[title="Zen Mode OFF"]').click();
+    await expect(page.locator('button[title="Zen Mode ON"]')).toBeVisible({ timeout: 5000 });
+
+    // The zen center click-zone overlays the album art and toggles play/pause.
+    const playPauseZone = page.locator('[data-testid="zen-playpause-zone"]');
+    await expect(playPauseZone).toBeVisible({ timeout: 5000 });
+
+    const before = await playPauseZone.getAttribute('aria-label'); // "Play" | "Pause"
+    await playPauseZone.click();
+
+    // Play/pause state must flip...
+    await expect(playPauseZone).not.toHaveAttribute('aria-label', before!, { timeout: 5000 });
+
+    // ...and the art must NOT have flipped to the menu: the zen click-zone is
+    // rendered only while the art shows its front (visible && !isFlipped), so its
+    // continued presence proves the click toggled playback rather than flipping.
+    await expect(playPauseZone).toBeVisible();
   });
 });

--- a/src/components/PlayerContent/ZenClickZoneOverlay.tsx
+++ b/src/components/PlayerContent/ZenClickZoneOverlay.tsx
@@ -72,6 +72,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <IconButton
         onClick={(e) => { e.stopPropagation(); onPrevious(); }}
         aria-label="Previous track"
+        data-testid="zen-prev-zone"
       >
         <Icon>
           <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
@@ -80,6 +81,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <CenterIconButton
         onClick={(e) => { e.stopPropagation(); onPlayPause(); }}
         aria-label={isPlaying ? 'Pause' : 'Play'}
+        data-testid="zen-playpause-zone"
       >
         <Icon>
           {isPlaying
@@ -91,6 +93,7 @@ export const ZenClickZoneOverlay: React.FC<ZenClickZoneOverlayProps> = React.mem
       <IconButton
         onClick={(e) => { e.stopPropagation(); onNext(); }}
         aria-label="Next track"
+        data-testid="zen-next-zone"
       >
         <Icon>
           <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />

--- a/src/components/SettingsV2/sections/AdvancedSection.tsx
+++ b/src/components/SettingsV2/sections/AdvancedSection.tsx
@@ -237,6 +237,7 @@ export const AdvancedSection: React.FC = () => {
       <ControlBlock>
         <SectionGroupTitle>About</SectionGroupTitle>
         <ControlHelp>{`Vorbis Player${__APP_VERSION__ !== '0.0.0' ? ` ${__APP_VERSION__}` : ''} — keyboard-first music player.`}</ControlHelp>
+        <ControlHelp data-testid="build-info">{`Build ${__BUILD_SHA__ === 'unknown' ? 'dev' : __BUILD_SHA__.slice(0, 7)} · ${__BUILD_REF__} · ${__BUILD_ENV__}`}</ControlHelp>
         <ShortcutHintList>
           <ShortcutHintRow>
             <span>Show keyboard shortcuts</span>

--- a/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
+++ b/src/components/SettingsV2/sections/__tests__/AdvancedSection.test.tsx
@@ -124,6 +124,23 @@ describe('SettingsV2 AdvancedSection', () => {
     memoryStorage.clear();
   });
 
+  describe('build info', () => {
+    it('renders the deployed build SHA / ref / env for deploy verification', () => {
+      // #given / #when
+      render(
+        <Wrapper>
+          <AdvancedSection />
+        </Wrapper>,
+      );
+
+      // #then — the About block surfaces the baked-in build provenance so a
+      // tester can confirm exactly which commit is deployed.
+      const buildInfo = screen.getByTestId('build-info');
+      expect(buildInfo).toBeInTheDocument();
+      expect(buildInfo).toHaveTextContent(/^Build .+ · .+ · .+$/);
+    });
+  });
+
   describe('Quick Access Panel toggle', () => {
     it('writes the QAP-enabled storage key when toggled on', () => {
       // #given

--- a/src/hooks/__tests__/useRadio.test.ts
+++ b/src/hooks/__tests__/useRadio.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRadio } from '../useRadio';
+import { makeMediaTrack } from '@/test/fixtures';
+import { createDeferredFn } from '@/test/asyncRace';
+import type { MediaTrack } from '@/types/domain';
+import type { RadioResult, RadioSeed } from '@/types/radio';
+
+vi.mock('@/services/radioService', () => ({
+  generateRadioQueue: vi.fn(),
+}));
+vi.mock('@/services/lastfm', () => ({
+  isLastFmConfigured: vi.fn(() => true),
+}));
+vi.mock('@/lib/debugLog', () => ({
+  logRadio: vi.fn(),
+}));
+
+import { generateRadioQueue } from '@/services/radioService';
+
+const seed: RadioSeed = { type: 'track', artist: 'Radiohead', track: 'Creep' };
+
+function track(id: string, name: string): MediaTrack {
+  return makeMediaTrack({ id, name, provider: 'spotify' });
+}
+
+function result(queue: MediaTrack[], seedDescription: string): RadioResult {
+  return {
+    queue,
+    seedDescription,
+    matchStats: { requested: queue.length, matched: queue.length, unmatched: 0 },
+    unmatchedSuggestions: [],
+  };
+}
+
+describe('useRadio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('activates radio state with the seed description on success', async () => {
+    // #given
+    vi.mocked(generateRadioQueue).mockResolvedValue(
+      result([track('g1', 'Karma Police')], 'Songs like Creep'),
+    );
+    const { result: hook } = renderHook(() => useRadio());
+
+    // #when
+    await act(async () => {
+      await hook.current.startRadio(seed, [track('c1', 'Catalog')]);
+    });
+
+    // #then
+    expect(hook.current.radioState.isActive).toBe(true);
+    expect(hook.current.radioState.seedDescription).toBe('Songs like Creep');
+    expect(hook.current.radioState.isGenerating).toBe(false);
+  });
+
+  it('reports an error when no similar tracks are found', async () => {
+    // #given
+    vi.mocked(generateRadioQueue).mockResolvedValue(result([], 'Songs like Creep'));
+    const { result: hook } = renderHook(() => useRadio());
+
+    // #when
+    await act(async () => {
+      await hook.current.startRadio(seed, []);
+    });
+
+    // #then
+    expect(hook.current.radioState.isActive).toBe(false);
+    expect(hook.current.radioState.error).toBe('No similar tracks found in your library.');
+  });
+
+  it('keeps the newer generation state when an older startRadio resolves later', async () => {
+    // #given a controllable generateRadioQueue settled out of order
+    const gen = createDeferredFn<[RadioSeed, MediaTrack[]], RadioResult>();
+    vi.mocked(generateRadioQueue).mockImplementation(gen.fn);
+    const { result: hook } = renderHook(() => useRadio());
+
+    // #when two generations overlap — sequence them so index 0 = older, 1 = newer
+    let older!: Promise<RadioResult | null>;
+    let newer!: Promise<RadioResult | null>;
+    await act(async () => {
+      older = hook.current.startRadio(seed, []);
+      await waitFor(() => expect(gen.callCount).toBe(1));
+      newer = hook.current.startRadio(seed, []);
+      await waitFor(() => expect(gen.callCount).toBe(2));
+    });
+
+    // ...the newer (index 1) resolves first, then the stale older (index 0)
+    await act(async () => {
+      gen.resolve(1, result([track('new', 'Fresh')], 'Newer seed'));
+      gen.resolve(0, result([track('old', 'Stale')], 'Older seed'));
+      await Promise.all([older, newer]);
+    });
+
+    // #then the guard keeps the newer generation's state; the stale resolution
+    // returns null and does not overwrite it.
+    expect(hook.current.radioState.seedDescription).toBe('Newer seed');
+    await expect(older).resolves.toBeNull();
+  });
+
+  it('stopRadio invalidates an in-flight generation so its result is dropped', async () => {
+    // #given a generation in flight
+    const gen = createDeferredFn<[RadioSeed, MediaTrack[]], RadioResult>();
+    vi.mocked(generateRadioQueue).mockImplementation(gen.fn);
+    const { result: hook } = renderHook(() => useRadio());
+
+    let pending!: Promise<RadioResult | null>;
+    await act(async () => {
+      pending = hook.current.startRadio(seed, []);
+      await waitFor(() => expect(gen.callCount).toBe(1));
+    });
+
+    // #when the user stops radio before it finishes, then it finishes
+    await act(async () => {
+      hook.current.stopRadio();
+      gen.resolve(0, result([track('late', 'Late')], 'Late seed'));
+      await pending;
+    });
+
+    // #then the stale result is dropped and state stays inactive
+    expect(hook.current.radioState.isActive).toBe(false);
+    expect(hook.current.radioState.seedDescription).toBeUndefined();
+    await expect(pending).resolves.toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useRadioSession.test.ts
+++ b/src/hooks/__tests__/useRadioSession.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useRadioSession } from '../useRadioSession';
-import type { RadioProgress } from '@/types/radio';
+import type { RadioProgress, RadioResult } from '@/types/radio';
 import { makeMediaTrack, makeProviderDescriptor } from '@/test/fixtures';
 import type { MediaTrack } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
+import { createDeferredFn } from '@/test/asyncRace';
 
 vi.mock('@/providers/registry', () => ({
   providerRegistry: {
@@ -462,6 +463,99 @@ describe('useRadioSession', () => {
 
     // #then
     expect(initMock).toHaveBeenCalled();
+  });
+
+  it('newer radio generation wins when an older one resolves later (stale-write race)', async () => {
+    // #given a catalog with tracks so the pipeline proceeds to generateQueue,
+    // and a generateQueue whose two invocations we settle out of order.
+    descriptor = makeProviderDescriptor({
+      id: 'spotify',
+      catalog: {
+        providerId: 'spotify',
+        listCollections: vi.fn(),
+        listTracks: vi.fn().mockResolvedValue([track('a1', 'OK Computer', 'Radiohead')]),
+      },
+    });
+
+    const gen = createDeferredFn<[unknown, MediaTrack[]], RadioResult | null>();
+    const queueA = [track('A1', 'Stale Song', 'Old Seed')];
+    const queueB = [track('B1', 'Fresh Song', 'New Seed')];
+    const asResult = (queue: MediaTrack[]): RadioResult => ({
+      queue,
+      seedDescription: 'seed',
+      matchStats: { requested: queue.length, matched: queue.length, unmatched: 0 },
+      unmatchedSuggestions: [],
+    });
+
+    const { result } = renderSession({ startRadio: gen.fn });
+
+    // #when two radio generations overlap — the second (B) supersedes the first
+    // (A). Sequence the starts so each reaches the awaited generateQueue before
+    // the next begins: this pins call index 0 → A (older), index 1 → B (newer).
+    let pA!: Promise<void>;
+    let pB!: Promise<void>;
+    await act(async () => {
+      pA = result.current.handleStartRadio();
+      await waitFor(() => expect(gen.callCount).toBe(1));
+      pB = result.current.handleStartRadio();
+      await waitFor(() => expect(gen.callCount).toBe(2));
+    });
+
+    // ...and B (the newer, call index 1) resolves BEFORE the stale A (index 0).
+    await act(async () => {
+      gen.resolve(1, asResult(queueB));
+      gen.resolve(0, asResult(queueA));
+      await Promise.all([pA, pB]);
+    });
+
+    // #then the committed queue must reflect the newer generation B, not the
+    // stale A that resolved last. (runRadioPipeline prepends the seed and returns
+    // a new combined array, so assert on content, not reference.) Without a
+    // generation guard the late A clobbers B.
+    const committedNames = trackOps.mediaTracksRef.current.map((t) => t.name);
+    expect(committedNames).toContain('Fresh Song');
+    expect(committedNames).not.toContain('Stale Song');
+
+    const lastSetTracks = trackOps.setTracks.mock.calls.at(-1)?.[0] as MediaTrack[];
+    expect(lastSetTracks.map((t) => t.name)).toContain('Fresh Song');
+    expect(lastSetTracks.map((t) => t.name)).not.toContain('Stale Song');
+  });
+
+  it('does not commit a radio queue that finishes generating after stopRadio', async () => {
+    // #given a generation in flight
+    descriptor = makeProviderDescriptor({
+      id: 'spotify',
+      catalog: {
+        providerId: 'spotify',
+        listCollections: vi.fn(),
+        listTracks: vi.fn().mockResolvedValue([track('a1', 'OK Computer', 'Radiohead')]),
+      },
+    });
+    const gen = createDeferredFn<[unknown, MediaTrack[]], RadioResult | null>();
+    const queue = [track('g1', 'Karma Police', 'Radiohead')];
+    const { result } = renderSession({ startRadio: gen.fn });
+
+    let started!: Promise<void>;
+    await act(async () => {
+      started = result.current.handleStartRadio();
+      await waitFor(() => expect(gen.callCount).toBe(1));
+    });
+
+    // #when the user stops radio before generation completes, then it completes
+    await act(async () => {
+      result.current.stopRadio();
+      gen.resolve(0, {
+        queue,
+        seedDescription: 'seed',
+        matchStats: { requested: 1, matched: 1, unmatched: 0 },
+        unmatchedSuggestions: [],
+      });
+      await started;
+    });
+
+    // #then the stale result must not populate the queue
+    expect(trackOps.setTracks).not.toHaveBeenCalled();
+    expect(trackOps.mediaTracksRef.current).toEqual([seedTrack]);
   });
 
   it('does not invoke searchTrack on a provider whose hasTrackSearch is false', async () => {

--- a/src/hooks/__tests__/useSpotifyControls.seekGuard.test.ts
+++ b/src/hooks/__tests__/useSpotifyControls.seekGuard.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { MediaTrack, PlaybackState, ProviderId } from '@/types/domain';
+import { makeMediaTrack } from '@/test/fixtures';
+
+// The seek guard (#1671) rejects stale pre-seek position emits that would drag
+// the timeline cursor back after a seek. Drive the hook's playback subscription
+// directly and assert what the cursor (currentPosition) does.
+
+let listeners: Array<(state: PlaybackState | null) => void> = [];
+const seek = vi.fn().mockResolvedValue(undefined);
+
+const descriptor = {
+  id: 'spotify' as ProviderId,
+  playback: {
+    subscribe: (fn: (state: PlaybackState | null) => void) => {
+      listeners.push(fn);
+      return () => {
+        listeners = listeners.filter((l) => l !== fn);
+      };
+    },
+    getState: vi.fn().mockResolvedValue(null),
+    seek,
+  },
+};
+
+vi.mock('@/contexts/ProviderContext', () => ({
+  useProviderContext: () => ({ activeDescriptor: descriptor }),
+}));
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: { get: vi.fn(() => descriptor) },
+}));
+vi.mock('@/lib/debugLog', () => ({ logSeek: vi.fn() }));
+
+import { useSpotifyControls } from '../useSpotifyControls';
+
+function state(positionMs: number, isPlaying = true): PlaybackState {
+  return {
+    isPlaying,
+    positionMs,
+    durationMs: 300_000,
+    currentTrackId: 'track-1',
+    currentPlaybackRef: null,
+  };
+}
+
+function emit(s: PlaybackState) {
+  act(() => {
+    listeners.forEach((l) => l(s));
+  });
+}
+
+const track: MediaTrack = makeMediaTrack({ id: 'track-1', provider: 'spotify' });
+
+function render() {
+  return renderHook(() =>
+    useSpotifyControls({
+      currentTrack: track,
+      isLiked: false,
+      isLikePending: false,
+      onPlay: vi.fn(),
+      onPause: vi.fn(),
+      onNext: vi.fn(),
+      onPrevious: vi.fn(),
+      onLikeToggle: vi.fn(),
+    }),
+  );
+}
+
+describe('useSpotifyControls seek guard (#1671)', () => {
+  beforeEach(() => {
+    listeners = [];
+    seek.mockClear();
+  });
+
+  it('accepts position emits normally when no seek is pending', () => {
+    const { result } = render();
+    emit(state(10_000));
+    expect(result.current.currentPosition).toBe(10_000);
+    emit(state(11_000));
+    expect(result.current.currentPosition).toBe(11_000);
+  });
+
+  it('moves the cursor to the seek target immediately and rejects a stale pre-seek emit', async () => {
+    const { result } = render();
+    emit(state(10_000));
+    expect(result.current.currentPosition).toBe(10_000);
+
+    // #when the user seeks forward to 2:00
+    await act(async () => {
+      await result.current.handleSeek(120_000);
+    });
+    // #then the cursor jumps to the target optimistically
+    expect(result.current.currentPosition).toBe(120_000);
+    expect(seek).toHaveBeenCalledWith(120_000);
+
+    // #when a STALE pre-seek emit arrives (old position, far from target)
+    emit(state(10_500));
+    // #then it is rejected — the cursor stays at the seek target
+    expect(result.current.currentPosition).toBe(120_000);
+  });
+
+  it('resumes tracking once a fresh emit lands near the seek target', async () => {
+    const { result } = render();
+    emit(state(10_000));
+
+    await act(async () => {
+      await result.current.handleSeek(120_000);
+    });
+    // stale emit rejected
+    emit(state(10_500));
+    expect(result.current.currentPosition).toBe(120_000);
+
+    // #when a fresh emit near the target arrives, the guard clears...
+    emit(state(120_400));
+    expect(result.current.currentPosition).toBe(120_400);
+
+    // ...and subsequent emits flow normally again
+    emit(state(121_400));
+    expect(result.current.currentPosition).toBe(121_400);
+  });
+
+  it('still syncs isPlaying while rejecting a stale position', async () => {
+    const { result } = render();
+    emit(state(10_000, true));
+
+    await act(async () => {
+      await result.current.handleSeek(120_000);
+    });
+
+    // stale position + paused → cursor held, but isPlaying reflects the emit
+    emit(state(9_000, false));
+    expect(result.current.currentPosition).toBe(120_000);
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/src/hooks/useRadioSession.ts
+++ b/src/hooks/useRadioSession.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { MediaTrack, ProviderId } from '@/types/domain';
 import type { ProviderDescriptor } from '@/types/providers';
 import type { TrackOperations } from '@/types/trackOperations';
@@ -40,17 +40,27 @@ export function useRadioSession({
   setAuthExpired,
 }: UseRadioSessionProps): UseRadioSessionReturn {
   const { setError, setTracks, setOriginalTracks, setCurrentTrackIndex, setSelectedPlaylistId, mediaTracksRef } = trackOps;
+
+  // Monotonic generation guard. Radio generation is async (catalog fetch +
+  // Last.fm pipeline); a second start — or a stop — must supersede an in-flight
+  // one so its late result cannot clobber the newer queue. Mirrors the guard in
+  // useCollectionLoader.
+  const generationRef = useRef(0);
+
   const clearAuthExpired = useCallback(() => {
     setAuthExpired(null);
   }, [setAuthExpired]);
 
   const stopRadio = useCallback(() => {
+    generationRef.current += 1;
     stopRadioBase();
     setAuthExpired(null);
   }, [stopRadioBase]);
 
   const handleStartRadio = useCallback(async () => {
     if (!activeDescriptor || !currentTrack) return;
+
+    const generation = ++generationRef.current;
 
     try {
       const searchProviders = providerRegistry.getAll().filter(
@@ -74,6 +84,10 @@ export function useRadioSession({
         generateQueue: startRadio,
       });
 
+      // Superseded by a newer start or a stop while we were generating — drop
+      // this stale result rather than overwrite the current queue / progress.
+      if (generationRef.current !== generation) return;
+
       if (!pipelineResult) {
         onProgress(null);
         return;
@@ -92,6 +106,9 @@ export function useRadioSession({
         onProgress(null);
       }
     } catch (err) {
+      // A superseded generation's failure must not surface an error or clear the
+      // newer generation's progress.
+      if (generationRef.current !== generation) return;
       console.warn('[Radio] Generation failed:', err);
       setError(err instanceof Error ? err.message : 'Failed to start radio.');
       onProgress(null);

--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -3,6 +3,16 @@ import type { MediaTrack } from '@/types/domain';
 import { useProviderContext } from '@/contexts/ProviderContext';
 import { providerRegistry } from '@/providers/registry';
 import type { PlaybackState, ProviderId } from '@/types/domain';
+import { logSeek } from '@/lib/debugLog';
+
+// After a seek, the SDK can still emit a stale pre-seek position (notably after
+// a re-auth re-subscribe / getState), which would yank the timeline cursor back
+// and "disconnect" it from playback (#1671). Until a position emit lands near the
+// seek target, reject stale ones. Tolerance absorbs normal play drift between
+// emits; the window is a safety valve so the cursor can never get stuck if the
+// SDK never reports near the target.
+const SEEK_TOLERANCE_MS = 2000;
+const SEEK_GUARD_WINDOW_MS = 5000;
 
 interface UseSpotifyControlsProps {
   currentTrack: MediaTrack | null;
@@ -63,8 +73,47 @@ export const useSpotifyControls = ({
   );
   const [isDragging, setIsDragging] = useState(false);
   const isDraggingRef = useRef(false);
+  // Set when a seek is issued; cleared once a position emit is accepted near the
+  // target (or the guard window lapses). See SEEK_* constants above.
+  const pendingSeekRef = useRef<{ target: number; at: number } | null>(null);
 
   const { activeDescriptor } = useProviderContext();
+
+  // Decide whether an incoming position emit should move the cursor. Returns
+  // true (accept) when no seek is pending, when the emit is near the expected
+  // post-seek position, or when the guard window has lapsed; false (reject) for a
+  // stale pre-seek position. Reads/writes refs only, so it is stable and does not
+  // re-subscribe the playback listeners.
+  const shouldAcceptPosition = useCallback((positionMs: number, playing: boolean): boolean => {
+    const pending = pendingSeekRef.current;
+    if (!pending) return true;
+
+    const elapsed = performance.now() - pending.at;
+    if (elapsed > SEEK_GUARD_WINDOW_MS) {
+      pendingSeekRef.current = null;
+      logSeek('guard window lapsed → accept (pos=%dms)', Math.round(positionMs));
+      return true;
+    }
+
+    const expected = pending.target + (playing ? elapsed : 0);
+    const drift = Math.abs(positionMs - expected);
+    if (drift <= SEEK_TOLERANCE_MS) {
+      pendingSeekRef.current = null;
+      logSeek('post-seek confirmed → accept (pos=%dms, expected=%dms, drift=%dms)',
+        Math.round(positionMs), Math.round(expected), Math.round(drift));
+      return true;
+    }
+
+    logSeek('REJECT stale position (pos=%dms, expected=%dms, drift=%dms, target=%dms)',
+      Math.round(positionMs), Math.round(expected), Math.round(drift), Math.round(pending.target));
+    return false;
+  }, []);
+
+  // Drop the guard on track change — a new track starts at 0, unrelated to any
+  // pending seek on the previous one.
+  useEffect(() => {
+    pendingSeekRef.current = null;
+  }, [currentTrack?.id]);
 
   const getPlayingDescriptor = useCallback(() =>
     currentTrackProvider && currentTrackProvider !== activeDescriptor?.id
@@ -88,7 +137,9 @@ export const useSpotifyControls = ({
 
     function handleProviderStateChange(state: PlaybackState | null) {
       if (!state) return;
-      if (isDraggingRef.current) {
+      // While dragging, or when a stale pre-seek position arrives, sync
+      // isPlaying/duration but leave the cursor where the user/seek put it.
+      if (isDraggingRef.current || !shouldAcceptPosition(state.positionMs, state.isPlaying)) {
         dispatchTiming({ type: 'update_no_position', isPlaying: state.isPlaying, durationMs: state.durationMs });
       } else {
         dispatchTiming({ type: 'update', isPlaying: state.isPlaying, positionMs: state.positionMs, durationMs: state.durationMs });
@@ -99,13 +150,13 @@ export const useSpotifyControls = ({
 
     // Also check initial state once
     playback.getState().then((state) => {
-      if (state) {
+      if (state && shouldAcceptPosition(state.positionMs, state.isPlaying)) {
         dispatchTiming({ type: 'update', isPlaying: state.isPlaying, positionMs: state.positionMs, durationMs: state.durationMs });
       }
     });
 
     return unsubscribe;
-  }, [getPlayingDescriptor]);
+  }, [getPlayingDescriptor, shouldAcceptPosition]);
 
   // Lightweight position poll — only to update the timeline slider smoothly.
   // Poll the adapter that is actually playing, which may differ from the active
@@ -119,13 +170,13 @@ export const useSpotifyControls = ({
     const interval = setInterval(async () => {
       if (isDraggingRef.current) return;
       const state = await playback.getState();
-      if (state) {
+      if (state && shouldAcceptPosition(state.positionMs, state.isPlaying)) {
         dispatchTiming({ type: 'position', positionMs: state.positionMs });
       }
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isPlaying, getPlayingDescriptor]);
+  }, [isPlaying, getPlayingDescriptor, shouldAcceptPosition]);
 
   const handlePlayPause = useCallback(async () => {
     const playingDescriptor = getPlayingDescriptor();
@@ -153,6 +204,12 @@ export const useSpotifyControls = ({
       const playingDescriptor = getPlayingDescriptor();
       const playback = playingDescriptor?.playback;
       if (!playback) return;
+      // Arm the guard and optimistically move the cursor to the target so it
+      // reflects the seek immediately and cannot be dragged back by a stale
+      // pre-seek emit before the SDK reports the new position (#1671).
+      pendingSeekRef.current = { target: position, at: performance.now() };
+      logSeek('seek issued → target=%dms (guard armed)', Math.round(position));
+      dispatchTiming({ type: 'position', positionMs: position });
       await playback.seek(position);
     } catch (error) {
       console.error('Failed to seek:', error);

--- a/src/lib/debugLog.ts
+++ b/src/lib/debugLog.ts
@@ -34,3 +34,15 @@ export const logSession = createDebug('vorbis:session');
 const _logArtRace = createDebug('vorbis:art-race');
 export const logArtRace = (fmt: string, ...args: unknown[]) =>
   _logArtRace(`[t=%sms] ${fmt}`, performance.now().toFixed(1), ...args);
+
+/**
+ * Focused trace for the seek-cursor guard (#1671): every seek arms a guard, and
+ * each subsequent position emit is logged as accepted or rejected (with target /
+ * expected / drift) so a post-reauth "cursor disconnects after seek" repro can be
+ * diagnosed from a single console capture.
+ *
+ * Enable with: localStorage.debug = 'vorbis:seek' (or 'vorbis:*').
+ */
+const _logSeek = createDebug('vorbis:seek');
+export const logSeek = (fmt: string, ...args: unknown[]) =>
+  _logSeek(`[t=%sms] ${fmt}`, performance.now().toFixed(1), ...args);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,19 @@ import './styles/shadcn-tokens.css'
 import App from './App.tsx'
 import { logSw } from '@/lib/debugLog'
 
+// Deploy provenance: always log the running build and expose it on window so the
+// exact deployed commit can be confirmed from any environment (staging/prod).
+const buildInfo: BuildInfo = {
+  sha: __BUILD_SHA__,
+  ref: __BUILD_REF__,
+  env: __BUILD_ENV__,
+  version: __APP_VERSION__,
+};
+window.__BUILD__ = buildInfo;
+console.info(
+  `Vorbis build ${buildInfo.sha === 'unknown' ? 'dev' : buildInfo.sha.slice(0, 7)} · ${buildInfo.ref} · ${buildInfo.env}`,
+);
+
 // Mock provider loads when VITE_MOCK_PROVIDER=true or in any dev build (so
 // `?provider=mock` URL activation works without restarting). Both constants are
 // build-time, so production builds DCE the branch and tree-shake the mock.

--- a/src/services/spotify/__tests__/api.test.ts
+++ b/src/services/spotify/__tests__/api.test.ts
@@ -162,3 +162,63 @@ describe('spotifyApiRequest — structured errors and retry-after-refresh', () =
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('spotifyApiRequest — response body parsing', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    getAccessToken.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves undefined for a successful non-JSON body (e.g. player seek) instead of throwing', async () => {
+    // #given a 200 with a non-JSON body and no application/json content-type,
+    // as Spotify's player seek endpoint sometimes returns (#1671 diagnosis).
+    fetchMock.mockResolvedValueOnce(
+      new Response('FERpzaDjxZabc', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    // #when a void-returning write is issued
+    const result = await spotifyApiRequest<void>(
+      'https://api.spotify.com/v1/me/player/seek?position_ms=1000',
+      'token-1',
+      { method: 'PUT' },
+    );
+
+    // #then it resolves cleanly rather than throwing a JSON parse error
+    expect(result).toBeUndefined();
+  });
+
+  it('resolves undefined for a 204 no-content response', async () => {
+    fetchMock.mockResolvedValueOnce(emptyResponse(204));
+    const result = await spotifyApiRequest<void>(
+      'https://api.spotify.com/v1/me/player/pause',
+      'token-1',
+      { method: 'PUT' },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('still throws when an application/json body is malformed (a real error)', async () => {
+    // #given a body declared as JSON but syntactically broken
+    fetchMock.mockResolvedValueOnce(
+      new Response('{ not json', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    // #then the parse error surfaces — we only swallow non-JSON bodies
+    await expect(
+      spotifyApiRequest<{ id: string }>('https://api.spotify.com/v1/me', 'token-1'),
+    ).rejects.toThrow();
+  });
+
+  it('parses a well-formed JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'me-1' }));
+    const result = await spotifyApiRequest<{ id: string }>('https://api.spotify.com/v1/me', 'token-1');
+    expect(result).toEqual({ id: 'me-1' });
+  });
+});

--- a/src/services/spotify/api.ts
+++ b/src/services/spotify/api.ts
@@ -91,7 +91,19 @@ async function executeApiRequest<T>(
   if (!text) {
     return undefined as T;
   }
-  return JSON.parse(text);
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    // Some successful write endpoints (e.g. player seek/pause) occasionally
+    // return a non-JSON body instead of a clean 204, so a void-returning caller
+    // has nothing to parse. Only swallow when the body wasn't declared JSON —
+    // a malformed *application/json* body is a real error and still throws.
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      return undefined as T;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/test/__tests__/asyncRace.test.ts
+++ b/src/test/__tests__/asyncRace.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deferred, createDeferredFn, flushMicrotasks } from '../asyncRace';
+
+describe('deferred', () => {
+  it('resolves with the provided value', async () => {
+    // #given a deferred
+    const d = deferred<number>();
+    expect(d.settled).toBe(false);
+
+    // #when resolved
+    d.resolve(42);
+
+    // #then it settles and yields the value
+    expect(d.settled).toBe(true);
+    await expect(d.promise).resolves.toBe(42);
+  });
+
+  it('rejects with the provided reason', async () => {
+    // #given a deferred
+    const d = deferred<number>();
+
+    // #when rejected
+    d.reject(new Error('boom'));
+
+    // #then it settles rejected
+    expect(d.settled).toBe(true);
+    await expect(d.promise).rejects.toThrow('boom');
+  });
+});
+
+describe('createDeferredFn', () => {
+  it('records each invocation with its args, in call order', () => {
+    // #given an injected deferred fn
+    const load = createDeferredFn<[string], string[]>();
+
+    // #when invoked twice
+    void load.fn('A');
+    void load.fn('B');
+
+    // #then calls are recorded in order
+    expect(load.callCount).toBe(2);
+    expect(load.calls[0]?.args).toEqual(['A']);
+    expect(load.calls[1]?.args).toEqual(['B']);
+  });
+
+  it('lets the test settle calls OUT OF ORDER', async () => {
+    // This is the core capability: model a superseded async load. Operation A
+    // starts, operation B supersedes it, B resolves first, then the stale A
+    // resolves late. A consumer that guards correctly keeps B's result.
+    const load = createDeferredFn<[string], string>();
+
+    // #given two in-flight loads and a "latest wins" consumer guarded by
+    // request order (the shape every fixed race path uses)
+    let latestRequested = '';
+    let committed = '';
+    const request = async (id: string) => {
+      latestRequested = id;
+      const result = await load.fn(id);
+      // Guard: only commit if this request is still the latest.
+      if (latestRequested === id) committed = result;
+    };
+
+    void request('A'); // call 0
+    void request('B'); // call 1 — supersedes A
+
+    // #when the newer load (B) resolves first, then the stale one (A) resolves
+    load.resolve(1, 'result-B');
+    await flushMicrotasks();
+    load.resolve(0, 'result-A'); // stale — arrives after B
+    await flushMicrotasks();
+
+    // #then the stale A must not have overwritten B
+    expect(committed).toBe('result-B');
+  });
+
+  it('demonstrates the bug a missing guard would cause', async () => {
+    // Same interleaving, but WITHOUT the latest-wins guard — the stale write
+    // clobbers the newer result. This is the failure the harness is built to catch.
+    const load = createDeferredFn<[string], string>();
+
+    let committed = '';
+    const requestUnguarded = async (id: string) => {
+      const result = await load.fn(id);
+      committed = result; // no guard — always writes
+    };
+
+    void requestUnguarded('A');
+    void requestUnguarded('B');
+
+    load.resolve(1, 'result-B');
+    await flushMicrotasks();
+    load.resolve(0, 'result-A');
+    await flushMicrotasks();
+
+    // The stale A clobbered B — exactly the class of bug (#1638, #1651, #1336, …).
+    expect(committed).toBe('result-A');
+  });
+
+  it('throws a helpful error when settling a non-existent call', () => {
+    const load = createDeferredFn<[], void>();
+    expect(() => load.resolve(0, undefined)).toThrow(/no call at index 0/);
+  });
+});
+
+describe('flushMicrotasks', () => {
+  it('runs queued microtasks before resolving', async () => {
+    const order: string[] = [];
+    void Promise.resolve().then(() => order.push('microtask'));
+    order.push('sync');
+
+    await flushMicrotasks();
+
+    expect(order).toEqual(['sync', 'microtask']);
+  });
+
+  it('is a no-op-safe await point', async () => {
+    const spy = vi.fn();
+    await flushMicrotasks();
+    spy();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test/asyncRace.ts
+++ b/src/test/asyncRace.ts
@@ -1,0 +1,114 @@
+/**
+ * Utilities for testing stale-async-write / cancellation-race bugs — the single
+ * most recurring bug mechanism in this codebase (superseded async loads writing
+ * state after a newer one already won: collection loader, album art, library
+ * sync, shuffle, playback subscription guard).
+ *
+ * The pattern these enable:
+ *   1. Trigger operation A (it awaits some async dependency).
+ *   2. Trigger operation B (supersedes A).
+ *   3. Resolve the dependencies OUT OF ORDER — B first, then the stale A.
+ *   4. Assert the final state reflects B, and that A's late resolution did NOT
+ *      overwrite it.
+ *
+ * A single boundingBox-style "resolve in call order" test never exercises step 3,
+ * which is exactly where these bugs live.
+ */
+
+/** A promise whose settlement the test controls explicitly. */
+export interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+  /** True once resolve() or reject() has been called. */
+  readonly settled: boolean;
+}
+
+/** Create a promise that the test resolves/rejects on demand. */
+export function deferred<T = void>(): Deferred<T> {
+  let resolveFn!: (value: T) => void;
+  let rejectFn!: (reason?: unknown) => void;
+  let isSettled = false;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolveFn = res;
+    rejectFn = rej;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => {
+      isSettled = true;
+      resolveFn(value);
+    },
+    reject: (reason?: unknown) => {
+      isSettled = true;
+      rejectFn(reason);
+    },
+    get settled() {
+      return isSettled;
+    },
+  };
+}
+
+/**
+ * A function you inject in place of an async dependency. Every invocation returns
+ * a fresh, unresolved promise; the test settles each call by index, in any order.
+ *
+ *   const load = createDeferredFn<[collectionId: string], Track[]>();
+ *   render(<Thing loader={load.fn} />);
+ *   // component calls load.fn('A') then load.fn('B')
+ *   load.resolve(1, tracksB);   // newer wins first
+ *   load.resolve(0, tracksA);   // stale A resolves late — must NOT overwrite B
+ */
+export interface DeferredFn<Args extends unknown[], T> {
+  /** Inject this where the real async dependency goes. */
+  readonly fn: (...args: Args) => Promise<T>;
+  /** One entry per invocation, in call order. */
+  readonly calls: ReadonlyArray<{ readonly args: Args; readonly deferred: Deferred<T> }>;
+  /** Number of times fn has been invoked. */
+  readonly callCount: number;
+  /** Resolve the i-th invocation's promise. */
+  resolve: (index: number, value: T) => void;
+  /** Reject the i-th invocation's promise. */
+  reject: (index: number, reason?: unknown) => void;
+}
+
+export function createDeferredFn<Args extends unknown[], T>(): DeferredFn<Args, T> {
+  const calls: Array<{ args: Args; deferred: Deferred<T> }> = [];
+
+  const at = (index: number) => {
+    const call = calls[index];
+    if (!call) {
+      throw new Error(
+        `createDeferredFn: no call at index ${index} (only ${calls.length} call(s) so far)`,
+      );
+    }
+    return call;
+  };
+
+  return {
+    fn: (...args: Args): Promise<T> => {
+      const d = deferred<T>();
+      calls.push({ args, deferred: d });
+      return d.promise;
+    },
+    get calls() {
+      return calls;
+    },
+    get callCount() {
+      return calls.length;
+    },
+    resolve: (index: number, value: T) => at(index).deferred.resolve(value),
+    reject: (index: number, reason?: unknown) => at(index).deferred.reject(reason),
+  };
+}
+
+/**
+ * Flush pending microtasks so awaited continuations run before assertions.
+ * Prefer React Testing Library's `waitFor` inside components; use this for
+ * plain-promise / service-level races where there is no DOM to poll.
+ */
+export function flushMicrotasks(): Promise<void> {
+  return Promise.resolve().then(() => undefined);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,19 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string
+/** Full git SHA of the deployed build (Vercel VERCEL_GIT_COMMIT_SHA, or local git; 'unknown' if unavailable). */
+declare const __BUILD_SHA__: string
+/** Git ref/branch of the deployed build (e.g. 'staging', 'main'). */
+declare const __BUILD_REF__: string
+/** Deploy environment: 'production' | 'preview' | 'development' (Vercel) or 'local'. */
+declare const __BUILD_ENV__: string
+
+interface BuildInfo {
+  readonly sha: string
+  readonly ref: string
+  readonly env: string
+  readonly version: string
+}
 
 interface ImportMetaEnv {
   readonly VITE_DROPBOX_APP_KEY: string
@@ -11,4 +24,9 @@ interface ImportMetaEnv {
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+interface Window {
+  /** Build provenance, exposed for quick deploy verification from the console. */
+  __BUILD__?: BuildInfo
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,14 +42,32 @@ import react from '@vitejs/plugin-react'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
+import { execSync } from 'node:child_process'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 const pkg = require('./package.json') as { version: string }
 
+// Build provenance, baked in at build time so the running app can report exactly
+// which commit is deployed (staging / production verification). On Vercel the
+// VERCEL_GIT_* system env vars are authoritative; locally we fall back to git.
+function git(args: string): string {
+  try {
+    return execSync(`git ${args}`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+  } catch {
+    return 'unknown'
+  }
+}
+const buildSha = process.env.VERCEL_GIT_COMMIT_SHA || git('rev-parse HEAD')
+const buildRef = process.env.VERCEL_GIT_COMMIT_REF || git('rev-parse --abbrev-ref HEAD')
+const buildEnv = process.env.VERCEL_ENV || (process.env.NODE_ENV === 'production' ? 'production' : 'local')
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_SHA__: JSON.stringify(buildSha),
+    __BUILD_REF__: JSON.stringify(buildRef),
+    __BUILD_ENV__: JSON.stringify(buildEnv),
   },
   plugins: [react()],
   build: {


### PR DESCRIPTION
Found via the `vorbis:seek` trace while testing #1671 on a real Premium session.

## Bug
`executeApiRequest` (`src/services/spotify/api.ts`) called `JSON.parse(text)` on every non-204, non-empty response. Spotify's player **seek** endpoint returns 200 with a **non-JSON body** ("FERpzaDjxZ…"), so `seek()` rejected on every call:

```
Failed to seek: SyntaxError: Unexpected token 'F', "FERpzaDjxZ"... is not valid JSON
```

The HTTP request lands (playback actually moves), but the promise always rejects — so `seek()` never resolves cleanly and any *genuine* seek failure is indistinguishable from this noise. Pre-existing; unrelated to the cursor guard, just made visible by the new logging.

## Fix
Wrap the parse: on failure, return `undefined` when the body wasn't declared `application/json` (a void write has nothing to parse), but still throw on a malformed `application/json` body — a real error we must not swallow.

## Verified
- 4 new tests (non-JSON→undefined, 204→undefined, malformed JSON→throws, valid JSON→parses). The seek-body test **fails without the fix**.
- `tsc -b` clean.