### PR TITLE
test(e2e): make playlist-selection specs assert real behavior

### DIFF
--- a/playwright/specs/playlist-selection.spec.ts
+++ b/playwright/specs/playlist-selection.spec.ts
@@ -19,35 +19,65 @@ test.describe('Playlist Selection', () => {
     await navigateToLibrary(page);
     await expect(page.getByText('Connect Spotify')).not.toBeVisible({ timeout: 5000 });
     await expect(page.locator('[data-testid="library-home"]')).toBeVisible({ timeout: 5000 });
+    // "Shows library UI" must mean a *populated* library — the container alone
+    // renders even when the catalog fails to load. Assert at least one real
+    // collection tile is present so an empty-shell regression fails here.
+    await expect(page.locator('[data-testid^="library-card-"]').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  test('renders playlist tiles when snapshot has playlists', async ({ page }) => {
+  test('renders playlist tiles bound to real snapshot data', async ({ page }) => {
     if (!hasPlaylists) {
       test.skip(true, 'Snapshot has no playlists — skipping playlist-render test');
       return;
     }
+    const firstPlaylist = spotifySnapshot.playlists[0];
+    if (!firstPlaylist) return;
+
     await navigateToLibrary(page);
-    await expect(page.locator('[data-testid^="library-card-playlist-"]').first()).toBeVisible({ timeout: 10_000 });
+
+    // Target the tile for a specific snapshot playlist by id and assert it
+    // renders that playlist's real name. A presence-only check ("some card is
+    // visible") would pass on an empty-shell/placeholder card that lost its
+    // data binding; asserting the name proves the catalog data reached the DOM.
+    const card = page.locator(`[data-testid="library-card-playlist-${firstPlaylist.id}"]`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText(firstPlaylist.name);
   });
 
-  test('clicking a playlist tile navigates to the player view', async ({ page }) => {
+  test('clicking a playlist tile loads that playlist into the player', async ({ page }) => {
     if (!hasPlaylists) {
       test.skip(true, 'Snapshot has no playlists — skipping playlist-click test');
       return;
     }
     await navigateToLibrary(page);
     await page.locator('[data-testid^="library-card-playlist-"]').first().click();
+
+    // Navigating away from the library is necessary but not sufficient — the
+    // player view must actually load a track from the selected playlist. Assert
+    // the transport chrome appears AND the now-playing track name is populated,
+    // proving the click drove real playback state, not merely a route change.
     await expect(page.locator('[data-testid="library-home"]')).not.toBeVisible({ timeout: 10_000 });
     await expect(page.locator('button[title^="Zen Mode"]')).toBeVisible({ timeout: 10_000 });
+    const trackName = page.locator('[data-testid="player-track-info-name"]');
+    await expect(trackName).toBeVisible({ timeout: 15_000 });
+    await expect(trackName).not.toHaveText('');
   });
 
-  test('renders album tiles when snapshot has albums', async ({ page }) => {
+  test('renders album tiles bound to real snapshot data', async ({ page }) => {
     if (!hasAlbums) {
       test.skip(true, 'Snapshot has no albums — skipping album-render test');
       return;
     }
+    const firstAlbum = spotifySnapshot.albums[0];
+    if (!firstAlbum) return;
+
     await navigateToLibrary(page);
-    await expect(page.locator('[data-testid^="library-card-album-"]').first()).toBeVisible({ timeout: 10_000 });
+
+    // As above: assert the specific album tile renders its real name, not just
+    // that a card element exists.
+    const card = page.locator(`[data-testid="library-card-album-${firstAlbum.id}"]`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText(firstAlbum.name);
   });
 
   test('library section renders without auth errors', async ({ page }) => {


### PR DESCRIPTION
## Summary

Follow-up to #1679. That PR made the player-controls and zen-mode specs honest; this one does the same for `playlist-selection.spec.ts`, the remaining Playwright spec that asserted element *presence/visibility* rather than a behavioral outcome. An empty-shell card or a route change with no playback would have passed the old assertions.

## Changes

- `renders playlist tiles` / `renders album tiles`: target the tile by its committed-snapshot id and assert it renders the collection's real name (proves catalog data bound to the DOM, not just that *a* card element exists).
- `clicking a playlist tile`: after the click, assert the now-playing track name is populated — proving the click actually loaded the playlist into the player, not merely swapped routes.
- `shows library UI when authenticated`: assert at least one real collection tile renders, so the test fails on an empty-shell/catalog-load regression instead of passing on the bare container.
- Audited the other specs (`auto-advance`, `provider-auth-reauth`, `persisted-session-hydrate`, `queue-context-menu`) — they already assert real state changes and were left untouched.

## Test plan

- [ ] `npm run test:e2e` — 19 passed
- [ ] `CI=1 npm run test:e2e` — 19 passed
- [ ] `npx playwright test playwright/specs/playlist-selection.spec.ts --repeat-each=3` — no flakes
- [ ] `npm run test:run` — 2040 passed
- [ ] `npx tsc -b --noEmit` and `npm run lint` — clean (0 errors)