### PR TITLE
test(async-race): expand stale-generation coverage + fix 3 latent races

### DIFF
--- a/src/hooks/__tests__/useAccentColor.race.test.ts
+++ b/src/hooks/__tests__/useAccentColor.race.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createDeferredFn } from '@/test/asyncRace';
+import type { MediaTrack } from '@/types/domain';
+
+type Extracted = { hex: string; rgb: string; hsl: string } | null;
+
+const extract = createDeferredFn<[string], Extracted>();
+
+vi.mock('@/utils/colorExtractor', () => ({
+  extractDominantColor: (...args: [string]) => extract.fn(...args),
+}));
+
+vi.mock('@/contexts/ProfilingContext', () => ({
+  isProfilingEnabled: () => false,
+}));
+
+import { useAccentColor } from '../useAccentColor';
+import { makeTrack } from '@/test/fixtures';
+
+function color(hex: string): Extracted {
+  return { hex, rgb: hex, hsl: hex };
+}
+
+describe('useAccentColor — auto re-extract stale-write race', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a late auto re-extraction for the previous track does not clobber the current track color', async () => {
+    // #given track A rendered (its effect kicks off an extraction we never
+    // settle — the isCurrent guard already covers the effect path)
+    const setAccentColor = vi.fn();
+    const setAccentColorOverrides = vi.fn();
+    const trackA: MediaTrack = makeTrack({ albumId: 'album-A', image: 'imgA' });
+    const trackB: MediaTrack = makeTrack({ albumId: 'album-B', image: 'imgB' });
+
+    const { result, rerender } = renderHook(
+      ({ track }: { track: MediaTrack }) =>
+        useAccentColor(track, {}, setAccentColor, setAccentColorOverrides),
+      { initialProps: { track: trackA } },
+    );
+
+    await waitFor(() => expect(extract.callCount).toBe(1)); // effect(A) → call 0 (imgA)
+
+    // #when the user picks "auto" while track A is showing — an unguarded
+    // async re-extraction of A's art starts...
+    act(() => {
+      result.current.resetToAutoColor();
+    });
+    await waitFor(() => expect(extract.callCount).toBe(2)); // auto(A) → call 1 (imgA)
+
+    // ...then the track advances to B, whose effect extracts B's art...
+    rerender({ track: trackB });
+    await waitFor(() => expect(extract.callCount).toBe(3)); // effect(B) → call 2 (imgB)
+
+    // ...and B (the newest) resolves BEFORE the stale auto(A) resolves.
+    await act(async () => {
+      extract.resolve(2, color('#B0B0B0'));
+      extract.resolve(1, color('#A0A0A0')); // stale auto for the old track A
+      extract.resolve(0, color('#A0A0A0')); // stale effect for the old track A
+      await Promise.resolve();
+    });
+
+    // #then the last committed accent color must be B's, not the stale A that
+    // resolved last. Without a generation guard the late auto(A) clobbers B.
+    const committed = setAccentColor.mock.calls.map((c: [string]) => c[0]);
+    expect(committed.at(-1)).toBe('#B0B0B0');
+    expect(committed).not.toContain('#A0A0A0');
+  });
+});

