### PR TITLE
refactor(deploy): make the deploy path provider-agnostic

### DIFF
--- a/.github/workflows/staging-pr.yml
+++ b/.github/workflows/staging-pr.yml
@@ -1,7 +1,16 @@
 name: Deploy PR to Staging
 
-# Manually-triggered workflow: rebuild the `staging` branch from `main`,
-# then merge a chosen pull request on top so it can be tested in isolation.
+# Manually-triggered workflow: rebuild the `staging` branch from `main`, then
+# merge a chosen pull request on top so it can be tested in isolation.
+#
+# This workflow is deliberately host-agnostic. Its job is purely git plumbing:
+# it publishes a `staging` branch containing main + the PR. How that branch
+# becomes a live URL is left to whatever host you point at it:
+#   - Git-integration hosts (Vercel/Netlify/Cloudflare Pages/…) that watch the
+#     `staging` branch build and serve it automatically — nothing more to do.
+#   - Otherwise, configure the STAGING_DEPLOY_TARGET repository variable with a
+#     deploy command (see the "Deploy staging build" step and docs/deploy.md);
+#     it runs `npm run deploy` against that target after the branch is pushed.
 on:
   workflow_dispatch:
     inputs:
@@ -85,3 +94,27 @@ jobs:
           done
           echo "::error::Failed to push staging after multiple attempts."
           exit 1
+
+      # Optional explicit deploy for hosts that do NOT auto-build the `staging`
+      # branch. Skipped entirely unless the STAGING_DEPLOY_TARGET repository
+      # variable is set, so git-integration hosts stay a no-op here.
+      # STAGING_DEPLOY_TARGET is passed through as DEPLOY_TARGET; see docs/deploy.md.
+      - name: Set up Node
+        if: ${{ vars.STAGING_DEPLOY_TARGET != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Deploy staging build
+        if: ${{ vars.STAGING_DEPLOY_TARGET != '' }}
+        env:
+          DEPLOY_TARGET: ${{ vars.STAGING_DEPLOY_TARGET }}
+          VITE_SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
+          VITE_SPOTIFY_REDIRECT_URI: ${{ vars.VITE_SPOTIFY_REDIRECT_URI }}
+          VITE_DROPBOX_CLIENT_ID: ${{ secrets.VITE_DROPBOX_CLIENT_ID }}
+          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run deploy:preview

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ For radio recommendations, also set `VITE_LASTFM_API_KEY` in `.env.local` (see `
 
 ### Deployment
 
-| Platform | Guide |
-|----------|-------|
-| Vercel | **[Deploy to Vercel](./docs/deployment/deploy-to-vercel.md)** |
+Vorbis Player builds to a static `dist/` bundle that any static host can serve.
+
+| Guide | Scope |
+|-------|-------|
+| **[Deploy contract](./docs/deploy.md)** | Provider-agnostic deploy path (`npm run deploy`, `DEPLOY_TARGET`, staging) |
+| **[Deploy to Vercel](./docs/deployment/deploy-to-vercel.md)** | Worked example using one host |
 
 ## Testing & Playwright
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,8 @@ Step-by-step setup guides for each supported music provider:
 
 ## Deployment
 
-- **[Deploy to Vercel](./deployment/deploy-to-vercel.md)** — Vercel deployment instructions
+- **[Deploy contract](./deploy.md)** — provider-agnostic deploy path: the static `dist/` build, `npm run deploy` / `DEPLOY_TARGET`, and staging PR deploys
+- **[Deploy to Vercel](./deployment/deploy-to-vercel.md)** — worked example deploying to one specific host
 
 ## Quick Links
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,8 +35,8 @@ npm run test           # Run tests in watch mode
 npm run test:run       # Run tests once
 npm run test:ui        # Run tests with UI
 npm run test:coverage  # Run tests with coverage
-npm run deploy         # Deploy to production (Vercel)
-npm run deploy:preview # Deploy preview (Vercel)
+npm run deploy         # Deploy to production (see docs/deploy.md)
+npm run deploy:preview # Deploy preview (see docs/deploy.md)
 ```
 
 ## Project Structure

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,94 @@
+# Deploying Vorbis Player
+
+Vorbis Player is a fully static single-page app. `npm run build` emits a
+self-contained `dist/` directory (HTML, JS, CSS, assets) that any static host
+can serve — there is no server runtime and no host-specific code in the repo.
+
+This document defines the **provider-agnostic deploy contract**. The app repo
+knows nothing about Vercel, Netlify, S3, nginx, or any other host; it only knows
+how to produce `dist/` and how to hand that build to a deploy command you supply.
+
+## The build
+
+```bash
+npm run build      # tsc -b && vite build  →  writes ./dist
+```
+
+Build-time configuration comes from `VITE_*` environment variables (read from
+`.env.local` locally, or from the CI/host environment). See
+[Environment Configuration](../CLAUDE.md#environment-configuration):
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `VITE_SPOTIFY_CLIENT_ID` | yes | Spotify OAuth client id |
+| `VITE_SPOTIFY_REDIRECT_URI` | yes | Spotify OAuth callback (must match the deployed origin) |
+| `VITE_DROPBOX_CLIENT_ID` | no | enables the Dropbox provider |
+| `VITE_LASTFM_API_KEY` | no | enables radio recommendations |
+
+> The build also bakes in provenance constants (`__BUILD_SHA__`,
+> `__BUILD_REF__`, `__BUILD_ENV__`) surfaced in Settings → Advanced → About.
+> These read from `VERCEL_GIT_*` when present and otherwise fall back to local
+> `git`; they are informational only and impose no host requirement.
+
+## Serving `dist/`
+
+Any static file host works. The app is a client-routed SPA, so the host must
+**rewrite unknown paths to `/index.html`** (so deep links like
+`/auth/spotify/callback` load the app). Beyond that single rule there are no
+requirements — no Node runtime, no serverless functions, no build hooks.
+
+## `npm run deploy` — the deploy driver
+
+`scripts/deploy.cjs` builds `dist/` and then invokes a deploy command you
+define via environment variables. It is host-agnostic: it never references a
+specific provider.
+
+| npm script | Command | `DEPLOY_ENV` passed to target |
+|---|---|---|
+| `npm run deploy` | `node scripts/deploy.cjs --prod` | `production` |
+| `npm run deploy:preview` | `node scripts/deploy.cjs` | `preview` |
+
+### Contract
+
+| Env var | Required | Meaning |
+|---|---|---|
+| `DEPLOY_TARGET` | yes | Shell command that publishes `./dist` to your host. |
+| `DEPLOY_TARGET_PROD` | no | Production override used by `npm run deploy`; falls back to `DEPLOY_TARGET`. |
+| `DEPLOY_ENV` | (set by the driver) | `production` or `preview`, exported into the target command's environment so a wrapper can branch on it. |
+
+If `DEPLOY_TARGET` is unset the driver prints the contract and exits non-zero —
+it never assumes a default host.
+
+### Examples
+
+```bash
+# Vercel CLI
+DEPLOY_TARGET="vercel" DEPLOY_TARGET_PROD="vercel --prod" npm run deploy
+
+# Netlify CLI
+DEPLOY_TARGET="netlify deploy --dir=dist" \
+  DEPLOY_TARGET_PROD="netlify deploy --dir=dist --prod" npm run deploy
+
+# Plain rsync to a static host
+DEPLOY_TARGET="rsync -a --delete dist/ user@host:/srv/vorbis-player" npm run deploy
+
+# AWS S3 + CloudFront
+DEPLOY_TARGET="aws s3 sync dist/ s3://my-bucket --delete" npm run deploy
+```
+
+The target runs **after** a successful build, with the freshly-built `dist/`
+present and `DEPLOY_ENV` exported.
+
+## Staging / preview PR deploys
+
+`.github/workflows/staging-pr.yml` is a manually-triggered workflow that
+rebuilds a `staging` branch from `main`, merges a chosen PR onto it, and pushes
+it. This is pure git plumbing and carries no host coupling. Turning that branch
+into a live URL is the host's job:
+
+- **Git-integration hosts** (Vercel, Netlify, Cloudflare Pages, …) that watch
+  the `staging` branch build and serve it automatically — nothing else needed.
+- **Other hosts**: set the `STAGING_DEPLOY_TARGET` repository variable to a
+  deploy command. The workflow passes it through as `DEPLOY_TARGET` and runs
+  `npm run deploy:preview` after pushing the branch. Provide the `VITE_*` build
+  values as repository secrets/variables so the CI build can read them.

--- a/docs/deployment/deploy-to-vercel.md
+++ b/docs/deployment/deploy-to-vercel.md
@@ -1,6 +1,10 @@
 # 🚀 Deploy Vorbis Player to Vercel
 
-This guide will help you deploy your Vorbis Player to Vercel in just a few simple steps.
+This guide walks through deploying to Vercel as **one worked example**. Vorbis
+Player is host-agnostic — it builds to a static `dist/` bundle that any static
+host can serve. For the provider-neutral deploy contract (the `DEPLOY_TARGET`
+env var, `npm run deploy`, and staging PR deploys), see
+[deploy.md](../deploy.md).
 
 ## Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "test:coverage": "node scripts/check-node-modules.mjs && vitest run --coverage",
     "deploy": "node scripts/deploy.cjs --prod",
     "deploy:preview": "node scripts/deploy.cjs",
-    "deploy:quick": "vercel --prod",
-    "deploy:env": "vercel env pull .env.local",
     "favicon": "node scripts/generate-favicon.js",
     "knip": "knip",
     "test:e2e": "playwright test",

--- a/scripts/deploy.cjs
+++ b/scripts/deploy.cjs
@@ -1,61 +1,76 @@
 #!/usr/bin/env node
 
+/**
+ * Provider-agnostic deploy driver.
+ *
+ * The app repo knows nothing about any specific host (Vercel/Netlify/S3/nginx/…).
+ * It produces a static `dist/` bundle, then hands that bundle off to a deploy
+ * command defined entirely outside the repo via the DEPLOY_TARGET env var.
+ *
+ * Contract (see docs/deploy.md):
+ *   DEPLOY_TARGET       Shell command that publishes ./dist to your host. Required.
+ *   DEPLOY_TARGET_PROD  Optional production override; used for `--prod`,
+ *                       falls back to DEPLOY_TARGET when unset.
+ *   The chosen command is spawned with DEPLOY_ENV=production|preview in its
+ *   environment so a wrapper can branch on the deploy kind if it needs to.
+ *
+ * Usage:
+ *   npm run deploy           # production  (node scripts/deploy.cjs --prod)
+ *   npm run deploy:preview   # preview     (node scripts/deploy.cjs)
+ */
+
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-console.log('🚀 Vorbis Player Deployment Script');
-console.log('=====================================\n');
+const isProduction = process.argv.includes('--prod');
+const deployEnv = isProduction ? 'production' : 'preview';
 
-// Check if .env.example exists and .env.local doesn't
+console.log('Vorbis Player deploy');
+console.log('====================\n');
+
+// Resolve the deploy target. Production may use a dedicated command; otherwise
+// both preview and production share DEPLOY_TARGET.
+const target = isProduction
+  ? (process.env.DEPLOY_TARGET_PROD || process.env.DEPLOY_TARGET)
+  : process.env.DEPLOY_TARGET;
+
+if (!target) {
+  console.error('No deploy target configured.\n');
+  console.error('Set DEPLOY_TARGET to the command that publishes ./dist to your host, e.g.:');
+  console.error('  DEPLOY_TARGET="vercel"                                  npm run deploy:preview');
+  console.error('  DEPLOY_TARGET="netlify deploy --dir=dist"               npm run deploy:preview');
+  console.error('  DEPLOY_TARGET="rsync -a --delete dist/ user@host:/srv"  npm run deploy');
+  console.error('\nSee docs/deploy.md for the full deploy contract.');
+  process.exit(1);
+}
+
+// Nudge if credentials likely aren't set up yet (build reads VITE_* from .env.local).
 const envExamplePath = path.join(process.cwd(), '.env.example');
 const envLocalPath = path.join(process.cwd(), '.env.local');
-
 if (fs.existsSync(envExamplePath) && !fs.existsSync(envLocalPath)) {
-  console.log('📋 Setting up environment variables...');
-  console.log('   Please copy .env.example to .env.local and fill in your Spotify credentials');
-  console.log('   Or use: cp .env.example .env.local\n');
+  console.log('Note: .env.local not found. Copy .env.example and fill in credentials before building.\n');
 }
 
-// Check if Vercel CLI is installed
-try {
-  execSync('vercel --version', { stdio: 'ignore' });
-  console.log('✅ Vercel CLI is installed');
-} catch (error) {
-  console.log('📦 Installing Vercel CLI...');
-  execSync('npm install -g vercel', { stdio: 'inherit' });
-  console.log('✅ Vercel CLI installed successfully');
-}
-
-console.log('\n🔨 Building the project...');
+console.log('Building the project...');
 try {
   execSync('npm run build', { stdio: 'inherit' });
-  console.log('✅ Build completed successfully');
+  console.log('Build completed.\n');
 } catch (error) {
-  console.error('❌ Build failed');
+  console.error('Build failed.');
   process.exit(1);
 }
 
-console.log('\n🚀 Deploying to Vercel...');
+console.log(`Deploying (${deployEnv}) via: ${target}\n`);
 try {
-  const isProduction = process.argv.includes('--prod');
-  const command = isProduction ? 'vercel --prod' : 'vercel';
-  
-  execSync(command, { stdio: 'inherit' });
-  console.log(`✅ Deployment ${isProduction ? 'to production' : 'preview'} completed successfully`);
-  
-  console.log('\n🎵 Next steps:');
-  console.log('1. Update your Spotify app redirect URI with your Vercel URL');
-  console.log('2. Make sure environment variables are set in Vercel dashboard');
-  console.log('3. Test your deployment by connecting to Spotify');
-  
+  execSync(target, {
+    stdio: 'inherit',
+    env: { ...process.env, DEPLOY_ENV: deployEnv },
+  });
 } catch (error) {
-  console.error('❌ Deployment failed');
-  console.log('\n🔧 Troubleshooting tips:');
-  console.log('1. Make sure you\'re logged in to Vercel: vercel login');
-  console.log('2. Check that your environment variables are set');
-  console.log('3. Verify your Spotify app configuration');
+  console.error('\nDeployment failed.');
+  console.error('Verify DEPLOY_TARGET is correct and any host CLI it uses is authenticated.');
   process.exit(1);
 }
 
-console.log('\n🎉 Deployment complete! Your Vorbis Player is now live!');
+console.log(`\nDeployment (${deployEnv}) complete.`);


### PR DESCRIPTION
## Summary

Decouples the app repo from a Vercel-specific deploy path (issue #1681). The approach is **generalize + document** — the deploy path stays, but it is no longer hardcoded to any single host. The repo now only knows how to produce a static `dist/` bundle and hand it to a deploy command supplied via env vars.

## Changes

- **`scripts/deploy.cjs`** — rewritten to be host-agnostic. Reads the deploy command from `DEPLOY_TARGET` (with optional `DEPLOY_TARGET_PROD` for `--prod`) instead of shelling out to the Vercel CLI. Exports `DEPLOY_ENV=production|preview` into the target command's environment, and errors clearly (printing the contract) when no target is configured.
- **`package.json`** — dropped the Vercel-only `deploy:quick` (`vercel --prod`) and `deploy:env` (`vercel env pull`) scripts. `deploy` / `deploy:preview` still drive the now-generic script.
- **`.github/workflows/staging-pr.yml`** — documented that the workflow is pure git plumbing (rebuild `staging` from `main`, merge the PR, push) with no host coupling. Added an **opt-in** deploy step gated on the `STAGING_DEPLOY_TARGET` repository variable for hosts that do not auto-build the branch; git-integration hosts leave it unset and it is skipped.
- **`docs/deploy.md`** — new provider-agnostic deploy contract: the static `dist/` build, the `DEPLOY_TARGET` env-var contract, SPA rewrite requirement, and staging PR deploys. The Vercel guide is reframed as one worked example; READMEs point at the contract.

## Deploy contract

| Env var | Required | Meaning |
|---|---|---|
| `DEPLOY_TARGET` | yes | Shell command that publishes `./dist` to your host |
| `DEPLOY_TARGET_PROD` | no | Production override for `npm run deploy`; falls back to `DEPLOY_TARGET` |
| `DEPLOY_ENV` | set by driver | `production` / `preview`, exported into the target's env |

## Verification

- `npx tsc -b --noEmit` — clean
- `npm run build` — passes
- `npm run test:run` — 2040 tests pass
- The build-time SHA provenance constants (`__BUILD_SHA__` / `__BUILD_REF__` / `__BUILD_ENV__` in `vite.config.ts`, from #1676) are intentionally **untouched** — they are generic and read `VERCEL_GIT_*` only as one fallback source.

Closes #1681