--- a/src/hooks/__tests__/usePlaybackSubscription.getStateRace.test.ts
+++ b/src/hooks/__tests__/usePlaybackSubscription.getStateRace.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { PlaybackState } from '@/types/domain';
+import { createDeferredFn } from '@/test/asyncRace';
+
+// The effect resolves the driving provider's initial state via
+// providerRegistry.get(id).getState(). We make that a deferred fn so the test
+// controls when — and after which lifecycle events — it settles.
+const getState = createDeferredFn<[], PlaybackState | null>();
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: {
+    getAll: vi.fn().mockReturnValue([]),
+    get: vi.fn(() => ({ playback: { getState: getState.fn } })),
+  },
+}));
+
+vi.mock('@/lib/debugLog', () => ({
+  logQueue: vi.fn(),
+  logArtRace: vi.fn(),
+}));
+
+import { usePlaybackSubscription } from '../usePlaybackSubscription';
+import { makeMediaTrack, makeProviderDescriptor } from '@/test/fixtures';
+
+describe('usePlaybackSubscription — initial getState stale-write race', () => {
+  let setIsPlaying: ReturnType<typeof vi.fn>;
+  let setPlaybackPosition: ReturnType<typeof vi.fn>;
+
+  const tracks = [makeMediaTrack({ id: 'track-a', provider: 'spotify' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setIsPlaying = vi.fn();
+    setPlaybackPosition = vi.fn();
+  });
+
+  function makeProps() {
+    const descriptor = makeProviderDescriptor({
+      playback: {
+        ...makeProviderDescriptor().playback,
+        subscribe: vi.fn().mockReturnValue(vi.fn()),
+        getState: getState.fn,
+      },
+    });
+    return {
+      activeDescriptor: descriptor,
+      drivingProviderRef: { current: null as string | null },
+      tracksRef: { current: tracks },
+      currentTrackIndexRef: { current: 0 },
+      expectedTrackIdRef: { current: null as string | null },
+      setIsPlaying,
+      setPlaybackPosition,
+      setCurrentTrackIndex: vi.fn(),
+      setTracks: vi.fn(),
+    };
+  }
+
+  it('does not commit playback state from a getState that resolves after unmount', async () => {
+    // #given a mounted subscription whose initial getState() is in flight
+    const { unmount } = renderHook(() => usePlaybackSubscription(makeProps()));
+    await waitFor(() => expect(getState.callCount).toBeGreaterThanOrEqual(1));
+
+    // #when the hook unmounts (provider switch / teardown) before getState settles,
+    // then the stale getState resolves
+    unmount();
+    await act(async () => {
+      getState.resolve(0, {
+        isPlaying: true,
+        positionMs: 4000,
+        durationMs: 210000,
+        currentTrackId: 'track-a',
+        currentPlaybackRef: { provider: 'spotify', ref: 'spotify:track:track-a' },
+      });
+      await Promise.resolve();
+    });
+
+    // #then the superseded getState must not write playback state into the
+    // torn-down subscription.
+    expect(setIsPlaying).not.toHaveBeenCalled();
+    expect(setPlaybackPosition).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useProviderPlayback.playTrackRace.test.ts
+++ b/src/hooks/__tests__/useProviderPlayback.playTrackRace.test.ts
@@ -1,0 +1,99 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { MediaTrack, ProviderId } from '@/types/domain';
+import { createDeferredFn } from '@/test/asyncRace';
+
+// The adapter's playTrack is the awaited async dependency whose two invocations
+// we settle out of order. Each render of the descriptor shares this deferred fn.
+const play = createDeferredFn<[MediaTrack, unknown], void>();
+const mockPause = vi.fn().mockResolvedValue(undefined);
+const mockPrepareTrack = vi.fn();
+
+const mockRegistryGet = vi.fn();
+
+vi.mock('@/providers/registry', () => ({
+  providerRegistry: { get: (...args: unknown[]) => mockRegistryGet(...args) },
+}));
+
+vi.mock('@/services/sessionPersistence', () => ({
+  loadSession: () => null,
+}));
+
+import { useProviderPlayback } from '../useProviderPlayback';
+
+function makeTrack(id: string, provider: ProviderId = 'spotify' as ProviderId): MediaTrack {
+  return {
+    id,
+    provider,
+    playbackRef: { provider, ref: `spotify:track:${id}` },
+    name: `Track ${id}`,
+    artists: 'Test Artist',
+    album: 'Test Album',
+    durationMs: 180000,
+    image: '',
+  };
+}
+
+function makeDescriptor() {
+  return {
+    id: 'spotify' as ProviderId,
+    capabilities: { hasNativeQueueSync: false, hasExternalLink: false },
+    playback: {
+      providerId: 'spotify' as ProviderId,
+      playTrack: play.fn,
+      pause: mockPause,
+      resume: vi.fn().mockResolvedValue(undefined),
+      prepareTrack: mockPrepareTrack,
+      seek: vi.fn(),
+      next: vi.fn(),
+      previous: vi.fn(),
+      setVolume: vi.fn(),
+      getState: vi.fn(),
+      subscribe: vi.fn(),
+    },
+  };
+}
+
+describe('useProviderPlayback — playTrack stale-write race', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistryGet.mockReturnValue(makeDescriptor());
+  });
+
+  it('newer playTrack wins when an older adapter call resolves later', async () => {
+    // #given a queue and two overlapping playTrack invocations
+    const tracks = [makeTrack('t0'), makeTrack('t1'), makeTrack('t2')];
+    const mediaTracksRef: React.MutableRefObject<MediaTrack[]> = { current: tracks };
+    const setCurrentTrackIndex = vi.fn();
+
+    const { result } = renderHook(() =>
+      useProviderPlayback({ setCurrentTrackIndex, mediaTracksRef }),
+    );
+
+    // #when playTrack(1) then playTrack(2) both reach the awaited adapter call,
+    // pinning adapter call index 0 → index 1 (older), index 1 → index 2 (newer).
+    let pOld!: Promise<void>;
+    let pNew!: Promise<void>;
+    await act(async () => {
+      pOld = result.current.playTrack(1);
+      await waitFor(() => expect(play.callCount).toBe(1));
+      pNew = result.current.playTrack(2);
+      await waitFor(() => expect(play.callCount).toBe(2));
+    });
+
+    // ...and the newer (index 2) adapter call resolves BEFORE the stale (index 1).
+    await act(async () => {
+      play.resolve(1, undefined);
+      play.resolve(0, undefined);
+      await Promise.all([pOld, pNew]);
+    });
+
+    // #then the committed current-track index must reflect the newer call (2),
+    // and the stale older call (1) must not clobber it after resolving last.
+    const committed = setCurrentTrackIndex.mock.calls.map((c: [number]) => c[0]);
+    expect(committed).toContain(2);
+    expect(committed.at(-1)).toBe(2);
+    expect(setCurrentTrackIndex).not.toHaveBeenCalledWith(1);
+  });
+});

--- a/src/hooks/useAccentColor.ts
+++ b/src/hooks/useAccentColor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, startTransition } from 'react';
+import { useCallback, useEffect, useRef, startTransition } from 'react';
 import type { MediaTrack } from '@/types/domain';
 import { isProfilingEnabled } from '@/contexts/ProfilingContext';
 import { theme } from '@/styles/theme';
@@ -14,34 +14,46 @@ export const useAccentColor = (
   const albumImage = currentTrack?.image;
   const albumOverride = albumId ? accentColorOverrides[albumId] : undefined;
 
+  // Monotonic generation guard shared by the track-change effect and the
+  // user-invoked "auto" re-extraction. Both do async color extraction; the
+  // latest request wins, so a superseded extraction (a previous track, or an
+  // effect the user's auto pick replaced) cannot commit its stale color. The
+  // mounted ref covers the unmount case. Mirrors useCollectionLoader /
+  // useRadioSession.
+  const accentGenerationRef = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
+
+  const commitAccentColor = useCallback((generation: number, colorValue: string) => {
+    if (!isMountedRef.current) return;
+    if (accentGenerationRef.current !== generation) return;
+    setAccentColor(colorValue);
+  }, [setAccentColor]);
+
   useEffect(() => {
-    let isCurrent = true;
+    const generation = ++accentGenerationRef.current;
 
     if (!albumId && !albumImage) {
-      setAccentColor(theme.colors.accent);
-      return () => {
-        isCurrent = false;
-      };
+      commitAccentColor(generation, theme.colors.accent);
+      return;
     }
 
     if (albumId && albumOverride) {
-      setAccentColor(albumOverride);
-      return () => {
-        isCurrent = false;
-      };
+      commitAccentColor(generation, albumOverride);
+      return;
     }
 
     if (albumImage) {
       const extractStart = isProfilingEnabled() ? performance.now() : 0;
       extractDominantColor(albumImage)
         .then(dominantColor => {
-          if (!isCurrent) return;
+          if (accentGenerationRef.current !== generation) return;
           if (extractStart > 0) {
             console.debug(`[Profiling] useAccentColor.extract: ${(performance.now() - extractStart).toFixed(1)}ms`);
           }
           const applyColor = () => {
             startTransition(() => {
-              setAccentColor(dominantColor ? dominantColor.hex : theme.colors.accent);
+              commitAccentColor(generation, dominantColor ? dominantColor.hex : theme.colors.accent);
             });
           };
           if (typeof requestIdleCallback === 'function') {
@@ -51,20 +63,20 @@ export const useAccentColor = (
           }
         })
         .catch(() => {
-          if (!isCurrent) return;
-          setAccentColor(theme.colors.accent);
+          commitAccentColor(generation, theme.colors.accent);
         });
     } else {
-      setAccentColor(theme.colors.accent);
+      commitAccentColor(generation, theme.colors.accent);
     }
-
-    return () => {
-      isCurrent = false;
-    };
-  }, [albumId, albumImage, albumOverride, setAccentColor]);
+  }, [albumId, albumImage, albumOverride, commitAccentColor]);
 
   const handleAccentColorChange = useCallback((color: string) => {
     const currentAlbumId = currentTrack?.albumId;
+
+    // Every path here is a fresh user intent — claim the newest generation so a
+    // still-in-flight extraction from the track-change effect cannot overwrite
+    // it, and (for the auto path) so a later track change supersedes this.
+    const generation = ++accentGenerationRef.current;
 
     if (color === 'auto') {
       if (currentAlbumId) {
@@ -78,28 +90,22 @@ export const useAccentColor = (
       if (currentTrack?.image) {
         extractDominantColor(currentTrack.image)
           .then(dominantColor => {
-            if (dominantColor) {
-              setAccentColor(dominantColor.hex);
-            } else {
-              setAccentColor(theme.colors.accent);
-            }
+            commitAccentColor(generation, dominantColor ? dominantColor.hex : theme.colors.accent);
           })
           .catch(() => {
-            setAccentColor(theme.colors.accent);
+            commitAccentColor(generation, theme.colors.accent);
           });
       } else {
-        setAccentColor(theme.colors.accent);
+        commitAccentColor(generation, theme.colors.accent);
       }
       return;
     }
 
     if (currentAlbumId) {
       setAccentColorOverrides(prev => ({ ...prev, [currentAlbumId]: color }));
-      setAccentColor(color);
-    } else {
-      setAccentColor(color);
     }
-  }, [currentTrack?.albumId, currentTrack?.image, setAccentColorOverrides, setAccentColor]);
+    commitAccentColor(generation, color);
+  }, [currentTrack?.albumId, currentTrack?.image, setAccentColorOverrides, commitAccentColor]);
 
   const resetToAutoColor = useCallback(() => {
     handleAccentColorChange('auto');

--- a/src/hooks/usePlaybackSubscription.ts
+++ b/src/hooks/usePlaybackSubscription.ts
@@ -32,6 +32,12 @@ export function usePlaybackSubscription({
     if (!playback) return;
     const activeProviderId = activeDescriptor.id;
 
+    // The initial and visibilitychange getState() calls are async and outlive
+    // this effect if the active provider switches or the component unmounts
+    // mid-flight. Cleanup flips this so a superseded getState cannot write the
+    // previous provider's playback state into a torn-down subscription.
+    let cancelled = false;
+
     function handleProviderStateChange(providerId: ProviderId, state: PlaybackState | null) {
       const drivingProviderId = drivingProviderRef.current ?? activeProviderId;
       if (providerId !== drivingProviderId) {
@@ -120,6 +126,7 @@ export function usePlaybackSubscription({
     const stateProviderId = drivingProviderRef.current ?? activeProviderId;
     const stateDescriptor = providerRegistry.get(stateProviderId);
     stateDescriptor?.playback.getState().then((state) => {
+      if (cancelled) return;
       if (state) {
         setIsPlaying(state.isPlaying);
         setPlaybackPosition(state.positionMs);
@@ -132,6 +139,7 @@ export function usePlaybackSubscription({
       const resyncProviderId = drivingProviderRef.current ?? activeProviderId;
       const resyncDescriptor = providerRegistry.get(resyncProviderId);
       resyncDescriptor?.playback.getState().then((state) => {
+        if (cancelled) return;
         if (state) {
           handleProviderStateChange(resyncProviderId, state);
         }
@@ -141,6 +149,7 @@ export function usePlaybackSubscription({
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
+      cancelled = true;
       unsubscribes.forEach((unsub) => unsub());
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };

--- a/src/hooks/useProviderPlayback.ts
+++ b/src/hooks/useProviderPlayback.ts
@@ -39,6 +39,14 @@ export const useProviderPlayback = ({
 
   const currentPlaybackProviderRef = useRef<ProviderId | null>(null);
 
+  // Monotonic generation guard. `playTrack` awaits the provider adapter (a
+  // network round-trip for Spotify transfer/play); overlapping invocations —
+  // e.g. mashing next — can resolve out of order. A later invocation supersedes
+  // an earlier one, so the earlier one's late resolution must not commit its
+  // (now-stale) index or fire its pre-warm. Mirrors the guard in
+  // useCollectionLoader / useRadioSession.
+  const playGenerationRef = useRef(0);
+
   // Re-prime the current track when its provider re-authenticates after a
   // session expiry. The dispatcher (ProviderContext) skips the initial mount,
   // so this only fires on genuine `not authenticated → authenticated`
@@ -129,6 +137,11 @@ export const useProviderPlayback = ({
         mediaTrack.id.slice(0, 8), index, trackProvider);
     }
 
+    // Claim this as the newest intended playback. A concurrent later call bumps
+    // this again; when our awaited adapter call resolves we drop the result if
+    // we're no longer the newest.
+    const generation = ++playGenerationRef.current;
+
     pausePreviousProvider(trackProvider);
     currentPlaybackProviderRef.current = trackProvider;
 
@@ -149,6 +162,11 @@ export const useProviderPlayback = ({
 
     try {
       await descriptor.playback.playTrack(mediaTrack, options);
+
+      // Superseded by a newer playTrack while the adapter was starting — drop
+      // this stale result rather than commit its index or pre-warm its next.
+      if (playGenerationRef.current !== generation) return;
+
       setCurrentTrackIndex(index);
 
       const nextIndex = (index + 1) % tracks.length;


### PR DESCRIPTION
## Summary

Audited every hook in `src/hooks/` and every provider in `src/contexts/` for the stale-async / stale-generation bug class (async work committed to state without guarding against a newer invocation, unmount, or provider switch superseding it). Three real latent races surfaced, each reproduced with a failing async-race test (built on the `src/test/asyncRace.ts` harness) and then fixed by mirroring the established `useCollectionLoader` / `useRadioSession` generation-guard pattern.

Most async-committing hooks were already correctly guarded (useCollectionLoader, useRadioSession, useRadio, useLibrarySearch, useUnifiedLikedTracks, useCatalogLibrarySync's load effect, useQueue{Duration,Thumbnail}Loader, useLikeTrack, useEngineLibrarySync). The three below were the genuine gaps.

## Changes

- **useProviderPlayback.playTrack**: added a monotonic `playGenerationRef`. Overlapping `playTrack` calls await the provider adapter and can resolve out of order; the post-await `setCurrentTrackIndex(index)` (and next-track pre-warm) had no guard, so a stale older call clobbered the newer one. The newest invocation now wins.
- **useAccentColor**: the track-change effect was guarded, but the user-invoked "auto" re-extraction committed `setAccentColor` unguarded — a track advancing mid-extraction let the old track's color overwrite the new one. Replaced the per-effect `isCurrent` flag with a generation ref shared by the effect and the auto/manual callbacks, plus a mounted ref for unmount.
- **usePlaybackSubscription**: the initial and visibilitychange `getState().then` commits wrote `isPlaying`/`playbackPosition` with no cleanup guard, so a provider switch or unmount mid-flight wrote a torn-down subscription's stale state. Added a `cancelled` flag flipped in effect cleanup.
- Three new colocated async-race regression tests under `src/hooks/__tests__/`.

## Test plan

- [ ] `npm run test:run` — full suite green (2043 tests)
- [ ] `npx tsc -b --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] Each new race test fails without its corresponding fix and passes with it